### PR TITLE
frontier-auto: mcp_tool_gating.md §4 — post-mount MCP endpoint drift checklist step

### DIFF
--- a/templates/.claude/rules/mcp_tool_gating.md
+++ b/templates/.claude/rules/mcp_tool_gating.md
@@ -129,6 +129,23 @@ not from sounding harmless.
    (e.g. Claude Code `permissions.ask` entries for `mcp__{server}__{tool}`) so the
    gate is mechanical, not prose-only. This rule file is the fallback for hosts
    without per-tool permission config.
+5. For `http`/`sse`-transport servers, record the resolved endpoint address at mount
+   (host + path) in the §3 table's Note column. This checklist gates tool *behavior*
+   at mount time — it does not by itself catch the server's *endpoint* being rewritten
+   afterward. A documented attack path does exactly that: a malicious npm postinstall
+   hook rewrote MCP server entries in `~/.claude.json` to point at an attacker-controlled
+   proxy, so the next session silently routed an authenticated MCP connection (and its
+   OAuth bearer token) through attacker infrastructure with no user-visible prompt, and
+   re-applied the rewrite on every session start to survive remediation
+   ([Mitiga, "MCP Token Theft in Claude Code," 2026-06](https://www.mitiga.io/blog/claude-code-mcp-token-theft-mitm)).
+   The session otherwise behaves normally throughout — this attack is engineered to be
+   behaviorally silent, so "diff only if something looks wrong" will not catch it.
+   Recording the endpoint at mount gives the operator a baseline for a **periodic**
+   diff (e.g. as part of an existing session-start or `install-doctor` check), not
+   an incident-triggered one. `stdio`-transport servers have no network endpoint to
+   pin for this threat, though the same config-rewrite class can still repoint a
+   `stdio` server's launch command — out of scope for this step, not out of scope
+   for config-integrity generally.
 
 Done When (per mounted server):
 - §3 table filled, every enumerated tool name present (check class: mandatory-pass — file inspection)
@@ -136,3 +153,5 @@ Done When (per mounted server):
   or this rule file is installed and loaded in the session (check class: mandatory-pass)
 - non-ask tiers assigned only with a behavior-confirmation note in the §3 Note column
   (check class: judged — pair with an adversarial pass asking "could this name mislead?")
+- for `http`/`sse`-transport servers, the mounted endpoint address is recorded in §3
+  (check class: mandatory-pass — file inspection; N/A for `stdio`-transport servers)


### PR DESCRIPTION
## Summary

Weekly FH frontier-auto self-evolution routine (autonomous, no operator online). Read 8 days of daily Frontier Digest comments on #102 (2026-07-06 → 2026-07-13), dispatched `persona-innovator` Mode F against current FH assets + those signals.

The innovator's ground-state discipline (H1/H1-b provenance floors) flagged its one candidate as `SPECULATIVE` because its sandbox's WebFetch was environment-blocked (403) and couldn't live-verify the cited source. I re-attempted the fetch in the orchestrating session: direct WebFetch also 403'd (confirmed environment-wide, not domain-specific, via a control fetch of a known-good arxiv.org page), but WebSearch succeeded and returned the cited URL as the top hit plus corroboration across ~8 independent security outlets (SecurityWeek, CSO Online, eSecurityPlanet, GBHackers, cybersecuritynews, Security Boulevard, GRID THE GREY, CXO Digitalpulse). That cleared the bar: **specific asset** (`templates/.claude/rules/mcp_tool_gating.md` §4 "Mount-time checklist") + **specific cited signal** (2026-07-09 digest comment → [Mitiga, "MCP Token Theft in Claude Code," 2026-06](https://www.mitiga.io/blog/claude-code-mcp-token-theft-mitm)).

**The gap**: §4 gates a mounted MCP server's *tool behavior* at mount time but has no step for the server's *endpoint address* being rewritten afterward. Mitiga documented exactly that: a malicious npm postinstall hook rewrites MCP server entries in `~/.claude.json` to route an authenticated session through an attacker-controlled proxy, silently exfiltrating the OAuth bearer token with no user-visible prompt, and re-applies the rewrite on every session start to survive remediation.

**The change**: adds checklist item 5 — for `http`/`sse`-transport servers, record the resolved endpoint at mount as a diff baseline — plus a matching "Done When" bullet. `stdio`-transport servers are carved out (no network endpoint to pin for this specific threat).

Purely additive: **19 insertions, 0 deletions**.

## Review chain

- **Dedup (H2, persona-innovator)**: checked all three plausible landing spots (`mcp_tool_gating.md`, `install-doctor/SKILL.md`, `mcp-circuit-breaker/SKILL.md`) — none cover post-mount endpoint drift; existing MCP-security coverage is mount-time-only or failure-loop-only.
- **Axis 1** (`regression_guard.sh --pr`): PASS, 0 M-tier / 0 S-tier.
- **Axes 2–3** (steel-quench / phantom-quench): not loaded as invocable skills in this runtime, so run inline via a dispatched opus-tier agent against this specific diff. **Verdict: PASS-WITH-NOTES.**
  - Axis 3 (source-grounding): every factual sub-claim in the added text mapped to a corroborated span across independent outlets; internal `§3`/`§4` cross-references resolve; no phantom path.
  - Axis 2 (adversarial): confirmed non-redundant (dedup grep); confirmed the addition does not overclaim protection it doesn't provide (it explicitly disclaims that recording alone doesn't catch a later rewrite). One should-fix (A-grade) applied before this commit: the original wording tied the diff-check to "if a mounted server starts behaving unexpectedly," but this attack is engineered to be behaviorally silent — reworded to recommend a **periodic** diff instead of an incident-triggered one. Two optional B-grade notes were left unaddressed (stdio carve-out could be over-read as "stdio is immune to config tampering" generally; minor causal-attribution compression between the postinstall hook and the session-start re-application step) — noted in the Axis 2/3 marker for a future pass if this file is touched again.
- **Axis 4** (edit-manifest): predicted-impact entry recorded — low-risk additive doc change, no new tooling/infra, cost is one operator-read checklist line per http/sse mount.

Full marker + manifest detail: `tracks/_meta/.axes_23_passed_claude_frontier-auto-2026-07-17_2026-07-17.marker` and `tracks/_meta/edit_manifest.yaml` (both local/gitignored per FH convention — not in this diff).

## Predicted impact

Low-risk, additive-only. Closes a genuine mount-time-only blind spot in an existing checklist without adding new infrastructure. A natural follow-on (not included here, out of scope for this minimal change) would be making the periodic-diff mechanical — e.g. via `install-doctor` or a session-start check — rather than leaving it as an operator-read prose step.

## Test plan

- [x] Diff reviewed as purely additive (19 insertions / 0 deletions) — no existing content altered or removed
- [x] Cited source verified live (WebSearch corroboration across 8 independent outlets; direct WebFetch environment-blocked)
- [x] Dedup-checked against all plausible existing landing spots in the repo
- [x] Adversarial pass applied and one finding fixed pre-commit
- [ ] Human review + merge decision (this PR is a draft — not to be merged autonomously)

🤖 Generated by the FH weekly frontier-auto self-evolution routine (autonomous run, no operator online). **Not to be merged without human review.**


---
_Generated by [Claude Code](https://claude.ai/code/session_01GNtHEcYcqkQQdNifWCicBL)_