### PR TITLE
feat(registry): add 3 new skills to CLAUDE.md autonomous triggers + skill lists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,9 @@ Proposal format: `"I see [X]. Want me to run /[skill] to [one-line description]?
 | "where does this go", "asset location", "hub vs project", "placement" | `/asset-placement-gate` |
 | "add to marketplace", "OK to publish", "pre-publish check" | `/marketplace-gate` |
 | "look at this again", "is this right", "counterargument", "re-validate" | `/verify-bidirectional` |
+| "MCP failing", "tool keeps erroring", "circuit-breaker", "same error looping" | `/mcp-circuit-breaker` |
+| "token budget", "how expensive", "estimate tokens", "will this cost a lot" | `/token-budget-gate` |
+| "did my rule change break anything", "regression check", "test harness changes" | `/prompt-regression` |
 | "ready to PR", "about to push", "merge this", "PR 올려줘", FH asset changed in session | 3-axis auto-gate (see above — runs automatically, no proposal needed) |
 
 **Guard**: Do not propose a skill that is already running. One signal = one-line proposal (no pressure).

--- a/templates/local_fh_context.md
+++ b/templates/local_fh_context.md
@@ -11,8 +11,8 @@ description: forge-harness path and skill list pointer — local only, do not co
 **forge-harness path**: `~/path/to/forge-harness` (replace with your actual install path)
 **Session records**: `{FH_ROOT}/tracks/_meta/`
 
-**Available skills (fh-meta, 23)**: agent-composer · apex-review · asset-placement-gate · context-bridge-dispatch · context-doctor · contention-layer · cross-ecosystem-synergy-detection · deep-clarify · field-harvest · frontier-digest · harness-doctor · harvest-loop · hub-cc-pr-reviewer · install-doctor · install-wizard · marketplace-gate · meta-prompt-builder · plugin-recommender · self-marketing-lint · sim-conductor · source-grounding-audit · steel-quench · verify-bidirectional
+**Available skills (fh-meta, 24)**: agent-composer · apex-review · asset-placement-gate · context-bridge-dispatch · context-doctor · contention-layer · cross-ecosystem-synergy-detection · deep-clarify · field-harvest · frontier-digest · harness-doctor · harvest-loop · hub-cc-pr-reviewer · install-doctor · install-wizard · marketplace-gate · meta-prompt-builder · plugin-recommender · prompt-regression · self-marketing-lint · sim-conductor · source-grounding-audit · steel-quench · verify-bidirectional
 
-**Available skills (fh-commons)**: convergence-loop · deliberation
+**Available skills (fh-commons)**: convergence-loop · deliberation · mcp-circuit-breaker · token-budget-gate
 
 Skill details available on demand at `{FH_ROOT}/plugins/{plugin}/skills/{skill-name}/SKILL.md`.


### PR DESCRIPTION
## Summary
- CLAUDE.md §Autonomous Initiative: 3 new trigger rows added
  - "MCP failing", "tool keeps erroring" → `/mcp-circuit-breaker`
  - "token budget", "estimate tokens" → `/token-budget-gate`
  - "regression check", "did my changes break anything" → `/prompt-regression`
- `templates/local_fh_context.md`: fh-meta 23→24 (+prompt-regression), fh-commons +mcp-circuit-breaker +token-budget-gate

## Test plan
- [ ] All 3 trigger phrases appear in CLAUDE.md signal table
- [ ] Template skill counts match actual directory contents
- [ ] No broken references in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)