### PR TITLE
docs(policy): 설정을 바꿨으면 그 설정을 설명하는 문장도 바꾼다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,13 +192,20 @@ so `--admin` after a completed review is the normal route, not a shortcut).
 feature-branch push passes untouched, override honored — over-blocking would just train the override
 into muscle memory and disarm it.
 
-> **Why a local hook when the server already requires a PR**: the server-side rule has
-> `enforce_admins: false`, so an admin push *satisfies* it and merely prints
-> `Bypassed rule violations` — a notice, not a block (observed 2026-07-20 on this repo). A rule that
-> announces its own bypass is not a floor. This hook is the honest-model floor; the **hard** floor is
-> still server-side (`enforce_admins: true`), which is an operator setting, not something a hook can
-> emulate. ⚠️ Flipping it while `required_approving_review_count: 1` locks a solo operator out of
-> merging their own PRs — pair it with `required_approving_review_count: 0` if enabled.
+> **Two layers, and which one is the floor**: the **hard floor is server-side** — this repo now runs
+> `enforce_admins: true` with `required_approving_review_count: 0` (set 2026-07-20; the count must be
+> `0`, because enabling `enforce_admins` while it is `1` locks a solo operator out of merging their
+> own PRs — self-approval is impossible). The hook is the **shift-left layer**: it fails at push time
+> and prints the actual remedy, and it keeps holding if the server setting is ever relaxed. It is
+> deliberately not the floor — a client-side hook is bypassable with `--no-verify`.
+> *Origin*: before that change the server had `enforce_admins: false`, so an admin push *satisfied*
+> the rule and merely printed `Bypassed rule violations` — a notice, not a block. A rule that
+> announces its own bypass is not a floor.
+> ⚠️ **Unresolved residual**: `allow_force_pushes` on `main` is still `true`. Two documented API
+> attempts to set it `false` were accepted without error and did **not** persist (verified by
+> independent GET, not by the write response). Force/non-ff pushes are blocked locally by this same
+> hook, so the honest-model case is covered — but the **server-side** history-rewrite surface on
+> `main` remains open. Re-check before relying on it.
 
 ## Permission-Denial Guidance (When Auto-Mode Blocks an Action)
 

--- a/templates/.git-hooks/pre-push
+++ b/templates/.git-hooks/pre-push
@@ -90,12 +90,15 @@ while read -r local_ref local_sha remote_ref remote_sha; do
 done
 
 # ── PR-only policy for the integration branch (operator decision 2026-07-20) ──────
-# WHY THIS EXISTS LOCALLY: GitHub branch protection on main requires a pull request, but the
-# repo has `enforce_admins: false` — so an admin push satisfies the API and only prints
-# "Bypassed rule violations", which is a NOTICE, not a block. A rule that announces its own
-# bypass is not a floor ([[feedback_non_defeasible_floor]]). This hook is the honest-model floor
-# that actually stops the push; the HARD floor remains server-side (`enforce_admins: true`),
-# which is the operator's setting to flip, not this hook's job to emulate.
+# WHY THIS EXISTS LOCALLY: it is the SHIFT-LEFT half of a two-layer floor.
+# History: on 2026-07-20 the server required a PR but had `enforce_admins: false`, so an admin
+# push satisfied the API and only printed "Bypassed rule violations" — a NOTICE, not a block.
+# A rule that announces its own bypass is not a floor ([[feedback_non_defeasible_floor]]).
+# The operator then flipped `enforce_admins: true` (+ `required_approving_review_count: 0` so a
+# solo operator can still merge their own PR), so the server IS now the hard floor.
+# This hook still earns its place: it fails at push time with the actual remedy in the message,
+# instead of a bare server rejection, and it keeps working if the server setting is ever relaxed.
+# It is deliberately NOT the hard floor — a client-side hook is bypassable by `--no-verify`.
 # Scope: blocks the PUSH, not the merge — `gh pr merge` operates server-side and is unaffected.
 if [ -n "$DIRECT_MAIN" ] && [ "${MAIN_PUSH_OK:-0}" != "1" ]; then
   echo ""
