### PR TITLE
feat: verify-axis check classes + selfcheck + new-skill gate item (supervisor-loops import arc)

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -8,6 +8,11 @@ AI reads this file first when searching past work. Open individual files for det
 
 <!-- Add entries in reverse date order (newest at top) -->
 
+### 2026-06-10 | forge-harness | #new-skill-gate, #check-class, #done-when, #g2
+**File:** CLAUDE.md
+G2 from the supervisor-loops audit: New Skill Creation Pre-Commit Gate extended 5→6 items — "Check-class declared": each Done When condition states its class (mandatory-pass / measured / judged per 6axis §Axis 5), and judged conditions must name their adversarial pairing (no judge-only path). The taxonomy now lives in the operating loop, not just the knowledge doc.
+- Decision: applies to new skills only; existing 28 backfill opportunistically when next edited — no retroactive block.
+
 ### 2026-06-10 | forge-harness | #selfcheck, #mandatory-pass, #npm-test, #self-application
 **File:** scripts/selfcheck.sh (+ package.json)
 G1 fix from the supervisor-loops 100%+ audit: FH's own shipped code (bin/fh-*.js, scripts/fh-*.sh) had zero deterministic checks. New selfcheck.sh runs node --check + bash -n over the npm-shipped executable surface and the gate-chain bash infra (15 checks), wired as `npm test` and `prepublishOnly` — a publish can no longer ship a syntactically broken executable.

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -8,6 +8,11 @@ AI reads this file first when searching past work. Open individual files for det
 
 <!-- Add entries in reverse date order (newest at top) -->
 
+### 2026-06-10 | forge-harness | #verify-axis, #check-classes, #supervisor-loops, #sister-asset
+**File:** knowledge/shared/harness-core/harness_6axis_framework.md
+Axis 5 check-class taxonomy added: every verify check classified as mandatory-pass (deterministic, blocking) / measured (quantitative, tracked) / judged (LLM-judge + cited evidence). Judged rule: a judge verdict never passes alone — paired adversarial re-verification + evidence itself phantom-checked. Import from supervisor-loops sister-audit (operator-approved; cross-audit + proposal in companion store).
+- Decision: descriptive labels over C1/C2/C3 numbering — avoids collision with unanchored "steel-quench C3 config" vocab (goal-quench:283, logged as fh_signal for separate fix).
+
 ### 2026-06-09 | forge-harness | #sidecar, #zero-config, #engine-resolution, #roadmap, #mode-c
 **File:** knowledge/shared/harness-core/multi_model_sidecar_strategy.md (+ hybrid_orchestration_architecture_roadmap.md)
 Added canonical §Sidecar Engine Resolution Protocol — Tier1 subscription-CLI → Tier2 API-key → Tier3 Claude-subagent guaranteed fallback. Principle: discovery automatic/free, invocation value-gated (intelligent default multi-AI, no hard-fail for Mode C). Wired pointers into goal-quench Step D / steel-quench runtime-adapter / harvest-loop Step 3.5-X; sim-conductor/pipeline-conductor/agent-composer inherit by reference. Source hybrid-orchestration design archived as proposed roadmap (versions→placeholders, Python pseudo-code→illustrative, non-shipped tagged Proposed). PR #80.

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -16,7 +16,7 @@ G1 fix from the supervisor-loops 100%+ audit: FH's own shipped code (bin/fh-*.js
 
 ### 2026-06-10 | forge-harness | #verify-axis, #check-classes, #supervisor-loops, #sister-asset
 **File:** knowledge/shared/harness-core/harness_6axis_framework.md
