### PR TITLE
field-harvest: gate-locality principle + 2 grounding/persona capability skills

### DIFF
--- a/knowledge/shared/harness-core/gate_locality_principle.md
+++ b/knowledge/shared/harness-core/gate_locality_principle.md
@@ -1,0 +1,57 @@
+---
+name: gate-locality-principle
+description: A safety gate must live where the actor that needs it actually reads it — a gate defined in a place the enforcing actor never loads is decorative, not enforced.
+type: reference
+date: 2026-06-20
+tags: [governance, gate-locality, multi-runtime, judge-robustness, field-harvest]
+originProjects: [two restricted-env field harnesses]
+---
+
+# Gate-Locality Principle
+
+> **A safety gate must live where the actor that needs it actually reads it.**
+> A gate defined in a place the enforcing actor never loads provides the *appearance* of safety
+> with none of the enforcement. Locality is part of the gate's correctness, not an afterthought.
+
+This is a sibling of the **judge-robustness / mechanical-anchor** spine: judge-robustness says *don't
+let a foolable judge hold the terminal verdict*; gate-locality says *don't put the gate somewhere the
+enforcer can't see it*. Both fail the same way — a control that looks present but cannot actually fire.
+
+## The failure mode (two observed shapes)
+
+| Shape | Where the gate was | Who needed it | Why it didn't fire |
+|---|---|---|---|
+| **Code-locality** | absent from the write path entirely | the function that writes to JIRA | the writeback gate checked confidence but not provenance, so a self-inferred finding auto-posted as if verified |
+| **File-locality** | only in a Claude-only `CLAUDE.md` | a Gemini/Codex orchestrator that auto-loads root `AGENTS.md`, not `CLAUDE.md` | the runtime assumed the commander *role* without inheriting the *gates* |
+
+Both were found 2026-06-20 across **two field harnesses** (Harness-A: a provenance gate missing from a
+write path; Harness-B + Harness-A: orchestration gates that lived only in a Claude-only file). The
+recurrence across two contexts is what lifts this past a
+single anecdote; it is N=2 within one operator's projects, so **cross-operator confirmation is the
+upgrade path** that would harden it from a working principle to a validated one.
+
+## The fix pattern
+
+Move the gate into the artifact the enforcing actor actually reads:
+- **Code path** → put the guard *in the function that performs the irreversible action* (e.g. gate the
+  writeback candidate generator on `provenance == verified`, not in a doc that describes it).
+- **Multi-runtime orchestration** → put orchestration gates in a **model-agnostic** file every
+  runtime loads (`AGENTS.md`), not in a Claude-only `CLAUDE.md`. A non-Claude orchestrator that never
+  reads `CLAUDE.md` otherwise gets the role without the governance.
+
+## Verification (how to know the locality fix worked)
+
+A **blind target-tier sim** is the honest check: feed the enforcing actor ONLY the file/path it
+actually loads (e.g. `AGENTS.md` alone, no `CLAUDE.md`) and present a trap the gate should catch
+(e.g. a high-confidence but unverified finding to auto-write). Pre-fix the actor has no basis to
+refuse; post-fix it refuses, citing the now-local gate. The behavioral delta *is* the proof of
+locality — review alone cannot show it (review reads all files; the runtime does not).
+
+## Relationship to other FH assets
+
+- **steel-quench** carries this as a Wave-1 attack angle ("Gate-locality — is every safety gate
+  readable by the actor that must enforce it?").
+- **judge-robustness / mechanical-anchor** (`[[feedback_judge_robustness_mechanical_anchor]]`) — the
+  sibling principle for *verdict* placement; gate-locality is for *gate* placement.
+- **Non-Model Ground** — multi-runtime orchestration is exactly where gate-locality bites, because
+  different runtimes load different files.

--- a/plugins/fh-meta/skills/corpus-grounding-expander/SKILL.md
+++ b/plugins/fh-meta/skills/corpus-grounding-expander/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: corpus-grounding-expander
+description: Fetches and normalizes multi-version public-domain corpora into a single verified-axiom store for verbatim-relay grounding, recording per-version license and provenance.
+user-invocable: true
+allowed-tools: ["Read", "Bash", "WebFetch", "Write"]
+model: sonnet
+---
+
+# corpus-grounding-expander
+
+Builds or broadens the **grounded axiom** a relay system quotes from. When a system's output must be
+constrained to verbatim source (fail-closed grounding), the corpus IS the axiom — this skill expands
+that corpus from multiple public-domain versions so grounding is robust and non-biased (a quote
+verified in ANY version counts), without ever adding a generator.
+
+> Origin: harvested from the-bible (2026-06-20) — 6 public-domain Bible versions, 197k verses, as the
+> fail-closed grounding axiom. Generalizes to any verbatim-relay corpus (legal statute, RFC text,
+> standards). See `tracks/_contrib/field_harvest_2026-06-20_gate-locality-and-grounding-capabilities.md`.
+
+## Triggers
+- "get more sources" / "broaden the grounded corpus"
+- "add another version of the corpus"
+- "ingest the full <source> as the grounding axiom"
+- `/corpus-grounding-expander {source or version}`
+
+### Natural Language Triggers (example user phrases)
+- "이 코퍼스 여러 버전으로 통째로 가져와줘"
+- "the grounding DB is just a sample — pull the whole thing, multiple editions"
+- "add a second public-domain edition so we're not biased to one"
+
+## Steps
+1. **Source + license check** — identify the public-domain source(s) and confirm each is genuinely
+   free to redistribute. Record the license literally (no assumption).
+2. **Fetch (retry-disciplined)** — pull each version; on transient error, backoff-retry before
+   declaring the source unavailable (do not silently drop a version).
+3. **Normalize to a single key schema** — map every version to the SAME addressable key
+   (e.g. `ref → text`) so cross-version quotation stays aligned. Write per-version files +
+   an `_index` recording version id, license, scope, and record count.
+4. **Wire grounding as a union** — the grounding check passes if the quote matches the canonical text
+   at that key in ANY version. Never add a path that generates text — grounding is quote-only.
+5. **Relay-integrity check** — confirm the consumer (the gate) QUOTES the corpus and cannot emit
+   un-grounded text; run a fabrication probe (a known non-source quote must fail-closed).
+
+## Done When
+- **Each added source carries a verifiable public-domain/license record** in the index. *Check class: mandatory-pass (binary — license field present and non-empty per version).*
+- **Every version is normalized to the same key schema** (cross-version keys align). *Check class: mandatory-pass (a shared sample key resolves in each version or is explicitly canon-scoped).*
+- **The index declares the quote-only union contract** (grounding matches verbatim text in ANY version; no generation path) and ships a fabrication-probe spec for the consumer to run. *Check class: mandatory-pass (binary — quote-only contract + probe-spec present in the index).*
+
+## Guards
+- **Grounding, never a generator** — the relay constraint is structural; this skill wires *grounding*.
+- **License-literal** — record the actual license per source; never assume public-domain.
+- **No silent version drop** — a fetch failure is a named residual in the index, not a quiet omission.
+
+## Independently executable
+Yes — needs only a network fetch + file write. No dependency on other FH skills (a consumer gate that
+reads the corpus is the system's own, not this skill's).

--- a/plugins/fh-meta/skills/persona-roster-expander/SKILL.md
+++ b/plugins/fh-meta/skills/persona-roster-expander/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: persona-roster-expander
+description: Expands a named persona seed into a tiered, judgment-mapped cast — tiering each persona by a domain safety rule, mapping each to a decision-lens in the user's vocabulary, then proposing additional voices with sourced anchors.
+user-invocable: true
+allowed-tools: ["Read", "Grep", "WebSearch", "WebFetch"]
+model: sonnet
+---
+
+# persona-roster-expander
+
+Takes a seed set of named personas and turns it into a usable judgment cast: each persona tiered by a
+domain safety rule, mapped to a concrete decision-lens, plus a few proposed additions filling
+uncovered lenses with real anchors. An innovator-family skill — generative, but bounded by a
+caller-supplied safety rule so the expansion stays faithful to the domain's constraints.
+
+> Origin: harvested from the-bible (2026-06-20) — an operator persona seed (priest/nun/angel/devil/
+> God/Jesus/Holy-Spirit/apostles) tiered relay-vs-lens by a relay-safety rule and mapped to
+> engineering-judgment lenses, +4 sourced proposals. See
+> `tracks/_contrib/field_harvest_2026-06-20_gate-locality-and-grounding-capabilities.md`.
+
+## Triggers
+- "broaden these personas" / "what other voices fit this cast"
+- "map these roles to a decision lens"
+- "expand the persona roster and keep it faithful to <rule>"
+- `/persona-roster-expander {seed personas + domain + safety rule}`
+
+### Natural Language Triggers (example user phrases)
+- "내가 명명한 페르소나 후보군을 더 넓혀줘, 판단 매핑이랑 같이"
+- "take these character archetypes and tell me what engineering judgment each one provides"
+- "add a few more voices that cover a perspective these don't"
+
+## Steps
+1. **Collect the seed + the safety rule** — the named personas, the domain (what decisions they
+   reflect on), and the caller-supplied **tiering rule** (the hard constraint that decides what each
+   persona is allowed to do). Without an explicit safety rule, ask for one — do not invent authority.
+2. **Tier each persona** by the safety rule (e.g. relay/quote-only vs lens/framed-perspective). State
+   a one-line justification per persona; the tier caps what the persona may emit.
+3. **Map each to a decision-lens** in the **user's domain vocabulary** — what concrete judgment-
+   perspective does this voice provide, and when to invoke it. Pair any adversarial voice with a
+   constructive counter-voice (no adversary as the last word).
+4. **Propose 2–4 additions** filling lenses the seed doesn't cover (delegate net-new *name*
+   generation to the `persona-innovator` agent — this skill's distinct value is the tiering +
+   lens-mapping, not naming). For the strongest 2–3, find a real anchor (a sourced
+   example/reference), not a shallow stub.
+5. **Emit the tiered, lens-mapped cast** (named + proposed) as a structured artifact the system can
+   load (e.g. `personas.json`).
+
+## Done When
+- **Every persona has a tier + lens label + invoke-condition.** *Check class: mandatory-pass (binary — all three fields present per persona).*
+- **Each net-new proposal names a real anchor** (not a stub). *Check class: judged, pair: an anchor-existence check (the cited source/reference resolves).*
+- **The tiering respects the caller's safety rule** (no persona exceeds its tier's allowed emission). *Check class: judged, pair: an adversarial read — find a persona whose mapping lets it act beyond its tier.*
+
+## Guards
+- **Caller-supplied safety rule is mandatory** — the skill tiers by the domain's rule, it does not
+  invent one (inventing authority is the failure this guard prevents).
+- **Adversary never last** — any devil's-advocate voice is paired with a constructive counter-voice.
+- **Anchors must be real** — a proposal without a resolvable anchor is a stub, not a candidate.
+
+## Relationship to `persona-innovator` (agent)
+`persona-innovator` *generates* names, frames, and frontier-absorption signals from scratch. This skill
+takes an **existing seed** and adds the **tier-by-safety-rule + lens-to-domain mapping** — it is the
+*structuring/governance* layer, not the *generator*. When net-new names are needed (Step 4), it
+delegates to `persona-innovator` rather than reinventing generation.
+
+## Independently executable
+Yes — needs only the seed + rule + (for anchors) web search. Delegates name *generation* to
+`persona-innovator` when invoked, but has no hard dependency on it for the core tier+lens mapping.

