### PR TITLE
chore(agents): Codex 진입점에 Author-Exposure 규칙 이식 — 진입점 drift 폐쇄

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,11 +104,11 @@ For complex multi-step tasks, run `/agent-composer` first to plan which agents t
 
 The methodology layer (`tracks/`, `knowledge/`, `SKILL.md` docs) is Codex-compatible beta. Any AI model can follow skill workflows by reading SKILL.md files directly; the automation layer (hooks, plugin-channel agents under `plugins/*/agents/`, `/model`) is Claude Code-native and requires manual adaptation. FH's own agents are auto-loaded via the plugin channel when the plugin is enabled — `.claude/agents/` is the field-project override slot, not where FH ships its agents. Non-Claude runtimes use this `AGENTS.md`, `plugins/*/agents/*.md`, and `scripts/fh-run.sh` to apply the same methodology via adapter.
 
-### Non-Claude runtimes: two things CLAUDE.md holds that you will not auto-load
+### Non-Claude runtimes: three things CLAUDE.md holds that you will not auto-load
 
 `.claude/rules/*.md` with `paths:` frontmatter is a **Claude Code platform feature** — those files are
 auto-loaded into a Claude Code session when it reads a matching file, and **your runtime has no equivalent**.
-So two things that govern behavior are not going to reach you on their own. Read them explicitly:
+So three things that govern behavior are not going to reach you on their own. Read them explicitly:
 
 1. **FH asset changes run a mandatory 4-axis verification chain before the session's first commit.**
    Detail (axis definitions · marker required fields · lightweight exception · substantive carve-out):
@@ -121,6 +121,16 @@ So two things that govern behavior are not going to reach you on their own. Read
    log, comment, or paste. Outbound gets a **sanitized summary only**; exceptions need explicit operator
    approval plus a gitignored audit note. This binds every runtime, not just Claude Code — a leak does not
    un-happen, and the guard is worth nothing if it only lives where one runtime reads.
+
+3. **Before calling a material work product done, name what you are blind to.** CLAUDE.md routes the
+   everyday "commit and merge this" moment to `agent-composer` **§Author-Exposure Table** — a review
+   pass keyed on *what the author cannot self-detect* (cold entry → `beginner` · everyday friction →
+   `main-player` · outside currency → `expert` · optimistic self-verification → `challenger` +
+   cross-family · rebuilding what exists → `fact-checker` · ungrounded numbers → `phantom-quench`),
+   with a materiality gate and an `Exposure-unclear → challenger` default so "no row applies" is not
+   an exit. **This row exists because the triggering utterance names no agent** — nothing will fire it
+   for you. Your runtime *can* run these lenses: substitute `Agent(subagent_type=...)` per §M2 above
+   (`fh-run`, or `codex exec` reading the agent spec). The lens returns evidence, never the verdict.
 
 The irreversible-surface gates (Pre-Publish · Destructive-Op) likewise live in CLAUDE.md and fire on
 **intent**, not on a file — read them before any publish, delete, or history-rewrite. `pre-push` enforces


### PR DESCRIPTION
마감 ④-b 가 CC→Codex drift 후보를 띄웠고, **판정 결과 실제 drift** 였다(grep 은 플래그, 판정은 사람).

**왜 이식이 필요한가**: PR #158 이 고친 결함은 *"규칙이 행위자가 읽지 않는 곳에 있었다"* 였다. CLAUDE.md 전용 규칙은 Codex 세션에게 **바로 그 상태**다 — 같은 구멍을 다른 런타임에 남기는 셈.

**장식이 아니다**: `AGENTS.md §167(M2)` 이 `Agent(subagent_type=...)` → `fh-run`/`codex exec` 대체 패턴을 주므로 **비-Claude 런타임도 이 렌즈를 실제로 돌릴 수 있다.** 실행 가능성을 소스로 확인한 뒤 이식했다.

- §107 `two things` → `three things`, 3번 항목 신설
- 트리거가 에이전트 이름을 발화하지 않는다는 점(= 이 행의 존재 이유) 명시
- materiality gate · `Exposure-unclear → challenger` 기본 · "렌즈는 증거지 판정 아님" 동반

**새 독트린 0건** — PR #158(cross-family 6/6 · Sonnet sim 2라운드 CONVERGED)을 통과한 규칙의 축자 이식이라 sim 재실행은 생략하고 마커에 사유를 기록했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)