### PR TITLE
feat(knowledge): return-path-gate pattern — closed-loop skill chain formalization

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -8,6 +8,11 @@ AI reads this file first when searching past work. Open individual files for det
 
 <!-- Add entries in reverse date order (newest at top) -->
 
+### 2026-05-29 | harness-core | return-path-gate, skill-chain, conditional-pass, closed-loop
+**File:** knowledge/shared/harness-core/return_path_gate.md
+Pattern: downstream skill returns structured verdict (PASS/CONDITIONAL_PASS/FAIL/ESCALATE) back to caller, which gates next step on it. Verified in apex-review→sim-conductor and agent-composer↔deliberation.
+- Decision: promoted to knowledge/shared/ — same pattern appeared independently in 2 skill pairs
+
 ### 2026-05-29 | fh-commons | token-budget-gate, token-estimation, cost-guard, multi-agent
 **File:** plugins/fh-commons/skills/token-budget-gate/SKILL.md
 New skill: pre-task token cost estimation with Green/Yellow/Orange/Red gate verdict. Post-task calibration loop improves future estimates. Auto-proposed before agent-composer, sim-conductor, steel-quench, harvest-loop.

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -13,6 +13,11 @@ AI reads this file first when searching past work. Open individual files for det
 Pattern: downstream skill returns structured verdict (PASS/CONDITIONAL_PASS/FAIL/ESCALATE) back to caller, which gates next step on it. Verified in apex-review→sim-conductor and agent-composer↔deliberation.
 - Decision: promoted to knowledge/shared/ — same pattern appeared independently in 2 skill pairs
 
+### 2026-05-29 | harness-core | meta-harness-engineering, definition, frontier, academic-convergence
+**File:** knowledge/shared/harness-core/meta_harness_engineering_definition.md
+Formal definition of meta harness engineering + FH positioning vs. academic convergence (arXiv 2605.18747 "Code as Agent Harness", arXiv 2604.14228 98.4% finding). Maps FH 6-axis to 3-layer taxonomy; distinguishes human-in-loop (FH) vs automation-first vs automation-maximalist approaches.
+- Decision: FH differentiator = human judgment gate on all PRs, not automation maximization
+
 ### 2026-05-29 | fh-commons | token-budget-gate, token-estimation, cost-guard, multi-agent
 **File:** plugins/fh-commons/skills/token-budget-gate/SKILL.md
 New skill: pre-task token cost estimation with Green/Yellow/Orange/Red gate verdict. Post-task calibration loop improves future estimates. Auto-proposed before agent-composer, sim-conductor, steel-quench, harvest-loop.

