### PR TITLE
identity ①: project harness-ification + loop linkage as a core capability (+ Full-Harness Mode)

### DIFF
--- a/.claude/rules/auto_project_mapping.md
+++ b/.claude/rules/auto_project_mapping.md
@@ -1,5 +1,5 @@
 ---
-description: When the user requests "connect a project" or similar, automatically scans parent directories for candidates and handles the full 5-step flow: discovery, filtering, confirmation, mapping, and summary report.
+description: When the user requests "connect a project" or similar, automatically scans parent directories for candidates and handles the 5-step mapping flow (discovery, filtering, confirmation, mapping, summary). Also covers §6 opt-in Full-Harness Mode ("harness-ify this project") — installs project-local harness assets from templates/.
 ---
 
 # Auto Project Mapping Protocol
@@ -61,6 +61,30 @@ Mapping complete: N projects
 - {proj-b}: tracks/proj_b/ created, hub block added to top of existing CLAUDE.md
 - {proj-c}: tracks/proj_c/ created, CLAUDE.md unchanged (user declined block addition)
 ```
+
+## 6. Full-Harness Mode (opt-in) — harness-ify the mapped project
+
+Basic mapping (steps 1–5) registers a project *lightly* (tracks/ + a starter CLAUDE.md + hub link). **Full-Harness Mode adds the project-local harness assets** — identity ① (Control Tower) propagating harness structure to a connected project; the *how* is executed via the Core Axis.
+
+**Scope**: target *mapped* projects only. For FH-self setup / acceleration baseline (zshrc, sentinels, the FH self-gate) use `/install-wizard` — do **not** run §6 on the FH hub itself. **Prerequisite**: the project is already mapped (steps 1–5); §6 is strictly additive.
+
+**Triggers**: "harness-ify this project", "full harness setup", "프로젝트 하네스화", "promote to full harness", or an opt-in prompt offered right after a basic mapping (*"Promote {project} to a full harness now?"*).
+
+**Installs (each item approval-gated · never overwrite — propose skip/merge if it exists · all from `templates/`):**
+
+| # | Item | Source → target | Effect |
+|---|---|---|---|
+| 1 | Session rules | `templates/.claude/rules/session.md` → `{project}/.claude/rules/session.md` | Session-start auto-read, backup, rule hierarchy |
+| 2 | Context filter | `templates/.claudeignore` → `{project}/.claudeignore` | Token footprint control |
+| 3 | Env card | `templates/fh_env_context.jsonc` → `{project}/.claude/rules/fh_env_context.jsonc` | Environment context for sessions |
+
+**Not installed (deliberately)**: the FH 4-axis **pre-commit gate** (`templates/.git-hooks/`) is FH-*internal* infra — it hard-codes hub paths and requires hub markers (`tracks/_meta/.axes_23_passed_*`, `tracks/_meta/edit_manifest.yaml`), so dropping it into a target project would **block that project's commits**, not help. A project-generic regression gate is a future candidate, not shipped today.
+
+**Loop linkage (honest — no autonomous daemon)**: `tracks/{project}/` (created in step 1, basic mapping) is what makes the project's **session-synced** learnings visible to the hub's `harvest-loop` weekly audit — *once the user runs the Session Sync Protocol from that project*. §6 adds project-local harness assets; it does **not** add loop automation inside the project, and the session-start cadence (frontier-digest 7d / harness-doctor 30d) runs in the **hub cwd**, not the project. "Acceleration" = the hub's compounding loop ingests the project on sync — not a process running in the project.
+
+**Report (required)**: list each item as `installed` / `skipped (exists)` / `declined`, then state: *"{project}: mapped (light) → project-local harness installed; learnings feed the hub loop on sync."*
+
+**Guards**: respects all Boundaries below (no overwrite, confirm-first). If the project already has its own `.claude/rules/`, propose side-by-side/merge — never clobber. Hub common principles outrank project rules (scope hierarchy); project-specific rules are preserved.
 
 ## Boundaries and caution
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ The forge-harness hub is not just a repository — it is the **command center fo
 
 | Layer | Role | Representative Assets |
 |---|---|---|
-| **① Control Tower** | Coordinates all projects. Each project is an execution site; this is command HQ. | `CATALOG.md` · `knowledge/shared/harness-core/harness_6axis_framework.md` · `knowledge/shared/harness-core/hub_compounding_loop.md` |
+| **① Control Tower** | Coordinates all connected projects and **drives harness-ification across them** — decides *which* projects to harness and *when*, propagates harness assets to each, and feeds their synced learnings into the hub's compounding loop. The *how* (rules · gates · 6-axis) is executed via the Core Axis. Command HQ, not a passive registry. | `.claude/rules/auto_project_mapping.md` (mapping + **Full-Harness Mode**) · `harvest-loop` (compounding loop) · `templates/` (project-harness bundle) · `CATALOG.md` |
 | **② Frontier → Org Propagation** | Proactively applies global AI/harness frontier thinking and **translates it for your organization**. | `knowledge/shared/harness-core/harness_frontier_diagnosis_*.md` · `knowledge/{your-org}/` |
 | **③ AI Collaboration Guide** | Accumulates and distributes best practices for token efficiency and dialogue methodology — "how to ask, delegate, and record". | `CHEATSHEET.md` · `knowledge/shared/dialogue/ai_dialogue_playbook.md` · `MEMORY.md` keyword-triggered loading |
 | **Core Axis** | **Harness Engineering (How)** — the methodology and practice axis that realizes the three layers above. The 6-axis framework is the operating unit. **A harness is a means, not an end** — "A good harness gets simpler over time. If it's getting more complex, something is wrong." | `harness_6axis_framework.md` · `hub_compounding_loop.md` · `claude_code_runtime_flow.md` · `.claude/agents/` (sub-agents) |
@@ -46,6 +46,8 @@ Four foundational assets for hub operations. **Mandatory pre-reference** before 
 3. Automatically included in the weekly audit scanner (`tracks/*/` glob-based)
 4. Even if a project has its own rules, **hub common principles must not be overridden** (lower in scope hierarchy)
 5. Insert reference links to `ai_dialogue_playbook.md` (principles/intent) + `claude_code_runtime_flow.md` (runtime flow/sub-agents) at the top of each project's CLAUDE.md or session.md (Layer ③ standard compliance)
+
+> **Promotion to full harness**: steps 1–5 register a project *lightly*. To add its project-local harness assets (session rules + context filter + env card), run **Full-Harness Mode** (`.claude/rules/auto_project_mapping.md §6`) — approval-gated, never overwrites. This is identity ① (Control Tower): the hub propagates harness structure to each project and feeds its synced learnings into the compounding loop (the *how* executed via the Core Axis). The FH self-gate is **not** installed into projects (it would block their commits).
 
 ## Harness Drift Prevention Principles
 
@@ -346,6 +348,8 @@ Proposal format: `"I see [X]. Want me to run /[skill] to [one-line description]?
 | "orchestrate agents", "parallel dispatch", "combine skills", "multiple agents" | `/agent-composer` |
 | "run a simulation", "external user perspective", "internal audit", "quality check" | `/sim-conductor` |
 | "first install", "FH setup", "wizard", "install-wizard" | `/install-wizard` |
+| "connect a project", "map this project", "link to hub" | `auto_project_mapping.md` (mapping) |
+| "harness-ify this project", "full harness setup", "프로젝트 하네스화", "promote to full harness" | `auto_project_mapping.md §6` (Full-Harness Mode) |
 | "check install", "verify setup", "confirm install", "install-doctor" | `/install-doctor` |
 | "where does this go", "asset location", "hub vs project", "placement" | `/asset-placement-gate` |
 | "add to marketplace", "OK to publish", "pre-publish check" | `/marketplace-gate` |
@@ -506,9 +510,9 @@ Temporary change within session: Say "use light mode for this one" or "switch to
 
 ## Auto Project Mapping Protocol
 
-> Detailed 5-step procedure: `.claude/rules/auto_project_mapping.md`
+> Detailed procedure: `.claude/rules/auto_project_mapping.md` (5-step mapping + §6 Full-Harness Mode)
 
-When the user requests **"connect a project"** · **"link to hub"** · **"map this project"** · **"scan parent directory and connect"**, follow the `auto_project_mapping.md` protocol.
+When the user requests **"connect a project"** · **"link to hub"** · **"map this project"** · **"scan parent directory and connect"**, follow the `auto_project_mapping.md` protocol. When they request **"harness-ify this project"** · **"full harness setup"** · **"프로젝트 하네스화"** (or accept the post-mapping promotion prompt), run **§6 Full-Harness Mode** — installs project-local harness assets (session rules · context filter · env card) from `templates/`, approval-gated and non-overwriting. (The FH self-gate is FH-internal and is not installed into projects.)
 
 ## Searching Past Work
 


### PR DESCRIPTION
## Summary

Per directive — **the ability to harness-ify a mapped project and feed it into the improvement loop must be part of FH's core identity.** This was previously only partially built (mapping installed a starter CLAUDE.md; no one-shot promotion). This PR elevates it to identity ① and adds the mechanism.

## Changes

**`CLAUDE.md` §Identity — ① Control Tower reframed**
From passive *"coordinates all projects"* → **orchestration**: decides *which* projects to harness and *when*, propagates harness assets to each, and feeds their synced learnings into the hub's compounding loop. The *how* (rules · gates · 6-axis) is explicitly **executed via the Core Axis** — so ① stays distinct from the Core Axis rather than absorbing it. Also replaced two phantom asset refs in the ① cell with real ones. Wired triggers into the onboarding promotion note, the Autonomous-Initiative table, and the Auto-Project-Mapping section.

**`auto_project_mapping.md` §6 Full-Harness Mode (opt-in)**
Promotes a mapped project by installing project-local harness assets from `templates/` — session rules, `.claudeignore`, env card (→ `.claude/rules/`) — approval-gated, never overwriting. Scope-limited to target projects (FH-self setup stays with `/install-wizard`).

## Honest scoping (what it deliberately does NOT do)

- **Does not install the FH 4-axis git gate into projects** — it hard-codes hub paths/markers and would *block* a target project's commits. Documented as a deliberate non-goal; a project-generic gate is a future candidate.
- **No autonomous loop daemon in the project** — "loop linkage" means the hub's `harvest-loop` ingests the project's learnings via the `tracks/{project}/` glob **once Session Sync runs**. The session-start cadence runs in the hub cwd. Stated plainly, no overclaim.

## Verification — Axis-2 (steel-quench), two rounds

- **Round 1: REWORK.** Caught real load-bearing defects: the original draft installed the FH-internal 4-axis gate into target projects (would brick commits), misconfigured `core.hooksPath` (relative path), overclaimed "loop-accelerated" with no wiring, blurred ① into the Core Axis, and a few B/C issues (env-card path, step duplication, scope statement, stale frontmatter).
- **Reworked** all 8 findings.
- **Round 2: MERGE-READY**, 0 new defects — identity ① genuinely re-scoped, §6 installs only safe verified template assets, loop-linkage matches the real mechanism, internally consistent, no phantom refs.
- **Axis 1** (`regression_guard.sh`): PASS, 0 blockers. **Axis 3**: phantom-ref scan clean (and removed two pre-existing phantoms from ①).

https://claude.ai/code/session_01AjUTjKeKEucgYnDuBMbNnJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjUTjKeKEucgYnDuBMbNnJ)_