### PR TITLE
chore(release): v1.4.66 — lockstep bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,13 @@
   "plugins": [
     {
       "name": "fh-meta",
-      "version": "1.4.65",
+      "version": "1.4.66",
       "description": "Hub meta-operations toolkit — 34 skills + 7 agents. New in 1.4.53: `fh-codex-doctor` (npm bin) — Codex adapter drift scanner; reads the documented M1/M2/M3 skill tier map + skill/agent source and reports codex-native/adapter-required/claude-native/unclassified per unit, wired into `npm test`/`prepublishOnly` (fail-closed on unclassified Claude-native primitives). New in 1.4.49: steel-quench gains Step 0.6 Verdict-Invariance Probe (groundedness axis — a load-bearing judged gate's verdict must track behavior, not rubric phrasing; measured flip-count over cross-family paraphrases; arXiv:2605.06161 Policy Invariance anchor); multi_model_sidecar_strategy §Vendor-native harness (a model is strongest in its own vendor CLI — Claude/CC, GPT/codex, Gemini/Antigravity; a universal router degrades all of them, so it stays an autocomplete/QA sidecar, never orchestration); predelete_check.sh fail-closed rewrite; memory-hygiene A-TMA anchor. New in 1.4.48: phantom-quench + steel-quench gain external frontier anchors (arXiv:2607.02052 package-hallucination; arXiv:2607.02057 prompt-coverage-adequacy); README model-flat claim reframed from a per-release point-curve to structural invariants (operation flattens across tiers; depth tier-order fixed within a generation). New in 1.4.47: onboarding step ① surfaces the Mode D companion-store session-start load in the auto-read salience anchor (previously only in the local binding + rules, so a greeting could skip the load). New in 1.4.46: context-doctor command-output axis (route to rtk/proxy for verbose CLI stdout, complementing .claudeignore; risk-gated to token-scarce envs). New in 1.4.41: context-doctor 2026 trigger vocab (context engineering/rot/collapse) + phantom-citation hardening; hub measurement-integrity-checklist (cross-model measurement pre-flight: display-name pin/reps≥3/discriminating probe). New in 1.4.40: install-wizard queryable-wiki scaffold (INDEX + session-start read + R/W/C ingest). New in 1.4.39: auto-decorrelation (cross-family verifier sidecar recruitment) + video-ingest (capability-routed video ingestion). New in 1.4.x: verify-axis check-class taxonomy (mandatory-pass/measured/judged), no-reinvention Tier-0 inventory, 7-class failure taxonomy, Destructive-Op Gate, Wave-T (Temper), tier-floor governance, Mode D Model Notice, FC consent lane, default-Sonnet guidance. New in 1.3.0: public-surface-audit, field-harvest Mode B auto-trigger, 4-axis gate scope ext. Validated cross-CLI: Claude Code, Codex, Gemini.",
       "source": "./plugins/fh-meta"
     },
     {
       "name": "fh-commons",
-      "version": "1.4.65",
+      "version": "1.4.66",
       "description": "Project-agnostic utility skills — 4 skills (convergence-loop · deliberation · mcp-circuit-breaker · token-budget-gate) + 1 agent (quench-challenger). Domain-independent utilities transplantable into any project.",
       "source": "./plugins/fh-commons"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrono-meta/fh-gate",
-  "version": "1.4.65",
+  "version": "1.4.66",
   "description": "FH runtime adapters — run FH governance, skills, and agents via Claude or Codex with machine-parseable gates.",
   "license": "MIT",
   "keywords": [

--- a/plugins/fh-commons/.claude-plugin/plugin.json
+++ b/plugins/fh-commons/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-commons",
-  "version": "1.4.65",
+  "version": "1.4.66",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/.claude-plugin/plugin.json
+++ b/plugins/fh-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-meta",
-  "version": "1.4.65",
+  "version": "1.4.66",
   "engines": {
     "claudeCode": ">=1.0.0"
   },


### PR DESCRIPTION
## 발행 범위

`v1.4.65`(`dadee5e`) 이후 누적된 npm-shipped 자산 변경분.

| PR | 내용 |
|---|---|
| #161 | Intent Marshaling 독트린 — `CLAUDE.md` §Intent Marshaling + `knowledge/shared/harness-core/intent_marshaling_general_work.md` |
| #162 | CATALOG 세션 항목 + 페르소나 감사 호출 로그 |
| #163 | `AGENTS.md` 진입점 이식 + target-tier sim 이 잡은 문구 결함 수리 |

변경 파일 5개 (`git diff dadee5e..HEAD`): `AGENTS.md` · `CATALOG.md` · `CLAUDE.md` · `intent_marshaling_general_work.md` · `subagent_invocations_log.yaml`.

> 📌 주간 감사 07-22 에서 범위 정정됨: 카드는 `#153·#158·#159·#161·#162` 5건으로 기재했으나, `dadee5e` 가 `#153`/`#158`/`#159` **뒤**에 있어 그 3건은 이미 1.4.65 로 발행됐다. 실제 미발행분은 위 3건.

## Lockstep — 5곳

| 파일 | |
|---|---|
| `package.json` | ✅ 1.4.66 |
| `plugins/fh-meta/.claude-plugin/plugin.json` | ✅ 1.4.66 |
| `plugins/fh-commons/.claude-plugin/plugin.json` | ✅ 1.4.66 |
| `.claude-plugin/marketplace.json` (2 엔트리) | ✅ 1.4.66 ×2 |

잔존 `1.4.65` 0건 · JSON 유효성 4/4 · 단일 소스 = `package.json`.

## Pre-Publish Surface Gate

### 1. 전체표면 기밀 스캔 — PASS
`scripts/public_surface_scan_files.sh` (via `prepublishOnly`).
**published 141 파일 전수 스캔** — diff 가 아니라 발행 표면 전체 (`[[feedback_public_push_full_surface_scan]]`: 07-09 KPAP 키 평문을 diff 스캔이 놓친 이력).
→ operator-private 토큰 **0건**.

### 2. 코드 보안 패스 — 적용대상, findings 0
**적용성은 기계 판정** — `npm pack --dry-run` 으로 발행 파일셋을 열거해 확장자 grep:
실행코드 **10개 출하** (`bin/*.js` ×4, `scripts/*.sh` ×6) → **`skipped: docs-only` 는 틀린 주장이 됐을 것.**

`/security-review` 실행 → **HIGH/MEDIUM 0건.**
근거: 이번 diff 의 실행코드 변경 **0** — `git diff --stat dadee5e..HEAD -- bin/ scripts/` 무출력, 즉 출하되는 코드는 이미 게이트를 통과한 `v1.4.65` 와 byte-identical. 이 PR 자체의 변경 표면은 JSON 버전 문자열 4개뿐이라 데이터 흐름·입력 처리·역직렬화 경로가 없음.
→ **"코드가 없어서 통과"가 아니라 "코드가 안 바뀌어서 통과"** — 적용-후-통과이지 not-applicable 이 아니다.

### 3. Lockstep + 유효성 — PASS
위 표.

## 머지 후

`npm publish` → `git tag v1.4.66` (발행 시점에 태깅).