### PR TITLE
fix(onboarding): fold 🐿️ into returning-user door skeleton + ship below-floor re-run consumer

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -27,8 +27,9 @@ The hub audits and improves itself weekly.
 
 **Phase 1.5 (manual + scanner):**
 1. `./tracks/_audit/_scanner.sh "7 days ago"` — commit/tag/stale file/sub-agent invocation log/self-asset reference audit aggregation
-2. Copy `_template_weekly.md` → `weekly_audit_YYYY-MM-DD.md`
-3. Propose 3-tier improvements (🟥mandatory/🟧strong/🟩recommended)
+2. `bash scripts/below_floor_scan.sh` — below-floor marker re-run queue (the standing consumer §Floor governance promises: exit 1 = pending floor-tier re-validations, treat as S-tier; resolve via `floor-rerun:` / `floor-writeoff:` appended to the marker)
+3. Copy `_template_weekly.md` → `weekly_audit_YYYY-MM-DD.md`
+4. Propose 3-tier improvements (🟥mandatory/🟧strong/🟩recommended)
 
 **Recurrence escalation** (N=3 threshold): Scanner output shows the same defect class in 3+ distinct commits or sessions within the audit window → S-tier signal; propose instrumenting as a CI probe (`npm test` extension or pre-commit hook) rather than adding a new habit rule. Three recurrences indicate the defect class is structural — habits don't hold.
 

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -8,6 +8,12 @@ AI reads this file first when searching past work. Open individual files for det
 
 <!-- Add entries in reverse date order (newest at top) -->
 
+### 2026-06-11 | forge-harness | #identity-marker, #door-skeleton, #target-tier-sim, #below-floor-consumer, #false-control-kill
+**File:** CLAUDE.md §Active Onboarding (+ fh_detail_protocols.md, scripts/below_floor_scan.sh, .claude/rules/operations.md)
+Cloud session (Mode D): 🐿️ marker folded into the returning-user door skeleton — one salience unit with the menu, closing the sonnet-sim marker-drop residual (`fh_signal_2026-06-11`); verified by blind sonnet Agent sim PASS (verification tier = failure tier; in-session model-pinned dispatch available in cloud, no headless fallback needed). 6/15 billing one-line amendment rode the same CLAUDE.md edit (no churn commit). below_floor_scan.sh ships as the standing consumer the pre-commit hook promised ("weekly audit re-queues below-floor markers") but never had — resolution via `floor-rerun:`/`floor-writeoff:` marker appends, wired as weekly Phase 1.5 step 2.
+- Decision: ack rubber-stamp (card item 4) closed via route-around — build the re-run consumer, leave the ack untouched (per opus-challenger verdict on the reverted regex attempt).
+- Decision: opus challenger PASS 0S+3B — marker-append/hook-collision replicated CLEAN; P9 check: "builds the control, not paper-over".
+
 ### 2026-06-10 | forge-harness | #destructive-op-gate, #irreversibility, #silent-loss, #branch-cleanup-incident
 **File:** CLAUDE.md §Destructive-Op Gate (+ templates/predelete_check.sh, scripts/selfcheck.sh)
 Third irreversibility gate (sibling of Pre-Publish): enumerate → recover → destroy, never destroy-then-check. predelete_check.sh classifies branches SAFE/CHECK/REVIEW (CHECK = 0 unique paths but commits off base — shared files may hold newer content, the silent-loss class); REVIEW blocks scripted deletes (exit 1); the recovery step is judged/depth-sensitive (strongest-tier floor semantics). Signal-table row fires on destructive intents proactively. Origin: same-day incident — a parallel session's card (weekly-audit done + #88) lived only on an unmerged 0-unique-path branch; pre-deletion enumeration recovered it. Dogfood replay: the script lands that exact branch in CHECK.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,9 +103,14 @@ Simplification guard: trivial denials with one obvious fix → state block + sin
 
 **4-step summary**: ① Auto-read CLAUDE.md + CATALOG + session card + registry scan → ② One-line proposal (new user / exploratory / returning branches) → ③ 5-skill cascade (plugin-recommender → synergy → .claudeignore → model → verify) → ④ Approval + setup
 
