### PR TITLE
docs: chamber run #7 (cluster-wizard hub-internal) KILL — chamber-scope clarification

### DIFF
--- a/knowledge/shared/harness-core/harness_incubator_doctrine.md
+++ b/knowledge/shared/harness-core/harness_incubator_doctrine.md
@@ -121,6 +121,17 @@ standalone graduations — not yet *birthing*. **Graduation order** (run #6's po
 hub-state-dependent capability graduates hub-internal → proven in use → THEN extracted portable, never
 speculated standalone-first — the only path every successfully-portable FH asset actually took.
 
+**Chamber scope — what belongs in the chamber at all (run #7, 2026-07-14)**: run #7 tested a hub-internal
+reactivation of the cluster-wizard signal and KILLed it — decisively on its own merits (its "narrow
+net-new" claim collapsed against the real shipped registry and an already-existing synergy skill), but
+it also surfaced a scope question worth keeping regardless: **a small feature graft onto an
+already-shipped hub-internal mechanism is ordinary Mode D self-development under the 4-axis gate, not
+automatically a chamber-EMIT question.** The chamber screens candidates that would become a **new
+independent artifact** (a skill, a plugin, a standalone tool) — not every internal feature extension.
+Route by this test: *would this, if built, be net-new as a standalone thing someone installs/adopts, or
+is it two lines added to something already shipped?* The former is chamber-scope; the latter is ordinary
+self-dev review.
+
 *Vocabulary reservation (term hygiene, not standardization)*: a run of this skeleton is a **chamber
 run** — going forward, run/workspace/log labels use "chamber" for incubation and keep "sim/simulation"
 for *verification* sims (target-tier blind sim, sim-conductor persona sims). Established names are


### PR DESCRIPTION
## What
Operator-authorized reactivation attempt ("챔버로 지금 돌려봐") of the hub-internal `cluster-wizard` form — the form run #6 confirmed was the *correct* one (vs the standalone form that failed on residency-blindness). KILLed again, but for genuinely different, instructive reasons.

## Why KILL
1. **Prematurity vs the run's own prior verdict**: run #6's EMISSION_VERDICT, written 24h earlier, explicitly re-confirmed "the next real acceleration-door ask" as the reactivation trigger. An authority-override inside a meta-conversation about EMIT criteria isn't that trigger.
2. **The "narrow net-new" claim collapses against the real shipped files** (main-player + challenger both read them): the registry is auto-generated (hand tags get wiped on regen), confirmed general-purpose harness count = **0** today, and the "cluster-synergy pass" substantially **already exists** as `cross-ecosystem-synergy-detection` Step 7.
3. **Residency guard is prose-only** — no machine field exists in the registry; unsatisfiable as specified.

## The valuable finding — chamber scope
Challenger surfaced something worth keeping regardless of this candidate: **a small feature graft onto an already-shipped hub-internal mechanism is ordinary Mode D self-development under the 4-axis gate — not automatically a chamber-EMIT question.** The chamber screens candidates that would become a **new independent artifact**. Documented as a routing test in the incubator doctrine.

EMIT stays **0/7**. `cluster-wizard` signal gets a concrete 5-item un-park checklist (some doable today without another chamber run: confirm ≥1 general-purpose harness, add residency+generality as machine fields, define output landing-surface rule, reconcile against Step 7 first, wait for an organic ask).

## 4-axis
Axis1 regression_guard PASS · Axes2-3 marker (4 personas, 2 read real shipped files inline) · Axis4 manifest. Pre-commit: ALL AXES PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)