### PR TITLE
feat(codex): add compatibility drift doctor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,8 +138,8 @@ echo "Apply the following skill to the artifact below." | \
 
 | Tier | Definition | Examples |
 |---|---|---|
-| **M1 — Full** | All phases run without CC-native dependencies — no Stop hook, no `.claude/agents/` dispatch, no `/model` | `token-budget-gate`, `asset-placement-gate`, `phantom-quench`, `deep-clarify`, `deliberation`, `convergence-loop` |
-| **M2 — Partial** | Core workflow runs; CC-native phases require manual adaptation or skip | `steel-quench` (Wave 1–3 ✅; quench-challenger agent = manual), `harness-doctor`, `context-doctor`, `sim-conductor`, `harvest-loop` (git scan phase ✅; PR auto-proposal = manual) |
+| **M1 — Full** | All phases run without CC-native dependencies — no Stop hook, no `.claude/agents/` dispatch, no `/model` | `token-budget-gate`, `asset-placement-gate`, `phantom-quench`, `deep-clarify`, `convergence-loop` |
+| **M2 — Partial** | Core workflow runs; CC-native phases require manual adaptation or skip | `deliberation` (Mediator/Jury Agent steps = manual), `steel-quench` (Wave 1–3 ✅; quench-challenger agent = manual), `harness-doctor`, `context-doctor`, `sim-conductor`, `harvest-loop` (git scan phase ✅; PR auto-proposal = manual) |
 | **M3 — CC-only** | Requires CC Stop hook or session-scoped agent dispatch; methodology reference only | `goal-quench` (Phase 3 Stop hook), `hub-cc-pr-reviewer` (CC session context), `install-wizard` (settings.json write) |
 
 **M2 adaptation pattern**: when a step references `Agent(subagent_type=...)` or a slash command, substitute with `fh-run` (preferred) or a direct `codex exec` call reading the sub-agent's SKILL.md — same workflow, different runtime.

--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -197,6 +197,7 @@ FH_BACKEND=codex npx --package @chrono-meta/fh-gate fh-gate   # Codex backend (d
 # Run a skill or agent doc through a backend, outside Claude Code
 npx --package @chrono-meta/fh-gate fh-run --skill <name>
 npx --package @chrono-meta/fh-gate fh-goal "<goal text>"      # goal runner