-**Returning-user door skeleton (summary-level — applies even if the detail file read is skipped; returning users only, new/exploratory branches stay in the detail file)**: open with the fixed 3-door menu — *"① Connect/map a project · ② Work on a mapped project — {field candidates} · ③ FH self-development — {FH worklist}"* — composing session-card candidates **into doors ②/③**, never as a raw priority dump that replaces the menu. An urgent open item (time-windowed handoff · blocking external deadline) outranks the menu; an explicit task utterance skips it entirely (see Guards below); cadence reminders (§Cadence Rules) ride below it, they don't displace it. Canonical source: `fh_detail_protocols.md` Step 2 §Returning user — keep door labels in sync.
+**Returning-user door skeleton (summary-level — applies even if the detail file read is skipped; returning users only, new/exploratory branches stay in the detail file)**: open with the fixed 3-door menu, **🐿️ on its own line as the skeleton's first line** —
 
-**Identity marker**: every greeting response (Step ②) opens with 🐿️ on its own line. FH's session-start signal — see `fh_detail_protocols.md` Step 2 for full greeting templates.
+> 🐿️
+> *"① Connect/map a project · ② Work on a mapped project — {field candidates} · ③ FH self-development — {FH worklist}"*
+
+The marker is part of this skeleton — one salience unit with the menu, not a separate rule (origin: a sonnet-tier sim emitted the menu but dropped the standalone marker rule, `fh_signal_2026-06-11`). Compose session-card candidates **into doors ②/③**, never as a raw priority dump that replaces the menu. An urgent open item (time-windowed handoff · blocking external deadline) outranks the menu; an explicit task utterance skips it entirely (see Guards below); cadence reminders (§Cadence Rules) ride below it, they don't displace it. Canonical source: `fh_detail_protocols.md` Step 2 §Returning user — keep door labels in sync.
+
+**Identity marker**: every greeting response (Step ②) opens with 🐿️ on its own line. For returning users it is embedded in the door skeleton above (do not strip it when composing doors); new/exploratory branch templates carry it in `fh_detail_protocols.md` Step 2.
 
 **Guards**: explicit task-entry utterance → skip onboarding · once per session · code/debug requests → start working directly · project routing is a suggestion, mention at most once
 **Metadata-is-not-intent guard**: the trigger is the user's **typed message only**. Session metadata — branch name (auto-derived from the first message, e.g. `claude/korean-greeting-*`), repo name, file paths — is **never** a task spec and never suppresses or redirects the greeting trigger. A bare greeting fires onboarding even when the branch name looks like a feature request; if the only "task" signal lives in metadata and not in what the user typed, treat the message as a greeting and run the 3-axis scaffold.
@@ -178,7 +183,9 @@ the operator (one line), mirroring §Floor governance.
 
 If `model:`-pinned dispatch is unavailable (plan/billing gate), fall back to a cross-session headless
 run (`claude -p "<trigger>" --model <tier>` in the target cwd) — stronger isolation, zero instruction
-contamination. Record sim results in the Axes 2–3 marker + sub-agent invocation log.
+contamination. 2026-06-15+: headless `claude -p` draws from the hard-capped credit pool, not the
+subscription — prefer in-session Agent dispatch when the plan gate allows; take the headless fallback
+knowingly. Record sim results in the Axes 2–3 marker + sub-agent invocation log.
 
 **Axis ownership** (each skill is already complete — orchestrator only coordinates):
 

--- a/knowledge/shared/harness-core/fh_detail_protocols.md
+++ b/knowledge/shared/harness-core/fh_detail_protocols.md
@@ -46,7 +46,7 @@ Group by project → update `.claude/registry/LOCAL_SKILL_REGISTRY.md`. Propose 
 
 ### Step 2 — Active Proposal
 
-Identity marker: every greeting response opens with **🐿️** on its own line before the first sentence. This is FH's session-start signal — friendly, consistent, distinct.
+Identity marker: every greeting response opens with **🐿️** on its own line before the first sentence. This is FH's session-start signal — friendly, consistent, distinct. For the returning-user branch the marker is **part of the door skeleton itself** (one salience unit with the menu — do not strip it when composing doors; mirrored in CLAUDE.md §Active Onboarding door skeleton).
 
 **New user** (empty tracks/ or 0 session files):
 > 🐿️