--- a/plugins/fh-meta/skills/steel-quench/SKILL.md
+++ b/plugins/fh-meta/skills/steel-quench/SKILL.md
@@ -135,11 +135,11 @@ Treat the adapter output as the isolated challenger result for Wave 1. This pres
 
 ---
 
-## Wave 1 — 5 Mandatory Attack Angles
+## Wave 1 — 6 Mandatory Attack Angles
 
 **Execution principles**: Attacks must be based on real code/files/configs — abstract criticism prohibited.
 Assign severity: **S** (immediate blocker) / **A** (required before deployment) / **B** (improvement recommended).
-Call **fh-commons:quench-challenger** in isolation first (6-axis structural attack); apply 5 angles in parallel.
+Call **fh-commons:quench-challenger** in isolation first (6-axis structural attack); apply 6 angles in parallel.
 
 Isolation can be achieved by Claude Code `Agent(...)` or by `fh-run --agent fh-commons:quench-challenger` under Codex. Do not run the challenger inline in the same reasoning pass when the attack result gates the defense.
 
@@ -150,6 +150,7 @@ Isolation can be achieved by Claude Code `Agent(...)` or by `fh-run --agent fh-c
 | 3 | **Bus factor** | "Single-person dependency — can it operate if that person is absent?" |
 | 4 | **Platform obsolescence** | "Does this structure survive when the external ecosystem expands or changes?" |
 | 5 | **Self-referential structure** | "Is there a closed circuit that evaluates itself by its own criteria?" |
+| 6 | **Gate-locality** | "Is every safety gate readable by the actor that must enforce it? Name any gate defined only in a file/layer the enforcing runtime never loads (e.g. a rule in a Claude-only `CLAUDE.md` that a Gemini/Codex orchestrator reading `AGENTS.md` never sees; a provenance check described in a doc but absent from the write path)." (see `knowledge/shared/harness-core/gate_locality_principle.md`) |
 
 **S-grade Immediate Human Gate**: If Wave 1 contains 1+ S-grade blocker → pause, surface options (a) proceed to Wave 2 / (b) human review first / (c) abort. Do not silently enter Wave 2 with unreviewed S-grade items.
 

--- a/tracks/_contrib/field_harvest_2026-06-20_gate-locality-and-grounding-capabilities.md
+++ b/tracks/_contrib/field_harvest_2026-06-20_gate-locality-and-grounding-capabilities.md
@@ -1,0 +1,82 @@
+---
+name: field-harvest-2026-06-20-gate-locality-and-grounding-capabilities
+description: 3 generalizable FH-capability candidates harvested from two field-harness governor sessions + the-bible build (HITL — proposal, not yet PR'd)
+type: contrib-candidate
+date: 2026-06-20
+status: DRAFT — awaiting operator PR approval (feedback_no_personal_commit_to_shared_repo)
+tags: [field-harvest, gate-locality, corpus-grounding, persona-roster, hitl]
+originProjects: [two restricted-env field harnesses, the-bible]
+---
+
+# Field-Harvest 2026-06-20 — 3 generalizable patterns → FH capability candidates
+
+Harvested from one session's field work (two field-harness dev-repo governor refactors; the-bible build).
+Each passes the generalization gate (recurs across 2+ contexts OR validated by an FH agent).
+**HITL**: these are *proposals* — AI does not commit to the FH shared repo without operator PR approval.
+
+---
+
+## Candidate 1 — Gate-Locality Principle (governance) → knowledge doc + steel-quench angle
+
+**Pattern**: *A safety gate must live where the actor that needs it actually reads it.* A gate
+defined in a place the enforcing actor never loads is decorative — it provides the *appearance* of
+safety with none of the enforcement.
+
+**Recurrence (generalization gate: 2+ contexts ✓)**:
+- **Harness-A C-1** (code): a tracker-writeback provenance gate was *absent from the write path*
+  (the writeback-candidate generator checked confidence only, not provenance). A self-inferred
+  finding could auto-post to the issue tracker as if externally verified. Fixed by putting the gate
+  *in the code path that writes*.
+- **Harness-B + Harness-A AGENTS.md** (file locality): the orchestration safety gates lived only in
+  Claude-only `CLAUDE.md`, so a Gemini/Codex twin-orchestrator (which auto-loads root `AGENTS.md`,
+  not `CLAUDE.md`) assumed the commander *role* without inheriting the *gates*. Fixed by lifting the
+  gates into a model-agnostic `## Orchestration Gates` section of `AGENTS.md`.
+
+**Validation**: blind target-tier sim (isolated Sonnet, AGENTS.md-only) — pre-hardening the runtime
+had no basis to refuse a hallucinated writeback; post-hardening it refused, citing the lifted gate.
+The delta *is* the principle.
+
+**FH backport**: (a) a `knowledge/shared/harness-core/` doc stating the principle; (b) a
+**steel-quench Wave-1 attack angle**: *"Gate-locality — is every safety gate readable by the actor
+that must enforce it? Name any gate defined only in a file/layer the enforcing runtime never loads."*
+Reuses existing steel-quench machinery; net-new is only the angle.
+
+---
+
+## Candidate 2 — `corpus-grounding-expander` (autonomous corpus expansion)
+
+**Pattern**: on an operator "get more sources / broaden the grounded corpus" intent, an agent fetches
+and **normalizes** multi-version public-domain corpora into a single verified-axiom store (per-version
+provenance + license tag + aligned key schema), so output can be *grounded by verbatim quotation*
+against any version. Demonstrated in the-bible: 6 public-domain Bible versions (197,009 verses,
+Protestant + Catholic + Apocrypha) ingested as the fail-closed grounding axiom; multi-version =
+non-biased + more robust grounding (a quote verified in ANY version counts).
+
+**Done-When**: each added source carries a verifiable public-domain/license record · a normalized key
+schema · a relay-integrity check (corpus is *quoted*, never generated).
+
+**Generalizes beyond scripture** to any verbatim-relay grounded axiom (legal statute, RFC text,
+standards corpus). **Guard**: the expander wires *grounding*, never a generator — relay constraint is
+structural. Reuses fetch+normalize plumbing; net-new = the relay-integrity gate.
+
+---
+
+## Candidate 3 — `persona-roster-expander` (persona auto-expansion + judgment-mapping)
+
+**Pattern** (innovator-family skill): takes a named persona *seed*, then (1) tiers each persona by a
+domain-supplied safety rule, (2) maps each to a concrete decision-lens in the *user's* domain
+vocabulary, (3) proposes 2-4 additional voices filling uncovered lenses, each with a sourced anchor
+for the strongest candidates. Demonstrated in the-bible: operator seed (priest/nun/angel/devil/God/
+Jesus/Holy-Spirit/apostles) → tiered relay-vs-lens by a relay-safety rule, mapped to engineering-
+judgment lenses (devil=failure-mode, solomon=trade-off, job=unexplained-incident, nathan=
+self-accountability), +4 sourced proposals.
+
+**Done-When**: every persona has a tier + lens label + invoke-condition · each net-new proposal names
+a real anchor (not a shallow stub). Reuses FH's naming-taxonomy + adversarial-pairing discipline;
+net-new = the *tier-by-safety-rule + lens-to-domain mapping* step.
+
+---
+
+## Next step (HITL)
+Operator approval → promote 1-3 into FH (Candidate 1 = knowledge doc + steel-quench angle is the
+lowest-friction first PR; 2 & 3 are new skills needing the New-Skill-Creation gate). No PR opened yet.


