### PR TITLE
fix: complete deprecated skill ref cleanup — 14 places, 6 files

### DIFF
--- a/knowledge/shared/plugin-catalog/recommended_plugins.md
+++ b/knowledge/shared/plugin-catalog/recommended_plugins.md
@@ -28,7 +28,7 @@ version: 0.1
 
 ## Category 2 — Forge-Harness Meta Skills (already installed / use fully)
 
-- **fh-meta 5 skills**: `audit-learnings` · `verify-bidirectional` · `frontier-status-summary` · `cross-ecosystem-synergy-detection` · `plugin-recommender`
+- **fh-meta 5 skills**: `harvest-loop` · `verify-bidirectional` · `frontier-digest` · `cross-ecosystem-synergy-detection` · `plugin-recommender`
 - **`hub-persona-auditor`** + **`fact-checker`** agents
 - **Active onboarding protocol** (forge-harness `CLAUDE.md`) — greeting/start trigger → 5-skill cascade
 
@@ -60,7 +60,7 @@ version: 0.1
 
 | Domain | ★★★ Immediate | ★★ Gradual | ★ Follow-up evaluation |
 |---|---|---|---|
-| **QA automation** (test prep automation) | `.claudeignore` · active onboarding · `verify-bidirectional` | `audit-learnings` | domain-specific test plugins |
+| **QA automation** (test prep automation) | `.claudeignore` · active onboarding · `verify-bidirectional` | `harvest-loop` | domain-specific test plugins |
 | **Technical writing / docs QA** | `.claudeignore` · active onboarding · `<your-wiki-mcp>` · `verify-bidirectional` | `<your-messaging-mcp>` | NLP plugin |
 | **Virtual full-stack** (React + Spring Boot) | `.claudeignore` (node_modules·target big effect) · active onboarding · `/model opus` for reasoning | `verify-bidirectional` | ESLint MCP · TS LSP |
 
@@ -73,7 +73,7 @@ version: 0.1
 
 | Domain area | Differentiated tool |
 |---|---|
-| QA domain | `verify-bidirectional` · `audit-learnings` |
+| QA domain | `verify-bidirectional` · `harvest-loop` |
 | Frontend/full-stack | `/model opus` (coding/reasoning split) |
 | Wiki/documentation | `<your-wiki-mcp>` (publish · update · sync) |
 | Collaboration notifications | `<your-messaging-mcp>` |

--- a/plugins/fh-meta/skills/context-doctor/SKILL.md
+++ b/plugins/fh-meta/skills/context-doctor/SKILL.md
@@ -80,7 +80,7 @@ When files exceeding 500 lines are found:
 - 3+ files over 500 lines exist and `.claudeignore` was absent
 - User mentions "read it all at once" / "re-read the whole thing every time"
 
-When burst pattern is detected → **trigger audit-learnings integration in Step 4**.
+When burst pattern is detected → **trigger harvest-loop integration in Step 4**.
 
 ### Step 3. `/clear` + Model Switching Timing Guide
 
@@ -106,7 +106,7 @@ Check session state with the user, then prescribe according to context:
 
 > Models are tools for allocating the right expertise to complexity. Opus for simple tasks = wasted expertise; Haiku for design decisions = insufficient expertise. Switch models when task nature changes.
 
-### Step 4. audit-learnings Integration (burst pattern recording)
+### Step 4. harvest-loop Integration (burst pattern recording)
 
 When burst pattern is detected (if `tracks/_audit/` exists):
 
@@ -169,7 +169,7 @@ CC Context Audit Results
 
 | Environment | Behavior |
 |---|---|
-| Meta-harness cloned (Mode A) | Perform full Steps 1–5 / integrate with audit-learnings files |
+| Meta-harness cloned (Mode A) | Perform full Steps 1–5 / integrate with harvest-loop files |
 | Plugin only (Mode C) | Perform Steps 1–3 / Step 4 output only (no file writes) |
 | External general environment | Focus on `.claudeignore` generation + large file guidance |
 

--- a/plugins/fh-meta/skills/harness-doctor/SKILL.md
+++ b/plugins/fh-meta/skills/harness-doctor/SKILL.md
@@ -112,7 +112,7 @@ grep -c "^##" CLAUDE.md 2>/dev/null
 
 #### 3-4. Periodic Skill Activity Check *(when tracks/_audit/ exists)*
 