--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -64,3 +64,15 @@
   trigger: operator request (gate codified same session); model-pinned Agent dispatch (sonnet, haiku) blocked by plan gate -> cross-session fallback
   outcome: accepted
   note: "PASS — 3-door menu fired with card candidates composed into doors 2/3, cadence below menu; residual: missing 🐿️ marker (fh_signal_2026-06-11_fh-direct)"
+- date: 2026-06-11
+  agent: general-purpose (sonnet, blind sim, in-session Agent dispatch)
+  task: target-tier sim gate — blind greeting sim verifying 🐿️-in-skeleton fold-in (Option A) at the failure tier
+  trigger: 4-axis auto-gate Mode D supplement (salience-dependent change, observed sonnet miss fh_signal_2026-06-11)
+  outcome: accepted
+  note: "PASS — 🐿️ on its own line as skeleton first line + 3-door menu emitted; cadence rode below menu; model-pinned dispatch available in cloud env (plan gate absent), no claude -p fallback needed"
+- date: 2026-06-11
+  agent: general-purpose (opus, quench-challenger role)
+  task: steel-quench Axis 2 on 🐿️ fold-in + 6/15 billing amendment + below_floor_scan.sh consumer + operations.md wiring
+  trigger: 4-axis auto-gate Axis 2 (FH asset modified)
+  outcome: accepted
+  note: "PASS 0S+3B — marker-append/hook-collision CLEAN (replicated validate_marker_floor), P9 check verdict 'builds the control, not paper-over'; B1 scanner-autoinvoke implication fixed, B2 signal status update routed to fh-be, B3 opus hardcode accepted (matches hook convention)"

--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -76,3 +76,9 @@
   trigger: 4-axis auto-gate Axis 2 (FH asset modified)
   outcome: accepted
   note: "PASS 0S+3B — marker-append/hook-collision CLEAN (replicated validate_marker_floor), P9 check verdict 'builds the control, not paper-over'; B1 scanner-autoinvoke implication fixed, B2 signal status update routed to fh-be, B3 opus hardcode accepted (matches hook convention)"
+- date: 2026-06-11
+  agent: claude (background, frontier-digest skill execution)
+  task: cadence-overdue frontier-digest run (16d+ since 2026-05-26) — WebSearch mode, incremental-only
+  trigger: CLAUDE.md cadence rule (7d+ overdue) + operator door-3 batch approval
+  outcome: accepted
+  note: "digest written to companion store only (no FH asset touched, no commit — reviewed by main session); headline: NLAH arXiv:2603.25723 = convergence candidate n=6, Fable 5 tier shift, Stop-hook additionalContext channel; 5 candidates parked as unapproved checklist"

