### PR TITLE
feat(frontier-digest): chain persona-innovator for external pattern absorption

### DIFF
--- a/plugins/fh-meta/agents/persona-innovator.md
+++ b/plugins/fh-meta/agents/persona-innovator.md
@@ -23,6 +23,9 @@ The main agent passes you one of:
 
 Optionally: a focus area (e.g., "token efficiency", "agent orchestration", "cascade patterns")
 
+**Automatic invocation from frontier-digest (`--chain` flag or Step 4 option [4])**:
+When invoked by frontier-digest, you receive the "FH Immediate Application Candidates" section as structured input. Run **Mode E** with those candidates as the external signal — compare each candidate against existing FH skill/agent vocabulary, propose concrete naming actions or new framing where the external pattern has no FH equivalent yet. Output: naming proposals + gap analysis + recommended next action (field-harvest / new skill / reject).
+
 ## Phase 0 — Technical constraint bridge scan (Mode T only)
 
 Run this phase when invoked with a technical blocker. Goal: reframe "not possible" into "not possible *this way* — but possible *this other way*."

--- a/plugins/fh-meta/skills/frontier-digest/SKILL.md
+++ b/plugins/fh-meta/skills/frontier-digest/SKILL.md
@@ -173,11 +173,14 @@ Immediately after Step 3 output, if **"FH Immediate Application Candidates"** ha
 ```
 💡 Improvement candidate found — would you like to connect to:
 
-  [1] /field-harvest  — absorb above candidates into FH skills/plugins
-  [2] /meta-prompt-builder  — write immediate candidates as skill prompts
-  [3] Save fh_signal  — record signal to tracks/_meta/fh_signal_{today}.md
-  [4] Skip (insights only for now)
+  [1] /field-harvest       — absorb above candidates into FH skills/plugins
+  [2] /meta-prompt-builder — write immediate candidates as skill prompts
+  [3] Save fh_signal       — record signal to tracks/_meta/fh_signal_{today}.md
+  [4] persona-innovator    — run innovator agent against candidates (naming/framing proposals + gap analysis)
+  [5] Skip (insights only for now)
 ```
+
+**→ When to use [4] persona-innovator**: Frontier candidates contain new architectural patterns, naming opportunities, or design frames not yet in FH vocabulary. persona-innovator compares the external signal against existing FH assets and proposes concrete naming/framing actions. Runs as Mode E (external scan) with the frontier candidates as input context.
 
 If user selects [3], create signal file in this format:
 
@@ -213,7 +216,8 @@ If keywords related to user projects appear in collected data:
 
 When running `/frontier-digest --chain`:
 1. Auto-save immediate application candidates as fh_signal file (with `--save`)
-2. Auto-propose `field-harvest` skill (with user approval gate)
+2. Auto-invoke `persona-innovator` Mode E with candidates as input — extracts naming/framing proposals (no user prompt needed)
+3. Auto-propose `field-harvest` skill with persona-innovator output as context (with user approval gate)
 
 ---
 
@@ -240,10 +244,13 @@ To save key permanently (~/.cc_secrets pattern):
 |---|---|
 | Step 3 synthesis result printed in conversation | ✅ Basic execution complete |
 | With `--save` flag: `✅ Saved: {path}` confirmed | ✅ Save complete |
-| With `--chain` flag: field-harvest handoff proposed | ✅ Chaining complete |
+| With `--chain` flag: persona-innovator Mode E invoked + field-harvest proposed | ✅ Chaining complete |
 | All curl failures → fallback to WebSearch synthesis output | ✅ Fallback complete |
 
 **Incomplete**: Exiting without collection + synthesis output = Fail. `--save` invoked but no file = Fail.
+
+**→ Auto-propose chain when 1+ Immediate Application Candidates found (without --chain flag):**
+Present Step 4 menu options [1]–[5]. Do not skip to [5] silently — surface the chain options even for basic runs.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the frontier-digest → persona-innovator gap identified in the 25-skill chain audit.

## Problem

frontier-digest Step 4 offered field-harvest / meta-prompt-builder / fh_signal as next steps — but the natural next step when external patterns need comparing against FH vocabulary is **persona-innovator Mode E**.

Without this chain:
- External signals get saved as fh_signal but never processed through innovator framing
- frontier-digest results lose their naming/gap analysis dimension
- persona-innovator is only invoked by harvest-loop (Step H3) or steel-quench — never from the primary external signal intake point

## Changes

### `frontier-digest` SKILL.md
- **Step 4 menu**: add option [4] `persona-innovator` with Mode E guidance
- **`--chain` flag**: now sequences → persona-innovator Mode E → field-harvest (with innovator output as context)
- **Done When**: reflect chain update (`--chain` = persona-innovator invoked + field-harvest proposed)
- **Auto-propose guard**: Step 4 menu must always surface when candidates found (no silent skip)

### `persona-innovator.md`
- Add `Automatic invocation from frontier-digest` section
- Mode E input structure defined for frontier-digest callers

## Chain after this PR

```
frontier-digest --chain
    → persona-innovator Mode E (naming/framing against existing FH vocabulary)
    → field-harvest (with innovator output as context for absorption decision)
```

## Regression Guard

```
✅ PASS — 1 file checked (SKILL.md), 0 M-tier, 0 S-tier
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)