### PR TITLE
fix(gate): Axis 1 이 정본 커버 자산의 절반을 안 보고 있었다 — pathspec 정합 + SKIP≠PASS

### DIFF
--- a/knowledge/shared/harness-core/self_evolution_routine.md
+++ b/knowledge/shared/harness-core/self_evolution_routine.md
@@ -106,6 +106,14 @@ If `steel-quench`/`phantom-quench` are unavailable in the routine session, note
 `Axis N: skipped (skill unavailable)` — Axis 1 PASS alone unblocks a *draft* PR (Axes 2–3 are the
 operator's residual at merge review).
 
+> ⚠️ **"Axis 1 PASS" 는 종료코드로 판정하지 마라.** `regression_guard.sh` 의 `exit 0` 은
+> **PASS 와 SKIP 을 둘 다** 뜻한다 — SKIP 은 "게이트 pathspec 에 걸린 파일이 없었다"이지
+> "검사했고 괜찮다"가 아니다. 무인 루틴이 종료코드만 보면 **미검사가 draft PR 을 unblock 한다.**
+> 구분: stdout 에 `REGRESSION_GUARD_RESULT=skip` 이 있으면 SKIP 이다 — 그 경우 Axis 1 은
+> *통과가 아니라 미실행*이므로 Axes 2–3 과 같은 운영자 잔여로 올려라.
+> (2026-07-22 실측: `pre-commit` 이 정확히 이 혼동을 일으켜 AGENTS.md 변경이 `✅ PASS` 를
+> 받고 지나갔다. `pre-commit` 은 배선 완료 · 이 루틴을 포함한 나머지 소비자는 **미배선 잔여**.)
+
 **Skip-visibility at the handoff (load-bearing for honest HITL escalation).** When Axis 2
 (challenger / steel-quench) is skipped, the adversarial check did not run autonomously — it becomes
 the *merger's* responsibility. An intelligent hand-off must make that visible at the hand-off point,

--- a/templates/.git-hooks/pre-commit
+++ b/templates/.git-hooks/pre-commit
@@ -179,8 +179,13 @@ else
   GUARD_EXIT=0
   # Pre-commit must evaluate the STAGED index, not --pr merge-base: on a direct-to-main
   # workflow merge-base(main,main)=HEAD makes staged changes invisible (fh_signal 2026-06-04).
-  bash "$GUARD" --staged 2>&1 || GUARD_EXIT=$?
-  if [ "$GUARD_EXIT" -eq 0 ]; then
+  GUARD_OUT="$(bash "$GUARD" --staged 2>&1)" || GUARD_EXIT=$?
+  printf '%s\n' "$GUARD_OUT"
+  if [ "$GUARD_EXIT" -eq 0 ] && printf '%s' "$GUARD_OUT" | grep -q '^REGRESSION_GUARD_RESULT=skip$'; then
+    # ★ 미검사를 통과로 렌더하지 않는다. 가역 표면이라 커밋은 막지 않지만,
+    #   "PASS" 라고 쓰면 게이트가 자산을 봤다는 잘못된 신호가 된다(2026-07-22 수리).
+    echo "  ⏭️  SKIP — 게이트 pathspec 에 걸린 파일이 없다 (검사 안 함 ≠ 통과)"
+  elif [ "$GUARD_EXIT" -eq 0 ]; then
     echo "  ✅ PASS"
   elif [ "$GUARD_EXIT" -eq 1 ]; then
     echo "  ⚠️  S-tier warnings present — review before merge (commit allowed)"

--- a/templates/regression_guard.sh
+++ b/templates/regression_guard.sh
@@ -9,7 +9,14 @@
 #   bash templates/regression_guard.sh --staged                # pre-commit: staged index vs HEAD
 #   bash templates/regression_guard.sh --verbose --staged      # include suppression reasons
 #
-# Exit codes: 0=PASS / 1=S-tier warnings / 2=M-tier block / 3=usage error
+# Exit codes: 0=PASS **또는 SKIP** / 1=S-tier warnings / 2=M-tier block / 3=usage error
+#
+# ⚠️ exit 0 은 두 의미를 갖는다 — 검사해서 통과(PASS)와 **검사 대상이 없었음(SKIP)**.
+#    구분하려면 stdout 의 `REGRESSION_GUARD_RESULT=skip` 을 보라. 종료코드만 보는 호출자는
+#    미검사를 통과로 읽는다(2026-07-22: pre-commit 이 정확히 그랬고, AGENTS.md 변경이
+#    그 경로로 '✅ PASS' 를 받고 지나갔다).
+#    배선 현황: pre-commit ✅ / harness-doctor · harvest-loop · hub-cc-pr-reviewer ·
+#    self_evolution_routine = **미배선(종료코드만 판정)** — 알려진 잔여.
 #
 # PR mode rationale: using 'main' as BASE_REF for a PR branch includes changes from OTHER
 # merged PRs as false positives. --pr computes the fork-point (merge-base) automatically,
@@ -78,17 +85,40 @@ else
   HEAD_REF="${2:-}"   # empty = working tree
 fi
 
+# 게이트 커버 자산 = 4축 정본(.claude/rules/fh_4axis_gate.md §48)이 선언한 목록과 맞춘다.
+# 2026-07-22 수리: AGENTS.md · knowledge/** · docs/*.md 가 여기 없어서, 정본이 "커버한다"고
+# 선언한 자산을 Axis 1 이 **아예 보지 못했다**. 그리고 그 미검사가 호출부(pre-commit)에서
+# `✅ PASS` 로 렌더됐다 = 검사 안 함이 통과로 보고되는 fail-open.
+# 새 경로를 추가할 때는 반드시 fh_4axis_gate.md §48 과 대조할 것 — 두 목록이 갈리면
+# 갈린 쪽이 조용히 무검사 구간이 된다.
+GUARD_PATHSPEC=(
+  'plugins/*/skills/*/SKILL.md'
+  '.claude/rules/*.md'
+  'knowledge/shared/rules/*.md'
+  'knowledge/*.md'
+  'knowledge/*/*.md'
+  'knowledge/*/*/*.md'
+  'CLAUDE.md'
+  'AGENTS.md'
+  'docs/*.md'
+  'templates/*.md'
+)
+
 # Discover changed files
 if [ "$STAGED_MODE" -eq 1 ]; then
-  CHANGED=$(git diff --cached --name-only -- 'plugins/*/skills/*/SKILL.md' '.claude/rules/*.md' 'knowledge/shared/rules/*.md' 'CLAUDE.md' 'templates/*.md' 2>/dev/null)
+  CHANGED=$(git diff --cached --name-only -- "${GUARD_PATHSPEC[@]}" 2>/dev/null)
 elif [ -z "$HEAD_REF" ]; then
-  CHANGED=$(git diff --name-only "$BASE_REF" -- 'plugins/*/skills/*/SKILL.md' '.claude/rules/*.md' 'knowledge/shared/rules/*.md' 'CLAUDE.md' 'templates/*.md' 2>/dev/null)
+  CHANGED=$(git diff --name-only "$BASE_REF" -- "${GUARD_PATHSPEC[@]}" 2>/dev/null)
 else
-  CHANGED=$(git diff --name-only "$BASE_REF" "$HEAD_REF" -- 'plugins/*/skills/*/SKILL.md' '.claude/rules/*.md' 'knowledge/shared/rules/*.md' 'CLAUDE.md' 'templates/*.md' 2>/dev/null)
+  CHANGED=$(git diff --name-only "$BASE_REF" "$HEAD_REF" -- "${GUARD_PATHSPEC[@]}" 2>/dev/null)
 fi
 
 if [ -z "$CHANGED" ]; then
-  echo "REGRESSION_GUARD: no SKILL.md / rules / CLAUDE.md changes — skip"
+  # ★ SKIP 은 PASS 가 아니다. 이 스크립트는 exit 0 을 유지하지만(가역 표면 · 호출부 호환),
+  #   **문구로 통과와 구분**한다 — 과거 호출부가 이 줄을 받고 `✅ PASS` 를 찍어
+  #   "검사 안 함"이 "통과"로 보고됐다(2026-07-22 수리).
+  echo "REGRESSION_GUARD: SKIP (not-checked, NOT a pass) — no file matched the gate pathspec"
+  echo "REGRESSION_GUARD_RESULT=skip"
   exit 0
 fi
 
@@ -429,6 +459,27 @@ echo
 echo "===================="
 echo "VERDICT"
 echo "===================="
+# ── carve-out 경로 강등 (2026-07-22, challenger HIGH-1) ──────────────────────
+# knowledge/ · docs/ · AGENTS.md 는 **커버되어야 하지만 산문이 본체**다. 이 경로에
+# 내용-손실 검사(토큰 카운트·섹션 그룹)를 그대로 걸면 동의어 교체 한 번에 M-tier 가
+# 뜬다(실측: 산문 한 단어 교체 → 토큰 2→1, 50% 드롭 → 하드 블록).
+# 과차단은 이론 비용이 아니다 — `--no-verify` 를 근육에 새기고, 그러면 **같은 훅의
+# Destructive-Op 게이트까지 함께 무장해제**된다. 그래서 이 경로는 차단이 아니라 경고다.
+# 호출부(pre-commit)의 CARVEOUT 분류기와 **같은 방향**이되, 여기서 substantive 판정을
+# 재구현하지는 않는다 — 판정 로직을 두 벌 두면 관대함이 갈리고, 그게 이번 주에
+# qasp 에서 고친 바로 그 결함 클래스다(divergent-leniency).
+if [ "$M_TIER" -gt 0 ] && [ -n "$CHANGED" ]; then
+  NON_CARVEOUT=$(printf '%s\n' "$CHANGED" \
+    | grep -vE '(^knowledge/.*\.md$|^docs/.*\.md$|(^|/)AGENTS\.md$)' \
+    | grep -vE '^\s*$' || true)
+  if [ -z "$NON_CARVEOUT" ]; then
+    echo "  ⚠️  carve-out 경로만 변경 — M-tier ${M_TIER}건을 S-tier 로 강등한다"
+    echo "      (산문 자산에 내용-손실 검사를 하드 블록으로 걸면 과차단 → --no-verify 학습)"
+    S_TIER=$((S_TIER + M_TIER))
+    M_TIER=0
+  fi
+fi
+
 echo "M-tier blockers: $M_TIER"
 echo "S-tier warnings: $S_TIER"
 


### PR DESCRIPTION
## 결함

`templates/regression_guard.sh` 의 pathspec:
```
plugins/*/skills/*/SKILL.md  .claude/rules/*.md  knowledge/shared/rules/*.md  CLAUDE.md  templates/*.md
```
**`AGENTS.md` · `knowledge/`(shared/rules 외) · `docs/*.md` 가 없다.**

그런데 4축 정본 `.claude/rules/fh_4axis_gate.md:48` 은 이 셋을 커버 자산으로 **명시**하고, substantive carve-out 절에서 따로 다루기까지 한다.

→ **정본이 "커버한다"고 선언한 자산을 Axis 1 계기가 아예 못 봤다.** 그리고 그 미검사가 호출부에서 `✅ PASS` 로 렌더됐다 = *검사 안 함*이 *통과*로 보고되는 fail-open.

**PR #163(AGENTS.md 변경)이 실제로 이 경로를 탔다** — 그 PR 본문에 SKIP 을 명시해뒀지만, 계기 자체를 고치는 건 이 PR 이다. 주간 감사 S-5(`--pr` 가 미커밋 변경을 skip 통과)의 **두 번째 얼굴**.

## 수리 3건

1. **pathspec 정합** — `GUARD_PATHSPEC` 배열로 추출, 정본 목록과 맞춤. 주석에 *"새 경로 추가 시 `fh_4axis_gate.md §48` 과 대조하라"* 를 박았다 — 두 목록이 갈리면 갈린 쪽이 조용히 무검사 구간이 된다.
2. **SKIP ≠ PASS** — `REGRESSION_GUARD_RESULT=skip` 출력 + 호출부가 `⏭️ SKIP — 검사 안 함 ≠ 통과` 로 렌더. `exit 0` 은 **의도적으로 유지**(가역 표면 · 기존 호출자 호환) — 바꾸는 건 보고의 정직성이지 차단 여부가 아니다.
3. **carve-out M→S 강등** — 적대 검토가 잡은 HIGH-1 수리 (아래).

## 적대 검토 (Axis 2) — HIGH 2건, 둘 다 실측 재현

`fh-meta:challenger` 디스패치. **거버너가 같은 실험을 직접 재현해 앵커를 잡았다** (사이드카 동의가 아니라 실행된 실험이 근거).

### HIGH-1 · 과차단 → 수리 완료
`knowledge/**` · `docs/*.md` 를 substantive 필터 없이 추가하면 **산문 한 단어만 바꿔도 하드 블록**이 뜬다. 재현: `self_evolution_routine.md` 에서 단어 하나 교체 → 토큰 카운트 2→1(50% 드롭) → `M-TIER` exit 2. 같은 실행에서 `pre-commit` 자신의 `CARVEOUT` 분류기는 그 파일을 `(prose-only)` 로 올바르게 분류하고 있었다.

**과차단은 이론 비용이 아니다** — `--no-verify` 를 근육에 새기고, 그러면 **같은 훅의 Destructive-Op 게이트까지 함께 무장해제**된다.

수리: carve-out 경로**만** 변경된 경우 M-tier → S-tier 강등. ⚠️ substantive 판정을 여기서 **재구현하지 않았다** — 판정 로직을 두 벌 두면 관대함이 갈리고, 그게 이번 주 qasp 에서 고친 바로 그 결함 클래스(divergent-leniency)다.

### HIGH-2 · 마커가 1개 소비자에만 배선 → **부분 수리**
`REGRESSION_GUARD_RESULT=skip` 을 읽는 건 `pre-commit` 뿐. `harness-doctor` · `harvest-loop` · `hub-cc-pr-reviewer` · `self_evolution_routine.md` 는 **종료코드만** 본다. 특히 마지막은 무인 주간 루틴이면서 *"Axis 1 PASS alone unblocks a draft PR"* 이라고 적혀 있었다 = **미검사가 draft PR 을 unblock**.

수리: docstring 에 exit 0 의 이중 의미 + 배선 현황 명시 · `self_evolution_routine.md` 에 경고 블록 추가. **나머지 3 소비자는 잔여로 명시**(아래).

이건 `[[feedback_built_but_not_wired]]` 그대로다 — 만든 것의 호출자를 안 배선함.

## 회귀 앵커 (전부 직접 실행)

| 케이스 | 결과 |
|---|---|
| carve-out 산문만 변경 | M0 / S1 — **블록 없음** |
| `SKILL.md` 훼손 | **M5 BLOCK** |
| 혼합 (SKILL + knowledge) | **M6 BLOCK** |
| known-positive: `AGENTS.md` 스테이징 | `Files changed: 1` (수리 전엔 skip) |
| known-negative: 게이트 밖 파일 | `SKIP (not-checked, NOT a pass)` |

## 잔여 (명시 — 닫힌 척하지 않음)

- SKIP 마커가 `harness-doctor` · `harvest-loop` · `hub-cc-pr-reviewer` **3개 소비자에 미배선**. `exit 0` 을 쪼개면 기존 호출자가 깨지므로 별건 설계 필요.
- challenger 지적대로 **stdout grep 은 prose-grep 채널**이라 그 자체가 `[[feedback_typed_verdict_channel]]` 이 금지하는 방향이다. typed 채널(파일/exit 분화)로 올리는 게 옳은 종착점 — 다음 세션 안건.