### PR TITLE
docs(readme): dedup stale model-guidance block + commoditization-defense positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ forge-harness is structured as **two distinct layers**:
 
 The methodology layer is the portable core — persistent hub, accumulating learnings, curating cross-project knowledge. The automation layer makes it frictionless when running Claude Code.
 
+**Where this sits (2026):** "harness engineering" is now a public paradigm — and basic agent
+orchestration is rapidly commoditizing into standard infrastructure. FH deliberately stakes nothing on
+that plumbing. Its durable layer is what does *not* commoditize: the governance gates (adversarial ·
+phantom · regression), drift control, and the cross-project compounding loop. Routing and dispatch are
+means; **the gate and the loop are the asset.**
+
 ```
 forge-harness/   ← the hub (persistent brain)
 ├── knowledge/   → shared across all projects
@@ -272,13 +278,6 @@ a top-tier anchor at 100, with the rules in context doing most of the work. The 
 above-rubric *design* increments (developing the harness, not running it) — which is why the default is
 Sonnet with **tier-floored dispatch** covering the depth-sensitive turns, and a pinned stronger model is
 recommended only for harness-editing sessions. Details: `docs/OUTPUT_EVIDENCE.md` §Validation signals.
-
-**Measured, not asserted** (2026-06-10, worked example): on a 30-point blind rule-application battery,
-*operating* FH was nearly model-flat — Opus 4.8 / Sonnet 4.6 / Haiku 4.5 scored **100 / 97 / 94** against
-a top-tier anchor at 100, with the rules in context doing most of the work. The tiers separated only on
-above-rubric *design* increments (developing the harness, not running it) — which is exactly why the
-recommendation stays Opus for harness-editing and gate turns, while field operation tolerates lower tiers.
-Details: `docs/OUTPUT_EVIDENCE.md` §Validation signals.
 
 If you use external CLIs (Gemini, Codex, `gh copilot`) as sidecars, their costs are billed to their own quota and not visible in CC's token display.
 


### PR DESCRIPTION
## What

Two surgical README fixes (public asset, light gate path):

1. **Dedup**: the "Measured, not asserted" paragraph appeared twice in §Model setup. The second copy predated tier-floor resolution and **contradicted** the current stance — it said "recommendation stays Opus for harness-editing and gate turns" while the surviving copy (and §Model setup itself) says default Sonnet + tier-floored dispatch, Opus pinned only for Mode D. Removed the stale copy.

2. **Positioning ("Where this sits, 2026")**: one paragraph added to §What it is — harness orchestration is commoditizing into standard infrastructure; FH's durable layer is the governance gates (adversarial · phantom · regression), drift control, and the compounding loop. *The gate and the loop are the asset.*

## Why

- (1) is a correctness fix: two contradictory model-guidance claims on the public README.
- (2) originates from the SC3 seed-candidate vetting (fh-be `vetting_2026-06-11_seed-candidates-SC1-4.md`): 2026 sources confirm "harness engineering" as public canon **and** flag basic orchestration as rapidly commoditizing — bet ID must defend on the non-commoditizing layer, not plumbing. Partial execution of the ledger action "Revise FH public README to crystallized identity."

## Gate

Light path — Axis 1 `regression_guard.sh --pr` PASS (no SKILL/rules/CLAUDE.md changes) · Axis 4 manifest line recorded · Axes 2–3 N/A (prose-only README diff) · target-tier sim skipped (human-facing prose, not salience-dependent).

Note: README is on the npm `files[]` surface — this rides the pending 1.4.14 republish once merged (handoff amended in fh-be).

https://claude.ai/code/session_01QFZtsnXyShJXeBTbd8i3xk

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFZtsnXyShJXeBTbd8i3xk)_