### PR TITLE
docs: FH v0.1.0 honest baseline + chamber run #5 measured EMIT-worthiness screen

### DIFF
--- a/knowledge/shared/harness-core/harness_incubator_doctrine.md
+++ b/knowledge/shared/harness-core/harness_incubator_doctrine.md
@@ -99,6 +99,20 @@ this chamber's field emit terminus); an **FH-internal utility** (a skill/script/
 field harness) instead routes through the **New-Skill Pre-Commit gate + `asset-placement-gate`** (the
 same gate every FH asset passes). KILL emits nothing — the workspace stays as the evidence record.
 
+**EMIT-worthiness — the measured screening criterion (run #5, 2026-07-14)**: five chamber runs, EMIT 0/5,
+all KILL. Run #5 (`degrade-lint`) measured *why* the chamber has not birthed, and the finding is a reusable
+screen: a candidate is emit-worthy only if it clears **all three** of — (1) **net-new** (not a reinvention
+of an existing FH/official asset, nor a cosmetic re-wrap of code that already ships — runs #2–#4 died here);
+(2) **artifact-shaped** (a tool/script/rule that stands alone, *not* a judgment-method — run #5's genuine
+niche was real, but its value lived in a scan∪cross-family *lens*, i.e. an LLM judgment, which cannot be
+`npm publish`ed); (3) **real-code-precision-adequate** (its mechanical form, measured on real external code,
+does not cry-wolf — run #5's rule scored 5/5 false-positive on 111 real files because the fail-open shape is
+syntactically identical to ubiquitous-benign skip-if-empty code; the real/benign split is semantic, not
+grep-able). 0/5 candidates cleared all three. This is not "keep trying" — it is a **pre-screen for future
+candidates**: a KILL that fails (1) or (2) is cheap to predict; only (3) needs a measurement leg (semgrep
+baseline + real-repo FP run), which run #5 established as the decisive test. The chamber's honest value to
+date remains *screening* — preventing reinventions and low-precision births — not yet *birthing*.
+
 *Vocabulary reservation (term hygiene, not standardization)*: a run of this skeleton is a **chamber
 run** — going forward, run/workspace/log labels use "chamber" for incubation and keep "sim/simulation"
 for *verification* sims (target-tier blind sim, sim-conductor persona sims). Established names are

--- a/knowledge/shared/harness-core/ship_readiness_gate.md
+++ b/knowledge/shared/harness-core/ship_readiness_gate.md
@@ -84,9 +84,23 @@ Score with the same triangulation the 2026-07-14 audit used — no single-source
 The formal release tag is **independent of the npm package version**. The npm version (currently in the
 `1.4.x` range) is the **plugin-cache lockstep number** — it bumps on every shipped-asset change so Codex/
 marketplace cache-invalidate; it is not a maturity claim. The **formal identity-maturity release starts at
-`v0.1.0`** and advances only when the ship-readiness gate goes all-green. `v0.1.0` = "the first release
-whose every identity is proven, not aspirational." Do not conflate the two counters; a high npm number does
-not make the harness `v1.0`.
+`v0.1.0`**. Do not conflate the two counters; a high npm number does not make the harness mature.
+
+**The `0.x` ↔ `1.0` mapping (refined 2026-07-14, informed operator decision).** Semver `0.x` explicitly
+means *early / not-yet-complete*, so the formal track maps cleanly onto the identity gate:
+- **`v0.1.0` = the first formal-release baseline.** It is tagged when the harness has a *proven core*
+  (≥1 identity 🟢 by real artifact) and an *honest, evidence-scored status for the rest* — NOT when every
+  identity is green. `v0.1.0` makes **no all-green claim**; its release notes carry the real per-identity
+  status (🟢/🟡/🔴). This is the baseline *from which* all-green is tracked, not the all-green ship itself.
+- **`v1.0.0` = the all-green ship.** The original "ship only when every identity is 🟢" condition maps to
+  **v1.0.0**, not v0.1.0. A 🟡/🔴 blocks *v1.0*, and names exactly what real run is missing — it does not
+  block the honest v0.1.0 baseline.
+
+This refinement resolves the tension of tagging a baseline while identities are still maturing: `0.x` is
+*designed* to carry an incomplete-but-honest status. What it must never do is **lie** — a v0.x tag whose
+notes claim more green than the audit shows is the defect the gate exists to prevent. The operator, shown
+the non-all-green status (③⑤ 🟢, ④ 🟡, ①② 🔴), elected to tag `v0.1.0` as this honest baseline; the
+decision is logged here and the tag's notes state the real status.
 
 ## FH's own status (2026-07-14) — NOT yet all-green
 
@@ -96,16 +110,19 @@ not make the harness `v1.0`.
 | ⑤ | 증폭자 (amplifier) | 🟢 GREEN | short-intent→literature-grounding→ultimate-doc real instances; rules-diet −18.2k measured; intent-routing probe 94% (below) |
 | ④ | 프런티어→조직 전파 | 🟡 YELLOW | frontier-digest launchd auto + AX submission docs both real, but digest→org never closed as ONE pipeline |
 | ① | 멀티하네스 클러스터 (연속경유) | 🔴 RED | mapping/routing materials work, but continuous relay channel + external-harness recommend are "not built yet" (source-admitted); cluster-wizard parked |
-| ② | 프로젝트 인큐베이터 (챔버 EMIT) | 🔴 RED | chamber ran 3×, but **EMIT 0× (2/2 KILL)** — the chamber *screens*, has not *birthed*. Runner wired, autonomous emit is not |
+| ② | 프로젝트 인큐베이터 (챔버 EMIT) | 🔴 RED | chamber ran **5×, EMIT 0× (5 KILL)**. run #5 (2026-07-14) *measured* why it hasn't birthed: all 5 candidates were either **reinventions** (#2 sim-conductor, #3 G4/resume, #4 steel-quench) or a **non-artifact judgment-method** (#5 degrade-lint — a genuine niche, but the mechanical rule scored **5/5 false-positive on 111 real qasp files**; the valuable capability is scan∪cross-family *judgment*, which cannot be shipped as a standalone tool). A real EMIT needs **net-new ∧ artifact-shaped ∧ real-code-precision-adequate** — 0/5 cleared all three. Runner wired; the gap is a candidate, not the pipe |
 
 **Cross-cutting measured (intent-based autonomous completion)**: blind floor-tier Sonnet trigger-accuracy
 probe (n=10, 2026-07-14): **should-fire 7.5/8 (94%), false-fire 0/2**. One weak trigger (simulate-first /
 incubator entry absorbed into deep-clarify) — the identity-② weakness surfaces in routing too.
 
-**Verdict**: FH is **not shippable as v0.1.0 yet** — ①② are RED, ④ is YELLOW. The formal `v0.1.0` tag is
-reserved for the moment all five go 🟢. What's blocking is **real runs, not wiring**: ①'s live 2-node
-orchestration, ②'s first EMIT-worthy chamber run, ④'s closed digest→org pipeline. Each remedy is a run
-that leaves an artifact, tracked in `tracks/_meta/identity_audit_*.md`.
+**Verdict (2026-07-14)**: FH is tagged **`v0.1.0` = honest baseline**, not all-green. ③⑤ are 🟢, ④ 🟡,
+①② 🔴 — the `v0.1.0` notes state exactly this and make no all-green claim (per the refined 0.x↔1.0 mapping
+above). **`v1.0.0` remains the all-green target.** What blocks v1.0 is **real runs, not wiring**: ①'s live
+2-node orchestration, ②'s first *net-new ∧ artifact-shaped ∧ precision-adequate* chamber candidate (the
+measured criterion from run #5), ④'s closed digest→org pipeline. Each remedy is a run that leaves an
+artifact, tracked in `tracks/_meta/identity_audit_*.md`. The honest baseline is publishable *because* 0.x
+carries an incomplete status by design; forcing a green it hasn't earned would be the theater the gate bars.
 
 ## For a field harness (e.g. pmh, qasp)
 Same gate, its own identities. A field harness ships to its team when its identity checklist is all-green,

--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -210,3 +210,9 @@
   target: "governance craft dominance + degrade_direction_scan probes E/F"
   outcome: accepted
   note: "8 subtle holes (Fable 4 + Codex 4, test-set author ≠ method = decorrelated). plain 5/8 (2 distractor mis-ID) · degrade-lens 6/8 0-FP · both Sonnet lanes missed f2(falsy-sentinel)+c3(sep-negation) · cross-family codex caught both → STACK 8/8. Finding: dominance is architectural (decorrelated stack, not single lens). MATERIALIZED: degrade_direction_scan.sh probes E+F catch f2+c3 mechanically, 0-FP on FH scripts, templates synced. Reflected: dominance artifact round-2, ship_readiness_gate, README, AX qasp_실증이력, pmh 실증상세."
+- date: 2026-07-14
+  skill: "chamber run #5 degrade-lint EMIT attempt — 4 blind cross-family personas (beginner/main-player Sonnet, challenger Fable, expert Sonnet+websearch) + decisive semgrep measurement leg"
+  context: "operator: '②는 이상론으로 남는다 — 이걸 실제로 돌려보고 채운 후에 하는 건 불가능?' → genuinely attempt an EMIT (degrade-scanner as independent npm CLI), let the chamber decide honestly"
+  target: "incubator identity ② — first real EMIT vs disciplined KILL"
+  outcome: accepted
+  note: "VERDICT KILL (strongest-evidence of 5 runs). expert web + local semgrep(auto/security-audit/python/default)=0/8 → niche real (CWE-636/OWASP-A10:2025, no packaged rule). challenger sourced re-wrap (2 copies diff=14 lines all comments, logic byte-identical). DECISIVE: authored AST semgrep rule pack, ran on 111 real qasp-dev files → 5/5 FALSE-POSITIVE (skip-if-empty contracts, config toggle, content predicate). 'if not x: return permissive' is ubiquitous-benign; real-hole vs benign-absence is SEMANTIC not syntactic. ∴ valuable capability = judgment (scan∪cross-family lens), not artifact — can't npm publish a judgment. EMIT stays 0/5. MEASURED screening criterion for future candidates: net-new ∧ artifact-shaped ∧ real-code-precision-adequate; 0/5 cleared all three. Reflected: identity_audit ②, chamber ledger run #5, AX qasp/pmh 소개서."


### PR DESCRIPTION
## What
Wraps the 2026-07-14 identity-fulfillment arc.

- **ship_readiness_gate**: refine the formal-release versioning — `v0.1.0` = first *honest baseline* (semver 0.x carries incomplete status by design, makes **no all-green claim**); the all-green ship condition maps to **v1.0.0**. Informed operator decision logged in-doc. ② status → EMIT 0/5 with a measured reason.
- **incubator doctrine**: add the **measured EMIT-worthiness screen** from chamber run #5 — a candidate is emit-worthy only if net-new ∧ artifact-shaped ∧ real-code-precision-adequate. 0/5 chamber candidates cleared all three (run #5's mechanical rule scored **5/5 false-positive on 111 real qasp files** → the valuable capability is judgment, not a shippable artifact).
- **invocation log**: run #5 (4 blind cross-family personas + decisive semgrep measurement).

## Why honest, not 포장
Chamber run #5 genuinely attempted the first EMIT and the chamber correctly **KILLed** it (re-wrap + precision-failure). ②/① stay honest (🔴). v0.1.0 ships *because* 0.x is designed to carry an incomplete-but-honest status; forcing a green it hasn't earned is the theater the gate bars.

## 4-axis
Axis1 regression_guard PASS (no SKILL/rules/CLAUDE change) · Axes2-3 marker (run#5 leg: Fable challenger + semgrep FP mechanical anchor) · Axis4 manifest. Pre-commit hook: ALL AXES PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)