### PR TITLE
feat(install-wizard): Mode D companion store asks backend first

### DIFF
--- a/plugins/fh-meta/skills/install-wizard/SKILL.md
+++ b/plugins/fh-meta/skills/install-wizard/SKILL.md
@@ -86,9 +86,9 @@ If this is your first time with FH, confirm 3 things before install. All should 
 Fewer than 2 of 3 (first three) → Proceed with install but recommend using only core skills (`context-doctor`, `harness-doctor`) first.
 All 3 → Proceed in order: Step 0-B (token injection) → Step 0 (environment card) → Step 0-C (existing harness).
 
-**Mode D detected (FH developer/researcher)**: Guide companion-store setup before Step 1.
+**Mode D detected (FH developer/researcher)**: Guide companion-store setup before Step 1. **Ask the backend first** — the store is a role (durable private home for artifacts), not a fixed `*-be` git repo: Obsidian vault / gbrain-ingest / `*-be` git repo (default) all qualify. Do not assume the repo path.
 
-> **Detail**: See `SKILL_detail.md §Mode-D-Companion-Setup` — recommended public/private layout, remote-backed and local-only setup commands — read when Mode D is detected.
+> **Detail**: See `SKILL_detail.md §Mode-D-Companion-Setup` — backend-branching question (Obsidian / gbrain / *-be git default), remote-backed and local-only setup commands, cross-backend invariants — read when Mode D is detected.
 
 ### Step 0-B. Git Token Pre-injection (when repo creation/fork/push included)
 

--- a/plugins/fh-meta/skills/install-wizard/SKILL_detail.md
+++ b/plugins/fh-meta/skills/install-wizard/SKILL_detail.md
@@ -36,7 +36,8 @@ Q: Do you already run a durable knowledge store?
  │
  ├─ Run a queryable memory brain (gbrain / LLM-wiki)
  │    → your gbrain INGESTS the emitted markdown (`gbrain ingest <path>`).
- │      FH writes markdown to a staging path; the brain consumes it.
+ │      Set BE_DIR=/path/to/staging   (same env var as the other backends — FH
+ │      writes markdown there; your brain then `gbrain ingest`s that path).
  │      (A deeper FH→gbrain MCP integration is a future candidate — not wired today.)
  │
  └─ None of the above (DEFAULT) → a private *-be git repo

--- a/plugins/fh-meta/skills/install-wizard/SKILL_detail.md
+++ b/plugins/fh-meta/skills/install-wizard/SKILL_detail.md
@@ -12,33 +12,54 @@ load: on-demand
 
 ## §Mode-D-Companion-Setup
 
