### PR TITLE
fix: deprecated skill refs — audit-learnings → harvest-loop, frontier-status-summary → frontier-digest

### DIFF
--- a/.claude/rules/modes_and_value.md
+++ b/.claude/rules/modes_and_value.md
@@ -44,9 +44,9 @@ The forge-harness is not a simple plugin marketplace — it is an **integrated e
 |---|---|
 | `plugin-recommender` | Tier 1·2·3 classification + organization GHE + token check |
 | `cross-ecosystem-synergy-detection` | GHE cluster + Tier classification baseline |
-| `audit-learnings` | Weekly audit automation + Phase 2+ PR auto-proposal |
+| `harvest-loop` | Weekly audit + self-evolution pipeline + Phase 2+ PR auto-proposal |
 | `verify-bidirectional` | Bidirectional self-verification + user-AI baseline update circuit |
-| `frontier-status-summary` | External-facing asset cross-ref + per-audience guide |
+| `frontier-digest` | External-facing asset cross-ref + frontier trend + per-audience guide |
 | `hub-cc-pr-reviewer` | PR diff → baseline coherence check → review comment auto-generation |
 | `context-doctor` | `.claudeignore` auto-generation + large file detection + `/clear` timing guidance |
 | `harness-doctor` | Harness structure L1~L4 diagnosis + M/S/R prescription |
@@ -61,7 +61,7 @@ The forge-harness is not a simple plugin marketplace — it is an **integrated e
     ↓ results accumulated
 [Layer 1] memory system auto-persist → next session immediate awareness
     ↓ weekly reflection
