### PR TITLE
chore(agents): Codex 진입점에 Intent Marshaling 이식 — #161 이 다시 연 drift 폐쇄

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,11 +104,11 @@ For complex multi-step tasks, run `/agent-composer` first to plan which agents t
 
 The methodology layer (`tracks/`, `knowledge/`, `SKILL.md` docs) is Codex-compatible beta. Any AI model can follow skill workflows by reading SKILL.md files directly; the automation layer (hooks, plugin-channel agents under `plugins/*/agents/`, `/model`) is Claude Code-native and requires manual adaptation. FH's own agents are auto-loaded via the plugin channel when the plugin is enabled — `.claude/agents/` is the field-project override slot, not where FH ships its agents. Non-Claude runtimes use this `AGENTS.md`, `plugins/*/agents/*.md`, and `scripts/fh-run.sh` to apply the same methodology via adapter.
 
-### Non-Claude runtimes: three things CLAUDE.md holds that you will not auto-load
+### Non-Claude runtimes: four things CLAUDE.md holds that you will not auto-load
 
 `.claude/rules/*.md` with `paths:` frontmatter is a **Claude Code platform feature** — those files are
 auto-loaded into a Claude Code session when it reads a matching file, and **your runtime has no equivalent**.
-So three things that govern behavior are not going to reach you on their own. Read them explicitly:
+So four things that govern behavior are not going to reach you on their own. Read them explicitly:
 
 1. **FH asset changes run a mandatory 4-axis verification chain before the session's first commit.**
    Detail (axis definitions · marker required fields · lightweight exception · substantive carve-out):
@@ -131,6 +131,29 @@ So three things that govern behavior are not going to reach you on their own. Re
    an exit. **This row exists because the triggering utterance names no agent** — nothing will fire it
    for you. Your runtime *can* run these lenses: substitute `Agent(subagent_type=...)` per §M2 above
    (`fh-run`, or `codex exec` reading the agent spec). The lens returns evidence, never the verdict.
+
+4. **A plain work request is served by marshaling installed capability — not deflected.** CLAUDE.md
+   §Intent Marshaling makes this the runtime default: when the operator states a work intent in plain
+   language (write this doc, build this wiki page, organize this material — **any work-shaped ask, not
+   only harness building**), you scan what is actually installed, propose a one-line composition, and
+   run it. *"This is a harness hub, not for that"* is a **forbidden deflection** — serving general work
+   is identity, because the skill registry, the mapped harnesses, and the memory store exist only here.
+   Three things carry over unchanged to your runtime:
+   - **The scan is mechanical, never recall** — enumerate the skill list, `LOCAL_SKILL_REGISTRY`, and
+     mapped project assets. Marshal-by-feel is the defect this replaces.
+   - **Marshaling never upgrades a trust tier.** Run-first autonomy covers **FH-native capability whose
+     steps are per-action reversible**. A non-FH sibling capability stays at its registry `ask-tier`
+     (propose only), and an outward-mutating action (send · post · deploy · delete) keeps its own gate.
+   - **A capability gap is declared by citing the scan result**, never as a bare "nothing fits" — then
+     route at request scale (internal scan → external search → in-session synthesis). *Persist* routes
+     to the New-Skill gate; *install* routes to plugin-recommender's HITL. No new gates.
+
+   **This row exists because the triggering utterance is ordinary work language that names no skill and
+   no agent** — exactly like row 3, nothing will fire it for you.
+
+> **Detail**: See `knowledge/shared/harness-core/intent_marshaling_general_work.md` — the 5-step loop,
+> the gate-routing table, the Sonnet-floor boundaries, and the origin defect — **open it directly**
+> before applying the ladder or when a gap appears.
 
 The irreversible-surface gates (Pre-Publish · Destructive-Op) likewise live in CLAUDE.md and fire on
 **intent**, not on a file — read them before any publish, delete, or history-rewrite. `pre-push` enforces

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,24 +132,29 @@ So four things that govern behavior are not going to reach you on their own. Rea
    for you. Your runtime *can* run these lenses: substitute `Agent(subagent_type=...)` per §M2 above
    (`fh-run`, or `codex exec` reading the agent spec). The lens returns evidence, never the verdict.
 