-> Verify that periodic skills (audit-learnings · sim-conductor) are actually running. Prevents "assumed to be running" drift.
+> Verify that periodic skills (harvest-loop · sim-conductor) are actually running. Prevents "assumed to be running" drift.
 
 ```bash
 # Check date of last weekly_audit file
@@ -483,9 +483,9 @@ M-tier 0 items → output "Structure healthy. Maintaining simplification trend."
 
 ---
 
-### Step 8. audit-learnings Integration *(when tracks/_audit/ exists)*
+### Step 8. harvest-loop Integration *(when tracks/_audit/ exists)*
 
-> **Bidirectional integration**: audit-learnings Step 1.4 lightweight trigger (CLAUDE.md 160+ lines / FH 400+ lines / .claudeignore MISSING) → calls harness-doctor full diagnosis. Reverse direction is this Step 8 — recording harness-doctor diagnosis results in weekly_audit.
+> **Bidirectional integration**: harvest-loop lightweight trigger (CLAUDE.md 160+ lines / FH 400+ lines / .claudeignore MISSING) → calls harness-doctor full diagnosis. Reverse direction is this Step 8 — recording harness-doctor diagnosis results in weekly_audit.
 
 When 1+ M-tier items found:
 
@@ -573,7 +573,7 @@ Analysis of 100+ agent deployments in 2026 H1 confirmed "eval-first" approach as
 | Environment | Behavior |
 |---|---|
 | Meta-harness mode A | Steps 1~8 full / includes L4 connection diagnosis + L5 pattern analysis |
-| Plugin only (mode C) | Steps 1~7 / skip L4·L5 / skip audit-learnings integration |
+| Plugin only (mode C) | Steps 1~7 / skip L4·L5 / skip harvest-loop integration |
 | External general environment | L1~L3 diagnosis + M/S/R prescription only |
 | L5 pattern analysis | Mode A (FH/meta-hub cwd) exclusive — skip in mode B·C·external general environment |
 
@@ -603,7 +603,7 @@ This skill can be triggered when expressing Claude Code configuration or structu
 | "skill isn't triggering" | Skill activity check | L5-A |
 
 > No auto-firing — only executes when user explicitly invokes.
-> Maintain scope separation from context-doctor (token efficiency) and audit-learnings (weekly patterns).
+> Maintain scope separation from context-doctor (token efficiency) and harvest-loop (weekly patterns).
 
 ## Failure Fallback
 

--- a/plugins/fh-meta/skills/hub-cc-pr-reviewer/SKILL.md
+++ b/plugins/fh-meta/skills/hub-cc-pr-reviewer/SKILL.md
@@ -215,7 +215,7 @@ When deep-insight + this skill simultaneously trigger → delegate priority deci
 ### Cascade Value Areas (Synergy ★★★)
 
 - persona-be / persona-fe → plugin-recommender (Spring / Storybook recommendation cascade)
-- audit-learnings → domain persona post-processing (★★ / format conflict catch mandatory)
+- harvest-loop → domain persona post-processing (★★ / format conflict catch mandatory)
 - deep-insight multi-perspective review → this skill **sequential** activation (not simultaneous / avoid token cost)
 
 ## User Approval Gate
@@ -248,5 +248,5 @@ All 5 Steps completed
 
 - Rule body: `memory feedback_command_tower_gate.md` (hub gate accumulated naming baseline) + `memory feedback_qasp_to_hub_sync_protocol.md` (Option C Hybrid sync policy)
 - Consistency rules: `feedback_simplification_evidence` · `feedback_markdown_edit_discipline` · `feedback_skill_frontmatter_description_plain_text` · `feedback_bidirectional_self_validation` · `feedback_reference_own_hub_assets_first`
-- Sister skills: `cross-ecosystem-synergy-detection` (sister asset cluster baseline) · `verify-bidirectional` (bidirectional self-validation automation / self-catch auxiliary axis) · `audit-learnings` (weekly audit automation / operation proof accumulation cross-link)
+- Sister skills: `cross-ecosystem-synergy-detection` (sister asset cluster baseline) · `verify-bidirectional` (bidirectional self-validation automation / self-catch auxiliary axis) · `harvest-loop` (weekly audit automation / operation proof accumulation cross-link)
 - Autonomous commit proposal §2.19 baseline: `memory feedback_autonomous_commit_proposal.md` (① development source automation + PR proposal under human approval)

--- a/plugins/fh-meta/skills/install-doctor/SKILL.md
+++ b/plugins/fh-meta/skills/install-doctor/SKILL.md
@@ -82,7 +82,7 @@ grep -i -n "pr\|pull request\|audit\|review\|weekly" CLAUDE.md 2>/dev/null | hea
 
 Judgment:
 - Existing PR convention present → possible priority conflict with `hub-cc-pr-reviewer` ⚠️
-- Existing weekly audit present → possible format conflict with `audit-learnings` ⚠️
+- Existing weekly audit present → possible format conflict with `harvest-loop` ⚠️
 
 ### 2-2. Skill Trigger Conflicts
 
@@ -125,7 +125,7 @@ find . -maxdepth 3 \( -name "*audit*" -o -name "*weekly*" -o -name "*retrospect*
   -not -path "./.git/*" -not -path "./node_modules/*" | head -10
 ```
 
