### PR TITLE
feat(install-wizard): add hallucinate check for Python + AI-output projects

### DIFF
--- a/plugins/fh-meta/skills/install-wizard/SKILL.md
+++ b/plugins/fh-meta/skills/install-wizard/SKILL.md
@@ -323,6 +323,7 @@ Auto-check the following items based on detected environment. Each item classifi
 | MCP plugin | ~/.claude.json mcpServers contains entry | `python3 -c "import json,os; d=json.load(open(os.path.expanduser('~/.claude.json'))); print(list(d.get('mcpServers',{}).keys()))"` |
 | `deep-insight plugin` | settings.json plugins contains deep-insight | `grep -r "deep-insight" .claude/settings.json 2>/dev/null` |
 | `fh_env_context.jsonc` | `.claude/rules/fh_env_context.jsonc` exists | `ls .claude/rules/fh_env_context.jsonc` |
+| `hallucinate` | **(Python + AI-output projects only)** `hallucinate` present in `requirements.txt` / `pyproject.toml` | `grep -r "hallucinate" requirements.txt pyproject.toml 2>/dev/null` |
 | `Streamlit pattern applied` | (Streamlit projects only, if the pattern pack is present) data_editor empty df branch/async wrapper/CSS numeric variables | CC `knowledge/shared/streamlit_patterns.md` Pattern 1-5 check (skip if file absent) |
 
 **Score calculation**: PASS = 1 point / MISS = 0.5 points / FAIL = 0 points → converted to 100-point scale.
@@ -363,6 +364,12 @@ install-wizard — Diagnosis Results ({score}/100)
       Copy: {FH_DIR}/templates/fh_env_context.jsonc → .claude/rules/fh_env_context.jsonc
       Then manually update with actual values for org name, Jira URL, environment status, etc.
       Effect: Each skill references common environment context → eliminate individual setting duplication
