### PR TITLE
chore(release): 1.4.42 — ship referenced knowledge/ docs (close npm pointer gap)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,13 @@
   "plugins": [
     {
       "name": "fh-meta",
-      "version": "1.4.41",
+      "version": "1.4.42",
       "description": "Hub meta-operations toolkit — 33 skills + 7 agents. New in 1.4.41: context-doctor 2026 trigger vocab (context engineering/rot/collapse) + phantom-citation hardening; hub measurement-integrity-checklist (cross-model measurement pre-flight: display-name pin/reps≥3/discriminating probe). New in 1.4.40: install-wizard queryable-wiki scaffold (INDEX + session-start read + R/W/C ingest). New in 1.4.39: auto-decorrelation (cross-family verifier sidecar recruitment) + video-ingest (capability-routed video ingestion). New in 1.4.x: verify-axis check-class taxonomy (mandatory-pass/measured/judged), no-reinvention Tier-0 inventory, 7-class failure taxonomy, Destructive-Op Gate, Wave-T (Temper), tier-floor governance, Mode D Model Notice, FC consent lane, default-Sonnet guidance. New in 1.3.0: public-surface-audit, field-harvest Mode B auto-trigger, 4-axis gate scope ext. Validated cross-CLI: Claude Code, Codex, Gemini.",
       "source": "./plugins/fh-meta"
     },
     {
       "name": "fh-commons",
-      "version": "1.4.41",
+      "version": "1.4.42",
       "description": "Project-agnostic utility skills — 4 skills (convergence-loop · deliberation · mcp-circuit-breaker · token-budget-gate) + 1 agent (quench-challenger). Domain-independent utilities transplantable into any project.",
       "source": "./plugins/fh-commons"
     }

--- a/knowledge/shared/harness-core/multi_model_sidecar_strategy.md
+++ b/knowledge/shared/harness-core/multi_model_sidecar_strategy.md
@@ -272,8 +272,8 @@ multimodal "comprehensive read"** as a terminal verdict — a video claim (times
 *claim*, cross-checked on a second surface (e.g. Codex clicking the timestamp, or a caption grep)
 before it anchors a decision (`cross_runtime_routing` debate-loop; judge-robustness "judged →
 mechanical"). claude-video is the *executor* FH lacked; FH's cross-check discipline is the
-*governance* claude-video has no equivalent for — compose, don't trust. (Sister-asset intake:
-`fh-be/paper-signals/sister_2026-06-15_claude-video.md`.)
+*governance* claude-video has no equivalent for — compose, don't trust. (Sister-asset intake
+recorded in the private companion store's sister-asset signals.)
 
 ### Tier-floor resolution — the model dimension (added 2026-06-10)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrono-meta/fh-gate",
-  "version": "1.4.41",
+  "version": "1.4.42",
   "description": "FH runtime adapters — run FH governance, skills, and agents via Claude or Codex with machine-parseable gates.",
   "license": "MIT",
   "keywords": [
@@ -61,7 +61,8 @@
     "plugins/fh-meta/agents",
     "plugins/fh-commons/skills",
     "plugins/fh-commons/agents",
-    "knowledge/shared/harness-core/fh_integration_contract.md",
+    "knowledge/shared/harness-core",
+    "knowledge/shared/dialogue",
     "README.md"
   ]
 }

--- a/plugins/fh-commons/.claude-plugin/plugin.json
+++ b/plugins/fh-commons/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-commons",
-  "version": "1.4.41",
+  "version": "1.4.42",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/.claude-plugin/plugin.json
+++ b/plugins/fh-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-meta",
-  "version": "1.4.41",
+  "version": "1.4.42",
   "engines": {
     "claudeCode": ">=1.0.0"
   },


### PR DESCRIPTION
## Summary
The skill-splitter split (#114) + Runtime Authority doctrine (#115) added `> **Detail**: See knowledge/...` pointers, but `package.json` files[] shipped only ONE knowledge file. On the next npm republish, a Mode-C install would hit **dangling pointers**. Pre-existing gap (npm CLAUDE.md already pointed to ~11 non-shipped knowledge docs); the split widened it.

- **files[]**: ship `knowledge/shared/harness-core` + `knowledge/shared/dialogue` (dir globs — future pointers ship automatically).
- **version 1.4.41 → 1.4.42** in lockstep (package.json + both plugin.json + marketplace.json).
- **Pre-Publish scrub**: generalized one companion-store path literal in `multi_model_sidecar_strategy.md` — caught by the pre-publish surface scan *before* npm amplified an already-public leak.

Verified: npm pack ships all 11 referenced docs · selfcheck PASS · surface scan 0 hits · 4-axis light gate PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)