### PR TITLE
fix(goal-quench+catalog): R09 per-sub-goal threshold clarification + CATALOG #65-67

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -8,9 +8,24 @@ AI reads this file first when searching past work. Open individual files for det
 
 <!-- Add entries in reverse date order (newest at top) -->
 
+### 2026-06-03 | forge-harness | #goal-quench, #install-wizard, #calibration-schema, #done-when, #skill-evolution
+**File:** plugins/fh-meta/skills/goal-quench/SKILL.md, plugins/fh-meta/skills/install-wizard/SKILL.md
+PR #67: Calibration schema extended with `run_id`, `session_id`, `scope_hint` fields (R10 schema gaps). Phase 1.5 hand-off clarified: "update not re-create" `.active` file to preserve `start_commit`. install-wizard: Done When section added (6-step gate + `--dry-run` variant) — only active skill of 28 missing it (R07 M-tier).
+- Decision: schema fields added prospectively — backfilling retrospective N=10 rows with `mode`/`session_type` is a local fh-be task, not a SKILL.md change
+
+### 2026-06-03 | forge-harness | #catalog, #goal-quench, #skill-evolution
+**File:** CATALOG.md
+PR #66: Added CATALOG entries for PRs #61–64 (goal-quench evolution arc): mode-ladder refactor, micro R-tier cleanup, non-coercive guidance formalization, scope-driven sidecar routing + 4.7× overhead calibration.
+- Decision: tracks/** gitignored by design — calibration YAML records stay local; only CATALOG.md committed
+
+### 2026-06-03 | forge-harness | #goal-quench, #sidecar-routing, #step-d, #deprecated-refs, #return-path
+**File:** plugins/fh-meta/skills/goal-quench/SKILL.md, plugins/fh-meta/skills/install-wizard/SKILL.md, plugins/fh-meta/skills/frontier-digest/SKILL.md, plugins/fh-meta/skills/harvest-loop/SKILL.md
+PR #65: Fixed Step D return-path bug (all 3 sidecar chains were fire-and-forget → added Step 3-c blocking verdict gate). Added `estimation_error_pct` field to calibration schema. Removed 4 deprecated routing refs: `context-bridge-dispatch` (install-wizard Cluster C + frontier-digest core skills list) and `/self-marketing-lint` (harvest-loop P10 → `/harness-doctor --lint`). ESCALATE added to Done When conditions.
+- Decision: Step 3-c gate is blocking (not advisory) — sidecar verdict must resolve before Done When
+
 ### 2026-06-03 | forge-harness | #goal-quench, #sidecar-routing, #token-calibration, #steel-quench, #skill-evolution
 **File:** plugins/fh-meta/skills/goal-quench/SKILL.md
-Added scope-driven sidecar routing (Step D) to goal-quench Phase 1.5: task-type signals auto-route to steel-quench C3 (code review), agent-composer panel (architecture), or sim-conductor+steel-quench Wave 5 (external publish). Formalized session overhead calibration at 4.7× factor (N=10), adding `session_type`, `actual_vs_estimate_ratio`, and `sidecar` fields to the calibration schema. Resolved steel-quench meta-audit S+A+B findings: sub-goal loop rewritten as user-driven queue, pre-flight check added, Opus escalation cost disclosed.
+PR #64: Added scope-driven sidecar routing (Step D) to goal-quench Phase 1.5: task-type signals auto-route to steel-quench C3 (code review), agent-composer panel (architecture), or sim-conductor+steel-quench Wave 5 (external publish). Formalized session overhead calibration at 4.7× factor (N=10), adding `session_type`, `actual_vs_estimate_ratio`, and `sidecar` fields to the calibration schema. Resolved steel-quench meta-audit S+A+B findings: sub-goal loop rewritten as user-driven queue, pre-flight check added, Opus escalation cost disclosed.
 - Decision: overhead multiplier documented as empirical calibration constant; sidecar routing is scope-signal-driven, not mode-locked
 
 ### 2026-06-03 | forge-harness | #goal-quench, #non-coercive, #companion-store, #ephemeral-handoff

--- a/plugins/fh-meta/skills/goal-quench/SKILL.md
+++ b/plugins/fh-meta/skills/goal-quench/SKILL.md
@@ -275,6 +275,8 @@ goal-quench does not directly control /goal execution. The budget thresholds inj
 
 **Threshold enforcement caveat**: Claude cannot reliably read its own real-time token consumption during a /goal session. The 50/70/85/95% thresholds are instructional — Claude approximates consumption based on task complexity and turn count. They are not mechanically enforced. For hard enforcement, see the Anthropic feature request (--budget flag).
 
+**Queue mode (per-sub-goal threshold scope)**: When running sequential sub-goals from `.claude/goal-quench.queue`, each `/goal-quench` invocation is an independent core-mode run — thresholds are re-injected fresh for each sub-goal's Phase 1 estimate, not inherited from the outer pro/max run. The outer run owns the decomposition plan; each inner invocation owns its sub-goal's budget gate. Concretely: if sub-goal-1 estimate is 12K (YELLOW), thresholds are set against 12K — not against the outer RED estimate that triggered the queue in the first place.
+
 **What goal-quench cannot do in v1** (requires native Anthropic support):
 - Hard-enforce token ceiling mid-run (--budget flag, not yet available)
 - Auto-checkpoint commit on sub-goal completion (--checkpoint flag, not yet available)


### PR DESCRIPTION
## Summary

- **R09 fix (goal-quench Phase 2)**: Added explicit "Queue mode" paragraph clarifying that thresholds are re-injected per sub-goal invocation — each inner `/goal-quench` call uses its own Phase 1 estimate as the budget baseline, not the outer RED estimate that triggered the queue. Addresses LOW finding from calibration run R09.
- **CATALOG.md**: Added entries for PRs #65, #66, #67 (previously unlogged). Renamed existing top entry to reflect PR #64 origin.

## Changed files

| File | Change |
|---|---|
| `plugins/fh-meta/skills/goal-quench/SKILL.md` | Phase 2: queue mode threshold scope clarification |
| `CATALOG.md` | Entries added for PR #65, #66, #67 |

## Test plan

- [ ] Phase 2 queue mode note is accurate to Phase 1.5 sub-goal execution contract (each inner invocation = independent core-mode run with its own budget)
- [ ] CATALOG entries match the actual diffs from PR #65, #66, #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)