### PR TITLE
feat(cloner-readiness): install-wizard 4-axis hook step + sidecar load≠parity caveat

### DIFF
--- a/knowledge/shared/harness-core/multi_model_sidecar_strategy.md
+++ b/knowledge/shared/harness-core/multi_model_sidecar_strategy.md
@@ -70,6 +70,8 @@ FH's SKILL.md format is shared across all three major AI CLIs. FH skills load na
 
 This means FH is not just model-agnostic in theory — the methodology layer physically runs in all three CLI environments without modification. This is the empirical foundation for the cross-CLI portability claim.
 
+> **Load ≠ full parity**: "loads and lists as Enabled" means the SKILL.md *methodology* is readable and runnable as guidance. Skills whose steps dispatch a sub-agent (`Agent` tool, `fh-commons:*` challengers) or depend on slash-commands/hooks are **Claude-native** — on Gemini/Codex they degrade to manual methodology, not automated execution. Cross-CLI portability covers the *methodology layer*; the automation layer (sub-agents, hooks, slash commands) requires Claude Code as host. See `README.md §2-layer architecture`.
+
 ## Orchestrator–sidecar model strategy
 
 Use the strongest available model as orchestrator; delegate subsidiary tasks to lighter sidecar models for token economy:

--- a/plugins/fh-meta/skills/install-wizard/SKILL.md
+++ b/plugins/fh-meta/skills/install-wizard/SKILL.md
@@ -448,6 +448,14 @@ source "$FH_DIR/templates/fh_audit_check.zsh"
 EOF
 fi
 
+# 4-axis verification gate — install the FH pre-commit hook on the forge-harness clone (idempotent)
+# Git does NOT set core.hooksPath automatically on clone, so this one-time step is required for the gate to enforce (otherwise it stays advisory).
+if [ -d "$FH_DIR/templates/.git-hooks" ]; then
+  git -C "$FH_DIR" config core.hooksPath templates/.git-hooks
+  chmod +x "$FH_DIR/templates/.git-hooks/pre-commit" 2>/dev/null
+  echo "4-axis pre-commit gate: installed (core.hooksPath -> templates/.git-hooks)"
+fi
+
 # sentinel initialization (per-project independent — prevent conflicts with other projects on same machine)
 mkdir -p ~/.cc_sentinels
 touch ~/.cc_sentinels/$(basename "$(pwd)")_wizard_done


### PR DESCRIPTION
## Summary

클론 사용자 검증에서 나온 마지막 기능 갭 2건을 보강합니다 (goal-quench 게이트 통과).

## (1) install-wizard — 4-axis hook 설치 단계
**갭**: `templates/.git-hooks/pre-commit`(4-axis 게이트)은 있지만, **git은 clone 시 `core.hooksPath`를 자동 설정하지 않음** → cloner가 1회 설정을 안 하면 게이트가 **advisory에 그치고 enforce 안 됨**. install-wizard에 이 단계가 없었음(0건).
**수정**: Step 4(Acceleration Baseline)에 idempotent hook 설치 블록 추가 — `git config core.hooksPath templates/.git-hooks` + chmod. WHY 주석으로 "git 미자동설정" 명시.

## (2) sidecar 문서 — "load ≠ full parity" caveat
**갭**: 문서가 *"Gemini/Codex에 32개 스킬 native load"* 라 했지만, **로드 ≠ 기능 동등**. 서브에이전트(`Agent` tool, `fh-commons:*`)·슬래시커맨드 의존 스킬(9/33)은 Claude-native라 Gemini/Codex에선 수동 methodology로 degrade.
**수정**: 포터빌리티 섹션에 caveat 1줄 — automation layer는 Claude Code 호스트 필요, README §2-layer와 정합.

## goal-quench 게이트 (steel-quench + phantom 내장)
- Phase 1 budget: GREEN (10 insertions, 2 files)
- Phase 3 Step 2 (steel-quench/담금질): PASS — hook block `bash -n` ✓, idempotent/guarded, 신규 S-grade 0
- Phase 3 Step 3 (source-grounding/팬텀탐지): PASS — 참조 4/4 grounded (hook 경로·CLAUDE.md 지침·README 2-layer·fh-commons 에이전트)

https://claude.ai/code/session_011nFcHFJCjYqqD7UwG1D4iH

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFcHFJCjYqqD7UwG1D4iH)_