### PR TITLE
feat(registry): promote residency+generality to registry-scan schema (un-park items 1-3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -478,6 +478,10 @@ let the innovator center a recommend cascade, produce a ranked install plan, and
 **Guards**: (a) **non-overwriting is inviolable** — the one thing both revfactory surfaces get wrong; FH
 proposes merge, never clobbers; (b) **no-reinvention** — Tier 0/1 first, scaffold only what adds governance;
 (c) **company residency** — discovery of a company sibling repo surfaces it, does not auto-map/leak it;
+promoted to a machine field (`residency` on the skill registry, `fh_detail_protocols.md §1-c`) so any
+derived recommendation naming a `company`/`operator-private` entry lands only in gitignored `tracks/_meta/`
+or the private companion store, never a tracked public file (chamber run #7, 2026-07-14 — the guard was
+prose-only and the field didn't exist);
 (d) **autonomy floor** — the discover/rank judgment is trusted at opus-tier+; below-floor, present the raw
 recommend and ask; (e) **once per door-entry**, not a per-turn nag. This is the door ③ (accelerate) engine
 and the new-project/harness-write path made autonomous — the operator asks once and the harness discovers,

--- a/knowledge/shared/harness-core/fh_detail_protocols.md
+++ b/knowledge/shared/harness-core/fh_detail_protocols.md
@@ -58,10 +58,26 @@ Then **fail-closed** (irreversible-ish: a silent empty overwrite blinds the bus)
 **and** the existing registry has >0 entries, do **not** overwrite — flag `⚠️ scan returned 0 (root=$ROOT);
 kept existing registry` and skip the rewrite. Only rewrite when the scan is non-empty (or the registry
 was absent). Group by project (parent dir name). Record per skill: name · path · description · trigger
-phrases · `requires_cwd` · `direct-executable` · `origin(FH|project|external)`+trust. **Non-FH skills are
-propose-only (ask-tier), never auto-run** — a cross-project skill body is an injection surface. Propose
-cross-project skills when a request maps to the registry. Scan once per session. (Detection belongs at
-install too — `/install-wizard` records HUB/ROOT so the runtime never guesses; see install-wizard.)
+phrases · `requires_cwd` · `direct-executable` · `origin(FH|project|external)`+trust ·
+**`residency(public|company|operator-private)`** · **`generality(general-purpose|project-specific)`**.
+**Non-FH skills are propose-only (ask-tier), never auto-run** — a cross-project skill body is an
+injection surface. Propose cross-project skills when a request maps to the registry. Scan once per
+session. (Detection belongs at install too — `/install-wizard` records HUB/ROOT so the runtime never
+guesses; see install-wizard.)
+
+**`residency` derivation (mechanical, not asserted)** — from the project's git remote at scan time:
+company org/account (e.g. a known company-dev namespace) → `company`; the operator's own account, repo
+not `public` on the host → `operator-private`; else → `public`. **`generality` derivation (judged, not
+mechanical — the scan flags a candidate, a session confirms)**: a skill whose description names no
+project/company-specific noun and needs no project-local context to run elsewhere → `general-purpose`
+candidate; confirmed only when a session actually reads the skill body and judges it works outside its
+origin project (never auto-confirmed from the tag alone — chamber run #7, 2026-07-14, found the
+generality field itself absent and the confirmed-general-purpose seed count effectively 0, which is
+exactly the gap these two fields close). **Output landing-surface rule** (residency-restricted
+combinations must never reach a public surface): any derived recommendation, "better-together" list, or
+synergy output that names a `company`/`operator-private` residency entry lands **only** in gitignored
+`tracks/_meta/` (or the private companion store) — **never** in tracked `tracks/{project}/` or any other
+public-tracked file. A `public`-only combination may land in tracked docs.
 
 ### Step 2 — Active Proposal
 


### PR DESCRIPTION
## What
Closes checklist items 1-3 from the `cluster-wizard` un-park list (`fh_signal_2026-07-09_cluster-wizard.md`). Ordinary Mode D self-dev, not chamber-EMIT scope — per chamber run #7's own finding: a small procedural extension of an already-shipped registry-scan step.

1. **Confirmed ≥1 genuinely general-purpose harness**: read all 4 gstack skill bodies (investigate/office-hours/ceo-review/retro) — domain-agnostic reasoning, no project-local or tool coupling → **CONFIRMED general-purpose**. openhuman's 3 skills also read — Composio-GitHub-tool-coupled, kept project-specific (honest non-confirmation, not forced).
2. **Promoted residency+generality from prose guard to a schema field** (`fh_detail_protocols.md §1-c`) — `residency` mechanically derived from git remote (company/operator-private/public); `generality` judged by a session reading the skill body, never auto-confirmed from a tag alone.
3. **Landing-surface rule**: any derived recommendation naming a `company`/`operator-private` entry lands only in gitignored `tracks/_meta/` or the private companion store, never a tracked public file. Cross-referenced from CLAUDE.md's existing (c) company-residency guard (found→extend, not fork).

Applied locally to `.claude/registry/LOCAL_SKILL_REGISTRY.md` (gitignored, not part of this diff) — header-only edit, company skill body text never retyped.

## A note on process
Attempting to rewrite the full registry file (even though gitignored) was correctly **blocked by the auto-mode data-exfiltration classifier** — retyping confidential skill descriptions is a risk independent of git-tracking status. Resolved with a header-only edit instead, which is itself an instance of the landing-surface rule this PR documents.

Items 4 (reconcile against `cross-ecosystem-synergy-detection` Step 7) and 5 (wait for an organic acceleration-door ask) remain open.

## 4-axis
Axis1 regression_guard PASS (CLAUDE.md changed) · Axes2-3 marker · Axis4 manifest. Pre-commit: ALL AXES PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)