### PR TITLE
fix(regression_guard): --pr mode with auto merge-base — eliminate false positives

### DIFF
--- a/.github/workflows/regression-guard.yml
+++ b/.github/workflows/regression-guard.yml
@@ -1,0 +1,42 @@
+name: Regression Guard (Axis 1)
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'plugins/*/skills/*/SKILL.md'
+      - '.claude/rules/*.md'
+      - 'CLAUDE.md'
+      - 'templates/*.md'
+      - 'templates/regression_guard.sh'
+
+jobs:
+  regression-guard:
+    name: Axis 1 — Backward Regression Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history required for git merge-base
+
+      - name: Run regression_guard (--pr mode)
+        id: guard
+        run: |
+          set +e
+          bash templates/regression_guard.sh --pr "${{ github.head_ref }}"
+          EXIT=$?
+          echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
+          set -e
+          exit 0  # capture exit code; handle below
+
+      - name: Evaluate result
+        run: |
+          EXIT="${{ steps.guard.outputs.exit_code }}"
+          if [ "$EXIT" = "2" ]; then
+            echo "::error::Regression Guard BLOCK — M-tier issues found. Fix before merge."
+            exit 2
+          elif [ "$EXIT" = "1" ]; then
+            echo "::warning::Regression Guard S-tier warnings present. Review intent before merge."
+          else
+            echo "Regression Guard PASS"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,7 +235,7 @@ No user request is needed — this is a mandatory autonomous step, not a proposa
 FH asset modified
     │
     ▼
-Axis 1 — Backward   : bash templates/regression_guard.sh main
+Axis 1 — Backward   : bash templates/regression_guard.sh --pr {BRANCH}
     │
     ▼
 Axis 2 — Adversarial: /steel-quench  (trigger phrases, step conflicts, design attack surface)

--- a/templates/regression_guard.sh
+++ b/templates/regression_guard.sh
@@ -5,17 +5,41 @@
 #   bash templates/regression_guard.sh [BASE_REF]
 #   bash templates/regression_guard.sh main                    # compare working tree vs main
 #   bash templates/regression_guard.sh origin/main HEAD        # compare HEAD vs origin/main
+#   bash templates/regression_guard.sh --pr BRANCH             # PR mode: auto merge-base (recommended)
 #
 # Exit codes: 0=PASS / 1=S-tier warnings / 2=M-tier block / 3=usage error
+#
+# PR mode rationale: using 'main' as BASE_REF for a PR branch includes changes from OTHER
+# merged PRs as false positives. --pr computes the fork-point (merge-base) automatically,
+# so only THIS branch's own changes are evaluated.
 #
 # Called by:
 #   - harness-doctor Step 10 (Regression Guard)
 #   - harvest-loop Step 4 (harness-doctor invocation)
+#   - CLAUDE.md §3-axis auto-gate (Axis 1) — use --pr mode for PRs
 #   - manual pre-merge gate
 
 set -u
-BASE_REF="${1:-main}"
-HEAD_REF="${2:-}"   # empty = working tree
+
+# --pr mode: compute merge-base automatically
+if [ "${1:-}" = "--pr" ]; then
+  if [ -z "${2:-}" ]; then
+    echo "Usage: regression_guard.sh --pr BRANCH" >&2
+    exit 3
+  fi
+  PR_BRANCH="$2"
+  BASE_BRANCH="${3:-main}"
+  BASE_REF=$(git merge-base "$BASE_BRANCH" "$PR_BRANCH" 2>/dev/null)
+  if [ -z "$BASE_REF" ]; then
+    echo "ERROR: cannot compute merge-base for $PR_BRANCH vs $BASE_BRANCH" >&2
+    exit 3
+  fi
+  HEAD_REF="$PR_BRANCH"
+  echo "PR MODE: merge-base=$(git rev-parse --short "$BASE_REF") branch=$PR_BRANCH"
+else
+  BASE_REF="${1:-main}"
+  HEAD_REF="${2:-}"   # empty = working tree
+fi
 
 # Discover changed files
 if [ -z "$HEAD_REF" ]; then


### PR DESCRIPTION
## Problem
`bash templates/regression_guard.sh main BRANCH` compares ALL files between current main and the branch — including changes from OTHER merged PRs. This causes false M-tier positives when PRs were merged to main after branches were created.

## Fix
Add `--pr BRANCH` mode that auto-computes the fork-point (merge-base) as BASE_REF:
```bash
# Before (false positives from sibling PRs):
bash templates/regression_guard.sh main feat/my-branch

# After (only this branch's own changes):
bash templates/regression_guard.sh --pr feat/my-branch
```

## Verified
All 6 pending PRs (#24-29) re-checked with `--pr` mode — all PASS:
- #24 prompt-regression: ✅ PASS (1 file, frontmatter OK)
- #25 mcp-circuit-breaker: ✅ PASS (1 file, frontmatter OK)
- #26 token-budget-gate: ✅ PASS (1 file, frontmatter OK)
- #27 registry update: ✅ PASS (CLAUDE.md +3 lines)
- #28 return-path-gate: ✅ SKIP (knowledge/ only, no SKILL.md)
- #29 meta-harness-definition: ✅ SKIP (knowledge/ + scripts/ only)

## CLAUDE.md update needed (follow-up)
`§3-axis auto-gate Axis 1` usage example should reference `--pr` mode. Will update in this PR or next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)