### PR TITLE
fix(skills): resolve pre-existing bash syntax errors in SKILL.md docs — field-harvest · hub-cc-pr-reviewer · sim-conductor

### DIFF
--- a/plugins/fh-meta/skills/field-harvest/SKILL.md
+++ b/plugins/fh-meta/skills/field-harvest/SKILL.md
@@ -46,7 +46,7 @@ List discovered repos to user and ask to select target. If 0 repos found, prompt
 ## Step 1. Recent Commit Scan
 
 ```bash
-cd <field_path>
+cd "$FIELD_PATH"
 git log --oneline --since="<N> days ago" --no-merges
 ```
 
@@ -111,20 +111,20 @@ If 0 candidates, report "no absorption candidates — schedule next monitoring" 
 ## Step 4. PR Creation (upon user approval)
 
 ```bash
-cd <FH_ROOT>
-git checkout -b harvest/<field-project>-<YYYYMMDD>
+cd "$FH_ROOT"
+git checkout -b harvest/"$FIELD_PROJECT"-"$YYYYMMDD"
 
 # Apply approved patterns
 # - Update skill SKILL.md
 # - Update .claude/rules/
 # - Update templates/
 
-git add <changed files>
-git commit -m "harvest(<field>): <pattern summary> — <field commit hash> absorbed"
-git push origin harvest/<field-project>-<YYYYMMDD>
+git add -A   # stage approved pattern files
+git commit -m "harvest($FIELD_PROJECT): $PATTERN_SUMMARY — $FIELD_COMMIT_HASH absorbed"
+git push origin harvest/"$FIELD_PROJECT"-"$YYYYMMDD"
 
 gh pr create \
-  --title "harvest: <field project> pattern absorption (<date>)" \
+  --title "harvest: $FIELD_PROJECT pattern absorption ($DATE)" \
   --body "..."
 ```
 

--- a/plugins/fh-meta/skills/hub-cc-pr-reviewer/SKILL.md
+++ b/plugins/fh-meta/skills/hub-cc-pr-reviewer/SKILL.md
@@ -46,8 +46,8 @@ When a PR is submitted, checks consistency against the user environment's baseli
 ### Step 1. PR Diff Read
 
 ```bash
-gh pr diff <PR#>                                                    # Read changes directly
-gh pr view <PR#> --json files,additions,deletions,baseRefName,headRefName,title,body  # Metadata
+gh pr diff "$PR_NUMBER"                                             # Read changes directly
+gh pr view "$PR_NUMBER" --json files,additions,deletions,baseRefName,headRefName,title,body  # Metadata
 ```
 
 If this cc authored the change, `gh pr diff` can be skipped (directly state changed areas in PR body).
@@ -81,7 +81,7 @@ Self-catch areas 0 items = skip this entire catch matrix (no token-filling / fol
 ### Step 4. Review Comment Attachment
 
 ```bash
-gh pr comment <PR#> --body "$(cat <<'EOF'
+gh pr comment "$PR_NUMBER" --body "$(cat <<'EOF'
 ## Hub CC Review (Hub Gate — Accumulated Operation Proof)
 
 ### Baseline Consistency Check 8-Matrix
@@ -109,7 +109,7 @@ EOF
 
 ```bash
 # Execute after user decision (this skill does NOT execute)
-gh pr merge <PR#> --squash --admin --delete-branch
+gh pr merge "$PR_NUMBER" --squash --admin --delete-branch
 ```
 
 ## Sister Asset Utilization Path (cross-ecosystem-synergy-detection v0.2 baseline consistency)

--- a/plugins/fh-meta/skills/sim-conductor/SKILL.md
+++ b/plugins/fh-meta/skills/sim-conductor/SKILL.md
@@ -251,10 +251,12 @@ r_count: N
 
 ```bash
 cd "$HARNESS_ROOT"
-git checkout -b fix/sim-[YYYYMMDD]-m-tier
+git checkout -b fix/sim-"$(date +%Y%m%d)"-m-tier
 # Process M-tier items (fix descriptions, correct mismatches, etc.)
-git commit + push
-gh pr create (GH_HOST= your GHE host or github.com)
+git add -A && git commit -m "fix(sim): M-tier items from sim-conductor run"
+git push origin fix/sim-"$(date +%Y%m%d)"-m-tier
+# GH_HOST=your-ghe-host  # set if using GHE instead of github.com
+gh pr create --title "fix(sim): M-tier items" --body "..."
 ```
 
 PR body includes simulation report summary + processed item checklist.


### PR DESCRIPTION
## Problem

`regression_guard.sh` F7 (per-block `bash -n`) flagged 4 pre-existing syntax errors across 3 SKILL.md files. These were marked `ℹ️ pre-existing` in PR #19's guard output — this PR fixes them.

Root cause: Documentation code blocks used `<placeholder>` syntax which bash interprets as input redirection (`< file`), not literal text.

## Fixes

| File | Error | Fix |
|---|---|---|
| `field-harvest` | `cd <field_path>` → bash redirect | `cd "$FIELD_PATH"` |
| `field-harvest` | `git add <changed files>` | `git add -A  # stage approved files` |
| `hub-cc-pr-reviewer` | `gh pr diff <PR#>` (×4) | `gh pr diff "$PR_NUMBER"` |
| `sim-conductor` | `gh pr create (GH_HOST= ...)` parenthetical | comment syntax + explicit push step |

## Verification

```
field-harvest:       ✅ 0 bash errors
hub-cc-pr-reviewer:  ✅ 0 bash errors
sim-conductor:       ✅ 0 bash errors
regression_guard:    ✅ PASS (0 M-tier, 0 S-tier)
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)