### PR TITLE
ship-readiness gate + governance dominance benchmark (rounds 1-2) + degrade-scan probes E/F

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,15 +224,18 @@ The broader FH automation layer still depends on Claude Code for sub-agents, hoo
 
 **Empirical result (2026-05-31)**: Applied to OpenCode's AI-generated `permission/arity.ts` (163 lines, CI green). Current gate semantics classify this as BLOCKED: 2 A-grade findings CI didn't catch (short-token overflow in allowlist, executor tools absent from arity table).
 
-**Does the method actually add anything? A small measured check (2026-07-14).** On five unseen gate/verdict
-snippets — four with a planted *default-toward-PASS* (fail-open) hole, one correct-but-tempting control —
-we held the model fixed at a mid-tier floor and varied only the review *method*. A plain review caught 3/5
-(it missed the subtlest fail-open, distracted by a flashier secondary bug, and raised a false alarm on the
-correct control). The same model with FH's degrade-direction lens caught 5/5 with zero false alarms. The
-honest read: obvious fail-opens get caught either way — the method's value shows up on the *subtle* hole and
-in *not* crying wolf on correct code, and the gap is a method effect, not a bigger model. It is a small
-sample (n=5, single draw), and a decisive margin would need harder holes; we publish the number as-is rather
-than a rounder one. Method + reproduction: [`ship_readiness_gate.md`](knowledge/shared/harness-core/ship_readiness_gate.md).
+**Does the method actually add anything? A measured check (2026-07-14).** We held the model fixed at a
+mid-tier floor and varied only the review *method*, on unseen gate snippets with planted *default-toward-PASS*
+(fail-open) holes. On eight subtle holes — authored by two other models so the test set wasn't tuned to our
+method — a plain review caught 5/8 (and two of those "catches" were the wrong bug, i.e. false confidence);
+the same model with FH's degrade-direction lens caught 6/8 with zero false alarms. The honest part: **both
+single-model lanes missed the same two holes** (a falsy error-sentinel, and a separator-negation parse). A
+different model family, same lens, caught both — so the FH *stack* (lens + cross-family + a mechanical
+pre-screen) reaches 8/8. The takeaway isn't a headline score; it's that the value comes from the
+**decorrelated stack**, because even a well-prompted single model has a correlated blind spot that only a
+different family closes. The two missed classes are now caught mechanically (a lint pre-screen), one layer
+earlier. Small sample (single draw); reps and harder holes are the stated next step. Method + full result:
+[`ship_readiness_gate.md`](knowledge/shared/harness-core/ship_readiness_gate.md).
 
 Full spec: [`fh_integration_contract.md`](knowledge/shared/harness-core/fh_integration_contract.md)
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,16 @@ The broader FH automation layer still depends on Claude Code for sub-agents, hoo
 
 **Empirical result (2026-05-31)**: Applied to OpenCode's AI-generated `permission/arity.ts` (163 lines, CI green). Current gate semantics classify this as BLOCKED: 2 A-grade findings CI didn't catch (short-token overflow in allowlist, executor tools absent from arity table).
 
+**Does the method actually add anything? A small measured check (2026-07-14).** On five unseen gate/verdict
+snippets — four with a planted *default-toward-PASS* (fail-open) hole, one correct-but-tempting control —
+we held the model fixed at a mid-tier floor and varied only the review *method*. A plain review caught 3/5
+(it missed the subtlest fail-open, distracted by a flashier secondary bug, and raised a false alarm on the
+correct control). The same model with FH's degrade-direction lens caught 5/5 with zero false alarms. The
+honest read: obvious fail-opens get caught either way — the method's value shows up on the *subtle* hole and
+in *not* crying wolf on correct code, and the gap is a method effect, not a bigger model. It is a small
+sample (n=5, single draw), and a decisive margin would need harder holes; we publish the number as-is rather
+than a rounder one. Method + reproduction: [`ship_readiness_gate.md`](knowledge/shared/harness-core/ship_readiness_gate.md).
+
 Full spec: [`fh_integration_contract.md`](knowledge/shared/harness-core/fh_integration_contract.md)
 
 ---