-Axis 5 check-class taxonomy added: every verify check classified as mandatory-pass (deterministic, blocking) / measured (quantitative, tracked) / judged (LLM-judge + cited evidence). Judged rule: a judge verdict never passes alone — paired adversarial re-verification + evidence itself phantom-checked. Import from supervisor-loops sister-audit (operator-approved; cross-audit + proposal in companion store).
+Axis 5 check-class taxonomy added: every verify check classified as mandatory-pass (deterministic, blocking) / measured (quantitative, tracked) / judged (LLM-judge + cited evidence + corrective action — self-judges grade leniently). Judged rule: a judge verdict never passes alone — paired adversarial re-verification + evidence itself phantom-checked. Import from supervisor-loops sister-audit (operator-approved; cross-audit + proposal in companion store; corrective-action clause added after full-transcript delta check).
 - Decision: descriptive labels over C1/C2/C3 numbering — avoids collision with unanchored "steel-quench C3 config" vocab (goal-quench:283, logged as fh_signal for separate fix).
 
 ### 2026-06-09 | forge-harness | #sidecar, #zero-config, #engine-resolution, #roadmap, #mode-c

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -8,6 +8,12 @@ AI reads this file first when searching past work. Open individual files for det
 
 <!-- Add entries in reverse date order (newest at top) -->
 
+### 2026-06-10 | forge-harness | #selfcheck, #mandatory-pass, #npm-test, #self-application
+**File:** scripts/selfcheck.sh (+ package.json)
+G1 fix from the supervisor-loops 100%+ audit: FH's own shipped code (bin/fh-*.js, scripts/fh-*.sh) had zero deterministic checks. New selfcheck.sh runs node --check + bash -n over the npm-shipped executable surface and the gate-chain bash infra (15 checks), wired as `npm test` and `prepublishOnly` — a publish can no longer ship a syntactically broken executable.
+- Decision: syntax-only scope (zero side effects, runs anywhere); blocking wired at publish, not commit — doc commits stay unaffected.
+- Open: npm republish to ship selfcheck.sh in the tarball (machine-bound, laptop).
+
 ### 2026-06-10 | forge-harness | #verify-axis, #check-classes, #supervisor-loops, #sister-asset
 **File:** knowledge/shared/harness-core/harness_6axis_framework.md
 Axis 5 check-class taxonomy added: every verify check classified as mandatory-pass (deterministic, blocking) / measured (quantitative, tracked) / judged (LLM-judge + cited evidence). Judged rule: a judge verdict never passes alone — paired adversarial re-verification + evidence itself phantom-checked. Import from supervisor-loops sister-audit (operator-approved; cross-audit + proposal in companion store).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,17 +109,20 @@ Simplification guard: trivial denials with one obvious fix → state block + sin
 
 ## New Skill Creation Pre-Commit Gate
 
-All 5 items below must pass before committing a new SKILL.md. If any fails, fix and re-commit.
+All 6 items below must pass before committing a new SKILL.md. If any fails, fix and re-commit.
 
 | Item | Criterion |
 |---|---|
 | **Role duplication check** | Pass `/asset-placement-gate` — no overlap with existing role clusters |
 | **Description diet** | Plain text / 0 self-marketing expressions / 0 emphasis words (⭐, "critical", "groundbreaking") |
 | **Done When defined** | At least 1 explicit completion condition |
+| **Check-class declared** | Each Done When condition states its check class — mandatory-pass / measured / judged (`harness_6axis_framework.md` §Axis 5). Any judged condition names its adversarial pairing — no judge-only path |
 | **Natural language triggers** | At least 3 examples that work without internal vocabulary |
 | **Independently executable** | Confirmed to work without other FH skills (or dependencies are explicitly documented) |
 
 Skills without a Done When definition automatically qualify as harness-doctor L2 M-tier.
+Check-class declaration applies to **new** skills; existing skills backfill opportunistically
+(when next edited), not retroactively.
 
 ---
 

