### PR TITLE
feat(policy): main = PR 경유 — 산문이 아니라 pre-push 기계 차단으로

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,10 +176,29 @@ The forge-harness hub has a dual identity: **(a) a seed for others** + **(b) you
 - **Implementation:** Skills such as `harvest-loop` follow this principle — they generate skill drafts, prepare commits automatically, and propose PR creation. However, the final decision to submit a PR must always require the user's explicit approval (`y`). This ensures Human-in-the-loop while maximizing AI contribution.
 
 **PR Creation Principle:**
-- AI may commit and push automatically (when changes are approved)
+- AI may commit and push automatically (when changes are approved) — **to a feature branch, never to the integration branch**
 - **PR creation requires explicit user request** ("create PR", "PR 올려줘", "pull request")
 - **Reason:** Prevents PR fragmentation — logical units should be grouped into meaningful PRs, not atomized per commit
-- Default workflow: commit → push → wait for explicit PR request
+- Default workflow: branch → commit → push branch → wait for explicit PR request
+
+**Integration branch is PR-only** (operator decision 2026-07-20). Never `git push origin main`
+directly. Normal path: `git switch -c <branch>` → push the branch → `gh pr create` → after review
+`gh pr merge --squash --delete-branch --admin` (self-approval is impossible when you authored the PR,
+so `--admin` after a completed review is the normal route, not a shortcut).
+
+**Mechanically enforced** by `templates/.git-hooks/pre-push`, which blocks a direct push to
+`main`/`master` unless the explicit `MAIN_PUSH_OK=1` acknowledgment is set (same channel shape as
+`DESTRUCTIVE_OP_OK` / `PUBLIC_SURFACE_OK`). Known-pair calibrated: direct-to-main blocks,
+feature-branch push passes untouched, override honored — over-blocking would just train the override
+into muscle memory and disarm it.
+
+> **Why a local hook when the server already requires a PR**: the server-side rule has
+> `enforce_admins: false`, so an admin push *satisfies* it and merely prints
+> `Bypassed rule violations` — a notice, not a block (observed 2026-07-20 on this repo). A rule that
+> announces its own bypass is not a floor. This hook is the honest-model floor; the **hard** floor is
+> still server-side (`enforce_admins: true`), which is an operator setting, not something a hook can
+> emulate. ⚠️ Flipping it while `required_approving_review_count: 1` locks a solo operator out of
+> merging their own PRs — pair it with `required_approving_review_count: 0` if enabled.
 
 ## Permission-Denial Guidance (When Auto-Mode Blocks an Action)
 

--- a/scripts/test_prepush_stdin_integrity.sh
+++ b/scripts/test_prepush_stdin_integrity.sh
@@ -77,5 +77,43 @@ else
   _no "T5 could not run end-to-end (no exit code captured) — treat as unverified, not as pass"
 fi
 