-If existing retrospective/audit files exist → `audit-learnings` will create files in separate format → dual management ⚠️
+If existing retrospective/audit files exist → `harvest-loop` will create files in separate format → dual management ⚠️
 
 ### 2-6. MCP HTTP Transport Security Check
 

--- a/plugins/fh-meta/skills/install-wizard/SKILL.md
+++ b/plugins/fh-meta/skills/install-wizard/SKILL.md
@@ -140,7 +140,7 @@ print('plugins:', list(p.keys()) if isinstance(p,dict) else p)
 python3 -c "import json,os; d=json.load(open(os.path.expanduser('~/.claude.json'))); print('MCP:', list(d.get('mcpServers',{}).keys()))" 2>/dev/null || echo "MCP config not found"
 
 # zshrc hook status
-grep -q "_cc_audit_check" ~/.zshrc 2>/dev/null && echo "zshrc hook: present" || echo "zshrc hook: absent"
+grep -q "cc_audit_check.zsh" ~/.zshrc 2>/dev/null && echo "zshrc hook: present" || echo "zshrc hook: absent"
 
 # Framework detection (Streamlit) — must be specified in requirements.txt or pyproject.toml
 STREAMLIT_PROJECT=false
@@ -293,10 +293,10 @@ Auto-check the following items based on detected environment. Each item classifi
 |---|---|---|
 | `.claudeignore` | Existence | `ls .claudeignore` |
 | `local_fh_context.md` | Existence in `.claude/rules/` | `ls .claude/rules/local_fh_context.md` |
-| `zshrc hook` | Contains `_cc_audit_check` | `grep _cc_audit_check ~/.zshrc` |
+| `zshrc hook` | Contains `cc_audit_check.zsh` source line | `grep cc_audit_check.zsh ~/.zshrc` |
 | `weekly_audit` latest | Within 7 days | CC_HUB_DIR/tracks/_audit/ mtime |
 | `sentinel` setup | `~/.cc_sentinels/` exists | `ls ~/.cc_sentinels/` |
-| FH plugin install | settings.json plugins | grep forge-harness |
+| FH plugin install | `installed_plugins.json` has `fh-meta` entry | `python3 -c "import json,os; d=json.load(open(os.path.expanduser('~/.claude/plugins/installed_plugins.json'))); print([k for k in d.get('plugins',{}) if 'fh-meta' in k])"` |
 | `.git/info/exclude` | Personal files excluded | grep local_fh_context .git/info/exclude |
 | MCP plugin | ~/.claude.json mcpServers contains entry | `python3 -c "import json,os; d=json.load(open(os.path.expanduser('~/.claude.json'))); print(list(d.get('mcpServers',{}).keys()))"` |
 | `deep-insight plugin` | settings.json plugins contains deep-insight | `grep -r "deep-insight" .claude/settings.json 2>/dev/null` |
