### PR TITLE
fix(onboarding): metadata-is-not-intent guard + language-agnostic triggers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,13 +99,14 @@ Simplification guard: trivial denials with one obvious fix → state block + sin
 > **Full 4-step detail**: `knowledge/shared/harness-core/fh_detail_protocols.md`
 > **Read this file before Step 1 begins** — duplicate-install detection (Step 1-b) and registry scan (Step 1-c) are only defined there, not in this summary.
 
-**Triggers**: greetings (`hi`/`hello`/`hey`) · start intent (`resume`, `continue`, `where were we`) · new task (`new project`, `new task`) · discovery (`what is this`, `what can you do`, `first time here`)
+**Triggers**: greetings (`hi`/`hello`/`hey`/`안녕` — and the same word in any language; FH is English-based but language-agnostic, a bare greeting in any tongue fires this) · start intent (`resume`, `continue`, `where were we`) · new task (`new project`, `new task`) · discovery (`what is this`, `what can you do`, `first time here`)
 
 **4-step summary**: ① Auto-read CLAUDE.md + CATALOG + session card + registry scan → ② One-line proposal (new user / exploratory / returning branches) → ③ 5-skill cascade (plugin-recommender → synergy → .claudeignore → model → verify) → ④ Approval + setup
 
 **Identity marker**: every greeting response (Step ②) opens with 🐿️ on its own line. FH's session-start signal — see `fh_detail_protocols.md` Step 2 for full greeting templates.
 
 **Guards**: explicit task-entry utterance → skip onboarding · once per session · code/debug requests → start working directly · project routing is a suggestion, mention at most once
+**Metadata-is-not-intent guard**: the trigger is the user's **typed message only**. Session metadata — branch name (auto-derived from the first message, e.g. `claude/korean-greeting-*`), repo name, file paths — is **never** a task spec and never suppresses or redirects the greeting trigger. A bare greeting fires onboarding even when the branch name looks like a feature request; if the only "task" signal lives in metadata and not in what the user typed, treat the message as a greeting and run the 3-axis scaffold.
 
 ## New Skill Creation Pre-Commit Gate
 


### PR DESCRIPTION
## Root cause

Greeting trigger had no priority guard over session metadata. Branch names like `claude/korean-greeting-*` are auto-derived from the first message and look like task specs — AI promoted branch name to intent, bypassed onboarding, and implemented phantom features.

Secondary: CLAUDE.md trigger list omitted `안녕` while regression probe G-GREET-01 assumed it was covered (false-green).

## Changes (`CLAUDE.md`)

1. **Triggers**: add `안녕` + language-agnostic note — FH is English-based but any bare greeting in any tongue fires onboarding; no special per-language handling needed
2. **Metadata-is-not-intent guard**: typed message is the only trigger source; branch names / repo names / file paths are never task specs and never suppress the greeting trigger

## Failure class
Missing guard + trigger-list/probe drift

---
_Generated by [Claude Code](https://claude.ai/code/session_01MH2ogviurF5JVsoyvAt2Ds)_