+# ── PR-only policy guard (2026-07-20 operator decision) ──────────────────────────
+# KNOWN-PAIR calibration per CLAUDE.md §Instrument Calibration: a known-POSITIVE that must block
+# and a known-NEGATIVE that must NOT. A guard that fires on everything is as broken as one that
+# never fires — over-blocking trains MAIN_PUSH_OK=1 into muscle memory, which disarms it.
+_pp_run() { # _pp_run <refline> [env...]  -> echoes exit code
+  local refline="$1"; shift
+  local d; d=$(mktemp -d 2>/dev/null || echo "/tmp/fh_pp_$$"); mkdir -p "$d/scripts"
+  ( cd "$d" && git init -q . 2>/dev/null
+    printf '#!/usr/bin/env bash\nexit 0\n' > scripts/session_close_check.sh
+    chmod +x scripts/session_close_check.sh
+    cp "$HOOK" ./h
+    printf '%s\n' "$refline" | env "$@" bash ./h origin https://example.invalid/x.git >/dev/null 2>&1
+    echo "$?" > rc )
+  cat "$d/rc" 2>/dev/null; rm -rf "$d"
+}
+_SHA_A=1111111111111111111111111111111111111111
+_ZERO=0000000000000000000000000000000000000000
+# remote_sha = ZERO (new ref) ISOLATES the PR-only guard from the destructive classifier.
+# First draft used two synthetic non-zero SHAs; the hook could not resolve remote_sha, marked the
+# ref UNCLASSIFIED and fail-closed — so T7/T8 "failed" on the classifier, not on the guard under
+# test. The instrument was measuring itself. (Calibration caught it: the known-NEGATIVE is what
+# exposed it — CLAUDE.md §Instrument Calibration.)
+
+# T6 known-POSITIVE: a non-delete push aimed at main MUST block
+rc=$(_pp_run "refs/heads/main $_SHA_A refs/heads/main $_ZERO")
+[ "$rc" = "1" ] && _ok "T6 direct push to main BLOCKED (known-positive)" \
+                || _no "T6 direct push to main was NOT blocked (rc=$rc) — PR-only policy is fail-open"
+
+# T7 known-NEGATIVE: a feature branch must pass untouched (no over-blocking)
+rc=$(_pp_run "refs/heads/feat/x $_SHA_A refs/heads/feat/x $_ZERO")
+[ "$rc" = "0" ] && _ok "T7 feature-branch push allowed (known-negative, no over-block)" \
+                || _no "T7 feature-branch push was blocked (rc=$rc) — guard over-fires; that trains the override"
+
+# T8 the override is honored and stays explicit
+rc=$(_pp_run "refs/heads/main $_SHA_A refs/heads/main $_ZERO" MAIN_PUSH_OK=1)
+[ "$rc" = "0" ] && _ok "T8 MAIN_PUSH_OK=1 override honored" \
+                || _no "T8 override did not work (rc=$rc) — an unusable escape hatch gets --no-verify instead"
+
 echo "── prepush stdin integrity: $([ "$FAILED" -eq 0 ] && echo PASS || echo FAIL) ──"
 exit "$FAILED"

--- a/templates/.git-hooks/pre-push
+++ b/templates/.git-hooks/pre-push
@@ -52,6 +52,7 @@ DEL_BRANCHES=""   # space-separated "<tip-sha>|refs/heads/X" pairs — SHA first
 DEL_OTHER=""      # refs/tags/* refs/notes/* etc. being deleted
 FORCED_REFS=""
 UNCLASSIFIED=""   # force-check impossible (remote tip not fetched)
+DIRECT_MAIN=""    # non-delete update pushed straight at the integration branch (PR-only policy)
 
 while read -r local_ref local_sha remote_ref remote_sha; do
   [ -z "${remote_ref:-}" ] && continue
@@ -78,8 +79,47 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         fi ;;
     esac
   fi
+  # PR-only policy: a non-delete update aimed straight at the integration branch.
+  # Detected INSIDE this loop because this is the only place git's ref list is readable.
+  if [ "$local_sha" != "$ZERO" ]; then
+    case "$remote_ref" in
+      refs/heads/main|refs/heads/master) DIRECT_MAIN="$DIRECT_MAIN $remote_ref" ;;
+    esac
+  fi
   # remote_sha == ZERO → creating a new branch (not destructive) → ignore
 done
+
+# ── PR-only policy for the integration branch (operator decision 2026-07-20) ──────
+# WHY THIS EXISTS LOCALLY: GitHub branch protection on main requires a pull request, but the
+# repo has `enforce_admins: false` — so an admin push satisfies the API and only prints
+# "Bypassed rule violations", which is a NOTICE, not a block. A rule that announces its own
+# bypass is not a floor ([[feedback_non_defeasible_floor]]). This hook is the honest-model floor
+# that actually stops the push; the HARD floor remains server-side (`enforce_admins: true`),
+# which is the operator's setting to flip, not this hook's job to emulate.
+# Scope: blocks the PUSH, not the merge — `gh pr merge` operates server-side and is unaffected.
+if [ -n "$DIRECT_MAIN" ] && [ "${MAIN_PUSH_OK:-0}" != "1" ]; then
+  echo ""
+  echo "══════════════════════════════════════════════"
+  echo " ⛔ FH PR-Only Policy (pre-push)"
+  echo "══════════════════════════════════════════════"
+  echo "  Direct push to the integration branch:$DIRECT_MAIN"
+  echo ""
+  echo "  main is PR-only (operator decision 2026-07-20). Branch protection requires a PR but"
+  echo "  exempts admins (enforce_admins: false), so the server prints a bypass notice instead of"
+  echo "  blocking. This hook blocks it for real."
+  echo ""
+  echo "  Normal path:"
+  echo "      git switch -c <branch> && git push -u origin <branch>"
+  echo "      gh pr create --fill"
+  echo "      # after review:  gh pr merge --squash --delete-branch --admin"
+  echo ""
+  echo "  Deliberate exception (explicit, logged — mirrors DESTRUCTIVE_OP_OK / PUBLIC_SURFACE_OK):"
+  echo "      MAIN_PUSH_OK=1 git push …"
+  exit 1
+fi
+if [ -n "$DIRECT_MAIN" ]; then
+  echo "  ⚠️  FH PR-Only Policy: direct push to$DIRECT_MAIN allowed by MAIN_PUSH_OK=1 (conscious, gated intent)"
+fi
 
 # ── Session-close check (CLAUDE.md §Session Wrap-up ①–⑥) ─────────────────────────
 # WIRED 2026-07-20. Before this, scripts/session_close_check.sh was referenced ONLY by prose


