### PR TITLE
docs: two-layer storage principle — tracks/ vs memory/ 역할 명시

### DIFF
--- a/.claude/rules/sync_push_protocols.md
+++ b/.claude/rules/sync_push_protocols.md
@@ -48,6 +48,8 @@ Update the track mapping table in CLAUDE.md each time a project is added.
 
 **Underscore prefix convention**: `tracks/_audit/` · `tracks/_mcp/` etc. are for hub operations/meta work only. Consider promoting to parent directory when meta tracks accumulate to 3+.
 
+**Two-layer storage principle**: `tracks/` = detailed work history (local, machine-dependent). For critical cross-session state — pending codes, DOIs, active action items — also write to `~/.claude/projects/.../memory/` (durable, survives re-clone or machine change).
+
 ---
 
 ## Knowledge Push Protocol


### PR DESCRIPTION
## Summary

세션 중 발견된 갭: `tracks/`에만 저장하면 머신 교체/재클론 시 크리티컬 상태가 유실됨.

### 변경 내용

`sync_push_protocols.md`에 한 줄 추가:

> **Two-layer storage principle**: `tracks/` = detailed work history (local, machine-dependent). For critical cross-session state — pending codes, DOIs, active action items — also write to `~/.claude/projects/.../memory/` (durable, survives re-clone or machine change).

### 발견 경위

arXiv endorsement 코드(EGAPMM)를 세션 스타터에만 저장했다가, 머신 독립적인 백업이 없다는 점을 인식. memory/에도 저장하는 패턴을 명시적 지침으로 승격.

🤖 Generated with [Claude Code](https://claude.com/claude-code)