-Guide companion-store setup before Step 1 when Mode D (FH developer/researcher) is detected:
+Guide companion-store setup before Step 1 when Mode D (FH developer/researcher) is detected.
+
+**Ask the backend question FIRST — do not assume a `*-be` git repo.** The companion store is a
+*role* (durable private home for drafts · signals · handoffs · gitignored-session mirror), not a
+fixed technology. FH emits the same artifact for every backend — **markdown output files** — so the
+only thing that changes is where those files land. Branch on what the user already runs (see
+`modes_and_value.md §Pluggable backends`):
 
 ```
-You're developing FH itself — you need a private companion store
-alongside the public mirror.
+You're developing FH itself — you need a durable PRIVATE companion store
+alongside the public mirror. Where should research artifacts live?
 
-Recommended layout:
-  public:  {org}/{hub}        (methodology, skills, rules)
-  private: {org}/{hub}-be     (paper drafts, experiment logs,
-                               raw signals, handoff files)
+Q: Do you already run a durable knowledge store?
 
-Quick setup (remote-backed):
-  gh repo create {org}/{hub}-be --private
-  git clone https://github.com/{org}/{hub}-be ~/path/to/{hub}-be
-  mkdir -p {hub}-be/{paper-drafts,paper-signals,digests,handoff}
+ ┌─ Already garden knowledge in Obsidian
+ │    → point the output path AT the vault. Obsidian IS markdown, so drafts
+ │      are backlinked instantly — zero new infra, nothing to git init.
+ │      Set BE_DIR=/path/to/vault/fh   (the sync target is just a folder)
+ │      ⚠ use a NON-git vault subfolder: if BE_DIR lands inside a git-backed
+ │        vault (Obsidian Git plugin), the sync script auto-commits private
+ │        session-meta (incl. CLAUDE.local.md) into the vault's remote.
+ │
+ ├─ Run a queryable memory brain (gbrain / LLM-wiki)
+ │    → your gbrain INGESTS the emitted markdown (`gbrain ingest <path>`).
+ │      FH writes markdown to a staging path; the brain consumes it.
+ │      (A deeper FH→gbrain MCP integration is a future candidate — not wired today.)
+ │
+ └─ None of the above (DEFAULT) → a private *-be git repo
+      Quick setup (remote-backed):
+        gh repo create {org}/{hub}-be --private
+        git clone https://github.com/{org}/{hub}-be ~/path/to/{hub}-be
+        mkdir -p {hub}-be/{paper-drafts,paper-signals,digests,handoff}
+      Local-only variant (no GitHub — data never leaves the machine):
+        git init ~/path/to/{hub}-be      # no remote needed
+        mkdir -p ~/path/to/{hub}-be/{paper-drafts,paper-signals,digests,handoff}
+        → the sync script detects the missing upstream and skips push
+          automatically; local git history carries durability.
 
-Local-only variant (no GitHub — your data never leaves the machine):
-  git init ~/path/to/{hub}-be      # no remote needed
-  mkdir -p ~/path/to/{hub}-be/{paper-drafts,paper-signals,digests,handoff}
-  → the sync script detects the missing upstream and skips push
-    automatically; local git history carries durability. Any store
-    name works — set BE_DIR (and HUB_DIR) env vars to your paths.
+Any store name/path works — set BE_DIR (and HUB_DIR) env vars to your paths.
 
-Key rule: knowledge/shared/ drafts stay local via .gitignore glob.
-Push snapshots to the companion store explicitly — never auto-push.
-handoff/ files bridge cloud session → local without exposing content.
+Invariant across ALL backends:
+  · methodology stays in the public mirror (single-source guard) — NEVER copied
+    into the store; the store holds only OUTPUTS, never a rule copy
+  · knowledge/shared/ drafts stay local via .gitignore glob
+  · push/ingest snapshots explicitly — never auto-push
+  · handoff/ files bridge cloud session → local without exposing content
 ```
+
 
 ---
 
@@ -417,11 +438,15 @@ install-wizard — Complete
    New skill proposal → PR:
      https://github.com/chrono-meta/forge-harness
 
-🔬 Developing FH itself? Set up a private companion store:
-   gh repo create {org}/{hub}-be --private   # paper drafts, experiment logs, handoffs
-   (or local-only: git init ~/path/{hub}-be — no remote; push is auto-skipped)
-   → public mirror holds methodology · private store holds research artifacts
-   → field projects (internal harness) can use the same dual-repo pattern
+🔬 Developing FH itself? Set up a durable PRIVATE companion store.
+   Backend is your choice — the store is a role, not a fixed tech (it holds
+   research artifacts; methodology stays in the public mirror):
+   · Obsidian user → point output path at your vault (zero new infra)
+   · gbrain / memory-brain → it ingests FH's emitted markdown
+   · neither (default) → gh repo create {org}/{hub}-be --private
+                         (or local-only: git init ~/path/{hub}-be — push auto-skipped)
+   → see install-wizard SKILL_detail §Mode-D-Companion-Setup for the full branch
+   → field projects (internal harness) can use the same dual-store pattern
 
 🔀 Don't want to lose your accumulated assets — fork as your own hub:
    Personal skills/rules/notes added directly to FH may be lost on FH updates.


### PR DESCRIPTION
Mode D setup now asks backend question first (Obsidian vault / gbrain ingest / *-be git default) instead of assuming a *-be repo.

### Changes
- **install-wizard SKILL.md**: Added backend question note in Mode D detected step
- **SKILL_detail.md §Mode-D-Companion-Setup**: Rewritten to 3-branch decision tree with all-backends invariant
- **Aligns to**: `modes_and_value.md §Pluggable backends`
- **Obsidian privacy caveat**: Added git-vault warning (B-a fix from steel-quench)

### Gate Status
- Axis1 PASS · Axis2 CONDITIONAL (0S/0A, B-a applied, B-b residual) · Axis3 PASS (8/8 grounded) · Mode D Sonnet sim PASS

### Companion Work
- fh-be `bootstrap.sh`: 4-axis gate auto-install (Mode D, idempotent, owner-only)
- be handoff: npm 1.4.26 republish signal (install-wizard on `files[]` surface)

🤖 Claude via REST API