-4. **A plain work request is served by marshaling installed capability — not deflected.** CLAUDE.md
-   §Intent Marshaling makes this the runtime default: when the operator states a work intent in plain
-   language (write this doc, build this wiki page, organize this material — **any work-shaped ask, not
-   only harness building**), you scan what is actually installed, propose a one-line composition, and
-   run it. *"This is a harness hub, not for that"* is a **forbidden deflection** — serving general work
-   is identity, because the skill registry, the mapped harnesses, and the memory store exist only here.
-   Three things carry over unchanged to your runtime:
-   - **The scan is mechanical, never recall** — enumerate the skill list, `LOCAL_SKILL_REGISTRY`, and
-     mapped project assets. Marshal-by-feel is the defect this replaces.
+4. **General work is in scope here, and the mechanism for serving it is to marshal installed
+   capability.** CLAUDE.md §Intent Marshaling makes this the runtime default. It settles a *category*
+   question only — whether non-harness work belongs in this environment at all. Every ordinary check
+   about a specific request (is it safe, sensible, well-formed, worth doing) is yours and is unaffected.
+
+   The category answer is yes, for a concrete reason: the skill registry, the mapped field harnesses,
+   and the memory store exist **only** in this environment. So when the operator states a work intent in
+   plain language (write this doc, build this wiki page, organize this material — **any work-shaped ask,
+   not only harness building**), the scan below is what tells you whether capability for it is actually
+   present. An empty scan, reported with the scan cited, is a correct answer — see the third bullet.
+
+   Three constraints carry over unchanged to your runtime:
+   - **Enumerate rather than recall.** List the available skills, `LOCAL_SKILL_REGISTRY`, and the mapped
+     project assets. Recall under-reports what is installed, which is why the scan is a listing step.
    - **Marshaling never upgrades a trust tier.** Run-first autonomy covers **FH-native capability whose
      steps are per-action reversible**. A non-FH sibling capability stays at its registry `ask-tier`
      (propose only), and an outward-mutating action (send · post · deploy · delete) keeps its own gate.
-   - **A capability gap is declared by citing the scan result**, never as a bare "nothing fits" — then
+   - **A capability gap is declared by citing the scan result**, not as a bare "nothing fits" — then
      route at request scale (internal scan → external search → in-session synthesis). *Persist* routes
      to the New-Skill gate; *install* routes to plugin-recommender's HITL. No new gates.
 
-   **This row exists because the triggering utterance is ordinary work language that names no skill and
-   no agent** — exactly like row 3, nothing will fire it for you.
+   **This item exists because the triggering utterance is ordinary work language that names no skill and
+   no agent** — like item 3, no automatic trigger covers it; read it explicitly.
 
 > **Detail**: See `knowledge/shared/harness-core/intent_marshaling_general_work.md` — the 5-step loop,
 > the gate-routing table, the Sonnet-floor boundaries, and the origin defect — **open it directly**


### PR DESCRIPTION
## 배경

주간 감사 2026-07-22 🟧3 판정.

#161(Intent Marshaling)이 `CLAUDE.md` 에만 착지했다. `AGENTS.md` 는 `grep -n "Marshal|마셜링|marshal"` → **0 hits**, mtime 도 #161 이전(07-21 23:33). #159(`053f1e7`)가 Author-Exposure 로 닫았던 **같은 자리의 진입점 drift 가 재개방**된 상태였다.

## 왜 이식이 맞나

