### PR TITLE
fix(goal-quench+harness): Step D return-path closure + deprecated ref cleanup

### DIFF
--- a/plugins/fh-meta/skills/frontier-digest/SKILL.md
+++ b/plugins/fh-meta/skills/frontier-digest/SKILL.md
@@ -97,7 +97,7 @@ directly relevant to forge-harness (FH) operations and improvement.
 FH Context:
 - FH = AI collaboration meta-harness (skill · plugin · agent system)
 - Core skills: steel-quench, harness-doctor, sim-conductor,
-               context-bridge-dispatch, apex-review
+               agent-composer, apex-review
 - Areas of interest: multi-agent orchestration, context engineering,
                      self-check gate, frontier cross-diagnosis
 

--- a/plugins/fh-meta/skills/goal-quench/SKILL.md
+++ b/plugins/fh-meta/skills/goal-quench/SKILL.md
@@ -351,6 +351,18 @@ Run `pipeline-conductor --quick` on `$TARGET` (the artifact changed during this 
 
 Record actual token usage in `tracks/_meta/goal_quench_{YYYY-MM-DD}.md` for calibration (regardless of verdict).
 
+### Step 3-c — Sidecar verdict gate (pro + max, when sidecar ≠ none)
+
+After pipeline-conductor completes, read `sidecar:` from `.pending`. If non-none, gate on the sidecar's verdict before advancing to Done When:
+
+| Sidecar | Wait for | Failure action |
+|---|---|---|
+| `steel-quench-c3` | Wave 2 convergence: PASS or CONDITIONAL_PASS | FAIL → reopen Phase 2, surface blocking findings to user |
+| `agent-composer-panel` | Panel findings file written + incorporated into pipeline-conductor context | Not yet written → re-run pipeline-conductor with panel findings |
+| `sim-conductor` + `steel-quench-w5` | Both: sim-conductor Area A PASS **and** steel-quench W5 convergence PASS | Either FAIL → block Done When; surface failing verdict |
+
+This gate is **blocking** — Done When cannot be reached until the sidecar verdict is resolved. Record `sidecar_findings_count` in the calibration record before closing.
+
 ---
 
 ## Calibration Record
@@ -366,6 +378,7 @@ After each goal-quench run, append to `tracks/_meta/goal_quench_{YYYY-MM-DD}.md`
   budget_source: token-budget-gate | fallback-heuristic
   actual_tokens: N  # from ~/.claude/projects/*/conversation*.jsonl or user-reported; "unknown" if unavailable
   estimation_error: over | under | accurate
+  estimation_error_pct: "N%"  # e.g. "717%" — magnitude of under/over; omit if accurate
   actual_vs_estimate_ratio: N.N  # actual / estimated (e.g., 4.7 means actual was 4.7× estimate)
   budget_verdict: GREEN/YELLOW/ORANGE/RED
   pipeline_verdict: CLEAN/PENDING/BLOCKED/ESCALATE
@@ -430,7 +443,8 @@ Phase 1: token-budget-gate verdict output + mode resolved (core default, or pro/
   max additionally: GAP-triggered plugin-recommender + cross-ecosystem-synergy-detection pre-validation
 + Phase 3 (on next response after /goal): .pending file detected + pipeline-conductor run
   (--quick for core/pro, --full for max)
-+ Verification verdict output (CLEAN/PENDING/BLOCKED)
++ Verification verdict output (CLEAN/PENDING/BLOCKED/ESCALATE)
++ If sidecar invoked (pro/max Step D): Step 3-c sidecar verdict resolved (PASS/CONDITIONAL_PASS) before closing
 + .pending file deleted + calibration record appended
 ```
 

--- a/plugins/fh-meta/skills/harvest-loop/SKILL.md
+++ b/plugins/fh-meta/skills/harvest-loop/SKILL.md
@@ -206,7 +206,7 @@ Read reference_next_session_starter.md → apply Step 0-b removal list → add n
 | Design existing skill enhancement direction | `/meta-prompt-builder` |
 | Validate candidates from external user perspective | `fh-meta:hub-persona-auditor` |
 | Review before sharing with team | `/apex-review` |
-| Self-marketing pattern discovered as HIGH P10 | `/self-marketing-lint` auto-propose |
+| Self-marketing pattern discovered as HIGH P10 | `/harness-doctor --lint` auto-propose |
 | Edit predictions to verify / rejected buffer | `fh-meta:edit-manifest` (Step 0-c) |
 | Stale memory entries to re-verify | `fh-meta:memory-hygiene` (Step 0-c) |
 

--- a/plugins/fh-meta/skills/install-wizard/SKILL.md
+++ b/plugins/fh-meta/skills/install-wizard/SKILL.md
@@ -570,8 +570,8 @@ Only activate the cluster matching the utterance — loading all skills degrades
 |---|---|---|
 | **A — Harvest/Evolution** | harvest · session wrap-up · pattern · reverse absorption · fh evolution | field-harvest · harvest-loop · contention-layer · verify-bidirectional |
 | **B — Diagnosis (doctor)** | diagnose · health · check · inspect · token waste · install conflict · doctor | harness-doctor · context-doctor · sim-conductor · install-doctor · install-wizard |
-| **C — Compose (composer)** | agent composition · parallel · compose prompt · context card | agent-composer · meta-prompt-builder · context-bridge-dispatch |
-| **D — Audit/Review** | review · audit · PR review · steel quench · adversarial · marketing · placement | hub-cc-pr-reviewer · steel-quench · apex-review · self-marketing-lint · marketplace-gate · asset-placement-gate |
+| **C — Compose (composer)** | agent composition · parallel · compose prompt · context card | agent-composer · meta-prompt-builder |
+| **D — Audit/Review** | review · audit · PR review · steel quench · adversarial · lint · placement | hub-cc-pr-reviewer · steel-quench · apex-review · harness-doctor (--lint) · marketplace-gate · asset-placement-gate |
 | **E — Explore/Frontier** | trends · plugin recommendation · synergy · frontier | frontier-digest · plugin-recommender · cross-ecosystem-synergy-detection |
 | **F — Common (always-on)** | — | convergence-loop · deliberation (fh-commons) |
 


### PR DESCRIPTION
## Summary

N=10 prospective calibration runs (2026-06-03) found 2 categories of bugs:

**1. Step D return-path: all 3 sidecar chains OPEN (R04 audit)**
Step D dispatched sidecars but never gated Phase 3 on their verdicts — dispatch-and-observe, not dispatch-and-gate.

- `steel-quench C3`: done-when had no wait on Wave 2 convergence verdict
- `agent-composer panel`: findings never folded back before pipeline-conductor
- `sim-conductor + steel-quench W5`: neither callee appeared in Done When

Fix: added **Step 3-c sidecar verdict gate** — blocking table that maps each sidecar to its required verdict, with failure actions. Done When updated to require Step 3-c resolution.

**2. Deprecated refs in 3 skills (R07 harness-doctor scan)**

| File | Old ref | Replacement |
|---|---|---|
| install-wizard Cluster C | `context-bridge-dispatch` | `agent-composer` (absorbed 2026-06-02) |
| install-wizard Cluster D | `self-marketing-lint` | `harness-doctor (--lint)` (absorbed 2026-06-02) |
| frontier-digest core skills | `context-bridge-dispatch` | `agent-composer` |
| harvest-loop P10 trigger | `/self-marketing-lint` | `/harness-doctor --lint` |

**3. Schema fixes (R09/R10)**
- Added `estimation_error_pct` field to calibration schema
- Added `ESCALATE` to Done When verdict list

## Calibration data summary (N=10)

| Mode | Mean ratio | Pattern |
|---|---|---|
| core | 4.0× | Overhead dominates small tasks (GREEN 5-6×, YELLOW 2.2×) |
| pro | 1.84× | More accurate estimates; value/token high at ORANGE |
| max | 1.30× | Near-perfect at ORANGE (1.1-1.13×); zero value at YELLOW |

Key insight: pro/max don't reduce actual tokens — they produce more honest estimates. Token-honesty guard empirically validated.

## Test plan

- [ ] goal-quench SKILL.md: Step 3-c present in Phase 3, sidecar verdict gate table covers all 3 sidecars
- [ ] goal-quench Done When: sidecar verdict condition present
- [ ] install-wizard: no references to context-bridge-dispatch or self-marketing-lint
- [ ] frontier-digest: agent-composer in core skills list
- [ ] harvest-loop P10: /harness-doctor --lint trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)