### PR TITLE
feat(doctrine): Intent Marshaling — 리더 의도 기반 범용 업무 마셜링을 런타임 디폴트로

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -524,6 +524,7 @@ Proposal format: `"I see [X]. Want me to run /[skill] to [one-line description]?
 | "help me write a prompt", "build a prompt", "improve this prompt", "prompt template" | `/meta-prompt-builder` |
 | "/goal", "run this autonomously", "big multi-step task", "orchestrate this goal", or **any heavy autonomous/multi-agent run** (proactive — propose *before* running; it is expensive, so the proposal is mandatory, not the auto-run) | `/goal-quench` (budget gate + quality gate) |
 | "I don't know what to build", "how should I approach this", "organize this for me", "clarify this", "정리해줘" (ambiguous request before dispatch) | `/deep-clarify` |
+| **work-shaped request outside the harness domain** — "이 문서 만들어줘", "위키 페이지 써줘", "이 자료 표로 만들어줘", any general work ask no other row or skill catches (**fallback default** — a more specific row above/below always wins: 리서치→deep-research · ambiguous "정리해줘"→deep-clarify · heavy fleet→goal-quench) | **Intent-Marshaling loop** (§Intent Marshaling — mechanical capability scan → one-line compose proposal → run; gap → capability ladder) |
 | "memory feels bloated", "clean up memory", "memory too large", "memory hygiene" | `/memory-hygiene` |
 | "ready to PR", "about to push", "merge this", "PR 올려줘", FH asset changed in session | 4-axis auto-gate (see above — runs automatically, no proposal needed) |
 | **field verdict/gate/safety/irreversible code changed** in a mapped project (function returning a verdict enum / gate exit code / safety-invariant · publish/delete/history path) — **proactive, before merge** | **Field-Harness Load-Bearing Change Gate** (see above → degrade-lint → cross-family review → converge; same rigor as FH assets, applied to field code) |
@@ -597,6 +598,29 @@ Purpose: {task/session purpose}  |  Completed: {what's already done}
 This agent's task: {specific task + target files/paths}  |  Note: {constraints/history}
 ```
 Simple file-lookup agents may omit. Agent dispatch works from any mapped project cwd — for FH skills, specify `~/projects/forge-harness/` explicitly.