--- a/knowledge/shared/harness-core/harness_6axis_framework.md
+++ b/knowledge/shared/harness-core/harness_6axis_framework.md
@@ -77,12 +77,13 @@ Applies automatically when any FH asset is modified (SKILL.md, rules, templates,
 
 **Check classes**: every verify check is one of three classes — **mandatory-pass**
 (deterministic; blocks on fail), **measured** (quantitative; tracked, not blocking alone —
-e.g. `token-budget-gate`, goal-quench calibration), **judged** (LLM-judge with cited
-evidence). **Judged rule**: a judge verdict alone never passes — it must be paired with
-adversarial re-verification (`steel-quench` / `verify-bidirectional`), and its cited evidence
-is itself subject to `phantom-quench`. (Taxonomy adapted from external supervisor-loop
-discourse, 2026-06; FH adds the judged-pairing rule and evidence re-verification, which the
-source leaves open.)
+e.g. `token-budget-gate`, goal-quench calibration), **judged** (LLM-judge emitting verdict +
+cited evidence + a corrective action — a judge score without a fix path is unactionable, and
+self-judges grade leniently). **Judged rule**: a judge verdict alone never passes — it must be
+paired with adversarial re-verification (`steel-quench` / `verify-bidirectional`), and its
+cited evidence is itself subject to `phantom-quench`. (Taxonomy adapted from external
+supervisor-loop discourse, 2026-06; FH adds the judged-pairing rule and evidence
+re-verification, which the source leaves open.)
 
 **Hard gate**: git pre-commit hook (`templates/.git-hooks/pre-commit`) blocks commit until marker + manifest entry exist.
 

--- a/knowledge/shared/harness-core/harness_6axis_framework.md
+++ b/knowledge/shared/harness-core/harness_6axis_framework.md
@@ -68,12 +68,21 @@ New work arrives
 
 Applies automatically when any FH asset is modified (SKILL.md, rules, templates, CLAUDE.md, substantive knowledge/ docs).
 