### PR DESCRIPTION
운영자 결정 ⓐ(2026-07-20): **main 은 PR 경유.** 산문으로만 박으면 이 레포가 오늘 하루 내내 내린 판정("산문뿐인 floor 는 floor 가 아니다")을 그대로 어기므로, 기계 앵커부터 만들었다.

## 왜 서버 규칙이 있는데도 뚫렸나 (`gh api` 실측)

| 설정 | 값 | |
|---|---|---|
| `enforce_admins` | **false** | ← 원인. admin push 는 규칙을 *만족*하고 `Bypassed rule violations` 라는 **통지**만 찍는다 |
| `required_approving_review_count` | 1 | |
| `allow_force_pushes` | **true** | ⚠️ main 에 force push 허용 |
| `allow_deletions` | false | ✅ |

자기 우회를 스스로 공지하는 규칙은 floor 가 아니다.

## 구현

`templates/.git-hooks/pre-push` 가 `refs/heads/{main,master}` 대상 non-delete push 를 차단.
예외는 명시적 `MAIN_PUSH_OK=1` (`DESTRUCTIVE_OP_OK` · `PUBLIC_SURFACE_OK` 와 같은 채널 모양).
ref 감지는 stdin 소비 루프 **안**에서 한다 — refs 는 거기서만 읽히기 때문.

## 검증 — known-pair 캘리브레이션 (같은 날 출하한 규약을 이 가드에 적용)

- **T6 양성**: main 직접 push → **차단**
- **T7 음성**: 피처 브랜치 push → **무차단** (과발화 없음)
- **T8**: `MAIN_PUSH_OK=1` 오버라이드 동작

8/8, `selfcheck` 에 배선(`npm test` + `prepublishOnly`).

★ **첫 T7/T8 실패는 테스트 결함이었다** — 합성 SHA 두 개를 쓰니 훅이 `UNCLASSIFIED` 로 fail-closed 했고, 그건 가드가 아니라 **분류기를 잰 것**이다(`remote_sha=ZERO` 로 격리해 수정). **known-negative 가 그걸 노출했다** = 캘리브레이션 규약이 출하 당일 저자를 잡았다.
음성을 같이 재는 이유도 그대로다 — 과발화하면 오버라이드가 근육기억이 되고, 그건 무장해제다.

## 정직한 범위 (파일에 명시)

- 이건 **honest-model floor** 이고 **push 만** 막는다. `gh pr merge` 는 서버측이라 무관.
- 클라이언트측이라 `--no-verify` 로 우회 가능.
- **hard floor 는 여전히 서버측 `enforce_admins: true`** — 운영자 설정이지 훅이 흉내낼 것이 아니다.
- ⚠️ 단 `required_approving_review_count: 1` 인 채로 켜면 **단독 운영자가 자기 PR 을 못 머지한다.** 켤 거면 `required_approving_review_count: 0` 과 함께.

## 게이트

4축 전부 PASS (Axis1 M0/S0 · Axis2 known-pair · Axis3 서버설정 실측 대조 · Axis4 매니페스트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)