### PR TITLE
feat(skills): Three-Doctor Loop bidirectional back-refs + steel-quench ↔ sim-conductor mandatory gate

### DIFF
--- a/plugins/fh-meta/skills/context-doctor/SKILL.md
+++ b/plugins/fh-meta/skills/context-doctor/SKILL.md
@@ -261,3 +261,7 @@ context-doctor (token/context) · harness-doctor (structure) · sim-conductor (s
 **This skill's Done When = "diagnosis report output complete"**. Actual resolution of prescription items is in the user's or follow-up work domain and is not included in this skill's completion criteria.
 
 **External validation path**: harvest-loop Step 3.75 Critic isolated Agent can independently judge against the above criteria (`skill_quality_rubric.md` verifiable criteria). Automatically linked when subsequent steel-quench runs.
+
+**→ Three-Doctor Loop chain (auto-propose after diagnosis):**
+- Prescription modifies SKILL.md / rules / CLAUDE.md → **propose `/harness-doctor`** re-check after fix (structural integrity)
+- Prescription addresses user-facing context (onboarding, README, install guides) → **propose `/sim-conductor Area A`** (external user impact validation)

--- a/plugins/fh-meta/skills/harness-doctor/SKILL.md
+++ b/plugins/fh-meta/skills/harness-doctor/SKILL.md
@@ -635,6 +635,11 @@ For shared utility, see `templates/regression_guard.sh` — extract the `count_b
 
 **External validation path**: harvest-loop Step 3.75 Critic isolated Agent can independently judge based on above criteria (`skill_quality_rubric.md` verifiable criteria). Auto-connects when subsequent quench is run.
 
+**→ Three-Doctor Loop chain (auto-propose after prescription report):**
+- M-tier found AND token/context waste patterns detected → **propose `/context-doctor`** (current context axis)
+- M-tier found AND changes affect user-facing behavior (README, skill descriptions, onboarding) → **propose `/sim-conductor Area A`** (future behavior axis)
+- Both conditions → propose full Three-Doctor Loop in sequence: context-doctor → sim-conductor Area A
+
 ---
 
 ## External User Environment Adaptation

--- a/plugins/fh-meta/skills/steel-quench/SKILL.md
+++ b/plugins/fh-meta/skills/steel-quench/SKILL.md
@@ -324,15 +324,19 @@ Wave convergence criteria met: zero new S-grade blockers
 3. Full Wave results → recommend persisting to `tracks/_meta/steel_quench_YYYY_MM_DD_{slug}.md`
 
 ### Connected Skills
-| Situation | Connected Skill |
-|---|---|
-| Want to delegate improvements as prompts | `/meta-prompt-builder` |
-| Re-validate defense logic from external user perspective | `/sim-conductor Area A` |
-| Re-validate structural decision | `/verify-bidirectional` |
-| Attack angle is itself a harness structure problem | `/harness-doctor` |
-| After Wave convergence, propose new pattern rules | `fh-meta:persona-innovator` |
-| Wave 1 structure-specific attack (6-axis) | `fh-commons:quench-challenger` (built-in priority / deep-insight fallback) |
-| Back-track whether claims in artifact actually exist in source files | `/source-grounding-audit` |
+| Situation | Connected Skill | Mandatory? |
+|---|---|:---:|
+| Want to delegate improvements as prompts | `/meta-prompt-builder` | optional |
+| **External publish context: re-validate from external user perspective** | **`/sim-conductor Area A`** | **mandatory** |
+| Re-validate structural decision | `/verify-bidirectional` | optional |
+| Attack angle is itself a harness structure problem | `/harness-doctor` | optional |
+| After Wave convergence, propose new pattern rules | `fh-meta:persona-innovator` | optional |
+| Wave 1 structure-specific attack (6-axis) | `fh-commons:quench-challenger` (built-in priority / deep-insight fallback) | optional |
+| Back-track whether claims in artifact actually exist in source files | `/source-grounding-audit` | optional |
+
+**→ steel-quench ↔ sim-conductor bidirectional gate:**
+- steel-quench → sim-conductor: After Wave convergence in external-publish context, sim-conductor Area A is the **mandatory next step** (validates residual risks from an actual external user's perspective)
+- sim-conductor → steel-quench: sim-conductor Area A requires steel-quench to have run first (prerequisite defined in sim-conductor Done When)
 
 > **Attack surface limit**: steel-quench attacks output content patterns (self-declarations, cushion language, spec-only, structural flaws). Whether source files were actually read (Phantom Claim detection) is outside attack scope — that's `source-grounding-audit`'s job. Even if Wave 1 "real-use verification" angle catches logical inconsistency, plausible Phantoms generated without reading source can pass through.
 


### PR DESCRIPTION
## Summary

Fixes asymmetric chaining in the Three-Doctor Loop and steel-quench ↔ sim-conductor pair.

## Problem

From the 25-skill chain audit:
- harness-doctor / context-doctor / sim-conductor each mention the loop but have no explicit chain direction in Done When
- steel-quench lists sim-conductor as 'optional' in Connected Skills, but for external-publish scenarios it should be mandatory
- Loop activation required 'all three mentioned simultaneously' — passive, not proactive

## Changes

### `harness-doctor` Done When
New auto-propose section:
- Token waste patterns detected → **propose `/context-doctor`**
- User-facing behavior changes → **propose `/sim-conductor Area A`**
- Both → propose full Three-Doctor Loop in sequence

### `context-doctor` Done When
New auto-propose section:
- Prescription modifies SKILL.md/rules → **propose `/harness-doctor`** re-check
- Prescription affects user-facing context → **propose `/sim-conductor Area A`**

### `steel-quench` Connected Skills
- Added Mandatory? column to table
- `/sim-conductor Area A` = **mandatory** for external-publish context (was: optional)
- Added bidirectional gate documentation (steel-quench→sim and sim→steel-quench)

## Regression Guard

```
✅ PASS — 3 files, 0 M-tier, 0 S-tier
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)