### PR TITLE
fix(goal-quench+install-wizard): calibration schema gaps + Done When + hand-off clarification

### DIFF
--- a/plugins/fh-meta/skills/goal-quench/SKILL.md
+++ b/plugins/fh-meta/skills/goal-quench/SKILL.md
@@ -259,7 +259,7 @@ Do not ask for confirmation. The user may override by re-running `/goal-quench -
 
 ### Hand-off
 
-After orchestration, record the composed plan (or sub-goal list) into `.claude/goal-quench.active` alongside the budget fields (add a `mode:` and `composed_plan:` line), then proceed to threshold injection (Phase 1 Step 4) and hand off to /goal. Phase 3 verification then runs as in core — `pipeline-conductor --quick` for pro, `--full` for max (max implies external-facing stakes).
+After orchestration, **update** (not re-create) `.claude/goal-quench.active` — add `mode:` and `composed_plan:` lines alongside existing budget fields. Re-creating the file loses the `start_commit` field written in Phase 1 Step 3. Then proceed to threshold injection (Phase 1 Step 4) and hand off to /goal. Phase 3 verification then runs as in core — `pipeline-conductor --quick` for pro, `--full` for max (max implies external-facing stakes).
 
 ---
 
@@ -370,8 +370,11 @@ This gate is **blocking** — Done When cannot be reached until the sidecar verd
 After each goal-quench run, append to `tracks/_meta/goal_quench_{YYYY-MM-DD}.md`:
 
 ```yaml
-- date: YYYY-MM-DD
+- run_id: GQ-{YYYYMMDD}-{N}  # e.g. GQ-20260603-01 — unique per run, links to session JSONL
+  session_id: "{first-8-chars-of-jsonl-filename}"  # for JSONL back-trace
+  date: YYYY-MM-DD
   task: {one-line description}
+  scope_hint: "{N files affected, task type}"  # e.g. "3 new files, signal doc"
   mode: core | pro | max
   session_type: minor | normal | heavy | continuation  # for within-type comparison
   estimated_tokens: N

--- a/plugins/fh-meta/skills/install-wizard/SKILL.md
+++ b/plugins/fh-meta/skills/install-wizard/SKILL.md
@@ -585,6 +585,22 @@ On Claude API / MCP failure → refer to [`references/fallback-guide.md`](../../
 
 ---
 
+## Done When
+
+```
+☐ Environment detection complete: shell, CC version, OS, project type identified
+☐ Gap diagnosis output: present vs missing items listed
+☐ User approval/decline recorded for each suggested item
+☐ All approved items installed with no failure state
+  (failed installs surfaced to user — not silently skipped)
+☐ Acceleration baseline confirmed: zshrc alias + sentinels active (or user declined)
+☐ Summary output: "N items installed, M items skipped — setup complete"
+```
+
+`--dry-run` mode Done When: gap diagnosis report written, no installation executed.
+
+---
+
 ## Hub Orchestration Hint
 
 After setup, **where you work** significantly affects efficiency:


### PR DESCRIPTION
## Summary

N=10 prospective calibration 실증(R07/R09/R10)에서 발견된 잔여 갭 수정.

**goal-quench — 스키마 3필드 누락 (R10 critical gaps)**

`mode`, `session_type`이 fh-be 소급 데이터에 없어 모드별 분석 불가했던 근본 원인:
SKILL.md 스키마에 식별자/추적 필드가 없었음.

추가 필드:
| 필드 | 목적 |
|---|---|
| `run_id` | 실행 고유 ID (JSONL 연결) |
| `session_id` | JSONL 파일명 앞 8자 — 역추적용 |
| `scope_hint` | 스코프 자유 기술 (e.g. "3 new files, signal doc") |

**goal-quench — Phase 1.5 hand-off 명확화 (R09 P1 LOW)**

`.active` 파일을 재생성하면 Phase 1 Step 3에서 기록된 `start_commit` 필드가 소실됨.
"update, not re-create" 명시로 버그 예방.

**install-wizard — Done When 없음 (R07 harness-doctor M-tier)**

30개 활성 스킬 중 유일하게 Done When이 없었음. 6단계 완료 게이트 추가:
환경 감지 → 갭 진단 → 승인 → 설치 → acceleration baseline → summary.

## Test plan
- [ ] goal-quench 캘리브레이션 스키마: `run_id`, `session_id`, `scope_hint` 필드 존재
- [ ] goal-quench Phase 1.5 hand-off: "update not re-create" + start_commit 언급
- [ ] install-wizard: Done When 섹션 6개 체크박스 + --dry-run 변형 존재

🤖 Generated with [Claude Code](https://claude.com/claude-code)