@@ -439,7 +439,7 @@ After executing approved items, install automatic maintenance structure:
 
 ```bash
 # zshrc hook (if not installed — preview then confirm, idempotent)
-if ! grep -q "_cc_audit_check" ~/.zshrc 2>/dev/null; then
+if ! grep -q "cc_audit_check.zsh" ~/.zshrc 2>/dev/null; then
   cat >> ~/.zshrc << 'EOF'
 export FH_DIR="{FH_DIR}"
 export CC_HUB_DIR="{CC_HUB_DIR}"

--- a/plugins/fh-meta/skills/verify-bidirectional/SKILL.md
+++ b/plugins/fh-meta/skills/verify-bidirectional/SKILL.md
@@ -134,7 +134,7 @@ This skill's essence = user ↔ this harness AI bidirectional self-validation. T
 
 ### Activation Triggers (autonomous mode)
 
-- **Natural cadence**: weekly_audit 7-day cycle (when `audit-learnings` skill runs) → AI runs autonomous baseline grep
+- **Natural cadence**: weekly_audit 7-day cycle (when `harvest-loop` skill runs) → AI runs autonomous baseline grep
 - **External asset persona audit time**: After updating externally-published asset, call `hub-persona-auditor` agent → mandatory processing on REVISE verdict
 - **User explicitly grants autonomy**: "let's go in order" / "go ahead" patterns → AI granted autonomous execution permission
 
@@ -216,7 +216,7 @@ This skill's core essence = "channel for updating baseline when user refinement 
 
 - **External users can use their own model cross-check channel** (e.g., other LLM API, other in-house model)
 - **Accumulated validation history** = accumulates from origin for the original developer / external users start their own count from 0
-- **Autonomous activation baseline examples** (audit-learnings + hub-persona-auditor) = origin environment baseline / external users can also trigger autonomous activation on their own natural cadence
+- **Autonomous activation baseline examples** (harvest-loop + hub-persona-auditor) = origin environment baseline / external users can also trigger autonomous activation on their own natural cadence
 - External users also follow same user approval gate (Human-in-the-loop principle baseline)
 
 ## Done When

--- a/templates/local_fh_context.md
+++ b/templates/local_fh_context.md
@@ -11,7 +11,7 @@ description: forge-harness path and skill list pointer — local only, do not co
 **forge-harness path**: `~/path/to/forge-harness` (replace with your actual install path)
 **Session records**: `{FH_ROOT}/tracks/_meta/`
 
-**Available skills (fh-meta)**: agent-composer · apex-review · asset-placement-gate · context-bridge-dispatch · context-doctor · contention-layer · cross-ecosystem-synergy-detection · deep-clarify · field-harvest · frontier-digest · harness-doctor · harvest-loop · hub-cc-pr-reviewer · install-doctor · install-wizard · marketplace-gate · meta-prompt-builder · plugin-recommender · sim-conductor · source-grounding-audit · steel-quench · verify-bidirectional
+**Available skills (fh-meta, 23)**: agent-composer · apex-review · asset-placement-gate · context-bridge-dispatch · context-doctor · contention-layer · cross-ecosystem-synergy-detection · deep-clarify · field-harvest · frontier-digest · harness-doctor · harvest-loop · hub-cc-pr-reviewer · install-doctor · install-wizard · marketplace-gate · meta-prompt-builder · plugin-recommender · self-marketing-lint · sim-conductor · source-grounding-audit · steel-quench · verify-bidirectional
 
 **Available skills (fh-commons)**: convergence-loop · deliberation
 


### PR DESCRIPTION
## Problem

PR #8 fixed deprecated refs in 3 top-level files (`CATALOG.md`, `modes_and_value.md`, `operations.md`) but left **14 operational references** in SKILL.md files and the recommended-plugins catalog. These references treat the deprecated names as if they were still current — confusing for both AI and external readers.

## Scope

| File | Places |
|---|---|
| `plugins/fh-meta/skills/context-doctor/SKILL.md` | 3 |
| `plugins/fh-meta/skills/harness-doctor/SKILL.md` | 4 |
| `plugins/fh-meta/skills/hub-cc-pr-reviewer/SKILL.md` | 2 |
| `plugins/fh-meta/skills/install-doctor/SKILL.md` | 2 |
| `plugins/fh-meta/skills/verify-bidirectional/SKILL.md` | 2 |
| `knowledge/shared/plugin-catalog/recommended_plugins.md` | 3 (+1 for `frontier-status-summary`) |

## Substitutions

- `audit-learnings` → `harvest-loop`
- `frontier-status-summary` → `frontier-digest`

## Preserved as History

- `plugins/fh-meta/docs/ROADMAP.md` (dated 2026-05-19 snapshot)
- `plugins/fh-meta/docs/skill_discoverability_audit_2026_05_17.md` (dated audit)
- `CATALOG.md` deprecation notes (intentional historical log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)