### PR TITLE
chore(npm): drop docs/banner.png from package (2.7MB → 245kB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/banner.png" alt="forge-harness — A forkable Claude Code meta-harness for multi-project teams" width="680">
+  <img src="https://raw.githubusercontent.com/chrono-meta/forge-harness/main/docs/banner.png" alt="forge-harness — A forkable Claude Code meta-harness for multi-project teams" width="680">
 </p>
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrono-meta/fh-gate",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "FH runtime adapters — run FH governance, skills, and agents via Claude or Codex with machine-parseable gates.",
   "license": "MIT",
   "keywords": [
@@ -50,7 +50,6 @@
     "bin/fh-gate.js",
     "bin/fh-run.js",
     "bin/fh-goal.js",
-    "docs/banner.png",
     "docs/codex-compat.md",
     "docs/pillars.svg",
     "scripts/fh-gate.sh",


### PR DESCRIPTION
## Summary
`docs/banner.png` (2.4MB) was **92% of the published npm tarball** but is only needed for the README banner, not for running `fh-gate`/`fh-run`.

- Remove `docs/banner.png` from `package.json` `files[]`
- Point the README `<img>` at the GitHub raw URL so the npm page still renders the banner
- Bump `1.2.0 → 1.2.1` (packaging-only)

**Result:** package size 2.7MB → **244.6 kB** (~91% smaller), 70 → 69 files.

## Notes
- `docs/pillars.svg` (5kB) stays shipped — negligible.
- After merge, `npm publish` 1.2.1 ships the slim package.

## Test plan
- [x] `npm pack --dry-run` → 244.6 kB
- [x] banner removed from `files[]`, version 1.2.1
- [ ] npm page renders banner via raw URL after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)