### PR TITLE
fix: chain audit final — apex-review conditional-pass gate + deliberation↔agent-composer return path

### DIFF
--- a/plugins/fh-commons/skills/deliberation/SKILL.md
+++ b/plugins/fh-commons/skills/deliberation/SKILL.md
@@ -264,6 +264,8 @@ All Steps 0~3 completed (Steps 4~5 added if 5-layer selected)
 + User's final decision confirmed (deliberation output must never be auto-executed)
 ```
 
+**→ When invoked from agent-composer Wave next-D: synthesis verdict is the fan-in input for Wave continuation** — return the Mediator verdict + Conditions to agent-composer so the conflict is marked resolved in the fan-in result set. After this, agent-composer re-runs Step 4-b state transition evaluation with the conflict cleared; subsequent Waves (next-M / next-E / end) proceed based on the updated result.
+
 ## Simplification Guard
 
 - Simple information queries → deliberation is unnecessary. Respond directly.

--- a/plugins/fh-meta/skills/agent-composer/SKILL.md
+++ b/plugins/fh-meta/skills/agent-composer/SKILL.md
@@ -448,7 +448,7 @@ After outputting the fan-in completion report, evaluate the conditions below and
 | ① M-tier > 0 | **Wave next-M** | fact-checker (A) stale validation → hub-cc-pr-reviewer (S) PR plan |
 | ② persona-innovator naming candidates > 0 | **Wave next-I** | Delegate decision to user + asset-placement-gate (S) |
 | ③ External absorption signal High applicability > 0 | **Wave next-E** | persona-innovator Mode E (A) + meta-prompt-builder (S) |
-| ⑤ Design decision conflict or 2+ conflicting suggestions | **Wave next-D** | deliberation (separate FH skill) (S) — 3-layer default / 5-layer jury option |
+| ⑤ Design decision conflict or 2+ conflicting suggestions | **Wave next-D** | deliberation (separate FH skill) (S) — 3-layer default / 5-layer jury option; **after deliberation Done When: fold synthesis verdict back into fan-in result set → re-run Step 4-b state transition with conflict marked resolved** |
 | ④ All of ①②③⑤ are 0 | **End** | Output "backlog only, defer to next session" then complete |
 
 ```

--- a/plugins/fh-meta/skills/apex-review/SKILL.md
+++ b/plugins/fh-meta/skills/apex-review/SKILL.md
@@ -140,9 +140,12 @@ Gate result: {Passed / Conditionally passed / Rejected}
 Choose your next step:
   A. Revise and re-review
   B. Proceed to sim-conductor in current state (deep validation)
+     ← strongly recommended when verdict is "Conditionally passed"
   C. Use HTML deck only (as reference)
   D. Exit
 ```
+
+> **"Conditionally passed" → option B is the default path**: Conditions listed by personas remain unresolved until sim-conductor Area E runs devil/newcomer/power-user validation against them. Choosing C or D without sim-conductor leaves those conditions unverified — present B as the default choice and require explicit opt-out.
 
 ---
 
@@ -176,3 +179,5 @@ All steps 0–4 completed
 + Gate verdict (Passed / Conditionally passed / Rejected) stated
 + User next step selection (A/B/C/D) confirmed
 ```
+
+**→ Mandatory next (Conditionally passed verdict): `/sim-conductor Area E`** — run against `apex_review_deck_YYYYMMDD.html` before the proposal is considered ready for submission. Skipping sim-conductor on a conditional pass means unresolved persona conditions go unverified; present option B as default and require the user to explicitly choose A/C/D to override.


### PR DESCRIPTION
## Summary

Closes the last two items from the 25-skill mandatory chain audit.

### Changes

#### apex-review
- **Step 4 gate**: "Conditionally passed" verdict now marks option B *(sim-conductor Area E)* as strongly recommended with an explanatory callout — unresolved persona conditions are not verified without running sim-conductor
- **Done When**: Added `→ Mandatory next (Conditionally passed verdict): /sim-conductor Area E` chain marker

#### deliberation
- **Done When**: Added `→ When invoked from agent-composer Wave next-D`: synthesis verdict is the fan-in input — return Mediator verdict + Conditions to agent-composer so conflict is marked resolved; agent-composer re-runs Step 4-b state transition with updated result set

#### agent-composer
- **Step 4-b Wave next-D row**: After deliberation Done When, fold synthesis verdict back into fan-in result set and re-run Step 4-b state transition with conflict marked resolved — closes the caller→callee→caller loop

### Context

This is the final PR in the chain audit series (PRs #18–#22 covered the other 23 skills):
- PR #18: CLAUDE.md 3-axis auto-gate + regression_guard F5 fix
- PR #19: 4 mandatory chain gates (field-harvest, hub-cc-pr-reviewer, marketplace-gate, sim-conductor)
- PR #20: bash syntax fixes
- PR #21: Three-Doctor Loop back-refs + steel-quench↔sim-conductor bidirectional
- PR #22: frontier-digest → persona-innovator chain
- **This PR (#23)**: apex-review conditional-pass + deliberation↔agent-composer return path

All 25 FH skills now have explicit mandatory chain markers on critical paths.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)