--- a/knowledge/shared/harness-core/ship_readiness_gate.md
+++ b/knowledge/shared/harness-core/ship_readiness_gate.md
@@ -1,0 +1,104 @@
+# Ship-Readiness Gate — Identity All-Green as the Release Condition
+
+> **What this is**: the release gate for a harness (FH itself, or any field harness it incubates). A
+> harness **ships** — and earns a **formal release tag** — only when the identities that define it are
+> **all-green**: each proven REALIZED by a concrete track-record artifact (n≥1), not merely documented.
+> This is the "품질보증서 (quality-assurance certificate)" the operator asked for: it certifies the
+> harness does what its identity claims, with evidence, before it goes out. Origin: the 2026-07-14
+> identity-fulfillment audit (`tracks/_meta/identity_audit_2026-07-14.md`).
+
+## Why an identity gate, not a feature checklist
+A harness is a means, not a feature list. Shipping it means promising it *does what its identity claims*.
+A feature can be present yet the identity still be 이상론 (aspirational) — e.g. an incubator with a runner
+but zero real emits. So the gate scores **identities by evidence**, and the honest states are:
+
+| Status | Meaning | Bar |
+|---|---|---|
+| 🟢 GREEN | **REALIZED** | a concrete track-record artifact proves the identity fired for real, n≥1 (a real gate block, a measured probe, a real orchestration record) — *not* a doc that describes it |
+| 🟡 YELLOW | **PARTIAL** | pieces work but no single closed track record (e.g. two half-pipelines that never connected end-to-end) |
+| 🔴 RED | **이상론 (ideal-only)** | documented aspiration, never actually run; or the source itself says "not built yet / named target" |
+
+**All-green rule**: ship + tag only when **every** identity is 🟢. A 🟡 or 🔴 blocks the tag — and names
+exactly what real run is missing. The remedy for RED is never to relabel it green; it is to **run it and
+leave the artifact** (the operator's standing rule: "이상론이면 실제로 돌려봐서 실적을 남겨야 한다").
+
+## Dominance, not concession — the AlexNet bar
+A harness earns the right to say "we compose with other harnesses" **only from proven dominance**, never
+as a humble concession. The reference is AlexNet: on data it had never seen, it did not *participate* — it
+**crushed every competitor**. That is the bar for a shippable identity: on unseen input, in a head-to-head
+against the realistic alternative (a plain single-model session, a competing harness's flow), our harness
+must **decisively win**, not merely tie or "also work."
+
+The composition identity (멀티하네스 클러스터) is downstream of this: we equip *other* harnesses onto the
+parts **we deliberately chose not to cover, or left general-purpose** — a decision made from strength, after
+proving we would win the parts we do cover. Composing because we *can't* win is weakness wearing the costume
+of humility; composing because we *choose* the frontier and hand the rest to specialists is dominance.
+
+**The squirrel-and-equipment shape (operator, 2026-07-14)**: the squirrel (🐿️ FH) dons **specialized gear**
+for a specific harness/project — micro-work can't be done barehanded, and the gear (a field/domain harness)
+makes it easier and more specialized. But **the squirrel itself must be an all-rounder master** at the one
+thing it does everywhere: *creating and accelerating harnesses*. The mastery is the squirrel (general,
+must-dominate — the governance/quality/harness-craft); the specialization is the equipment (per-domain,
+composed-in). You never concede the craft; you equip for the domain. So the dominance bar applies to the
+**craft** (does FH out-govern / out-build any alternative on unseen ground?), and composition applies to the
+**gear** (which specialist harness to bolt on for this domain's micro-work).
+
+**First dominance result (governance craft, 2026-07-14)** — `tracks/_meta/dominance_benchmark_2026-07-14.md`.
+Model held fixed at the Sonnet floor; only the harness *method* varied. On unseen gate code with planted
+fail-open holes: FH's degrade-direction method **5/5 (100%, 0 false-positive)** vs a plain no-lens review
+**3/5 (1 missed fail-open + 1 false-alarm on correct code)**. The harness took the same floor-tier model from
+60%→100% — dominance isolated as *method*, not model. Honest scope: obvious fail-opens are caught by both;
+the harness's decisive win is concentrated on the **subtle** hole (attention held on the degrade direction)
+and on **not crying wolf** on correct fail-closed code. A true AlexNet-scale blowout needs subtler holes —
+which is exactly the diagnostic direction (where the gap does NOT yet widen tells us where to sharpen).
+
+**Gate consequence**: each 🟢 identity should carry not just an existence artifact (n≥1) but, where a
+competitor exists, a **dominance result** — a measured head-to-head where our harness catches / completes /
+survives what the alternative misses. The governance identity already has one (blind cross-family: FH's gate
+the *only* thing that caught the irreversibility/safety class; competitors HITL 8/8 ABSENT). The others owe
+theirs. A dominance benchmark is also *diagnostic*: where we do NOT yet dominate tells us exactly where to go
+next (the operator: "압도성을 결과로 봐야 앞으로 나아갈 방향을 안다").
+
+## The gate is the audit method (reusable)
+Score with the same triangulation the 2026-07-14 audit used — no single-source self-attestation:
+1. **Cross-family falsifiable checklist** — draft the per-identity PASS criteria with ≥2 decorrelated
+   models (e.g. Fable higher-tier + Codex cross-family); they must converge on the load-bearing checks.
+2. **Origin-grounding** — for each identity, quote its *original intent* from the accumulated record
+   (memory / tracks / companion store) and find the artifact that proves it fired (or prove none exists).
+3. **Blind floor-tier probe** — for any identity whose value is "intent-based autonomous completion"
+   (a user gets the value by intent, without naming the skill), *measure* it: blind Sonnet sessions given
+   novice-vocabulary intents, scored on whether the right skill/gate fires. Salience-only ≠ measured.
+
+## Versioning policy — the formal release track
+The formal release tag is **independent of the npm package version**. The npm version (currently in the
+`1.4.x` range) is the **plugin-cache lockstep number** — it bumps on every shipped-asset change so Codex/
+marketplace cache-invalidate; it is not a maturity claim. The **formal identity-maturity release starts at
+`v0.1.0`** and advances only when the ship-readiness gate goes all-green. `v0.1.0` = "the first release
+whose every identity is proven, not aspirational." Do not conflate the two counters; a high npm number does
+not make the harness `v1.0`.
+
+## FH's own status (2026-07-14) — NOT yet all-green
+
+| # | Identity | Status | Evidence / what's missing |
+|---|---|---|---|
+| ③ | 거버넌스 게이트 (governance) | 🟢 GREEN | pre-commit/pre-push physically block; moat measured 3–4 family blind (HITL 8/8 ABSENT); cross-family caught a real companion-store-name leak 2026-07-14 (fail-closed) |
+| ⑤ | 증폭자 (amplifier) | 🟢 GREEN | short-intent→literature-grounding→ultimate-doc real instances; rules-diet −18.2k measured; intent-routing probe 94% (below) |
+| ④ | 프런티어→조직 전파 | 🟡 YELLOW | frontier-digest launchd auto + AX submission docs both real, but digest→org never closed as ONE pipeline |
+| ① | 멀티하네스 클러스터 (연속경유) | 🔴 RED | mapping/routing materials work, but continuous relay channel + external-harness recommend are "not built yet" (source-admitted); cluster-wizard parked |
+| ② | 프로젝트 인큐베이터 (챔버 EMIT) | 🔴 RED | chamber ran 3×, but **EMIT 0× (2/2 KILL)** — the chamber *screens*, has not *birthed*. Runner wired, autonomous emit is not |
+
+**Cross-cutting measured (intent-based autonomous completion)**: blind floor-tier Sonnet trigger-accuracy
+probe (n=10, 2026-07-14): **should-fire 7.5/8 (94%), false-fire 0/2**. One weak trigger (simulate-first /
+incubator entry absorbed into deep-clarify) — the identity-② weakness surfaces in routing too.
+
+**Verdict**: FH is **not shippable as v0.1.0 yet** — ①② are RED, ④ is YELLOW. The formal `v0.1.0` tag is
+reserved for the moment all five go 🟢. What's blocking is **real runs, not wiring**: ①'s live 2-node
+orchestration, ②'s first EMIT-worthy chamber run, ④'s closed digest→org pipeline. Each remedy is a run
+that leaves an artifact, tracked in `tracks/_meta/identity_audit_*.md`.
+
+## For a field harness (e.g. pmh, qasp)
+Same gate, its own identities. A field harness ships to its team when its identity checklist is all-green,
+certified by a **실증상세 (demonstration-detail) doc in that harness's own repo** — the QA certificate
+listing each identity, its PASS criterion, and the artifact proving it. FH≡field parity: what FH proves
+about itself, a field harness proves about itself, by the same method. (Company-residency: a field
+harness's 실증상세 lives in its own private repo; FH holds only the method, never the field's evidence.)

--- a/knowledge/shared/harness-core/ship_readiness_gate.md
+++ b/knowledge/shared/harness-core/ship_readiness_gate.md
@@ -43,14 +43,25 @@ composed-in). You never concede the craft; you equip for the domain. So the domi
 **craft** (does FH out-govern / out-build any alternative on unseen ground?), and composition applies to the
 **gear** (which specialist harness to bolt on for this domain's micro-work).
 
-**First dominance result (governance craft, 2026-07-14)** — `tracks/_meta/dominance_benchmark_2026-07-14.md`.
-Model held fixed at the Sonnet floor; only the harness *method* varied. On unseen gate code with planted
-fail-open holes: FH's degrade-direction method **5/5 (100%, 0 false-positive)** vs a plain no-lens review
-**3/5 (1 missed fail-open + 1 false-alarm on correct code)**. The harness took the same floor-tier model from
-60%→100% — dominance isolated as *method*, not model. Honest scope: obvious fail-opens are caught by both;
-the harness's decisive win is concentrated on the **subtle** hole (attention held on the degrade direction)
-and on **not crying wolf** on correct fail-closed code. A true AlexNet-scale blowout needs subtler holes —
-which is exactly the diagnostic direction (where the gap does NOT yet widen tells us where to sharpen).
+**Dominance result (governance craft, 2026-07-14)** — `tracks/_meta/dominance_benchmark_2026-07-14.md`.
+Model held fixed at the Sonnet floor; only the harness *method* varied. Two rounds:
+- **Round 1 (5 easy holes)**: FH degrade-lens **5/5 (0 FP)** vs plain review **3/5** (1 miss + 1 false-alarm).
+  Honest read: obvious fail-opens are caught by both — the lens's edge showed only on the subtle hole and
+  in not crying wolf. Not a blowout; it pointed to harder holes as the real test.
+- **Round 2 (8 subtle holes, authored by Fable + Codex — decorrelated from the method under test)**: plain
+  review **5/8** (and 2 of its "catches" were distractor mis-identifications = false confidence, worse than
+  a clean miss); degrade-lens **6/8, 0 FP**; and critically **both single Sonnet lanes missed the same 2
+  holes** (a falsy-error-sentinel return, and a separator-negation parse). A **cross-family (Codex) lane
+  with the same lens caught both** — the correlated blind spot inside one model family, closed only by a
+  *different* family. **FH stack (degrade-lens ∪ cross-family) = 8/8, 0 FP.**
+
+The load-bearing finding is architectural, not a headline number: **dominance comes from the decorrelated
+stack (`degrade-lint ∪ cross-family ∪ mechanical-anchor`), not from any single clever reviewer** — even a
+well-prompted floor model has a correlated blind spot that only a different family closes. This is the
+*empirical* basis for why FH is a stack, not a prompt. And the two blind-spot classes round 2 exposed were
+**immediately mechanized** — `degrade_direction_scan.sh` probes E (falsy-sentinel→PASS) and F
+(split-positional-verdict) now flag both at the pre-lens layer (0 false-positive on the FH codebase), so the
+correlated miss is caught one layer earlier. Forward direction: more such classes, and reps≥3 to fix the numbers.
 
 **Gate consequence**: each 🟢 identity should carry not just an existence artifact (n≥1) but, where a
 competitor exists, a **dominance result** — a measured head-to-head where our harness catches / completes /

--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -204,3 +204,9 @@
   target: "Autonomous Initiative routing table — does a novice-vocabulary intent fire the right skill/gate without naming it, on the Sonnet floor"
   outcome: accepted
   note: "should-fire 7.5/8 (94%) + false-fire 0/2. HITs: cross-project-skill-bus, pre-publish-gate, destructive-op(predelete ACTUALLY RAN → 3 REVIEW branches, caught unmerged goal-quench branch via memory cross-ref), frontier-digest(surfaced today's launchd digest, no re-run, +GRACE sister catch), deep-clarify ×2, context-doctor, field-harness-diagnostic. no-fire correct on 2 trivial edits (no skill spam). ONLY miss P2: simulate-first(incubator entry) absorbed into deep-clarify on textbook uncertain+failure-expensive utterance — identity-2 weakest trigger, measured. n=1 borderline → reps≥3 follow-up. Artifact: tracks/_meta/identity_audit_2026-07-14.md."
+- date: 2026-07-14
+  skill: "dominance HARD benchmark — Fable+Codex(hole authors, decorrelated) + 20× claude -p sonnet blind lanes + codex cross-family"
+  context: "materialize 'forward direction' — subtler fail-open holes to show decisive dominance; operator: 패이블 gpt로 열어젖혀라, fh/pmh/docs 반영"
+  target: "governance craft dominance + degrade_direction_scan probes E/F"
+  outcome: accepted
+  note: "8 subtle holes (Fable 4 + Codex 4, test-set author ≠ method = decorrelated). plain 5/8 (2 distractor mis-ID) · degrade-lens 6/8 0-FP · both Sonnet lanes missed f2(falsy-sentinel)+c3(sep-negation) · cross-family codex caught both → STACK 8/8. Finding: dominance is architectural (decorrelated stack, not single lens). MATERIALIZED: degrade_direction_scan.sh probes E+F catch f2+c3 mechanically, 0-FP on FH scripts, templates synced. Reflected: dominance artifact round-2, ship_readiness_gate, README, AX qasp_실증이력, pmh 실증상세."

--- a/scripts/degrade_direction_scan.sh
+++ b/scripts/degrade_direction_scan.sh
@@ -89,6 +89,24 @@ for f in "${FILES[@]}"; do
   done < <(grep -nE '^[[:space:]]*(if|elif|return|assert|while)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]+in[[:space:]]+[A-Za-z_][A-Za-z0-9_.]*[[:space:]]*[:)]?[[:space:]]*$' "$f" 2>/dev/null \
            | grep -vE '\bfor\b|in range|in enumerate|not in' \
            | grep -vE '\b(verdict|present|ground|state|match|expected)\w*\b')
+
+  # Probe E — negated-falsy guard returning permissive (dominance-benchmark round-2 f2 class): an error
+  # SENTINEL (None / {} / "" / []) is falsy, so `if not X: return <PASS>` treats "the check errored / never
+  # ran" identically to "the check ran and found nothing clean". Distinguish errored from clean before allowing.
+  while IFS= read -r ln; do
+    emit "$f" "$ln" "E:falsy-sentinel→PASS" "negated-falsy guard returns permissive — a falsy error sentinel (None/{}/'') masquerades as 'clean'; a gate must distinguish 'errored/absent' from 'verified clean'"
+  done < <(grep -nE -A2 '^[[:space:]]*if[[:space:]]+not[[:space:]]+[A-Za-z_][A-Za-z0-9_.]*[[:space:]]*:' "$f" 2>/dev/null \
+           | grep -E "return[[:space:]]+$PASS([[:space:],)]|$)" | grep -oE '^[0-9]+' | sort -u | sed 's/$/:/')
+
+  # Probe F — positional field-select from a split result feeding a decision (round-2 c3 class): taking the
+  # decision from `parts[-1]`/`parts[0]` of an attacker-influenceable split lets a crafted field (e.g. a
+  # signed DENY whose free-form comment ends "::ALLOW") negate the verdict. Validate structure, don't select by position.
+  if grep -qE '\.r?split\(' "$f" 2>/dev/null; then
+    while IFS= read -r m; do
+      emit "$f" "${m%%:*}" "F:split-positional-verdict" "decision taken by position ([-1]/[0]) from a split result — an attacker-controlled trailing/leading field can negate the verdict; validate structure, don't select by position"
+    done < <(grep -nE '\[[[:space:]]*-?[01][[:space:]]*\]' "$f" 2>/dev/null \
+             | grep -iE 'decision|verdict|allow|deny|approv|grant|status|result|policy')
+  fi
 done
 
 echo "----"

--- a/templates/degrade_direction_scan.sh
+++ b/templates/degrade_direction_scan.sh
@@ -89,6 +89,22 @@ for f in "${FILES[@]}"; do
   done < <(grep -nE '^[[:space:]]*(if|elif|return|assert|while)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]+in[[:space:]]+[A-Za-z_][A-Za-z0-9_.]*[[:space:]]*[:)]?[[:space:]]*$' "$f" 2>/dev/null \
            | grep -vE '\bfor\b|in range|in enumerate|not in' \
            | grep -vE '\b(verdict|present|ground|state|match|expected)\w*\b')
+
+  # Probe E — negated-falsy guard returning permissive: a falsy error sentinel (None/{}/"") makes
+  # `if not X: return <PASS>` treat "errored/never-ran" as "clean". Distinguish errored from clean.
+  while IFS= read -r ln; do
+    emit "$f" "$ln" "E:falsy-sentinel→PASS" "negated-falsy guard returns permissive — a falsy error sentinel (None/{}/'') masquerades as 'clean'; a gate must distinguish 'errored/absent' from 'verified clean'"
+  done < <(grep -nE -A2 '^[[:space:]]*if[[:space:]]+not[[:space:]]+[A-Za-z_][A-Za-z0-9_.]*[[:space:]]*:' "$f" 2>/dev/null \
+           | grep -E "return[[:space:]]+$PASS([[:space:],)]|$)" | grep -oE '^[0-9]+' | sort -u | sed 's/$/:/')
+
+  # Probe F — positional field-select from a split feeding a decision: `parts[-1]`/`parts[0]` of an
+  # attacker-influenceable split lets a crafted trailing/leading field negate the verdict.
+  if grep -qE '\.r?split\(' "$f" 2>/dev/null; then
+    while IFS= read -r m; do
+      emit "$f" "${m%%:*}" "F:split-positional-verdict" "decision taken by position ([-1]/[0]) from a split result — an attacker-controlled trailing/leading field can negate the verdict; validate structure, don't select by position"
+    done < <(grep -nE '\[[[:space:]]*-?[01][[:space:]]*\]' "$f" 2>/dev/null \
+             | grep -iE 'decision|verdict|allow|deny|approv|grant|status|result|policy')
+  fi
 done
 
 echo "----"


### PR DESCRIPTION
Three commits from the identity-audit → dominance follow-through.

- **`a1d030a`** ship_readiness_gate.md — identity all-green as the release condition; formal v0.1.0 tag independent of the npm plugin-cache version. Dominance-not-concession principle (squirrel = all-rounder harness-craft master; field harnesses = the equipment).
- **`0bc93ff`** README humble measured-evidence block in the governance-layer section.
- **`7470925`** dominance benchmark round 2 + degrade-scan probes E/F.

**Result (honest, model-fixed at Sonnet floor):** on 8 subtle fail-open holes authored by Fable + Codex (decorrelated from the method), plain review 5/8 (2 = distractor false-confidence), degrade-lens 6/8 zero-FP; **both single Sonnet lanes missed the same 2** (falsy-sentinel, separator-negation); a cross-family lane caught both → **stack 8/8**. Load-bearing finding: dominance is architectural (decorrelated stack), not a single lens. The 2 blind-spot classes are now mechanized as `degrade_direction_scan.sh` probes E/F (tested: catch them, 0 FP on the FH codebase; templates/ synced).

Not a blowout, single-draw sample, reps≥3 = stated next step. No dressing-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)