--- a/knowledge/shared/harness-core/return_path_gate.md
+++ b/knowledge/shared/harness-core/return_path_gate.md
@@ -1,0 +1,120 @@
+---
+name: return-path-gate
+description: Skill chain pattern where a downstream skill returns a structured conditional verdict back to its caller, which gates its next step on that verdict. Prevents fire-and-forget chains and closes the feedback loop.
+type: pattern
+date: 2026-05-29
+tags: [pattern, skill-chain, verdict, conditional-pass, closed-loop]
+instances:
+  - apex-review → sim-conductor
+  - agent-composer ↔ deliberation
+---
+
+# Return-Path Gate — Closed-Loop Skill Chain Pattern
+
+A skill chain is **closed** when the downstream skill's output feeds back into the upstream caller's decision logic. Without a return path, downstream calls are fire-and-forget: the caller can't act on results, conditions go unresolved, and the chain terminates with unverified state.
+
+The Return-Path Gate enforces closure: the caller registers a verdict expectation before calling downstream, the downstream returns a structured verdict, and the caller gates its next step on that verdict.
+
+---
+
+## Structure
+
+```
+[Caller Skill]
+  Step N: Detect trigger condition
+  Step N+1: Dispatch → [Callee Skill] (with topic + context)
+  Step N+2: ◀ WAIT for verdict ▶
+  Step N+3: Gate on verdict
+    PASS           → proceed normally
+    CONDITIONAL    → resolve listed conditions before proceeding
+    FAIL/ESCALATE  → block + surface to user
+
+[Callee Skill]
+  Processes topic
+  Returns structured verdict (not a binary win/lose)
+  ↓
+[Caller] receives verdict → re-enters decision logic
+```
+
+---
+
+## Verdict Format (standard)
+
+```
+Verdict: PASS | CONDITIONAL_PASS | FAIL | ESCALATE
+Conditions: [list — only present when CONDITIONAL_PASS]
+Basis: [one-line rationale]
+```
+
+- **PASS** — proceed without modification
+- **CONDITIONAL_PASS** — proceed only after listed conditions are addressed; conditions must be explicitly resolved, not silently skipped
+- **FAIL** — block; requires redesign before proceeding
+- **ESCALATE** — surface to user; decision requires human judgment
+
+---
+
+## Verified Instances
+
+### 1. apex-review → sim-conductor
+
+**Caller**: `apex-review`
+**Callee**: `sim-conductor` (Area E — external scenario validation)
+
+**Trigger**: apex-review produces `Conditionally passed` verdict
+**Return path**: sim-conductor Area E results fold back into the apex-review HTML deck
+**Gate logic**:
+- `Passed` → deck is submission-ready
+- `Conditionally passed` → **mandatory sim-conductor dispatch** (option B is default; user must explicitly opt out)
+- `Rejected` → redesign required
+
+**Why it matters**: Without this gate, persona conditions from apex-review are listed but never verified. sim-conductor's devil/newcomer/power-user validation is the only mechanism that resolves them.
+
+---
+
+### 2. agent-composer ↔ deliberation
+
+**Caller**: `agent-composer` (Step 4-b state transition)
+**Callee**: `deliberation` (3-layer: Innovator → Devil → Mediator)
+
+**Trigger**: 2+ conflicting suggestions or design decision conflict detected in fan-in results → `Wave next-D`
+**Return path**: deliberation synthesis verdict folds back into agent-composer Step 4-b fan-in result set → conflict marked resolved → state transition re-runs
+**Gate logic**:
+- Synthesis verdict (conditional, not binary) replaces the conflict entry
+- Step 4-b re-evaluates with conflict resolved
+- Auto-execution forbidden — user decision finalizes
+
+**Why it matters**: Without the return fold, deliberation output is displayed to the user but the agent-composer orchestration loop doesn't update — the conflict remains unresolved in the state machine.
+
+---
+
+## Anti-Pattern: Fire-and-Forget
+
+```
+[Caller] → [Callee]
+              ↓
+         outputs result (displayed to user)
+              ↓
+         [Caller continues independently — does not act on result]
+```
+
+This is the default failure mode when a skill chain has no return path defined. Symptoms:
+- Downstream output is shown but not acted on
+- Conditions listed by callee remain unverified
+- Caller proceeds as if callee succeeded unconditionally
+
+---
+
+## Implementation Checklist (when adding a Return-Path Gate to a skill)
+
+- [ ] Caller SKILL.md: `§Done When` — explicitly states "wait for callee verdict before proceeding"
+- [ ] Callee SKILL.md: `§Done When` — outputs structured verdict (PASS / CONDITIONAL_PASS / FAIL / ESCALATE)
+- [ ] Callee SKILL.md: `§Chains` — "returns verdict to `[caller]`"
+- [ ] Caller SKILL.md: `§Chains` — "→ Mandatory next (`[callee]`) when [condition]; verdict folds back into [step]"
+- [ ] CONDITIONAL_PASS gate: default path is resolution, not bypass
+
+---
+
+## Relation to Other Patterns
+
+- **Three-Doctor Loop** (`harness-doctor ↔ context-doctor ↔ sim-conductor`) uses return paths implicitly — each doctor's output triggers the next. A full Return-Path Gate implementation would make the fold-back explicit.
+- **verify-bidirectional** is a single-depth return path: AI recommendation → user counter-argument → AI baseline update. The verdict here is implicit (user correction = FAIL signal).


### PR DESCRIPTION
## Summary
- New pattern doc `knowledge/shared/harness-core/return_path_gate.md`
- Formalizes the Return-Path Gate: downstream skill returns structured verdict → caller gates next step
- Verdict format: PASS / CONDITIONAL_PASS / FAIL / ESCALATE
- Two verified instances documented:
  - `apex-review → sim-conductor` (CONDITIONAL_PASS → mandatory sim-conductor dispatch)
  - `agent-composer ↔ deliberation` (Wave next-D → verdict folds back into Step 4-b fan-in)
- Anti-pattern (fire-and-forget) documented
- Implementation checklist (5 items) for adding this pattern to future skills

## Test plan
- [ ] File at correct path: `knowledge/shared/harness-core/return_path_gate.md`
- [ ] Both verified instances match actual SKILL.md content
- [ ] Implementation checklist is actionable (can verify each item in a skill)
- [ ] CATALOG.md entry present

🤖 Generated with [Claude Code](https://claude.com/claude-code)