### PR DESCRIPTION
Field-harvest of 3 generalizable patterns from one session's work (two field-harness governor refactors + the-bible build). HITL — surfaced for review.

## What's in this PR
1. **gate-locality principle** (`knowledge/shared/harness-core/gate_locality_principle.md`) + a new **steel-quench Wave-1 attack angle #6** (gate-locality).
   > "A safety gate must live where the actor that needs it actually reads it."
   Recurred across 2 contexts (a provenance gate missing from a write path; orchestration gates only in a Claude-only file invisible to a Gemini/Codex orchestrator reading `AGENTS.md`). Blind target-tier sim validated the fix. Sibling of judge-robustness/mechanical-anchor.
2. **`corpus-grounding-expander`** skill — autonomous multi-version public-domain corpus expansion as a verbatim-relay grounded axiom (harvested from the-bible: 6 versions, 197k verses).
3. **`persona-roster-expander`** skill — tier a named persona seed by a caller safety rule + map each to a decision-lens (harvested from the-bible's 12-voice cast). Disambiguated from `persona-innovator` (this structures an existing seed; innovator generates).

## Gate results (4-axis, hook-enforced)
- **Axis 1** regression_guard: PASS (additive, no section loss)
- **Axis 2** quench-challenger @opus, 6-angle Wave-1: CONDITIONAL_PASS, 0S/0A/4B — all B fixed (+ a self-introduced steel-quench 5→6 regression fixed)
- **Axis 3** phantom-quench: PASS (all cross-refs resolve)
- **Axis 4** edit-manifest recorded
- **Confidentiality scan**: company tokens generalized (Harness-A/B); clean
- New-Skill gate cleared for both skills (description diet · ≥3 NL triggers · Done-When + check-class · independently-executable · role-dedup <60%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)