@@ -104,9 +107,8 @@ if [ -n "$DIRECT_MAIN" ] && [ "${MAIN_PUSH_OK:-0}" != "1" ]; then
   echo "══════════════════════════════════════════════"
   echo "  Direct push to the integration branch:$DIRECT_MAIN"
   echo ""
-  echo "  main is PR-only (operator decision 2026-07-20). Branch protection requires a PR but"
-  echo "  exempts admins (enforce_admins: false), so the server prints a bypass notice instead of"
-  echo "  blocking. This hook blocks it for real."
+  echo "  main is PR-only (operator decision 2026-07-20). The server enforces this too"
+  echo "  (enforce_admins: true, review_count: 0) — this hook just fails earlier, with the fix."
   echo ""
   echo "  Normal path:"
   echo "      git switch -c <branch> && git push -u origin <branch>"


### PR DESCRIPTION
직전 PR(#154)이 **자기 산문을 거짓으로 만들었다.** 훅과 CLAUDE.md 가 둘 다 *"enforce_admins: false 라서 서버가 못 막는다"* 로 자기 존재를 설명했는데, 운영자 승인으로 그 설정을 뒤집었으므로 근거가 더 이상 참이 아니다. 세상을 바꿔놓고 세상에 대한 서술을 안 고치면 이 세션이 종일 추적한 반쪽-픽스다.

## 적용된 서버 설정 (독립 GET 재확인 — PUT 응답 아님)

| 설정 | before → after | |
|---|---|---|
| `enforce_admins` | false → **true** | ✅ |
| `required_approving_review_count` | 1 → **0** | ✅ 1 인 채로 켜면 단독 운영자가 자기 PR 을 못 머지한다(자기승인 불가) |
| `allow_deletions` | false | ✅ 무변 |
| `allow_force_pushes` | true → true | ❌ **안 먹음 — 아래 잔여** |

## ⚠️ 미해결 잔여 — `allow_force_pushes`

문서화된 경로로 **두 번**(전체 PUT ×2) 시도했고 **오류 없이 수락됐으나 반영되지 않았다.** 전용 엔드포인트 추정은 404(내 잘못된 가정). 독립 GET 확인 = 여전히 `true`.

→ **완료로 보고하지 않고 CLAUDE.md 에 잔여로 명명했다.** 쓰기 응답을 믿었으면 "전부 적용됨"이라는 거짓 주장을 냈을 것이다 (§Instrument Calibration: 계기의 자기보고를 믿지 말고 독립 검증).

**완화**: force/non-ff push 는 이 훅이 로컬에서 이미 차단(실증 RC=1). honest-model 케이스는 덮이지만 **서버측 히스토리 재작성 표면은 열려 있다** — 완화지 수리가 아니다.

## 훅의 자기설명은 삭제가 아니라 재작성

서버가 hard floor 가 됐으니 훅은 **shift-left 층**으로 역할을 다시 쓴다 — push 시점에 실패하며 해법을 같이 찍고, 서버 설정이 완화돼도 계속 잡는다. 클라이언트측이라 `--no-verify` 로 우회 가능하다는 것도 그대로 명시.

## 이 PR 자체가 known-pair 검증이다

`enforce_admins:true` + `review_count:0` 이 단독 운영자에게 맞는 조합이라면, **이 PR 은 승인 없이 저자가 머지할 수 있어야 한다.** 그게 측정이고, 결과는 머지 시점에 확인된다.

## 게이트

4축 PASS. ★ 중간에 pre-commit 이 **내 마커를 반려**했다 — `axis2-evidence too vacuous (no count or verdict token)`. 서사만 쓰고 판정 토큰을 안 박았던 것이고, 훅이 맞았다. 비공허성 검사 통과 후 커밋.

🤖 Generated with [Claude Code](https://claude.com/claude-code)