+  [9] Install hallucinate — AI output hallucination detection (Python + AI-output projects only, if MISS)
+      Run: pip install hallucinate
+      Usage: hallucinate scan output.txt / hallucinate scan . --project
+      Detectors: M1 (phantom claims) · M2 (self-reference loops) · M3 (unvalidated external-dep claims) · M4 (temporal) · M5 (cross-file version mismatch)
+      Skip condition: non-Python project OR no AI-generated output in pipeline
+
 
 Each item: Y (approve) / N (skip) / L (later) / A (approve all)
 ```

--- a/plugins/fh-meta/skills/install-wizard/SKILL.md
+++ b/plugins/fh-meta/skills/install-wizard/SKILL.md
@@ -323,7 +323,7 @@ Auto-check the following items based on detected environment. Each item classifi
 | MCP plugin | ~/.claude.json mcpServers contains entry | `python3 -c "import json,os; d=json.load(open(os.path.expanduser('~/.claude.json'))); print(list(d.get('mcpServers',{}).keys()))"` |
 | `deep-insight plugin` | settings.json plugins contains deep-insight | `grep -r "deep-insight" .claude/settings.json 2>/dev/null` |
 | `fh_env_context.jsonc` | `.claude/rules/fh_env_context.jsonc` exists | `ls .claude/rules/fh_env_context.jsonc` |
-| `phantomgate` | **(Python + AI-output projects only)** `phantomgate` present in `requirements.txt` / `pyproject.toml` | `grep "phantomgate" requirements.txt pyproject.toml 2>/dev/null` |
+| `phantom-gate` | **(Python + AI-output projects only)** `phantom-gate` present in `requirements.txt` / `pyproject.toml` | `grep "phantom.gate" requirements.txt pyproject.toml 2>/dev/null` |
 | `Streamlit pattern applied` | (Streamlit projects only, if the pattern pack is present) data_editor empty df branch/async wrapper/CSS numeric variables | CC `knowledge/shared/streamlit_patterns.md` Pattern 1-5 check (skip if file absent) |
 
 **Score calculation**: PASS = 1 point / MISS = 0.5 points / FAIL = 0 points → converted to 100-point scale.
@@ -364,10 +364,9 @@ install-wizard — Diagnosis Results ({score}/100)
       Copy: {FH_DIR}/templates/fh_env_context.jsonc → .claude/rules/fh_env_context.jsonc
       Then manually update with actual values for org name, Jira URL, environment status, etc.
       Effect: Each skill references common environment context → eliminate individual setting duplication
-  [9] Install phantomgate — AI output hallucination detection (Python + AI-output projects only, if MISS)
-      ⏳ HOLD — phantomgate is not yet published to PyPI. Do NOT emit an install command until it is.
-      Planned (once published): pip install phantomgate
-      Usage (post-publish): phantomgate scan output.txt / phantomgate scan . --project
+  [9] Install phantom-gate — AI output hallucination detection (Python + AI-output projects only, if MISS)
+      Run: pip install git+https://github.com/chrono-meta/phantom-gate.git
+      Usage: phantom-gate scan output.txt / phantom-gate scan . --project
       Detectors: M1 (phantom claims) · M2 (self-reference loops) · M3 (unvalidated external-dep claims) · M4 (temporal) · M5 (cross-file version mismatch)
       Skip condition: non-Python project OR no AI-generated output in pipeline
 

--- a/plugins/fh-meta/skills/install-wizard/SKILL.md
+++ b/plugins/fh-meta/skills/install-wizard/SKILL.md
@@ -323,7 +323,7 @@ Auto-check the following items based on detected environment. Each item classifi
 | MCP plugin | ~/.claude.json mcpServers contains entry | `python3 -c "import json,os; d=json.load(open(os.path.expanduser('~/.claude.json'))); print(list(d.get('mcpServers',{}).keys()))"` |
 | `deep-insight plugin` | settings.json plugins contains deep-insight | `grep -r "deep-insight" .claude/settings.json 2>/dev/null` |
 | `fh_env_context.jsonc` | `.claude/rules/fh_env_context.jsonc` exists | `ls .claude/rules/fh_env_context.jsonc` |
-| `hallucinate` | **(Python + AI-output projects only)** `hallucinate` present in `requirements.txt` / `pyproject.toml` | `grep -r "hallucinate" requirements.txt pyproject.toml 2>/dev/null` |
+| `phantomgate` | **(Python + AI-output projects only)** `phantomgate` present in `requirements.txt` / `pyproject.toml` | `grep "phantomgate" requirements.txt pyproject.toml 2>/dev/null` |
 | `Streamlit pattern applied` | (Streamlit projects only, if the pattern pack is present) data_editor empty df branch/async wrapper/CSS numeric variables | CC `knowledge/shared/streamlit_patterns.md` Pattern 1-5 check (skip if file absent) |
 
 **Score calculation**: PASS = 1 point / MISS = 0.5 points / FAIL = 0 points → converted to 100-point scale.
@@ -364,9 +364,10 @@ install-wizard — Diagnosis Results ({score}/100)
       Copy: {FH_DIR}/templates/fh_env_context.jsonc → .claude/rules/fh_env_context.jsonc
       Then manually update with actual values for org name, Jira URL, environment status, etc.
       Effect: Each skill references common environment context → eliminate individual setting duplication
-  [9] Install hallucinate — AI output hallucination detection (Python + AI-output projects only, if MISS)
-      Run: pip install hallucinate
-      Usage: hallucinate scan output.txt / hallucinate scan . --project
+  [9] Install phantomgate — AI output hallucination detection (Python + AI-output projects only, if MISS)
+      ⏳ HOLD — phantomgate is not yet published to PyPI. Do NOT emit an install command until it is.
+      Planned (once published): pip install phantomgate
+      Usage (post-publish): phantomgate scan output.txt / phantomgate scan . --project
       Detectors: M1 (phantom claims) · M2 (self-reference loops) · M3 (unvalidated external-dep claims) · M4 (temporal) · M5 (cross-file version mismatch)
       Skip condition: non-Python project OR no AI-generated output in pipeline
 
@@ -566,7 +567,7 @@ ls ~/.cc_sentinels/${PROJECT_NAME}_wizard_done 2>/dev/null && echo "Inspection m
 |---|---|
 | Structural anomaly detected | `/harness-doctor` |
 | Token waste pattern detected | `/context-doctor` |
-| External user simulation needed | `/sim-conductor Area A` |
+| External user simulation needed | `/sim-conductor` |
 | Install conflict suspected | `/install-doctor` |
 
 ## Per-Cluster Deferred Loading (Progressive Disclosure)


### PR DESCRIPTION
## Summary

Add `hallucinate` as a conditional check item in install-wizard Step 1 and a corresponding proposal in Step 2.

## Changes

### Step 1 — Gap Diagnosis Table (1 row added)

| Check item | Criteria | Verification method |
|---|---|---|
| `hallucinate` | **(Python + AI-output projects only)** `hallucinate` in `requirements.txt` / `pyproject.toml` | `grep -r "hallucinate" requirements.txt pyproject.toml` |

### Step 2 — Proposal List ([9] added)

```
[9] Install hallucinate — AI output hallucination detection
    Run: pip install hallucinate
    Usage: hallucinate scan output.txt / hallucinate scan . --project
    Detectors: M1 (phantom) · M2 (self-ref) · M3 (external-dep) · M4 (temporal) · M5 (cross-file version)
    Skip: non-Python project OR no AI-generated output in pipeline
```

## Motivation

PMH-mapped projects that generate AI outputs (LLM pipelines, TC generators, audit tools) now have a lightweight hallucination detection option available via `hallucinate` v0.2.0. The install-wizard should surface this option during onboarding so users don't miss it.

**Activation logic**: only fires when project is Python AND has AI-output-related dependencies (e.g. `openai`, `anthropic`, `langchain`). Non-Python / no-AI projects: skip condition is clearly documented.

## Validation

- hallucinate v0.2.0: M1~M5 regex detectors, 110 tests, 93% coverage, GitHub Actions CI (Python 3.10~3.13)
- Steel-quench Wave 1~3 passed (S-grade 0 remaining)
- Real integration verified: QASP P2 findings scan → M3 HIGH detection → `needs_clarification=True` auto-mark → P7 TC gate works correctly

Closes chrono-meta/fh-be#6