### PR TITLE
feat(v1.2): absorb harness-evolver innovations — regression guard, worktree isolation, numeric scoring, positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ Meta-layer view (forge-harness):
 >
 > forge-harness is applied meta-harness engineering at exactly the layer these studies identify.
 
+#### FH vs. automated harness tools
+
+The Stanford Meta-Harness paper inspired [harness-evolver](https://github.com/raphaelchristi/harness-evolver) (MIT, 2026) — a fully automated 7-stage harness CODE optimizer requiring LangSmith + Python. forge-harness independently converged on the same loop architecture, but from the opposite direction:
+
+| Axis | harness-evolver (automated) | forge-harness (human-in-the-loop) |
+|---|---|---|
+| **Optimization target** | Harness code (prompts, routing, retrieval) | Harness knowledge (context, patterns, expertise) |
+| **Evolution mechanism** | Fully automated — winners auto-merge to git | Human-approved — every stage requires explicit confirmation |
+| **Infrastructure** | LangSmith + Python 3.10+ required | CLAUDE.md + skills only — zero additional infrastructure |
+| **Scope** | Single-harness optimization | Multi-project federation (N projects, shared skill bus) |
+| **Knowledge layer** | No persistent curation | `tracks/` + `knowledge/` cumulative files grow over time |
+
+**When to use FH**: You want accumulated domain knowledge, multi-project coordination, and human judgment at architectural gates — and prefer zero additional infrastructure. **When harness-evolver fits better**: You want fully automated harness CODE search at benchmark scale and have LangSmith already set up.
+
+These are complementary, not competing. FH's human-in-the-loop approval gates + multi-project knowledge layer address exactly the gaps harness-evolver leaves open.
+
 ### Environment Engineering
 
 forge-harness doesn't change the agent — it changes the environment. The MEMORY.md keyword-trigger, mandatory Context Card injection, and PFD domain knowledge pre-loading are practices of Environment Engineering that remove the "orientation tax" agents pay before they can find their direction.

--- a/plugins/fh-meta/skills/agent-composer/SKILL.md
+++ b/plugins/fh-meta/skills/agent-composer/SKILL.md
@@ -330,6 +330,33 @@ After user approval, dispatch background agents via the Agent tool.
 - **E**: User modifies the plan then re-confirms. Adding/removing agents and changing order are allowed.
 - **N**: Cancel. Keep the composition plan for reference only.
 
+### Step 3.1 — Worktree Isolation (Parallel Proposal Mode)  ← v1.2: harness-evolver pattern
+
+When parallel agents in the same Wave may write to the same files (e.g., proposing alternative SKILL.md drafts, competing harness designs, parallel feature patches), use **git worktree isolation** to prevent file conflicts and keep each proposal on a clean branch.
+
+**Activation condition**: 2+ agents in the same Wave targeting overlapping file paths, where each agent produces independent candidate outputs (not just reads).
+
+**Execution pattern**:
+
+```
+1. Before dispatch: create an isolated worktree per agent
+   EnterWorktree(branch="proposal/{agent-name}-{slug}")
+   → each agent operates on its own branch, no shared file state
+
+2. After Wave completes: fan-in results from each worktree
+   → compare outputs across branches
+   → winning proposal cherry-picked or merged to main branch
+   → losing worktrees discarded (auto-cleaned if unchanged)
+
+3. Composition plan output adds worktree marker:
+   [A] {agent name} — {role}  [worktree: proposal/A-{slug}]
+   [B] {agent name} — {role}  [worktree: proposal/B-{slug}]
+```
+
+**When to skip**: Read-only agents (recon, fact-checker), single-agent Waves, or agents targeting disjoint files → standard dispatch (no worktree overhead).
+
+**Tool prerequisite**: `EnterWorktree` / `ExitWorktree` tools must be available (Claude Code native). Check with `ToolSearch query "select:EnterWorktree"` before dispatching worktree-isolated agents.
+
 ---
 
 ## Step 3.5 — Inter-Wave Adaptation Check (Runtime Adaptation)

--- a/plugins/fh-meta/skills/harvest-loop/SKILL.md
+++ b/plugins/fh-meta/skills/harvest-loop/SKILL.md
@@ -44,7 +44,7 @@ Time: ~3 min (50% reduction vs full). Skip Steps 3/3.5/4 — creative synthesis 
 
 **Lightweight mode Done When**:
 ```
-Step 1 (field-harvest) + Step 2 (contention-layer) + Step 5 (verify-bidirectional) complete
+Step 0 (Regression Guard) + Step 1 (field-harvest) + Step 2 (contention-layer) + Step 5 (verify-bidirectional) complete
 + harvested pattern summary 1~3 lines output
 + "run full harvest-loop?" proposed (if patterns found)
 ```
@@ -75,6 +75,16 @@ Conditions for running mid-session harvest-loop without waiting for session end.
 
 ```
 Session end
+    │
+    ▼
+[Step 0] Regression Guard  ← v1.2: harness-evolver Learn-stage pattern
+    │  Before extracting new patterns, check: does anything from this session
+    │  conflict with or regress an already-validated skill?
+    │  → Scan tracks/{project}/learnings/ + existing FH SKILL.md Done When criteria
+    │  → Regression detected: flag the conflicting signal, route to contention-layer
+    │    for explicit resolution (do not silently overwrite validated patterns)
+    │  → No regression: proceed normally
+    │  → Output: "Regression check: clear / N conflicts flagged"
     │
     ▼
 [Step 1] field-harvest
@@ -404,7 +414,7 @@ synthesizer: [HIGH N / MED N / rejected N]
 ## Done When
 
 ```
-All stages Step 1 → 2 → 3 (parallel) → 3.5 → 3.75 → 4 → 5 complete
+All stages Step 0 → 1 → 2 → 3 (parallel) → 3.5 → 3.75 → 4 → 5 complete
 + synthesizer grade readjustment complete (rejected candidates separated)
 + Step 3.75 Critic verdict complete (PASS/CONDITIONAL PASS/FAIL stated)
 + Final proposal list output (sorted by HIGH/MED criteria)

--- a/plugins/fh-meta/skills/steel-quench/SKILL.md
+++ b/plugins/fh-meta/skills/steel-quench/SKILL.md
@@ -106,6 +106,13 @@ Call **fh-commons:quench-challenger** (built-in agent) in isolation, or if absen
 | Self-referential structure | S/A/B | [closed circuit detection result] | ○/△/× |
 
 S-grade blockers: N / A-grade: N / B-grade: N
+
+Optional numeric score (0.0–1.0):  ← v1.2: harness-evolver LLM-as-judge pattern
+  overall_score: {score}
+  [0.0–0.3] S-grade present → immediate blocker, do not proceed
+  [0.4–0.6] A-grade dominant → address before deployment
+  [0.7–1.0] B-grade or clean → proceed with monitoring
+  Scoring rationale: {one-line basis — weighted by S×3 + A×1, normalized to scale}
 ```
 
 ---


### PR DESCRIPTION
## Summary

forge-harness v1.2 — Sister asset integration: [harness-evolver](https://github.com/raphaelchristi/harness-evolver) (MIT) + [Meta-Harness (arXiv 2603.28052)](https://arxiv.org/abs/2603.28052) Stanford IRIS Lab

The cross-audit (`tracks/_audit/session_2026_05_26_harness_evolver.md`) confirmed FH and harness-evolver independently converged on the same outer-loop architecture. This PR absorbs the concrete innovations harness-evolver introduces, adapted to FH's human-in-the-loop + zero-infra philosophy.

---

## Track A — README Positioning

**New section**: `§ FH vs. automated harness tools`

Added a comparison table under the external validation block. Makes FH's differentiation explicit for external users evaluating harness-evolver vs. FH:

| Axis | harness-evolver | forge-harness |
|---|---|---|
| Optimization target | Harness code | Harness knowledge |
| Evolution mechanism | Fully automated | Human-approved |
| Infrastructure | LangSmith + Python | CLAUDE.md + skills only |
| Scope | Single-harness | Multi-project federation |

Positioned as complementary, not competing.

---

## Track B — 3 SKILL.md Upgrades

### 1. harvest-loop — Step 0 Regression Guard (P0③)

Added `[Step 0] Regression Guard` before `[Step 1] field-harvest`.
- Scans `tracks/{project}/learnings/` + existing SKILL.md Done When criteria before absorbing any new pattern
- Flags conflicting signals → routes to contention-layer for explicit resolution
- Prevents harvest contamination overwriting validated skills
- Applies to both full pipeline and lightweight mode
- Source: harness-evolver Learn-stage regression guard

### 2. agent-composer — Worktree Isolation (P0②)

Added `§ Step 3.1 — Worktree Isolation (Parallel Proposal Mode)`.
- Activates when 2+ agents target overlapping files with independent candidate outputs
- Uses `EnterWorktree` (CC native) to isolate each agent on its own branch
- Fan-in: compare proposals, cherry-pick winner, discard losing worktrees
- Eliminates parallel file conflicts; skip condition documented for read-only agents
- Source: harness-evolver proposer-in-isolated-worktree pattern

### 3. steel-quench — Optional Numeric Scoring (P0① partial)

Added optional numeric score block (0.0–1.0) after Wave 1 grade summary.
- Formula: `S×3 + A×1` weighted, normalized
- Bands: 0.0–0.3 (blocker) / 0.4–0.6 (deployment prep) / 0.7–1.0 (proceed)
- Qualitative S/A/B grades remain canonical; scoring is additive, not replacing
- Source: harness-evolver Evaluator LLM-as-judge rubric pattern

---

## PMH note (for claude-chrono)

These 3 patterns correspond to P0 items in `tracks/_audit/session_2026_05_26_harness_evolver.md`. PMH can adopt at full infrastructure depth (LangSmith for P0①, full worktree automation for P0②).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)