-[Layer 2] audit-learnings → pattern formalization → memory update
+[Layer 2] harvest-loop → pattern formalization → memory update
     ↓ precision counter-argument
 [Layer 2] verify-bidirectional → baseline update channel
 ```
@@ -77,8 +77,8 @@ The forge-harness is not a simple plugin marketplace — it is an **integrated e
 | "recommend a plugin", "what should I install" | Tool discovery | `plugin-recommender` |
 | "can I use what's in another project?", "what's available?" | Ecosystem synergy discovery | `cross-ecosystem-synergy-detection` |
 | "manage my context", "want to save tokens" | Context optimization | `context-doctor` |
-| "wrap up this week's work", "want to reflect" | Weekly audit | `audit-learnings` |
+| "wrap up this week's work", "want to reflect" | Weekly audit | `harvest-loop` |
 | "review my PR", "please review" | PR audit | `hub-cc-pr-reviewer` |
 | "check harness structure", "confirm everything's running well" | Structure diagnosis | `harness-doctor` |
-| "what are the latest AI tools?", "tell me about frontier trends" | External asset discovery | `frontier-status-summary` |
+| "what are the latest AI tools?", "tell me about frontier trends" | External asset discovery | `frontier-digest` |
 | "want to share this pattern", "can I post this here?" | Pattern harvesting | `field-harvest` |

--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -30,7 +30,7 @@ The hub audits and improves itself weekly.
 2. Copy `_template_weekly.md` → `weekly_audit_YYYY-MM-DD.md`
 3. Propose 3-tier improvements (🟥mandatory/🟧strong/🟩recommended)
 
-**Phase 2 (skill-ized):** `/audit-learnings` skill automates the above procedure (manual ~10 min → auto ~3 min target). Scanner invocation, prediction vs measurement comparison, repetitive pattern detection, promotion/deprecation candidate proposal automated.
+**Phase 2 (skill-ized):** `/harvest-loop` (lightweight mode) automates the above procedure (manual ~10 min → auto ~3 min target). Scanner invocation, prediction vs measurement comparison, repetitive pattern detection, promotion/deprecation candidate proposal automated.
 
 **Session start auto-detection (L1):** When Claude Code session starts in hub cwd, check mtime of recent `weekly_audit_*.md` file → propose audit if 7+ days elapsed.
 

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -52,19 +52,21 @@ Hub long-term evolution path frame. Phase I (entering maturity) → Phase II (fr
 
 ### 2026-05-08 | fh-meta v0.5.0 | six-skills-operation, path-b-generalization, command-tower-gate, mode-c-user, beta-release
 **File:** plugins/fh-meta/.claude-plugin/plugin.json + .claude-plugin/marketplace.json
-Hub meta operations tool bundle — 6 skills operation. audit-learnings path B generalization + verify-bidirectional path B generalization + frontier-status-summary path B generalization + cross-ecosystem-synergy-detection + plugin-recommender + **hub-cc-pr-reviewer** command tower gate operations rule automation (new). 2 agents (hub-persona-auditor + fact-checker). Beta operation — harness core principle *"beta + public release = practical capability obligation"* followed.
+Hub meta operations tool bundle — 6 skills operation. harvest-loop path B generalization + verify-bidirectional path B generalization + frontier-digest path B generalization + cross-ecosystem-synergy-detection + plugin-recommender + **hub-cc-pr-reviewer** command tower gate operations rule automation (new). 2 agents (hub-persona-auditor + fact-checker). Beta operation — harness core principle *"beta + public release = practical capability obligation"* followed.
 - Decision: hub-cc-pr-reviewer skill newly created — command tower gate operations rule automation + PR lifecycle 4-run accumulated + explicit decision trigger
 - Decision: plugin level v0.4.3 → v0.5.0 promoted — 6 skills operation baseline + path B generalization baseline followed
-- Decision: 3 skills path B generalization — audit-learnings + verify-bidirectional + frontier-status-summary / external user environment adaptation path enhanced
+- Decision: 3 skills path B generalization — harvest-loop + verify-bidirectional + frontier-digest / external user environment adaptation path enhanced
+- Note: audit-learnings deprecated from plugin (2026-05-xx) → transferred to hub-internal deprecated/; replaced by harvest-loop
+- Note: frontier-status-summary deprecated (2026-05-xx) → replaced by frontier-digest
 
 ---
 
 ## Skills
 
-### 2026-05-08 | fh-meta | audit-learnings, weekly-audit, real-time-pattern-catch, hub-cwd-only, phase-2-plus
-**File:** plugins/fh-meta/skills/audit-learnings/SKILL.md
-Hub weekly audit automation — `/audit-learnings [period]` runs scanner + drafts weekly_audit + detects repetitive patterns + searches existing matches first + proposes promotion/deprecation candidates + proposes Git commit/PR (user approval gate). Hub cwd only (Phase 2 · activated 2026-04-27 / Phase 2+ · PR automation 2026-05-06).
-- Decision: v0.2 official release — Phase 2+ PR automation baseline aligned
+### 2026-05-08 | fh-meta | harvest-loop, weekly-audit, self-evolution-pipeline, session-harvest, phase-2-plus
+**File:** plugins/fh-meta/skills/harvest-loop/SKILL.md
+Self-evolution pipeline — field-harvest → contention-layer → devil/innovator parallel → synthesizer → Critic Agent → harness-doctor → verify-bidirectional → curator (8 steps). Lightweight mode for weekly audit. Replaces deprecated audit-learnings.
+- Decision: harvest-loop = audit-learnings successor + full self-evolution pipeline integrated
 
 ### 2026-05-08 | fh-meta | verify-bidirectional, layer-5-cross-verification, conscious-self-activation, diff-gate
 **File:** plugins/fh-meta/skills/verify-bidirectional/SKILL.md


### PR DESCRIPTION
## 개요
weekly_audit_2026-05-28.md 🟥 mandatory 항목 처리.

## 변경 파일 (3개)

### CATALOG.md
- fh-meta v0.5.0 플러그인 항목: `audit-learnings` → `harvest-loop`, `frontier-status-summary` → `frontier-digest`
- Skills 섹션: `audit-learnings` 항목 → `harvest-loop` 항목으로 교체 (deprecation 이력 note 포함)

### .claude/rules/modes_and_value.md
- Layer 2 스킬 테이블 (1곳)
- Synergy 다이어그램 (1곳)
- NL→skill 연결 맵 (2곳)

### .claude/rules/operations.md
- Phase 2 설명 (1곳)

## 근거
- `audit-learnings`: plugin에서 deprecated → `plugins/fh-meta/deprecated/`로 이동. 후계자는 `harvest-loop`
- `frontier-status-summary`: deprecated → `frontier-digest`로 대체
- CHANGELOG 확인 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)