- `AGENTS.md §107` 이 정확히 **"비-Claude 런타임이 auto-load 못 하는 CLAUDE.md 규칙"** 을 담는 자리다.
- Intent Marshaling 은 옵션 스킬이 아니라 **런타임 디폴트 거버너 행동**이다 — #159 가 이식한 Author-Exposure 와 동일 클래스.
- *"Codex 는 audit 사이드카라 마셜링 불필요"* 는 성립하지 않는다: `AGENTS.md` 는 Codex 전용이 아니라 **모든 비-CC 런타임의 포터블 진입점**이고, gate-locality 상 규칙은 **행위자가 읽는 곳**에 있어야 장식이 아니다.
- 트리거가 **에이전트도 스킬도 호명하지 않는 평범한 업무 발화**라, 3번 행과 똑같이 *아무것도 대신 발동해주지 않는다*.

## 변경

`### Non-Claude runtimes: three things ...` → `four things`, 4번 항목 신설.

전문 복제가 아니라 **불변식 3개만** 이식하고 나머지는 Detail 포인터로 넘겼다:

1. **스캔은 기계적, 회상 금지** — 스킬 목록 · `LOCAL_SKILL_REGISTRY` · 매핑 자산 열거
2. **마셜링은 트러스트 티어를 승격하지 않는다** — run-first 는 FH-native ∧ per-action 가역까지. 비FH sibling = registry `ask-tier`(제안만), outward-mutating(send·post·deploy·delete)은 자체 게이트 유지
3. **capability gap 은 스캔 결과 인용으로만 선언** — bare "맞는 게 없음" 금지. persist → New-Skill 게이트, install → plugin-recommender HITL

## 게이트

| 축 | 결과 |
|---|---|
| Axis 1 | ⚠️ **SKIP (PASS 아님)** — 아래 별건 참조 |
| Axis 2+3 | SKIP — lightweight(prose-only, 코드펜스 0 · 인용토큰 0 → substantive carve-out 미해당) |
| Axis 3 손검증 | PASS — 참조 경로 4/4 실존, CLAUDE.md 앵커 2/2, ask-tier 문구는 detail 파일 `:35`/`:36`/`:45` 원문 대조 |
| Axis 4 | PASS — `edit_manifest.yaml` 2026-07-22 항목 기재(예측 3개 + 검증시점) |
| pre-commit | ✅ ALL AXES PASSED |

## ⚠️ 이 PR 이 발견한 별건 결함 (수리는 분리)

`templates/regression_guard.sh:83/85/87` 의 pathspec 은
`plugins/*/skills/*/SKILL.md` · `.claude/rules/*.md` · `knowledge/shared/rules/*.md` · `CLAUDE.md` · `templates/*.md`
— **`AGENTS.md` 가 없다.**

그런데 4축 게이트 정본 `.claude/rules/fh_4axis_gate.md:48` 은 `AGENTS.md` 를 커버 자산으로 **명시**하고, substantive carve-out 에서 따로 다루기까지 한다. 즉 **정본이 커버한다고 선언한 자산을 Axis 1 계기가 못 본다**.

그리고 그 미검사가 훅에서 `✅ PASS` 로 렌더된다 — *검사 안 함* 이 *통과* 로 보고되는 fail-open. 감사의 S-5(`regression_guard --pr` 가 미커밋 변경을 skip=PASS 로 통과) 와 **같은 결함 클래스의 두 번째 얼굴**이다.

같은 누락이 `knowledge/**`(shared/rules 외 substantive 문서)와 `docs/*.md` 에도 있다 — 둘 다 carve-out 이 Axes 2–3 대상으로 명시하는데 Axis 1 pathspec 엔 없다.

→ **별건 PR 로 수리 권고**(pathspec 확장 + skip↔PASS 분리 표기). 이 PR 에 섞으면 `templates/` 변경이 되어 light 분류가 깨지고, 게이트 계기 자체를 고치는 변경은 회귀 앵커를 따로 붙여야 한다.

## 잔여

- **target-tier(Sonnet) 블라인드 sim 미실행.** 살리언스 의존 변경이라 게이트상 near-mandatory 인데 이 세션은 에이전트 디스패치가 제한돼 미실행. **스킵이 아니라 미결**로 manifest `residual` 에 기재. 머지 전 실행 권고.

🤖 Generated with [Claude Code](https://claude.com/claude-code)