### PR TITLE
fix(gate+sidecar): close knowledge/ auto-gate gap + §9 coherence/bash fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,7 +235,7 @@ Skills without a Done When definition automatically qualify as harness-doctor L2
 
 ## FH Improvement 4-Axis Auto-Gate (Self-Verification Orchestrator)
 
-**Whenever the AI modifies FH assets** (SKILL.md · `.claude/rules/*.md` · `templates/` · `CLAUDE.md`),
+**Whenever the AI modifies FH assets** (SKILL.md · `.claude/rules/*.md` · `templates/` · `CLAUDE.md` · substantive `knowledge/` docs — see Substantive carve-out below),
 the 4-axis verification chain runs **automatically before the first commit** of that session.
 No user request is needed — this is a mandatory autonomous step, not a proposal.
 
@@ -280,6 +280,8 @@ Any FAIL  → fix inline, re-run failed axis, then proceed
 **Scope**: Active from the moment any FH file is modified in the current session — not deferred to the next session.
 
 **Lightweight exception** (Axis 1 + 4 only, skip Axes 2–3): Sessions where **zero SKILL.md / rules / templates files changed** (e.g., CATALOG.md entry, tracks/ update). The hook detects this automatically — no Axes 2+3 marker required for light-only commits. Judgment is file-based, not subjective.
+
+**Substantive `knowledge/` carve-out** (Axes 2–3 DO run, despite knowledge/ not being SKILL/rules/templates): a `knowledge/` doc change is **not** light if its diff adds a fenced code block (```` ``` ````) or a citation (`arXiv:` / `DOI` / `http`). Executable patterns and factual claims need phantom-detection + adversarial review *wherever they live* — this closes the gap where a substantive knowledge doc (e.g. an Implementation-Patterns section with runnable commands) slips through as "light." Prose-only knowledge edits (typos, rewording, link fixes) stay light. Detection is mechanical: `git diff` adds a ```` ``` ```` fence or a citation token → run Axes 2–3.
 
 **Unavailable axis**: If steel-quench or source-grounding-audit are not installed, note `Axis N: skipped (skill unavailable)` and proceed. Axis 1 PASS alone is sufficient to unblock a PR when Axes 2–3 are unavailable. Axis 4 (edit-manifest): if the skill is not installed, substitute a manual one-line prediction appended to `tracks/_meta/edit_manifest.yaml` — the record is what matters, not the skill.
 

--- a/knowledge/shared/harness-core/multi_model_sidecar_strategy.md
+++ b/knowledge/shared/harness-core/multi_model_sidecar_strategy.md
@@ -215,7 +215,7 @@ Suggested integration points:
 
 ## Implementation Patterns
 
-**Context**: §1–8 establish *why* sidecar distribution works and its validated patterns. This section adds *executable* implementation guidance reverse-harvested from PMH `sidecar-orchestrator` v1 (2026-06-01), generalized for any environment.
+**Context**: §1–8 establish *why* sidecar distribution works and its validated patterns. This section adds *executable* implementation guidance reverse-harvested from PMH `sidecar-orchestrator` v1 (2026-06-01), generalized for any environment. These are **reference** patterns for any caller — they do **not** supersede §Scope vs steel-quench Wave 5: for the steel-quench multi-team case specifically, Wave 5 remains the canonical implementation.
 
 > **CLI-syntax caveat**: Exact sidecar invocation flags differ by CLI and version. The forms below use FH's validated baselines (`gh copilot suggest`, `echo … | gemini`, `npx @openai/codex exec` — see §The capability). Flags such as `--model` are catalog/version-dependent — verify with the CLI's own `--help` before relying on them.
 
@@ -276,9 +276,9 @@ Requires the respective CLI installed and authenticated.
 RESULT=$(sidecar_command 2>&1); EXIT_CODE=$?
 if [[ $EXIT_CODE -ne 0 ]]; then
   echo "⚠️ sidecar failed (exit $EXIT_CODE)"
-  if   [[ "$RESULT" =~ "unknown model"|"invalid model" ]]; then echo "   → model name error — check catalog: gh copilot --help"
-  elif [[ "$RESULT" =~ "503"|"timeout" ]];                 then echo "   → network/API outage — escalate to Priority 2"
-  elif [[ "$RESULT" =~ "rate limit"|"quota exceeded" ]];   then echo "   → rate limited — retry after delay or use Priority 3"
+  if   [[ "$RESULT" =~ (unknown|invalid)\ model ]];      then echo "   → model name error — check catalog: gh copilot --help"
+  elif [[ "$RESULT" =~ (503|timeout) ]];                 then echo "   → network/API outage — escalate to Priority 2"
+  elif [[ "$RESULT" =~ (rate\ limit|quota\ exceeded) ]]; then echo "   → rate limited — retry after delay or use Priority 3"
   else echo "   → unknown failure: $RESULT"; fi
 fi
 ```


### PR DESCRIPTION
## Summary

PR #49(§9 reverse-harvest) 머지 후, 사용자 요청으로 §9에 **steel-quench + phantom 게이트를 수동 실행**했더니 누락됐던 결함이 나왔습니다. 그 결함 수정 + **근본 원인(게이트가 substantive knowledge/ 변경을 통과시킨 자동화 갭) 보강**을 함께 올립니다.

## (1) 자동화 취약점 보강 — `CLAUDE.md` 4-axis 게이트
**갭**: 기존 경량 예외가 "SKILL/rules/templates 0건 변경 = light"라, **실행 코드·인용이 든 `knowledge/` 문서(예: §9 Implementation Patterns)가 phantom/steel-quench 없이 통과**. PR #49가 정확히 이렇게 새어나갔음.

**보강**: `knowledge/` 변경이 **fenced code block(```` ``` ````) 또는 citation(arXiv/DOI/http)을 추가하면 light 아님 → Axes 2-3 강제**. prose-only 편집(오타·문구·링크)은 light 유지. 판정은 기계적(`git diff`에 코드펜스/인용 토큰 추가 여부).

## (2) §9 결함 수정 (게이트가 잡은 것)
- **A (내부 모순)**: §9 "Implementation Patterns"(실행 bash)가 "Scope vs Wave 5"(*Wave 5가 how 소유, 정본*) 경계와 충돌 → §9를 **reference 패턴**으로 명시, steel-quench 케이스는 Wave 5 canonical 로 reconcile.
- **B (bash 취약)**: error-handling `[[ =~ "a"|"b" ]]` 비관용 정규식 → 관용형 `(a|b)\ pattern` 으로. 5개 케이스 테스트 통과.

## 4-axis 자기적용 (CLAUDE.md = gated asset)
- Axis 1 backward: additive(+7/-5), critical 손실 없음
- Axis 2 steel-quench: 카브아웃은 실제 결함 차단용 기계적 룰 — 신규 S 0
- Axis 3 phantom: bash 정규식 5/5 동작 검증 · "§Scope vs Wave 5" 참조 grounded
- Axis 4 edit-manifest: 기록(local)

https://claude.ai/code/session_011nFcHFJCjYqqD7UwG1D4iH

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFcHFJCjYqqD7UwG1D4iH)_