### PR TITLE
Micro R-tier cleanup — probe expectations + honest optional trigger (follow-up to #61)

### DIFF
--- a/plugins/fh-meta/skills/cross-ecosystem-synergy-detection/SKILL.md
+++ b/plugins/fh-meta/skills/cross-ecosystem-synergy-detection/SKILL.md
@@ -21,7 +21,7 @@ Automatically discovers cross-invocable pairs in environments with multiple inst
 1. **Multi-ecosystem component environment specified**: "multiple plugins/cross-CLI installed", "synergy with other components", "cross-ecosystem", "run together"
 2. **New component added/removed**: "component install", "add/remove component"
 3. **Synergy check phrasing**: "are they working in isolation?", "can they be integrated?", "environment check", "combination effect"
-4. **Registry change detected**: When a new project or skill is registered in `LOCAL_SKILL_REGISTRY.md`, Step 7 runs automatically
+4. **Registry change detected** (optional): If a user-maintained `LOCAL_SKILL_REGISTRY.md` is present, Step 7 runs when a new project/skill is registered. The registry is not auto-created — absent file → Step 7 self-skips (see Step 7 guard).
 
 **Exception**: Single-component environments (1 or fewer installed → no meaningful activation)
 
@@ -101,7 +101,7 @@ When persisting results:
 
 ### Step 7. Proactive Discovery — Proactive Mode
 
-> Trigger: Runs automatically when new section/skill registered in `LOCAL_SKILL_REGISTRY.md`
+> Trigger: Runs when a new section/skill is registered in a user-maintained `LOCAL_SKILL_REGISTRY.md` (optional, user-created; absent → self-skip)
 
 **Purpose**: FH proactively discovers and proposes synergies that previously required human ideas to find.
 

--- a/plugins/fh-meta/skills/prompt-regression/SKILL.md
+++ b/plugins/fh-meta/skills/prompt-regression/SKILL.md
@@ -26,7 +26,7 @@ After CLAUDE.md edits, rule changes, or new skill additions, harness behavior ca
 
 - `/prompt-regression`
 - "prompt regression", "regression check", "regression test"
-- "did my rule change break anything", "test harness changes", "verify harness behavior"
+- "did my rule change break anything", "test harness changes", "verify harness behavior", "make sure my edit didn't change behavior"
 - After significant CLAUDE.md edits or new skill commits
 
 ---
@@ -69,8 +69,8 @@ ls .claude/regression/probes.md 2>/dev/null || echo "NO_CUSTOM_PROBES"
 | `P-TRIGGER-01` | `recommend a plugin` | plugin-recommender proposed | CLAUDE.md §Autonomous |
 | `P-TRIGGER-02` | `context is getting long` | context-doctor proposed | CLAUDE.md §Autonomous |
 | `P-TRIGGER-03` | `harness is complex` | harness-doctor proposed | CLAUDE.md §Autonomous |
-| `P-CHAIN-01` | `/field-harvest` | harvest-loop + sim-conductor gate present | field-harvest SKILL.md |
-| `P-CHAIN-02` | `/apex-review` | conditional-pass gate present | apex-review SKILL.md |
+| `P-CHAIN-01` | `/field-harvest` | harvest-loop close-chain referenced (wrap-up deferred to CLAUDE.md session-close chain — field-harvest has no inline sim-conductor gate) | field-harvest SKILL.md |
+| `P-CHAIN-02` | `/apex-review` | Conditional verdict present (apex-review vocabulary: "Conditional" / "Conditionally passed") | apex-review SKILL.md |
 | `P-GATE-01` | new skill commit | New Skill Pre-Commit Gate (5 items) invoked | CLAUDE.md §Gate |
 | `P-CLOSE-01` | `wrap up` / `good work` | Session close chain (4-step) triggered | CLAUDE.md §Wrap-up |
 
@@ -110,7 +110,7 @@ For each affected probe, evaluate:
 Output per probe:
 ```
 [PASS] P-TRIGGER-01 — plugin-recommender trigger phrase found in CLAUDE.md
-[FAIL] P-CHAIN-01 — field-harvest SKILL.md missing harvest-loop mandatory gate after edit
+[FAIL] P-CHAIN-01 — field-harvest SKILL.md no longer references the harvest-loop close chain after edit
 [SKIP] P-GREET-01 — §Onboarding not in changed files
 ```
 
@@ -130,7 +130,7 @@ Output per probe:
 ### FAIL Details
 | Probe | Location | Finding | Fix |
 |---|---|---|---|
-| P-CHAIN-01 | field-harvest SKILL.md | Missing harvest-loop mandatory gate | Re-add chain gate in §Done When |
+| P-CHAIN-01 | field-harvest SKILL.md | harvest-loop close-chain reference removed by edit | Restore the harvest-loop chain reference |
 
 ### Verdict
 ⚠️ REGRESSION DETECTED — 1 probe failed. Fix required before merge.


### PR DESCRIPTION
## Summary

Post-merge follow-up to PR #61 — closes the remaining **micro R-tier** backlog from the full-harness audit. Low-severity accuracy/honesty fixes only.

- **prompt-regression**: correct two probe expectations that mis-FAIL correct skills —
  - `P-CHAIN-01`: field-harvest defers wrap-up to the CLAUDE.md session-close chain; it has **no inline sim-conductor gate** (old expectation was wrong).
  - `P-CHAIN-02`: apex-review uses the **"Conditional"** verdict vocabulary (not `CONDITIONAL_PASS`).
  - Aligned the illustrative FAIL example + verdict-row to the corrected expectations; added one non-"regression" trigger phrasing.
- **cross-ecosystem-synergy-detection**: made the `LOCAL_SKILL_REGISTRY` trigger honestly **optional** (user-created; Step 7 self-skips when absent) instead of a dead "runs automatically" claim.

**Left intentionally** (verified non-defects): `challenger` already documents its planned-vs-actual wiring gap; `field-harvest`'s `<placeholder>` bash blocks are a consistent doc convention (bash -n false positive).

## Verification (meta-audit)
Grounding confirmed against reality: apex-review "Conditional" present; field-harvest references harvest-loop with no inline sim-conductor gate. The single regression_guard M-tier (`Done When` token 2→1) is a verified false positive — an incidental example-cell edit; the `## Done When` section is intact (L162). Adversarial: new trigger unique, no collision.

After this, the full-harness refactor backlog is empty (only the user's local native goal-quench 10-run calibration remains, to be done locally via the companion store).

https://claude.ai/code/session_01Dkd8sQpEpTehLU1RFUHM9i

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dkd8sQpEpTehLU1RFUHM9i)_