+npx --package @chrono-meta/fh-gate fh-codex-doctor --strict  # Codex adapter drift check
 ```
 
 | Knob | Values | Effect |

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ forge-harness is structured as **two distinct layers**:
 | Layer | Contents | AI compatibility |
 |---|---|---|
 | **Methodology layer** | `tracks/`, `knowledge/`, `SKILL.md` docs, session protocols | Any AI model |
-| **Automation layer** | `.claude/agents/`, hooks, slash commands, `CLAUDE.md` rules | Claude Code only |
+| **Automation layer** | `plugins/*/agents/` (FH agents), `.claude/agents/` (field-project overrides), hooks, slash commands, `CLAUDE.md` rules | Claude Code only |
 
 The methodology layer is the portable core — persistent hub, accumulating learnings, curating cross-project knowledge. The automation layer makes it frictionless when running Claude Code.
 
@@ -148,6 +148,17 @@ For direct skill or agent execution outside Claude Code, use `fh-run`:
 FH_BACKEND=codex npx --package @chrono-meta/fh-gate fh-run --skill phantom-quench --file docs/foo.md
 FH_BACKEND=codex npx --package @chrono-meta/fh-gate fh-run --agent fh-commons:quench-challenger --file plugins/fh-meta/skills/foo/SKILL.md
 ```
+
+To check whether a changed FH skill/agent surface still has a clean Codex adapter path, run:
+
+```bash
+npx --package @chrono-meta/fh-gate fh-codex-doctor --strict
+```
+
+`fh-codex-doctor` scans the canonical skill/agent registry and reports which units are Codex-native,
+adapter-required, Claude-native, or unclassified. It is a drift detector for the thin adapter boundary;
+it does not try to clone the Claude Code automation layer. When run from an FH checkout it scans the
+current working tree; outside a checkout it scans the installed package.
 
 For Codex-primary work, keep using Codex's native goal/session features when available. `fh-goal` is only a portable wrapper for one-off non-interactive runs that should be followed by FH governance:
 

--- a/bin/fh-codex-doctor.js
+++ b/bin/fh-codex-doctor.js
@@ -1,0 +1,419 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function usage() {
+  process.stdout.write(`Usage:
+  fh-codex-doctor [--root <path>] [--json] [--strict]
+
+Scans FH skills and agents for Codex runtime compatibility drift.
+
+Options:
+  --root <path>  Repository/package root. Defaults to cwd when it looks like FH,
+                 otherwise this package root.
+  --json         Emit machine-readable JSON.
+  --strict       Exit 1 when high-severity drift is found.
+  --help         Show this help.
+`);
+}
+
+function parseArgs(argv) {
+  const out = { root: defaultRoot(), json: false, strict: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      out.help = true;
+    } else if (arg === '--json') {
+      out.json = true;
+    } else if (arg === '--strict') {
+      out.strict = true;
+    } else if (arg === '--root') {
+      i += 1;
+      if (!argv[i]) throw new Error('--root requires a path');
+      out.root = path.resolve(argv[i]);
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return out;
+}
+
+function looksLikeFHRoot(dir) {
+  return exists(path.join(dir, 'package.json')) &&
+    exists(path.join(dir, 'plugins')) &&
+    exists(path.join(dir, 'AGENTS.md'));
+}
+
+function defaultRoot() {
+  const cwd = process.cwd();
+  if (looksLikeFHRoot(cwd)) return cwd;
+  return path.resolve(__dirname, '..');
+}
+
+function readText(file) {
+  return fs.readFileSync(file, 'utf8');
+}
+
+function maybeReadText(file) {
+  try {
+    return readText(file);
+  } catch (_err) {
+    return '';
+  }
+}
+
+function exists(file) {
+  try {
+    fs.accessSync(file, fs.constants.F_OK);
+    return true;
+  } catch (_err) {
+    return false;
+  }
+}
+
+function walk(dir, predicate) {
+  const results = [];
+  if (!exists(dir)) return results;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walk(p, predicate));
+    } else if (!predicate || predicate(p)) {
+      results.push(p);
+    }
+  }
+  return results;
+}
+
+function rel(root, file) {
+  return path.relative(root, file).split(path.sep).join('/');
+}
+
+function parseFrontmatter(text) {
+  if (!text.startsWith('---\n')) return {};
+  const end = text.indexOf('\n---', 4);
+  if (end === -1) return {};
+  const block = text.slice(4, end).split('\n');
+  const out = {};
+  for (const line of block) {
+    const m = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!m) continue;
+    out[m[1]] = m[2].replace(/^["']|["']$/g, '');
+  }
+  return out;
+}
+
+function extractBacktickNames(line) {
+  const names = [];
+  const re = /`([^`]+)`/g;
+  let m;
+  while ((m = re.exec(line)) !== null) {
+    const value = m[1].trim();
+    if (/^[a-z0-9][a-z0-9-]*$/.test(value)) names.push(value);
+  }
+  return names;
+}
+
+function documentedTiers(root) {
+  const sources = [
+    path.join(root, 'AGENTS.md'),
+  ];
+  const tiers = new Map();
+  const evidence = [];
+  for (const source of sources) {
+    const text = maybeReadText(source);
+    if (!text) continue;
+    const lines = text.split('\n');
+    lines.forEach((line, index) => {
+      const tierMatch = line.match(/\|\s*\*\*(M[123])\b/);
+      if (!tierMatch) return;
+      const tier = tierMatch[1];
+      for (const name of extractBacktickNames(line)) {
+        tiers.set(name, { tier, source: rel(root, source), line: index + 1 });
+        evidence.push({ name, tier, source: rel(root, source), line: index + 1 });
+      }
+    });
+  }
+  return { tiers, evidence };
+}
+
+function compatDocTierMentions(root, skillNames) {
+  const source = path.join(root, 'docs', 'codex-compat.md');
+  const text = maybeReadText(source);
+  const mentions = new Map();
+  if (!text) return mentions;
+  const lines = text.split('\n');
+  lines.forEach((line, index) => {
+    const tierMatch = line.match(/\b(M[123])\b/);
+    if (!tierMatch) return;
+    const tier = tierMatch[1];
+    for (const name of extractBacktickNames(line)) {
+      if (!skillNames.has(name)) continue;
+      if (!mentions.has(name)) mentions.set(name, []);
+      mentions.get(name).push({ tier, source: rel(root, source), line: index + 1 });
+    }
+  });
+  return mentions;
+}
+
+const PRIMITIVES = [
+  {
+    id: 'agent-dispatch',
+    severity: 'adapter',
+    regexes: [/Agent\s*\(/, /\bsubagent_type\b/, /\bAgent View\b/, /\bAgent\b tool\b/, /\bAgent invocation instruction\b/, /\bparallel-Agent dispatch\b/],
+  },
+  {
+    id: 'slash-command',
+    severity: 'adapter',
+    regexes: [/(^|[\s`])\/[a-z][a-z0-9-]+(?=($|[\s`),.;:}]))/m],
+  },
+  {
+    id: 'hook',
+    severity: 'claude-native',
+    regexes: [/\bStop hook\b/i, /\bPostToolUse\b/, /\bSessionStart\b/],
+  },
+  {
+    id: 'model-command',
+    severity: 'claude-native',
+    regexes: [/(^|[\s`])\/model\b/m],
+  },
+];
+
+function scanPrimitives(text) {
+  const hits = [];
+  for (const primitive of PRIMITIVES) {
+    for (const regex of primitive.regexes) {
+      const m = regex.exec(text);
+      if (!m) continue;
+      hits.push({
+        id: primitive.id,
+        severity: primitive.severity,
+        line: text.slice(0, m.index).split('\n').length,
+        match: m[0].trim(),
+      });
+      break;
+    }
+  }
+  return hits;
+}
+
+function classify(docTier, primitives) {
+  const hasClaudeNative = primitives.some((p) => p.severity === 'claude-native');
+  const hasAgentDispatch = primitives.some((p) => p.id === 'agent-dispatch');
+  const hasAdapter = primitives.some((p) => p.severity === 'adapter');
+  if (docTier === 'M1' && (hasClaudeNative || hasAgentDispatch)) return 'tier-drift';
+  if (docTier === 'M1') return 'codex-native';
+  if (docTier === 'M2') return 'adapter-required';
+  if (docTier === 'M3') return 'claude-native';
+  if (hasClaudeNative) return 'claude-native-unclassified';
+  if (hasAdapter) return 'adapter-required-unclassified';
+  return 'codex-native-candidate';
+}
+
+function collectSkills(root) {
+  const skillsRoot = path.join(root, 'plugins');
+  const files = walk(skillsRoot, (p) => path.basename(p) === 'SKILL.md');
+  return files.sort().map((file) => {
+    const text = readText(file);
+    const fm = parseFrontmatter(text);
+    const skillName = fm.name || path.basename(path.dirname(file));
+    return {
+      type: 'skill',
+      name: skillName,
+      path: rel(root, file),
+      frontmatter: fm,
+      primitives: scanPrimitives(text),
+    };
+  });
+}
+
+function collectAgents(root) {
+  const agents = [];
+  for (const plugin of ['fh-meta', 'fh-commons']) {
+    const dir = path.join(root, 'plugins', plugin, 'agents');
+    for (const file of walk(dir, (p) => p.endsWith('.md')).sort()) {
+      const text = readText(file);
+      agents.push({
+        type: 'agent',
+        name: path.basename(file, '.md'),
+        path: rel(root, file),
+        plugin,
+        primitives: scanPrimitives(text),
+      });
+    }
+  }
+  return agents;
+}
+
+function loadAgentCards(root) {
+  const file = path.join(root, '.claude', 'registry', 'agent_cards.json');
+  if (!exists(file)) return { present: false, count: 0 };
+  try {
+    const parsed = JSON.parse(readText(file));
+    const count = Array.isArray(parsed)
+      ? parsed.length
+      : (Array.isArray(parsed.agents) ? parsed.agents.length : (parsed.agent_count || Object.keys(parsed).length));
+    return { present: true, path: rel(root, file), count };
+  } catch (err) {
+    return { present: true, path: rel(root, file), error: err.message, count: 0 };
+  }
+}
+
+function buildReport(root) {
+  const docs = documentedTiers(root);
+  const skills = collectSkills(root).map((skill) => {
+    const doc = docs.tiers.get(skill.name);
+    return {
+      ...skill,
+      documentedTier: doc ? doc.tier : null,
+      tierEvidence: doc || null,
+      codexMode: classify(doc && doc.tier, skill.primitives),
+    };
+  });
+  const agents = collectAgents(root);
+  const skillNames = new Set(skills.map((s) => s.name));
+  const compatMentions = compatDocTierMentions(root, skillNames);
+  const findings = [];
+
+  for (const item of skills) {
+    if (item.documentedTier === 'M1') {
+      const bad = item.primitives.filter((p) => p.severity === 'claude-native' || p.id === 'agent-dispatch');
+      if (bad.length > 0) {
+        findings.push({
+          severity: 'HIGH',
+          code: 'M1_HAS_CLAUDE_NATIVE_PRIMITIVE',
+          path: item.path,
+          message: `${item.name} is documented M1 but contains ${bad.map((p) => p.id).join(', ')}`,
+        });
+      }
+    }
+  }
+
+  for (const entry of docs.evidence) {
+    if (!skillNames.has(entry.name)) {
+      findings.push({
+        severity: 'WARN',
+        code: 'DOC_TIER_REFERENCES_MISSING_SKILL',
+        path: `${entry.source}:${entry.line}`,
+        message: `${entry.name} is listed as ${entry.tier} but no matching SKILL.md was found`,
+      });
+    }
+  }
+
+  for (const item of skills) {
+    const mentions = compatMentions.get(item.name) || [];
+    for (const mention of mentions) {
+      if (item.documentedTier && mention.tier !== item.documentedTier) {
+        findings.push({
+          severity: 'HIGH',
+          code: 'CODEX_COMPAT_TIER_DISAGREES_WITH_AGENTS',
+          path: `${mention.source}:${mention.line}`,
+          message: `${item.name} is ${item.documentedTier} in AGENTS.md but ${mention.tier} in docs/codex-compat.md`,
+        });
+      }
+    }
+  }
+
+  const counts = {
+    skills: skills.length,
+    agents: agents.length,
+    modes: {},
+    tiers: { M1: 0, M2: 0, M3: 0, unclassified: 0 },
+    findings: {
+      HIGH: findings.filter((f) => f.severity === 'HIGH').length,
+      WARN: findings.filter((f) => f.severity === 'WARN').length,
+    },
+  };
+  for (const skill of skills) {
+    counts.modes[skill.codexMode] = (counts.modes[skill.codexMode] || 0) + 1;
+    counts.tiers[skill.documentedTier || 'unclassified'] += 1;
+  }
+
+  return {
+    status: findings.some((f) => f.severity === 'HIGH') ? 'DRIFT' : 'OK',
+    root,
+    counts,
+    agentCards: loadAgentCards(root),
+    findings,
+    skills,
+    agents: agents.map((agent) => ({
+      name: agent.name,
+      path: agent.path,
+      plugin: agent.plugin,
+      codexMode: 'adapter-runnable',
+      note: 'Agents are runnable via fh-run --agent or a runtime-specific dispatch adapter; auto-dispatch is host-specific.',
+    })),
+  };
+}
+
+function printText(report) {
+  const lines = [];
+  lines.push('FH Codex Doctor');
+  lines.push(`Status: ${report.status}`);
+  lines.push(`Root: ${report.root}`);
+  lines.push('');
+  lines.push('Summary');
+  lines.push(`- Skills scanned: ${report.counts.skills}`);
+  lines.push(`- Agents scanned: ${report.counts.agents}`);
+  lines.push(`- Documented tiers: M1=${report.counts.tiers.M1} M2=${report.counts.tiers.M2} M3=${report.counts.tiers.M3} unclassified=${report.counts.tiers.unclassified}`);
+  lines.push(`- Codex modes: ${Object.keys(report.counts.modes).sort().map((k) => `${k}=${report.counts.modes[k]}`).join(' ')}`);
+  if (report.agentCards.present) {
+    lines.push(`- Agent cards: ${report.agentCards.count}${report.agentCards.error ? ` (parse error: ${report.agentCards.error})` : ''}`);
+  } else {
+    lines.push('- Agent cards: missing');
+  }
+  lines.push('');
+  lines.push('Findings');
+  if (report.findings.length === 0) {
+    lines.push('- none');
+  } else {
+    for (const finding of report.findings) {
+      lines.push(`- ${finding.severity} ${finding.code} ${finding.path} :: ${finding.message}`);
+    }
+  }
+  lines.push('');
+  lines.push('Codex Runtime Contract');
+  lines.push('- codex-native: run directly with fh-run/codex exec.');
+  lines.push('- adapter-required: core method can run, but Agent/slash steps need adapter substitution.');
+  lines.push('- claude-native: do not auto-pass; require Claude Code host or explicit dedicated adapter.');
+  lines.push('- unclassified modes are drift signals for future manifest backfill.');
+  process.stdout.write(`${lines.join('\n')}\n`);
+}
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    process.stderr.write(`ERROR: ${err.message}\n`);
+    usage();
+    process.exit(11);
+  }
+  if (args.help) {
+    usage();
+    return;
+  }
+  const root = args.root;
+  if (!exists(path.join(root, 'package.json'))) {
+    process.stderr.write(`ERROR: root does not look like a package/repo root: ${root}\n`);
+    process.exit(11);
+  }
+  if (!looksLikeFHRoot(root)) {
+    process.stderr.write(`ERROR: root is missing required FH surfaces (AGENTS.md and plugins/): ${root}\n`);
+    process.exit(11);
+  }
+  const report = buildReport(root);
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    printText(report);
+  }
+  if (args.strict && report.counts.findings.HIGH > 0) {
+    process.exit(1);
+  }
+}
+
+main();

--- a/docs/codex-compat.md
+++ b/docs/codex-compat.md
@@ -2,7 +2,7 @@
 
 > Status: **beta**. This document is beta-removal condition #2 (see `AGENTS.md` → Codex Compatibility → Beta removal conditions). It lists what works, what breaks, and what to expect when applying forge-harness (FH) methodology through OpenAI Codex (`codex exec`) instead of Claude Code.
 
-FH is a 2-layer system: a **methodology layer** (`tracks/`, `knowledge/`, `SKILL.md` docs) that is model-agnostic, and an **automation layer** (Claude Code hooks, `.claude/agents/`, `/model`, settings.json) that is Claude-native. Codex users run the methodology layer by reading `SKILL.md` files directly; automation steps either run through runtime adapters (`fh-gate`, `fh-run`) or require manual substitution.
+FH is a 2-layer system: a **methodology layer** (`tracks/`, `knowledge/`, `SKILL.md` docs) that is model-agnostic, and an **automation layer** (Claude Code hooks, plugin-channel agents under `plugins/*/agents/`, field-project overrides under `.claude/agents/`, `/model`, settings.json) that is Claude-native. Codex users run the methodology layer by reading `SKILL.md` files directly; automation steps either run through runtime adapters (`fh-gate`, `fh-run`) or require manual substitution.
 
 ## Validated invocation pattern
 
@@ -65,6 +65,20 @@ Resolution order:
 | `--agent plugin:name` | `plugins/plugin/agents/name.md` first |
 | `--unit path` | explicit file path |
 
+### `fh-codex-doctor`
+
+`fh-codex-doctor` is the drift detector for the thin Codex adapter boundary. It reads the canonical
+FH skill/agent files plus the documented M1/M2/M3 tier table, then reports which surfaces are
+Codex-native, adapter-required, Claude-native, or unclassified:
+
+```bash
+npx --package @chrono-meta/fh-gate fh-codex-doctor --strict
+```
+
+Use it before promoting a new Codex automation path. Unknown Claude-native primitives fail closed as
+"manual adaptation required" instead of being treated as compatible by default. When run from an FH
+checkout it scans the current working tree; outside a checkout it scans the installed package.
+
 ### `fh-goal`
 
 Codex has native goal/session features. Use those directly when they fit. `fh-goal` is not a replacement for Codex goal; it is a non-interactive wrapper for "run backend task, then run FH governance on changed files":
@@ -92,7 +106,7 @@ Both ran end-to-end with no Claude-native dependency. The M1 tier claim holds fo
 When `codex exec` runs **inside this repo**, FH's Claude-native git/Stop/PostToolUse hooks attempt to fire and emit `hook: Stop Failed` / `hook: PostToolUse Failed` lines interleaved with output. These are **harmless to the skill result** — the skill's verdict is produced correctly — but they are visible noise. Running from a directory **without** FH's `.claude/settings.json` (the normal Codex-user case) avoids them entirely. Filter with `grep -vE "^hook:"` if needed.
 
 ### 2. M2 skills need manual agent substitution
-M2 skills (`steel-quench`, `harness-doctor`, `context-doctor`, `sim-conductor`, `harvest-loop`) have a core workflow that runs under Codex, but any step that dispatches `Agent(subagent_type=...)` or a slash command must be replaced by `fh-run` or a direct `codex exec` call reading the sub-agent's `SKILL.md`/agent `.md` — same workflow, different runtime (the "M2 adaptation pattern" in `AGENTS.md`). Example: `steel-quench` Waves 1–3 run; the `quench-challenger` agent step becomes `fh-run --agent fh-commons:quench-challenger`.
+M2 skills (`deliberation`, `steel-quench`, `harness-doctor`, `context-doctor`, `sim-conductor`, `harvest-loop`) have a core workflow that runs under Codex, but any step that dispatches `Agent(subagent_type=...)` or a slash command must be replaced by `fh-run` or a direct `codex exec` call reading the sub-agent's `SKILL.md`/agent `.md` — same workflow, different runtime (the "M2 adaptation pattern" in `AGENTS.md`). Example: `steel-quench` Waves 1–3 run; the `quench-challenger` agent step becomes `fh-run --agent fh-commons:quench-challenger`.
 
 ### 3. M3 skills do not run automatically under Codex
 M3 skills (`goal-quench` Phase-3 Stop hook, `hub-cc-pr-reviewer` CC session context, `install-wizard` settings.json write) require Claude-Code-native runtime and are **methodology reference only** under Codex unless a dedicated adapter exists. Use Codex's native goal/session features for goal control, and use `fh-gate` after completion for FH quality gating.
@@ -107,8 +121,8 @@ The sibling pattern for Gemini is `gemini -p "$(cat <skill+artifact>)"`. Outside
 
 | Tier | Under Codex | Action |
 |---|---|---|
-| **M1** | Runs fully | `cat SKILL.md artifact \| codex exec -m gpt-5.5 -` |
-| **M2** | Core runs; agent/slash steps via adapter | Substitute each dispatch with `fh-run` or a direct `codex exec` on the sub-agent's `.md` |
+| **M1** | Runs fully (`token-budget-gate`, `asset-placement-gate`, `phantom-quench`, `deep-clarify`, `convergence-loop`) | `cat SKILL.md artifact \| codex exec -m gpt-5.5 -` |
+| **M2** | Core runs; agent/slash steps via adapter (`deliberation`, `steel-quench`, `harness-doctor`, `context-doctor`, `sim-conductor`, `harvest-loop`) | Substitute each dispatch with `fh-run` or a direct `codex exec` on the sub-agent's `.md` |
 | **M3** | Does not run automatically | Use native Codex session features where available; otherwise read as methodology reference or use a dedicated adapter |
 
 ## Beta removal — remaining (external-blocked)

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
   "bin": {
     "fh-gate": "bin/fh-gate.js",
     "fh-run": "bin/fh-run.js",
-    "fh-goal": "bin/fh-goal.js"
+    "fh-goal": "bin/fh-goal.js",
+    "fh-codex-doctor": "bin/fh-codex-doctor.js"
   },
   "scripts": {
-    "prepare": "chmod +x bin/fh-gate.js bin/fh-run.js bin/fh-goal.js scripts/fh-gate.sh scripts/fh-run.sh scripts/fh-goal.sh",
+    "prepare": "chmod +x bin/fh-gate.js bin/fh-run.js bin/fh-goal.js bin/fh-codex-doctor.js scripts/fh-gate.sh scripts/fh-run.sh scripts/fh-goal.sh",
     "test": "bash scripts/selfcheck.sh",
     "prepublishOnly": "bash scripts/selfcheck.sh && bash scripts/public_surface_scan_files.sh",
     "release": "bash scripts/public_surface_scan_files.sh && npm publish"
@@ -45,10 +46,13 @@
   },
   "files": [
     "AGENTS.md",
+    ".claude-plugin/marketplace.json",
     "CATALOG.md",
     "CHEATSHEET.md",
     "CLAUDE.md",
+    ".claude/registry/agent_cards.json",
     "docs/CONTRIBUTING.md",
+    "bin/fh-codex-doctor.js",
     "bin/fh-gate.js",
     "bin/fh-run.js",
     "bin/fh-goal.js",
@@ -57,9 +61,13 @@
     "scripts/fh-gate.sh",
     "scripts/fh-run.sh",
     "scripts/fh-goal.sh",
+    "scripts/count_check.sh",
     "scripts/selfcheck.sh",
+    "templates/local_fh_context.md",
+    "plugins/fh-meta/.claude-plugin/plugin.json",
     "plugins/fh-meta/skills",
     "plugins/fh-meta/agents",
+    "plugins/fh-commons/.claude-plugin/plugin.json",
     "plugins/fh-commons/skills",
     "plugins/fh-commons/agents",
     "knowledge/shared/harness-core",

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -25,6 +25,11 @@ for f in bin/*.js; do
   check "node --check $f" node --check "$f"
 done
 
+# Codex adapter drift: the thin Codex runtime must keep reading canonical FH
+# skill/agent surfaces without silently accepting Claude-native primitives as
+# Codex-native.
+check "fh-codex-doctor --strict" bash -c 'node bin/fh-codex-doctor.js --strict >/dev/null'
+
 # Bash surface: npm-shipped scripts + local bin wrappers + gate-chain infra
 for f in scripts/*.sh bin/fh-gate bin/fh-run bin/fh-goal \
          templates/regression_guard.sh templates/temper_check.sh templates/predelete_check.sh templates/.git-hooks/pre-commit; do
@@ -43,26 +48,28 @@ if ! bash scripts/count_check.sh; then
   fail=1
 fi
 
-# Referenced-path existence: backtick-quoted repo-relative file refs in the always-loaded
-# governance surface (CLAUDE.md + .claude/rules/*.md) must exist. Phantom-reference class
-# recurred N>=3 in the 2026-06-11 audit window (operations.md _scanner.sh, claude-chrono path,
-# stale templates ref) — instrument-not-habit. Globs/placeholders/{vars} are excluded by the
-# filter; tracks/ is machine-local and deliberately out of scope. Gitignored refs (e.g.
-# `.claude/settings.json` named in prose *about* gitignored files) are skipped — they exist
-# locally but not on a fresh clone, and "must exist" here means "must ship".
-while IFS= read -r p; do
-  if git check-ignore -q "$p" 2>/dev/null; then
-    echo "SKIP  ref-path (gitignored): $p"
-  elif [ -f "$p" ]; then
-    echo "PASS  ref-path: $p"
-  else
-    echo "FAIL  ref-path: $p — referenced in CLAUDE.md/.claude/rules but missing"
-    fail=1
-  fi
-done < <(grep -hoE '\`[^\` ]+\`' CLAUDE.md .claude/rules/*.md 2>/dev/null \
-  | sed 's/\`//g' \
-  | grep -E '^(knowledge|templates|scripts|docs|plugins|\.claude)/[^*{}<>$]+\.(md|sh|ya?ml|jsonc|json)$' \
-  | sort -u)
+# Referenced-path existence is a source-tree check. The npm package intentionally
+# ships a narrower runtime surface, so package-mode selfcheck skips this section.
+if [ -d ".claude/rules" ]; then
+  # Backtick-quoted repo-relative file refs in the always-loaded governance surface
+  # (CLAUDE.md + .claude/rules/*.md) must exist. Phantom-reference class recurred
+  # N>=3 in the 2026-06-11 audit window — instrument-not-habit.
+  while IFS= read -r p; do
+    if git check-ignore -q "$p" 2>/dev/null; then
+      echo "SKIP  ref-path (gitignored): $p"
+    elif [ -f "$p" ]; then
+      echo "PASS  ref-path: $p"
+    else
+      echo "FAIL  ref-path: $p — referenced in CLAUDE.md/.claude/rules but missing"
+      fail=1
+    fi
+  done < <(grep -hoE '\`[^\` ]+\`' CLAUDE.md .claude/rules/*.md 2>/dev/null \
+    | sed 's/\`//g' \
+    | grep -E '^(knowledge|templates|scripts|docs|plugins|\.claude)/[^*{}<>$]+\.(md|sh|ya?ml|jsonc|json)$' \
+    | sort -u)
+else
+  echo "SKIP  ref-path (package mode: .claude/rules absent)"
+fi
 
 if [ "$fail" -ne 0 ]; then
   echo "SELFCHECK: FAIL"


### PR DESCRIPTION
## Summary
- Add `fh-codex-doctor`, a thin Codex compatibility drift gate for FH skills/agents.
- Wire the doctor into `package.json`, `npm test`, and package-mode selfcheck.
- Update README/CHEATSHEET/AGENTS/Codex docs to reflect the adapter boundary and the `deliberation` M2 tier correction.

This does **not** claim full Claude Code automation parity. It makes the Codex path maintainable by checking the documented skill tier map, package surface, agent card mirror, and Claude-native primitive drift before release.

Refs #72.

## Validation
- `node --check bin/fh-codex-doctor.js`
- `node bin/fh-codex-doctor.js --strict`
- invalid `--root` exits 11
- `npm test`
- extracted `npm pack` package, then `npm test`
- `git diff --check`
- split Codex `fh-gate` code/package verdict: PASS
- split Codex `fh-gate` docs/AGENTS verdict: PASS
- FH 4-axis pre-commit gate: PASS

## Sidecar Review
Claude Sonnet sidecar reviewed the tracked diff and returned:
- Blockers: none
- Verdict: ship

Non-blocking notes addressed here: removed dead `lineOf()` helper and added `fh-codex-doctor` to CHEATSHEET.