### PR TITLE
fix(session-start): frontier-digest 부재를 실패로 가시화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ tracks/**
 # pages; keep out of the public surface. Demo PNGs are local-only by default.
 .playwright-mcp/
 *-playwright-demo.png
+
+# frontier-digest 잡의 스크래치 (잡이 정리하지 않아 루트에 남는다 — 2026-07-21 실측)
+.fd_*

--- a/scripts/fh_session_load.sh
+++ b/scripts/fh_session_load.sh
@@ -27,6 +27,23 @@
 set -uo pipefail
 
 FH="${HUB_DIR:-${CLAUDE_PROJECT_DIR:-$HOME/projects/forge-harness}}"
+
+# ── frontier-digest: 부재를 0으로 읽지 않는다 ────────────────────────────────────
+# 왜: digest 는 launchd 로 매일 09:00 에 돌지만 **31회 중 6회(19%) 산출물 없이 끝났다**
+# (2026-07-21 실측: exit 1 / 재시도 후에도 없음 / Attempt 에서 hang — 세 형태).
+# 그런데 세션 시작은 "있으면 읽는다"만 했다 → **실패가 '오늘은 뉴스 없음'으로 읽혔다.**
+# 부재와 실패는 0이 아니다. 로그가 있는데 산출물이 없으면 그건 부재가 아니라 FAILED 다.
+_FD_TODAY="$FH/tracks/_meta/frontier_digest_$(date +%Y_%m_%d).md"
+_FD_LOG="$FH/tracks/_meta/logs/frontier_digest_$(date +%Y_%m_%d).log"
+if [ -f "$_FD_TODAY" ]; then
+  :
+elif [ -f "$_FD_LOG" ]; then
+  echo "⚠️  [frontier-digest] 오늘 잡은 돌았는데 **산출물이 없다** — 부재가 아니라 실패다."
+  echo "    마지막 로그: $(tail -1 "$_FD_LOG" 2>/dev/null | cut -c1-90)"
+  echo "    → 수동 재실행하거나 실패 원인을 보라. '오늘은 뉴스 없음'으로 읽지 말 것."
+else
+  echo "⚠️  [frontier-digest] 오늘 로그도 산출물도 없다 — 잡이 아예 안 돌았을 수 있다(launchd 확인)."
+fi
 BE="${BE_DIR:-}"   # companion-store path — supplied by the gitignored hook registration; no public default.
 
 # Non-Mode-D / no companion store → silent no-op (this is the majority path for public users).


### PR DESCRIPTION
## 측정 (회상 아님 — 로그 대 산출물 전수 대조)
**31회 실행 중 6회 산출물 없음 = 19%.** 실패 형태 3종:
`Exited with code 1`(07-17) · `No digest file after attempt 1`(07-19) · **`Attempt 1/3` 에서 멈춤, 종료 로그 없음**(07-21).

## 진짜 결함은 실패가 아니라 침묵
잡은 실패할 수 있다. 문제는 세션 시작이 **"있으면 읽는다"만 해서** 실패가
**"오늘은 뉴스 없음"과 구별 불가**였다는 것 — 19%가 통째로 무음이었다.

## 수리
로그 ∧ ¬산출물 → **FAILED 보고 + 마지막 로그 줄**. 로그도 산출물도 없음 → 잡 미실행 경고.
리마인더가 아니라 **파일 존재 대조**라 SessionStart 훅이 기억과 무관하게 돌린다.

## known-pair 캘리브레이션
양성(오늘 실제 상태) **발화** · 음성(산출물 있는 날) **무발화**.
음성을 같이 잰 이유 — 건강한 날에도 뜨는 경고는 **무시를 학습시켜 스스로를 무력화**한다.

부수: 잡 스크래치 `.fd_*` 가 gitignore 안 돼 루트 오염 + 커밋 사고 위험 → 추가.

> 부재와 실패는 0이 아니다 — 이 세션이 스캔 카운트·메모리 리콜·설정 쓰기에 적용한 같은 규칙을 카데스 산출물에.

🤖 Generated with [Claude Code](https://claude.com/claude-code)