+
+---
+
+## Intent Marshaling — General-Work Serving (runtime default)
+
+FH/PMH is a **purpose organization**, not only a meta-harness: when the leader states a work intent in
+plain language — wiki/document production, research-and-write, organizing, **any work-shaped ask, not
+just harness building** — the session **marshals installed capability** (skills · agents · mapped
+harnesses · memory) into a one-line composition proposal and runs it. "This is a harness hub, not for
+that" is a forbidden deflection — serving general work is identity (the registry + mapped harnesses +
+memory exist only here; a plain chatbot cannot marshal them). Marshal-by-feel is the defect this
+replaces (same shape as pre-#158 lens selection): the capability scan is **mechanical** (skill list ·
+`LOCAL_SKILL_REGISTRY` · mapped assets), never recall — and it **carries trust tiers**: run-first
+autonomy covers **FH-native capability with per-action-reversible steps only**; a non-FH sibling hit
+stays at its registry `ask-tier` (propose-only) and an outward-mutating action (send · post · deploy ·
+delete) keeps its own gate — marshaling never upgrades either. Capability gap (declared only by citing
+the scan result, never a bare "nothing fits") → the goal-quench Step C ladder semantics at request
+scale (internal scan → external search → in-session synthesis; **persist** routes to the New-Skill
+gate, **install** to plugin-recommender's HITL — no new gates).
+
+> **Detail (read before applying the ladder or when a gap appears)**:
+> `knowledge/shared/harness-core/intent_marshaling_general_work.md` — the 5-step loop, gate-routing
+> table, Sonnet-floor boundaries, and the origin defect.
 
 ---
 

--- a/knowledge/shared/harness-core/intent_marshaling_general_work.md
+++ b/knowledge/shared/harness-core/intent_marshaling_general_work.md
@@ -1,0 +1,75 @@
+# Intent Marshaling — General-Work Serving (runtime twin of intent machinization)
+
+> **Status**: doctrine (judgment-shaped, operator-forged 2026-07-22). Companion:
+> `harness_incubator_doctrine.md` covers **forge time** (`intent → forge → agreement → machinery`);
+> this file covers **run time** — what a mapped, skill-equipped environment does with a plain work
+> request. Floor companion: `sonnet_floor_doctrine.md`.
+
+## 1. Doctrine statement
+
+At forge time a harness machinizes intent into new machinery. At **run time**, an environment with
+installed skills, agents, mapped harnesses, and persistent memory is a **purpose organization**: the
+leader states a work intent in plain language, and the session **marshals installed capability into a
+composition and executes** — without the leader naming skills, agents, or files.
+
+**Scope is general work, not only harness work.** Wiki/document production, research-and-write,
+review, organizing, data shaping — any work-shaped request is in-scope. The environment moat is the
+point: a capability registry + mapped harnesses + memory exist *here*, so a plain chatbot session
+cannot marshal what it does not have. Serving general work is therefore **identity, not a favor** —
+"this is a harness hub, not for wiki work" is a forbidden deflection.
+
+## 2. Why doctrine, not mood (origin defect)
+
+2026-07-21: a session marshaled sim/persona skills onto wiki-polishing work "by feel" and the effect
+was large. That was orchestrator taste — the same failure shape lens selection had before the
+Author-Exposure Table (PR #158: picked right 4/4, but by judgment-luck, not machine). Taste survives
+only on strong tiers and good days; a Sonnet-tier session with the same assets would serve the same
+request thinly and call it done. This doctrine converts the marshal decision from taste into a
+mechanical default that survives at the Sonnet floor.
+
+## 3. The marshaling loop (every step Sonnet-runnable)
+
+| Step | Action | Mechanical form |
+|---|---|---|
+| **1 Intent read** | Restate the request as *deliverable + doneness* in one line. Genuinely ambiguous → the existing `/deep-clarify` route, not guessing. | one sentence, embedded in the compose proposal |
+| **2 Capability scan** | Scan what is actually installed/mapped — never recall from memory: ① in-session skill list (description match) ② `LOCAL_SKILL_REGISTRY` / Cross-Project Skill Bus ③ the target project's mapped harness assets. **The scan carries each hit's trust tier with it** (FH-native · non-FH sibling `ask-tier` · external) — trust is scan output, not a later afterthought. | list/grep, not vibes |
+| **3 Compose & run** | One-line composition proposal ("draft via X, then Y as the quality gate"), then **run-first, ask-last** — for **FH-native / session-installed capability whose actions are reversible**. A **non-FH sibling registry hit keeps its registry trust tier**: `ask-tier` = propose-only, never auto-run (`fh_detail_protocols.md` 1-c — sibling code is an injection surface). **Reversibility is judged per action, not per skill**: an installed skill whose step sends/posts/deploys/deletes outward hits that action's own gate (`mcp_tool_gating.md` ask-tier · the irreversibility gates) — marshaling never upgrades an ask-tier action to autonomous. | the one-liner IS the HITL surface for reversible work |
+| **4 Gap → ladder** | Gap may be declared **only by citing the Step-2 scan result** ("scanned ①②③, nothing covers X") — never a bare "nothing fits"; a gap claim without a named scan is the under-serve degrade direction this doctrine exists to close. Then reuse the goal-quench Phase 1.5 Step C **ladder semantics** (order + trust-gating + degrade direction — NOT its max-mode `fit_score` trigger, which stays goal-quench-local): internal registry scan → external search (`plugin-recommender`) → **in-session synthesis** from existing meta-skills (composition, not persisted) → net-new skill only as last resort. | same ladder order, no new machinery |
+| **5 Exposure check** | Deliverable is material (published · carries external claims · others rely on it) → the Author-Exposure Table (`agent-composer` §Author-Exposure) names the review pass before "done". | existing gate, unchanged |
+
+## 4. Gates — reused, none new
+
+| Surface | Gate |
+|---|---|
+| Scan · compose · run **FH-native** installed capability, **per-action reversible** | **none** — autonomous, one-line notice |
+| Dispatching a **non-FH sibling/registry skill** | its **registry trust tier** — `ask-tier` = propose-only, never auto-run (injection surface) |
+| An action that mutates **outward** (send · post · deploy · delete · payment — even via an installed skill) | that action's own gate (`mcp_tool_gating.md` ask-tier · irreversibility gates) — never converted to autonomous by marshaling |
+| External plugin/skill **install** | `plugin-recommender`'s own install-HITL (environment mutation) |
+| **Persisting** a synthesized skill | New-Skill Pre-Commit Gate + `asset-placement-gate` (ephemeral in-session composition needs neither) |
+| Irreversible surfaces (publish · delete · heavy autonomous fleet) | existing gates unchanged (Pre-Publish · Destructive-Op · the goal-quench proposal row) |
+
+## 5. Boundaries
+
+- **Not a heavy-orchestration auto-runner**: a run that would spawn a large multi-agent fleet still
+  proposes `/goal-quench` first (existing row). Marshaling defaults to the **cheapest composition
+  that serves the intent** — one skill beats three when one suffices.
+- **Sonnet floor**: every loop step is list/grep/one-liner/run — no depth-gated judgment on the
+  critical path. Depth escalation is dispatch (consent-gated), never substrate.
+- **Company residency unchanged** — marshaling never widens what may leave the machine.
+- **Operator-taste default**: tuning targets the operator's convenience (operator, 2026-07-22: "if
+  it's convenient for me, that's sufficient" — FH/PMH distributes *how the operator works well*).
+  Per-user adaptation is the UAP's layer, not this file's.
+- **Honesty**: marshaling quality is bounded by what is actually installed — a thin environment
+  marshals thin. The scan reports what it found; it never inflates the roster.
+
+## Done When (adoption, measured)
+
+- A general work request in a mapped environment produces a one-line composition proposal grounded in
+  an actual capability scan (check class: **measured** — target-tier sim at Sonnet, known-pair: one
+  work-shaped positive must marshal, one trivial/out-of-scope negative must NOT add ceremony).
+- No new gate machinery introduced; the mutation points (install · persist · non-FH dispatch ·
+  outward actions) route to existing gates (check class: **mandatory-pass** — grep this file for gate
+  names, confirm all resolve to pre-existing assets).
+- Trust tiers survive marshaling: no path in this file lets a non-FH `ask-tier` hit or an outward
+  action run without its own gate (check class: **mandatory-pass** — cross-family verified 2026-07-22,
+  codex F1/F2 closed).

--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -276,3 +276,30 @@
   outcome: accepted
   finding: "HARD 1 / SOFT 7, 'first success: YES'. Verdict 'GO — after one cp-path fix'. All 4 round-1 HARDs confirmed closed by re-execution, translation propagation verified line-by-line across ko/ja/zh. New HARD found that the fix itself introduced: the cp source stayed relative, so following the doc in order leaves cwd inside the knowledge repo and the copy fails. Refused to over-block — explicitly ruled the Status n=1 framing and undefined 'harness' non-blocking, and marked the clone URL UNCALIBRATED rather than guessing PASS."
   note: "Two rounds to converge: HARD 4 → 1 → 0. The round-2 HARD was self-inflicted by the round-1 fix, which is the argument for re-verify over single-pass ([[fh-commons:convergence-loop]]). The UNCALIBRATED flag was correct discipline and I closed it by actually running `git clone` — an agent declining to assert what it cannot measure is the behavior [[feedback_judge_robustness_mechanical_anchor]] asks for. Report shape (typed verdict + file:line anchor + counted severities) is why one read was enough to act; recorded as the compression contract candidate in fh_signal_2026-07-21_session.md."
+
+- date: 2026-07-22
+  agent: claude (isolated blind sim ×2)
+  model: sonnet
+  purpose: "Target-tier known-pair sim for the new Intent-Marshaling doctrine (CLAUDE.md §Intent Marshaling + intent_marshaling_general_work.md) — salience-dependent change, Mode D near-mandatory"
+  prompt_summary: "Blind fresh-session sims: positive = '팀 공유용 qasp 소개 위키 초안 만들어줘' (must marshal), negative = 'CATALOG.md 오타 하나 고쳐줘' (must NOT add ceremony). No expected-answer leakage."
+  outcome: accepted
+  finding: "Pair separated → instrument valid. Positive: marshaled (mechanical grounding scan found existing teamlead deck = found→extend, tone-rule self-applied, run-first, zero deflection). Negative: direct check-and-answer, no marshaling ceremony. Residual: first-response scope means skill-composition naming + Step-5 exposure gate unobserved."
+  note: "Known-pair discipline per CLAUDE.md §Instrument Calibration. Recorded before publishing the PASS claim anywhere else."
+
+- date: 2026-07-22
+  agent: codex-sidecar (headless x2 rounds)
+  model: gpt-5.5 (xhigh)
+  purpose: "Cross-family adversarial review of load-bearing Intent-Marshaling doctrine (auto-decorrelation standing path)"
+  prompt_summary: "R1: 4 attack angles (degrade direction / gate routing / overclaim / row collision). R2: stdin-inlined convergence check on the 4 fixes."
+  outcome: accepted
+  finding: "R1: 4/4 findings source-verified TRUE (2 HIGH, 2 MED) — trust-tier auto-run hole, per-action reversibility fail-open, subjective gap predicate, trigger collision. R2: CONVERGED, no new findings."
+  note: "Same-family review would likely have shared the optimistic 'installed = runnable' reading — the two HIGHs are exactly the correlated-blind-spot class. Transcript preserved for marker."
+
+- date: 2026-07-22
+  agent: fh-meta:hub-persona-auditor
+  model: session-inherit
+  purpose: "Pre-publication persona audit of a leader-briefing draft (private companion store, restricted-env publication pending)"
+  prompt_summary: "3 personas (바쁜 비기술 파트장 · 회의적 기술 실장 · QA 리드) + 수치 소스 대조 + 측정경계/와이어프레임/행동가능성 검증"
+  outcome: accepted
+  finding: "수치 불일치 0/8. SHIP_AFTER_M: M3(비용 부재·바통터치 1인→다인 과대·용어 무정의) S7 R4 — 문서가 자기 원칙(낙관 차단)을 2곳에서 스스로 위반한 것 적발(1.5막 라벨·제작방식 시제). 전건 반영."
+  note: "감사가 잡은 낙관 2건을 문서 §제작방식에 명시 — 게이트 작동의 셀프 실증으로 전환."


### PR DESCRIPTION
## What
- **신설** `knowledge/shared/harness-core/intent_marshaling_general_work.md` — 벼림-시점 독트린(intent machinization)의 **런타임 쌍둥이**: 의도 읽기 → 기계적 역량 스캔(트러스트 티어 동반) → 1줄 편성 제안 → run-first → 갭은 스캔-인용으로만 선언 → Step C 사다리 재사용
- CLAUDE.md **§Intent Marshaling** 앵커 + Autonomous Initiative **fallback 행** 1개 (구체 행 우선 명시 — deep-research/deep-clarify/goal-quench 충돌 제거)
- 신규 게이트 0 — 변이 지점(설치·영속화·바깥 행동·비FH 디스패치)은 전부 기존 게이트로 라우팅

## Why
운영자 통찰(2026-07-22): FH/PMH는 하네스 제작만이 아니라 **리더 의도로 범용 업무를 부리는 목적조직** — 전일의 '감' 마셜링(pre-#158 렌즈선택과 동형 결함)을 기계 디폴트로 전환.

## Verification
- Sonnet known-pair 심 **2/2 분리** (양성=마셜링 발동·음성=의례 0)
- cross-family codex(gpt-5.5 xhigh) R1 **4건 전건 유효 판정 후 수리** (HIGH 2: 비FH ask-tier auto-run 구멍 · per-action 가역성 fail-open) → **R2 CONVERGED, 신규 0**
- 4축 게이트 훅 ALL PASS (컨피덴셜 스캔이 로그의 사적 토큰 2건 적발 → 일반화 수리 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwpbqpH9S5CAm6EFFjisnk