### PR TITLE
docs(doctrine): codify Runtime Authority — single governor + routed sidecars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -426,6 +426,8 @@ Self-healing is not only FH-self-dev (Mode D 4-axis) and reactive (`verify-bidir
 
 ## Agent Dispatch Operation (FH cwd-Based)
 
+> **Runtime authority (canonical):** one explicit governor per context + capability-routed sidecars; sidecar findings are evidence candidates, not terminal verdicts, until source-closed by the governor *via a mechanical anchor* — never governor agreement alone. CC=action/governor · Codex=repo-grounded audit sidecar · Gemini/agy=breadth/multimodal sidecar · other runtimes=portable `AGENTS.md` entrypoint only. Full doctrine + Maintenance-Cost Rule: `knowledge/shared/harness-core/multi_model_sidecar_strategy.md §Runtime Authority`.
+
 Default operation is a **standard interactive session**. Agent dispatch (single or parallel) is used when the task warrants it — not as a default mode. Three execution paths:
 
 | Path | Situation | Method |

--- a/knowledge/shared/harness-core/multi_model_sidecar_strategy.md
+++ b/knowledge/shared/harness-core/multi_model_sidecar_strategy.md
@@ -116,6 +116,43 @@ Use the strongest available model as orchestrator; delegate subsidiary tasks to 
 
 This combination can be freely mixed across CLIs — e.g., Gemini Pro orchestrating with Claude Haiku as sidecar, or CC Opus orchestrating with Gemini Flash. FH methodology works regardless of which combination is chosen.
 
+## Runtime Authority — single governor + routed sidecars
+
+> **Canonical doctrine (single source — runtime files point here, do not restate per-runtime).** The
+> main/governor runtime is **context-specific and must be explicit**. Other models are
+> **capability-routed sidecars** unless a document explicitly defines a limited-runtime entrypoint.
+> **Sidecar findings are evidence candidates, not terminal verdicts, until source-closed by the governor
+> *via a mechanical anchor* (a local hit / literal source span / passing gate) — never governor agreement
+> alone** (the no-judge-only-path / mechanical-anchor principle, CLAUDE.md §FH Improvement 4-Axis Auto-Gate).
+
+FH is a **multi-runtime harness with explicit runtime authority**, not Claude-only:
+
+| Runtime | Authority | Fit task-class (aggressive *within* it, not blanket) |
+|---|---|---|
+| **Claude Code** | default **action/governor** — Claude-native automation, hooks, agents, MCP writeback, terminal verdict | orchestration · design-depth · synthesis · the writeback/commit path |
+| **Codex** | **audit / repo-grounded sidecar** | file reads · grep/source-close · diff & patch · gate execution · phantom/backtrace (`fh-run` / `codex exec`). **NOT** discovery/design-depth — below-floor there |
+| **Gemini / agy** | **breadth / multimodal sidecar** | wide alt-generation · multimodal/video/image · exploratory critique · non-code artifacts. Outputs stay **source candidates** until grounded |
+| **Other runtimes** | **portable entrypoint only** (`AGENTS.md`) | apply FH methodology via adapter; do **not** inherit Claude-native automation or writeback authority unless explicitly scoped |
+
+A sidecar is recruited where it adds *decorrelated* value; its ceiling is still set by the governor — the
+harness lifts a model to its own ceiling, it does not move it ([[feedback_harness_ceiling_principle]]).
+"Aggressive" Codex/Gemini use is bounded by the fit task-class above, never a blanket main-seat swap.
+
+**Maintenance-Cost Rule** — a compatibility layer is cheap as a *thin entrypoint*, expensive when it
+*duplicates canonical knowledge*. The test:
+
+| Pattern | Cost | Verdict |
+|---|---|---|
+| Runtime-specific `AGENTS.md` with capability routing + stop lines | Low | ✅ Good |
+| Sidecar-invocation docs pointing to canonical skills/agents | Low | ✅ Good |
+| Generated wrappers with drift checks | Medium | Use only if a need is proven |
+| Manual copies of agent/skill bodies per runtime | High | ✗ Avoid |
+| "Every model can be main" governance language | High (hidden) | ✗ Avoid |
+
+Keep canonical assets **single-source**: the method/agent/skill body lives once; runtime-specific files
+only describe *what auto-loads · what does not · allowed operations · handoff/sidecar invocation · hard
+stop lines*.
+
 ## Scope vs steel-quench Wave 5
 
 This document is the **rationale layer** (why sidecars, when, what value, what boundaries). `steel-quench/SKILL.md` Wave 5 (Multi-Team Adversarial Panel) is the **implementation layer** — the runnable team-formation + parallel-dispatch + cross-team-synthesis steps. They are not redundant: a skill cites this doc for *why* and *when*; Wave 5 (and any other caller) owns the *how*. If the how appears in two places, Wave 5 is canonical and this doc defers to it.


### PR DESCRIPTION
## Summary
Adopts the Codex multi-runtime proposal, **verified as ~85% codification of existing FH stance** (cross_runtime_routing, judge-robustness no-judge-only-path, the AGENTS.md plugin-channel fix in #114) — not a new direction. Gives the distributed doctrine one canonical home + an always-loaded CLAUDE.md summary.

- `multi_model_sidecar_strategy.md` → new **§Runtime Authority**: canonical one-sentence doctrine + runtime-authority table + Maintenance-Cost Rule table.
- `CLAUDE.md §Agent Dispatch` → always-loaded pointer-summary (CC=governor · Codex=repo audit sidecar · Gemini/agy=breadth sidecar · others=AGENTS.md entrypoint).

## 3 review sharpenings (governor-catch, applied)
1. source-close bound to a **mechanical anchor**, never governor agreement alone (matches CLAUDE.md no-judge-only-path).
2. "aggressive" sidecar use scoped to **fit task-class** (Codex=repo-grounded, NOT design-depth/below-floor).
3. **folded into the existing doc**, not a new file (single-source — avoids the proposal's own meta-irony).

## Verification
Axis1 regression PASS · phantom §Runtime-Authority + 8 Detail pointers resolve · Axis2 self-applied 6-angle no-S · **target-tier Sonnet blind sim PASS 0-insufficient** (Sonnet reproduces governor/sidecar roles + "governor agreement alone never sufficient" + the pointer, from CLAUDE.md alone).

PMH/QASP repo alignment is the operator's call in those repos (qasp = corp boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)