--- a/scripts/below_floor_scan.sh
+++ b/scripts/below_floor_scan.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# below_floor_scan.sh — standing consumer for below-floor adversarial markers
+#
+# The pre-commit hook accepts a below-floor Axis-2 pass when an operator ack is
+# present, on the promise that "the weekly audit re-queues below-floor markers
+# for floor-tier re-run" (§Floor governance, multi_model_sidecar_strategy.md).
+# This script IS that consumer: it enumerates below-floor markers and reports
+# which ones still await floor-tier re-validation. Read-only, zero side effects.
+#
+# Resolution protocol (append to the marker after acting — machine-greppable):
+#   floor-rerun: <YYYY-MM-DD> <model> PASS|FAIL   ← Axis 2 re-run at >= floor
+#   floor-writeoff: <YYYY-MM-DD> <one-line reason> ← operator writes the ack off
+#
+# Usage: bash scripts/below_floor_scan.sh [repo_root]
+# Exit:  0 = no pending below-floor markers; 1 = pending re-runs found
+#        (manual weekly-audit step — Phase 1.5; exit 1 = raise the pending
+#        items as S-tier. No automated caller is wired yet.)
+
+set -uo pipefail
+
+REPO_ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+MARKER_DIR="$REPO_ROOT/tracks/_meta"
+PENDING=0
+TOTAL=0
+
+echo "── below-floor marker scan: $MARKER_DIR ──"
+
+if [ ! -d "$MARKER_DIR" ]; then
+  echo "   (no tracks/_meta directory — nothing to scan)"
+  exit 0
+fi
+
+for m in "$MARKER_DIR"/.axes_23_passed_*.marker; do
+  [ -e "$m" ] || continue
+  grep -qE '^[[:space:]]*floor-status:[[:space:]]*below-floor' "$m" || continue
+  TOTAL=$((TOTAL + 1))
+  name=$(basename "$m")
+  model=$(grep -m1 -E '^[[:space:]]*axis2-model:' "$m" \
+          | sed -E 's/^[[:space:]]*axis2-model:[[:space:]]*//' || true)
+  ack=$(grep -m1 -E '^[[:space:]]*below-floor-ack:' "$m" \
+        | sed -E 's/^[[:space:]]*below-floor-ack:[[:space:]]*//' || true)
+  rerun=$(grep -m1 -E '^[[:space:]]*floor-rerun:' "$m" \
+          | sed -E 's/^[[:space:]]*floor-rerun:[[:space:]]*//' || true)
+  writeoff=$(grep -m1 -E '^[[:space:]]*floor-writeoff:' "$m" \
+             | sed -E 's/^[[:space:]]*floor-writeoff:[[:space:]]*//' || true)
+
+  if [ -n "$rerun" ]; then
+    echo "✅ RESOLVED (re-run)   $name — floor-rerun: $rerun"
+  elif [ -n "$writeoff" ]; then
+    echo "✅ RESOLVED (writeoff) $name — floor-writeoff: $writeoff"
+  else
+    PENDING=$((PENDING + 1))
+    echo "🟥 PENDING re-run      $name"
+    echo "     axis2-model: ${model:-<missing>} | ack: ${ack:-<missing>}"
+    echo "     action: re-run Axis 2 at >= floor (opus), append 'floor-rerun: ...'"
+    echo "             or operator writes off: append 'floor-writeoff: ...'"
+  fi
+done
+
+echo "── below-floor markers: $TOTAL total, $PENDING pending ──"
+[ "$PENDING" -gt 0 ] && exit 1
+exit 0


### PR DESCRIPTION
## What

Cloud session 2026-06-11 (door ③ batch, operator-approved):

1. **🐿️ marker folded into the returning-user door skeleton** (CLAUDE.md §Active Onboarding + `fh_detail_protocols.md` Step 2 sync) — the marker is now one salience unit with the 3-door menu, closing the sonnet-sim marker-drop residual (`fh_signal_2026-06-11`).
2. **2026-06-15 billing amendment** rode the same CLAUDE.md edit (per signal addendum — no standalone churn commit): headless `claude -p` fallback now noted as credit-pool metered; prefer in-session Agent dispatch.
3. **`scripts/below_floor_scan.sh`** — the standing consumer the pre-commit hook promised ("weekly audit re-queues below-floor markers") but never had. Read-only scan; resolution via `floor-rerun:` / `floor-writeoff:` marker appends; exit 1 = pending = S-tier. Wired into `.claude/rules/operations.md` Phase 1.5 step 2. This is the route-around for the below-floor-ack rubber-stamp item (build the control, leave the ack untouched).
4. CATALOG entry + sub-agent invocation log (3 dispatches, all accepted).

## Verification

- **4-axis gate (full mode, hook-enforced)**: Axis 1 staged guard PASS · Axis 2 opus challenger **0S+3B** (B1 fixed inline, B2 routed to companion signal, B3 accepted — matches hook convention) · Axis 3 phantom PASS · Axis 4 manifest recorded.
- **Target-tier sim gate**: blind in-session **sonnet** Agent sim PASS — 🐿️ own-line + 3-door menu both emitted (verification tier = failure tier).
- `below_floor_scan.sh` functional test: pending→exit 1, resolved→exit 0; challenger replicated `validate_marker_floor` against appended lines: CLEAN.

## Post-merge note

CLAUDE.md + `fh_detail_protocols.md` are on the npm `files[]` surface → joins the **1.4.14 republish** candidate (machine-bound, laptop).

https://claude.ai/code/session_01E6ZbKPrG6QRtYtHKQ5VfPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6ZbKPrG6QRtYtHKQ5VfPb)_