-| Gate axis | Tool | What it catches |
-|---|---|---|
-| **Backward** | `regression_guard.sh` | Critical section loss, broken refs, syntax errors, line reduction |
-| **Adversarial** | `steel-quench` | Trigger phrase collisions, design attack surface, over-engineered steps |
-| **Forward** | `phantom-quench` | Phantom references, paths that don't exist, stale external links |
-| **Record** | `edit-manifest RECORD` | Logs predicted impact — closes the predict-verify loop |
+| Gate axis | Tool | Class | What it catches |
+|---|---|---|---|
+| **Backward** | `regression_guard.sh` | mandatory-pass | Critical section loss, broken refs, syntax errors, line reduction |
+| **Adversarial** | `steel-quench` | judged | Trigger phrase collisions, design attack surface, over-engineered steps |
+| **Forward** | `phantom-quench` | judged | Phantom references, paths that don't exist, stale external links |
+| **Record** | `edit-manifest RECORD` | mandatory-pass | Logs predicted impact — closes the predict-verify loop |
+
+**Check classes**: every verify check is one of three classes — **mandatory-pass**
+(deterministic; blocks on fail), **measured** (quantitative; tracked, not blocking alone —
+e.g. `token-budget-gate`, goal-quench calibration), **judged** (LLM-judge with cited
+evidence). **Judged rule**: a judge verdict alone never passes — it must be paired with
+adversarial re-verification (`steel-quench` / `verify-bidirectional`), and its cited evidence
+is itself subject to `phantom-quench`. (Taxonomy adapted from external supervisor-loop
+discourse, 2026-06; FH adds the judged-pairing rule and evidence re-verification, which the
+source leaves open.)
 
 **Hard gate**: git pre-commit hook (`templates/.git-hooks/pre-commit`) blocks commit until marker + manifest entry exist.
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "fh-goal": "bin/fh-goal.js"
   },
   "scripts": {
-    "prepare": "chmod +x bin/fh-gate.js bin/fh-run.js bin/fh-goal.js scripts/fh-gate.sh scripts/fh-run.sh scripts/fh-goal.sh"
+    "prepare": "chmod +x bin/fh-gate.js bin/fh-run.js bin/fh-goal.js scripts/fh-gate.sh scripts/fh-run.sh scripts/fh-goal.sh",
+    "test": "bash scripts/selfcheck.sh",
+    "prepublishOnly": "bash scripts/selfcheck.sh"
   },
   "engines": {
     "node": ">=16"
@@ -54,6 +56,7 @@
     "scripts/fh-gate.sh",
     "scripts/fh-run.sh",
     "scripts/fh-goal.sh",
+    "scripts/selfcheck.sh",
     "plugins/fh-meta/skills",
     "plugins/fh-meta/agents",
     "plugins/fh-commons/skills",

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# selfcheck.sh — mandatory-pass (deterministic) checks on FH's own executable surface.
+# Class: mandatory-pass (harness_6axis_framework.md §Axis 5 check classes) — blocks on fail.
+# Scope: executables shipped via npm files[] + the bash infra driving the FH gate chain.
+# Syntax-only (node --check / bash -n): zero side effects, no network, runs anywhere.
+# Wiring: `npm test` for any session; `prepublishOnly` so a publish cannot ship a
+# syntactically broken executable.
+set -u
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+fail=0
+
+check() { # check <label> <cmd...>
+  local label="$1"; shift
+  if "$@" 2>/dev/null; then
+    echo "PASS  $label"
+  else
+    echo "FAIL  $label"
+    "$@" || true
+    fail=1
+  fi
+}
+
+# Node executables (npm-shipped)
+for f in bin/*.js; do
+  check "node --check $f" node --check "$f"
+done
+
+# Bash surface: npm-shipped scripts + local bin wrappers + gate-chain infra
+for f in scripts/*.sh bin/fh-gate bin/fh-run bin/fh-goal \
+         templates/regression_guard.sh templates/.git-hooks/pre-commit; do
+  [ -f "$f" ] || continue
+  check "bash -n $f" bash -n "$f"
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "SELFCHECK: FAIL"
+  exit 1
+fi
+echo "SELFCHECK: PASS"


### PR DESCRIPTION
Supervisor-loops sister-asset import arc, operator-approved at each step.

## Changes

1. **§Axis 5 check-class taxonomy** (`harness_6axis_framework.md`) — every verify check classified as **mandatory-pass** (deterministic, blocking) / **measured** (quantitative, tracked) / **judged** (LLM-judge emitting verdict + cited evidence + corrective action). Judged rule: a judge verdict never passes alone — paired adversarial re-verification (`steel-quench`/`verify-bidirectional`) + evidence itself subject to `phantom-quench`. Descriptive labels chosen over C1/C2/C3 numbering (collision with unanchored "steel-quench C3 config" vocab, goal-quench:283 — logged as fh_signal for separate fix).
2. **`scripts/selfcheck.sh` + `npm test`/`prepublishOnly`** — G1 fix: 15 deterministic checks (`node --check` / `bash -n`) over the npm-shipped executable surface + gate-chain bash infra. A publish can no longer ship a syntactically broken executable. 15/15 PASS.
3. **New Skill Creation Pre-Commit Gate 5→6 items** (CLAUDE.md) — "Check-class declared": each Done When condition states its class; judged conditions name their adversarial pairing (no judge-only path). New skills only; existing skills backfill opportunistically.
4. CATALOG entries for all of the above.

## Gates

4-axis gate run per change: Axis 1 PASS (CLAUDE.md +3 lines, 0 blockers; others out of scope) · Axes 2–3 focused-inline PASS (1 finding fixed: label rename) · Axis 4 manifest entries `em-2026-06-10{,b,c}` (mirrored durably in companion store).

## Post-merge

npm files[] surface changed (package.json, CLAUDE.md, selfcheck.sh) → 1.4.8 republish proposed, machine-bound — handoff `NEXT_ACTION_2026-06-10_npm-republish-selfcheck.md` in companion store.

Cross-audit record, import proposal, and 100%+ reflection audit live in the companion store (`tracks-audit/session_2026_06_10_supervisor-loops-sister.md`).

https://claude.ai/code/session_01JwgGnJHfTdRirJfJuKYJN9

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwgGnJHfTdRirJfJuKYJN9)_