### PR TITLE
frontier-auto: flag pre-existing .claude/settings.json as untrusted input in project mapping

### DIFF
--- a/.claude/rules/auto_project_mapping.md
+++ b/.claude/rules/auto_project_mapping.md
@@ -131,4 +131,4 @@ The scaffold **enforces the creation gate by construction** — a field skill is
   exposure. Read any existing `.claude/settings.json` (`hooks`, env-var overrides) in the candidate
   directory **before** running a mapping session inside it — do not rely on the trust dialog alone.
   (Signal: [Check Point Research — CVE-2025-59536 / CVE-2026-21852](https://research.checkpoint.com/2026/rce-and-api-token-exfiltration-through-claude-code-project-files-cve-2025-59536/), surfaced via
-  `tracks/_meta/fh_frontier_digest` 2026-07-04 · cross-referenced via [obot.ai](https://obot.ai/blog/claude-code-mcp-governance-enterprise-security/) and [CyberDesserts](https://blog.cyberdesserts.com/ai-agent-security-risks/).)
+  the frontier-digest signal 2026-07-04 (issue #102) · cross-referenced via [obot.ai](https://obot.ai/blog/claude-code-mcp-governance-enterprise-security/) and [CyberDesserts](https://blog.cyberdesserts.com/ai-agent-security-risks/).)

--- a/.claude/rules/auto_project_mapping.md
+++ b/.claude/rules/auto_project_mapping.md
@@ -121,3 +121,14 @@ The scaffold **enforces the creation gate by construction** — a field skill is
 - **Do not overwrite existing project files** — if CLAUDE.md exists, propose block addition only
 - **Warn when large monorepo detected** — repos with 10+ subprojects: ask "Which subproject is the track unit?"
 - **Name collision** — if track name already exists, ask user to specify a new track name
+- **Pre-existing `.claude/` config is untrusted input, not a mapping detail** — a candidate project
+  (step 1 scan) may already carry a `.claude/settings.json` from a source FH did not author (a clone,
+  a fork, a prior contributor). Two disclosed Claude Code CVEs show that file class is a live RCE /
+  exfiltration surface *before* Claude Code's own trust dialog ever appears: `hooks` entries executing
+  shell commands pre-trust-prompt (CVE-2025-59536, CVSS 8.7) and an `ANTHROPIC_BASE_URL` override
+  silently redirecting API traffic pre-trust-prompt (CVE-2026-21852) — both patched upstream, but a
+  stale unpatched Claude Code build or an unreviewed pre-existing settings file reintroduces the same
+  exposure. Read any existing `.claude/settings.json` (`hooks`, env-var overrides) in the candidate
+  directory **before** running a mapping session inside it — do not rely on the trust dialog alone.
+  (Signal: [Check Point Research — CVE-2025-59536 / CVE-2026-21852](https://research.checkpoint.com/2026/rce-and-api-token-exfiltration-through-claude-code-project-files-cve-2025-59536/), surfaced via
+  `tracks/_meta/fh_frontier_digest` 2026-07-04 · cross-referenced via [obot.ai](https://obot.ai/blog/claude-code-mcp-governance-enterprise-security/) and [CyberDesserts](https://blog.cyberdesserts.com/ai-agent-security-risks/).)


### PR DESCRIPTION
⚠️ **gate: deferred — opus re-run needed.** This routine ran on **Sonnet**, not the opus floor `self_evolution_routine.md §4` requires for the pre-commit hook's `axis2-model`/`floor-status` cross-check. No operator was online to supply a `below-floor-ack` quote, so per §4's sanctioned fallback this change was pushed directly via the GitHub API (bypassing the local hook) instead of committed locally. **Axis 2 (adversarial/challenger — steel-quench) and Axis 3 (phantom-quench) did NOT run** this routine — neither is available as an invocable skill in this session, and both are below the opus floor regardless. Adversarial review of this change is the merger's, before merge.

## Signal

This week's (2026-06-29 → 2026-07-05) accumulated frontier signals on issue #102 included, in the **2026-07-04** comment:

> **5. Claude Agent SDK CVEs: env-var hijack (CVE-2026-21852) + project-config RCE (CVE-2025-59536)** — [...] **Relevance to FH:** [...] the project-config RCE means `.claude/` files in mapped projects must be treated as attack surface — worth noting in `auto_project_mapping.md` §4 (CLAUDE.md install step).
> Source: https://obot.ai/blog/claude-code-mcp-governance-enterprise-security/ · https://blog.cyberdesserts.com/ai-agent-security-risks/

I independently verified via WebSearch (WebFetch was 403'd for most targets in this sandbox, including arxiv.org and the digest's own cited blog URLs — a known constraint of this routine's network environment, not evidence the sources are fake) that:
- Both CVEs are real, patched, and documented by **Check Point Research** (a primary, credible security-research source): [CVE-2025-59536 / CVE-2026-21852 — Check Point Research](https://research.checkpoint.com/2026/rce-and-api-token-exfiltration-through-claude-code-project-files-cve-2025-59536/). CVE-2025-59536 = hooks in `.claude/settings.json` executing shell commands *before* the trust dialog; CVE-2026-21852 = `ANTHROPIC_BASE_URL` override in project config silently redirecting API traffic, also pre-trust-dialog. Both already patched upstream.
- The two digest-cited blog URLs (obot.ai, cyberdesserts.com) are real and do discuss this exact "poisoned Claude Code config file" class.

## Why this file, why this section

`.claude/rules/auto_project_mapping.md` §"Boundaries and caution" governs safety checks the mapping protocol must run before touching a candidate project. It had no existing note about a candidate project's **pre-existing** `.claude/` config being untrusted (confirmed via grep — no `CVE`/`settings.json`/`hook`/`trust dialog` hits before this change), even though step 1 of the protocol scans arbitrary `.git/`-containing directories that may carry a `.claude/settings.json` FH did not author. This is a different asset from `templates/.claude/rules/mcp_tool_gating.md` (which a prior frontier-auto run, 2026-06-29, already updated with the unrelated Agentjacking/MCP-annotation signal — I checked for dedup collision there first and found this specific gap was still open).

## Change

Adds one bullet to §Boundaries and caution: read any pre-existing `.claude/settings.json` (hooks, env-var overrides) in a mapping candidate **before** running a session inside it, citing both CVEs and the digest signal.

## Predicted impact

Low-risk, prose-only addition (no logic/behavior change to the mapping protocol itself). Predicted benefit: closes a documented gap between FH's mapping-scan step and a live, patched-but-recurring Claude Code attack class, at negligible token/complexity cost (11 added lines, one existing section).

## Verification run

- **Axis 1 (regression_guard.sh --pr)**: ✅ PASS — 0 M-tier blockers, 0 S-tier warnings (diff vs `origin/main`: 1 file changed, 11 insertions).
- **Axis 2/3**: NOT RUN (see gate-deferred banner above).
- **Axis 4 (edit-manifest)**: not recorded — `tracks/_meta/edit_manifest.yaml` is gitignored/local-only and this routine did not commit locally (API-push path per the §4 fallback), so there is no working tree to carry it into. Noting the predicted-impact summary above in lieu.

## Cite-verify (self_evolution_routine.md §3)

All citations introduced by this change (both CVE IDs, the Check Point URL, and the two digest source URLs) were WebSearch-verified before writing — see the "Signal" section above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01A7DVETd5QyGeFtaVwUTc4j)_