### PR TITLE
refactor(gate): 스캔 로직 단일 소스화 + fh-gate FH_BACKEND=cross

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -198,7 +198,7 @@ FH_BACKEND=auto npx --package @chrono-meta/fh-gate fh-gate "src/foo.ts" full
 # → FH_GATE_VERDICT: PASS | PENDING | BLOCKED | ESCALATE
 ```
 
-`fh-gate` は両ランタイムに同じ FH ガバナンスプロンプトを使います。`FH_BACKEND=claude` は `claude --print` を、`FH_BACKEND=codex` は `codex exec` を実行し、`FH_BACKEND=auto` は両 CLI が揃っていれば Codex を優先します。
+`fh-gate` は両ランタイムに同じ FH ガバナンスプロンプトを使います。`FH_BACKEND=claude` は `claude --print` を、`FH_BACKEND=codex` は `codex exec` を実行し、`FH_BACKEND=auto` は両 CLI が揃っていれば Codex を優先します — ただし `auto` はフォールバック*選択*であり、レグは 1 つだけ走ります。`FH_BACKEND=cross` は両ファミリーを走らせて findings を union します(一方だけが見つけた指摘も指摘なので、投票ではなく union)。判定はレグ中で最も重いものです。コストは約 2 倍なので既定ではなく、判定・ゲート・不可逆な面の変更に使います。出力は実際に走ったレグを常に明示します(`FH_GATE_LEGS:`、`FH_GATE_DECORRELATED:`) — 片方のファミリーしかない環境では単一レグに縮退し、その事実を明記します。
 
 Claude Code の外でスキルやエージェントを直接実行するには `fh-run` を使います:
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -197,7 +197,7 @@ FH_BACKEND=auto npx --package @chrono-meta/fh-gate fh-gate "src/foo.ts" full
 # → FH_GATE_VERDICT: PASS | PENDING | BLOCKED | ESCALATE
 ```
 
-`fh-gate`는 두 런타임에 동일한 FH 거버넌스 프롬프트를 씁니다. `FH_BACKEND=claude`는 `claude --print`를, `FH_BACKEND=codex`는 `codex exec`를 실행하며, `FH_BACKEND=auto`는 두 CLI가 모두 있으면 Codex를 우선합니다.
+`fh-gate`는 두 런타임에 동일한 FH 거버넌스 프롬프트를 씁니다. `FH_BACKEND=claude`는 `claude --print`를, `FH_BACKEND=codex`는 `codex exec`를 실행하며, `FH_BACKEND=auto`는 두 CLI가 모두 있으면 Codex를 우선합니다 — 다만 `auto`는 폴백 *선택*이라 레그를 하나만 돌립니다. `FH_BACKEND=cross`는 두 패밀리를 모두 돌려 findings를 union 합니다(한쪽만 본 지적도 지적이므로 투표가 아니라 union). 판정은 레그 중 가장 무거운 것입니다. 비용이 약 2배라 기본값이 아니며, 판정·게이트·비가역 표면 변경에 씁니다. 출력은 실제로 돈 레그를 항상 밝힙니다(`FH_GATE_LEGS:`, `FH_GATE_DECORRELATED:`) — 한 패밀리만 설치된 머신에서는 단일 레그로 내려가되 그 사실을 명시합니다. 단일 패밀리 결과가 교차검증된 것처럼 읽히는 편이 더 나쁘기 때문입니다.
 
 Claude Code 밖에서 스킬이나 에이전트를 직접 실행하려면 `fh-run`을 씁니다:
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ FH_BACKEND=auto npx --package @chrono-meta/fh-gate fh-gate "src/foo.ts" full
 # → FH_GATE_VERDICT: PASS | PENDING | BLOCKED | ESCALATE
 ```
 
-`fh-gate` uses the same FH governance prompt for both runtimes. `FH_BACKEND=claude` runs `claude --print`; `FH_BACKEND=codex` runs `codex exec`; `FH_BACKEND=auto` prefers Codex when both CLIs are present.
+`fh-gate` uses the same FH governance prompt for both runtimes. `FH_BACKEND=claude` runs `claude --print`; `FH_BACKEND=codex` runs `codex exec`; `FH_BACKEND=auto` prefers Codex when both CLIs are present — note that `auto` is fallback *selection*: it runs ONE leg. `FH_BACKEND=cross` runs BOTH families and unions their findings (a finding only one family saw is still a finding, so it unions rather than votes); the verdict is the most severe across legs. It costs ~2x, so it is for load-bearing verdict/gate/irreversible-surface changes, not a default. The output always declares which legs actually ran (`FH_GATE_LEGS:`, `FH_GATE_DECORRELATED:`) — on a machine with only one family, `cross` degrades to that single leg and says so, because a single-family result that reads as cross-checked is worse than an honest one.
 
 For direct skill or agent execution outside Claude Code, use `fh-run`:
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -187,7 +187,7 @@ FH_BACKEND=auto npx --package @chrono-meta/fh-gate fh-gate "src/foo.ts" full
 # → FH_GATE_VERDICT: PASS | PENDING | BLOCKED | ESCALATE
 ```
 
-`fh-gate` 对两种运行时使用同一套 FH 治理提示。`FH_BACKEND=claude` 运行 `claude --print`；`FH_BACKEND=codex` 运行 `codex exec`；`FH_BACKEND=auto` 在两个 CLI 都存在时优先选择 Codex。
+`fh-gate` 对两种运行时使用同一套 FH 治理提示。`FH_BACKEND=claude` 运行 `claude --print`；`FH_BACKEND=codex` 运行 `codex exec`；`FH_BACKEND=auto` 在两个 CLI 都存在时优先选择 Codex —— 但 `auto` 是回退式*选择*，只运行一条腿。`FH_BACKEND=cross` 会运行两个模型家族并对 findings 取并集(只有一方发现的问题仍然是问题，因此是并集而非投票)，判定取各腿中最严重者。成本约为 2 倍，因此并非默认值，适用于判定/门禁/不可逆面的变更。输出始终声明实际运行了哪些腿(`FH_GATE_LEGS:`、`FH_GATE_DECORRELATED:`) —— 在只装了一个家族的机器上，`cross` 会降级为单腿并明确说明，因为让单家族结果读起来像交叉验证过更糟。
 
 若要在 Claude Code 之外直接执行技能或 agent，使用 `fh-run`：
 

--- a/scripts/fh-gate.sh
+++ b/scripts/fh-gate.sh
@@ -59,12 +59,86 @@ FH_TASK_DESCRIPTION="${FH_TASK_DESCRIPTION:-}"
 FH_DIFF_PATH="${FH_DIFF_PATH:-}"
 
 case "$FH_BACKEND" in
-  claude|codex|auto) ;;
+  claude|codex|auto|cross) ;;
   *)
-    echo "ERROR: FH_BACKEND must be 'claude', 'codex', or 'auto' (got: $FH_BACKEND)" >&2
+    echo "ERROR: FH_BACKEND must be 'claude', 'codex', 'auto', or 'cross' (got: $FH_BACKEND)" >&2
     exit $EXIT_ARG_ERROR
     ;;
 esac
+
+# ── FH_BACKEND=cross — decorrelated review (2026-07-26) ───────────────────────────────────────
+# `auto` is a FALLBACK: it picks codex if present, else claude, and runs ONE leg. That is backend
+# SELECTION, not decorrelation. A same-family reviewer shares the author's optimistic reading, which
+# is the failure mode the FH load-bearing gate exists to catch — and a 7-round cross-family audit of
+# that gate found 30 issues an in-family pass had not.
+#
+# `cross` runs BOTH families and UNIONs their findings. Union, not vote: detection is the task, and a
+# finding only one leg saw is still a finding (majority voting would discard exactly the decorrelated
+# signal this mode is for). The verdict is the most severe across legs.
+#
+# THE INVARIANT THAT MATTERS MOST: the output declares WHICH LEGS ACTUALLY RAN (`FH_GATE_LEGS:`).
+# `cross` is a REQUEST, not a guarantee — a machine may have only one family installed. When a leg is
+# unavailable or errors, this degrades to the surviving leg and SAYS SO, loudly, in both the human and
+# the machine-readable output. A single-leg result that reads as if it were cross-checked is the same
+# class of defect as a check that did not run reading as PASS.
+#
+# COST: cross is ~2x. It is deliberately NOT a default — [[feedback_decorrelation_not_fanout_cost_boundary]]
+# says match the parallelisation axis to the failure mode rather than multiply. Callers should request
+# it for load-bearing verdict/gate/irreversible-surface changes, which is exactly the trigger the
+# pre-commit load-bearing leg already computes.
+if [[ "$FH_BACKEND" == "cross" ]]; then
+  _CROSS_LEGS=""; _CROSS_OUT=""; _CROSS_WORST="PASS"; _CROSS_RAN=0; _CROSS_ERR=""
+  _sev_rank() { case "$1" in PASS) echo 0 ;; PENDING) echo 1 ;; ESCALATE) echo 2 ;; BLOCKED) echo 3 ;; *) echo -1 ;; esac; }
+  for _leg in claude codex; do
+    command -v "$_leg" >/dev/null 2>&1 || { _CROSS_ERR="${_CROSS_ERR}${_CROSS_ERR:+, }$_leg (not installed)"; continue; }
+    # `set -e` is on: an assignment from a command substitution carries the child's exit status, and
+    # this child EXITS NON-ZERO BY DESIGN for every non-PASS verdict (PENDING 1 / BLOCKED 2 /
+    # ESCALATE 3). Written bare, the first leg that found anything would kill the whole cross run —
+    # i.e. cross would work only when there was nothing to find. `|| _legrc=$?` keeps the status
+    # without letting it abort. Verified against a BLOCKED leg, not assumed.
+    _legrc=0
+    _legout=$(FH_BACKEND="$_leg" "$0" "$@" 2>/dev/null) || _legrc=$?
+    if [ "$_legrc" -ge 10 ]; then
+      _CROSS_ERR="${_CROSS_ERR}${_CROSS_ERR:+, }$_leg (harness error $_legrc)"; continue
+    fi
+    _legverdict=$(printf '%s' "$_legout" | grep -m1 '^FH_GATE_VERDICT:' | awk '{print $2}')
+    [ -z "$_legverdict" ] && { _CROSS_ERR="${_CROSS_ERR}${_CROSS_ERR:+, }$_leg (no verdict line)"; continue; }
+    _CROSS_RAN=$((_CROSS_RAN+1))
+    _CROSS_LEGS="${_CROSS_LEGS}${_CROSS_LEGS:+,}$_leg"
+    [ "$(_sev_rank "$_legverdict")" -gt "$(_sev_rank "$_CROSS_WORST")" ] && _CROSS_WORST="$_legverdict"
+    _CROSS_OUT="${_CROSS_OUT}
+# ── leg: $_leg (verdict $_legverdict) ──
+$(printf '%s' "$_legout" | sed -n '/^---$/,$p')"
+  done
+
+  if [ "$_CROSS_RAN" -eq 0 ]; then
+    echo "ERROR: FH_BACKEND=cross — no leg produced a verdict (${_CROSS_ERR:-none available}). Failing closed." >&2
+    exit $EXIT_HARNESS_ERROR
+  fi
+
+  printf 'FH_STATUS: SUCCESS\n'
+  printf 'FH_GATE_VERDICT: %s\n' "$_CROSS_WORST"
+  printf 'FH_GATE_MODE: cross\n'
+  printf 'FH_GATE_LEGS: %s\n' "$_CROSS_LEGS"
+  if [ "$_CROSS_RAN" -lt 2 ]; then
+    # Degraded, and it must be impossible to mistake this for a two-family result.
+    printf 'FH_GATE_DECORRELATED: no\n'
+    printf 'FH_GATE_DEGRADED: %s\n' "$_CROSS_ERR"
+    echo "WARN: FH_BACKEND=cross ran a SINGLE leg ($_CROSS_LEGS) — $_CROSS_ERR." >&2
+    echo "      This verdict is NOT decorrelated. Treat it as $_CROSS_LEGS alone." >&2
+  else
+    printf 'FH_GATE_DECORRELATED: yes\n'
+  fi
+  printf '%s\n' "$_CROSS_OUT"
+  echo "→ fh-gate: cross mode — legs [$_CROSS_LEGS], union verdict $_CROSS_WORST" >&2
+  case "$_CROSS_WORST" in
+    PASS)     exit $EXIT_PASS ;;
+    PENDING)  exit $EXIT_PENDING ;;
+    BLOCKED)  exit $EXIT_BLOCKED ;;
+    ESCALATE) exit $EXIT_ESCALATE ;;
+    *)        exit $EXIT_HARNESS_ERROR ;;
+  esac
+fi
 
 # FH_TIMEOUT lands in command position via the unquoted ${_TIMEOUT_CMD} idiom below.
 # `timeout DURATION COMMAND [ARG]...` treats the word after the duration as the command,

--- a/scripts/prepush_guard_check.sh
+++ b/scripts/prepush_guard_check.sh
@@ -57,6 +57,8 @@ newrepo() {  # echoes a fresh repo path with the pattern layers in place and one
   printf '.claude/rules/.public-surface-patterns\n' > "$d/.gitignore"
   printf 'HIGH\tzzsynthoperator\n' > "$d/.claude/rules/.public-surface-patterns"
   cp "$HOOK" "$d/templates/.git-hooks/pre-push"
+  mkdir -p "$d/scripts"
+  cp "$REPO_ROOT/scripts/psa_scan_lib.sh" "$d/scripts/psa_scan_lib.sh"
   ( cd "$d" && git init -q -b main && git config user.email t@example.com && git config user.name t \
     && git add -A >/dev/null 2>&1 && git commit -qm base >/dev/null 2>&1 ) || return 1
   printf '%s' "$d"
@@ -77,8 +79,19 @@ check() {
   # A hook killed by a signal, or one that dies printing nothing, produces no fault TEXT — the grep
   # above cannot see it, and rc alone would score it as a pass (R7 audit, 2026-07-26). So a `pass`
   # additionally requires the leg's own marker line: proof it ran to the point of making a claim.
+  # "It blocked" is not the same as "it blocked correctly". A missing dependency, an unreadable
+  # file, or any harness error also exits non-zero — and every BLOCK pair would score green while
+  # the gate was actually broken. (Observed: after the scan logic moved into a shared library, the
+  # sandbox repos lacked it, so 6 of 8 BLOCK pairs still "passed" — for the wrong reason.) A block
+  # therefore has to name a confidentiality cause.
   if [ "$rc" -ne 0 ]; then
-    got=block
+    if printf '%s' "$out" | grep -qE '(leak —|leak in pushed|incomplete confidentiality instrument|unusable pattern)'; then
+      got=block
+    else
+      echo "  ❌ $name — blocked, but for a HARNESS reason, not a confidentiality finding"
+      printf '%s\n' "$out" | sed 's/^/       | /' | head -6
+      FAILED=1; return
+    fi
   elif printf '%s' "$out" | grep -qF 'FH Pre-Publish'; then
     got=pass
   else

--- a/scripts/psa_scan_lib.sh
+++ b/scripts/psa_scan_lib.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# psa_scan_lib.sh — the ONE implementation of public-surface pattern loading and matching.
+#
+# WHY THIS FILE EXISTS
+#   Three copies of this logic existed (pre-commit, pre-push, public_surface_scan_files.sh). Across a
+#   single 2026-07-26 cross-family audit, EVERY confidentiality defect found was a divergence between
+#   them, not a flaw in the idea:
+#     • the publish copy checked that the override was readable and non-empty; the commit copy did not
+#     • the commit copy failed closed when no patterns loaded; the publish copy did too; the push copy
+#       had to be told separately
+#     • a row with a SPACE instead of a TAB failed closed in two copies and was silently skipped in the third
+#     • `head -1` per line (a placeholder shielding a real token) was fixed in one copy and not the others
+#     • the LOW-severity file allowlist existed in one copy only — which is how the push gate blocked
+#       its own first real push
+#   Each was repaired where it was found. The prescription this repo already had recorded for that
+#   pattern — [[feedback_divergent_leniency_duplicate_normalizers]]: single source, visible drops,
+#   fail-closed — was quoted during that session and then not applied; the duplication was repaired
+#   three times instead of removed. This file removes it.
+#
+# WHAT IS SHARED vs WHAT STAYS WITH THE CALLER — the split is deliberate, do not "unify" further:
+#   SHARED (here): loading the two pattern layers, validating rows, and deciding whether a given
+#                  token on a given path is a reportable hit.
+#   CALLER'S:      WHICH content is scanned (staged diff / pushed range / packed file set), and the
+#                  DEGRADE DIRECTION when the instrument is incomplete. Those genuinely differ:
+#                  a commit is local and re-committable, so an absent operator override warns; a push
+#                  and a publish are the acts that make content public, so the same state blocks.
+#                  Collapsing that would either block every fresh clone's first commit (training the
+#                  override into reflex) or let a real leak reach a public remote. This library
+#                  therefore REPORTS state and never exits.
+#
+# Usage:
+#   . "$REPO_ROOT/scripts/psa_scan_lib.sh"
+#   psa_load "$defaults_path" "$override_path"     # sets PSA_STREAM + the three state flags below
+#   psa_scan_tagged <<< "$path<TAB>line"…          # prints hits, returns 1 if any hit was reported
+#
+# State set by psa_load (read-only for callers):
+#   PSA_STREAM            validated rows only (invalid/malformed rows are dropped AND counted)
+#   PSA_DEFAULTS_OK       1 = committed defaults present, readable, non-empty
+#   PSA_OVERRIDE_PRESENT  1 = operator override present, readable, non-empty
+#   PSA_BAD_ROWS          count of rows dropped as unusable (uncompilable regex, or no TAB)
+# A caller that treats PSA_BAD_ROWS>0 or PSA_DEFAULTS_OK=0 as "clean" has a hole: those states mean
+# the instrument is incomplete, and an incomplete instrument cannot certify anything.
+
+# Placeholder shapes that must never count as a leak. Anchored whole-token: a substring match here
+# would let a real token pass by merely CONTAINING a placeholder word.
+PSA_PLACEHOLDER='^(<[a-z0-9_-]+>|\{[a-z_]+\}|EXAMPLE|dummy|changeme|REDACTED|xxxx|/Users/(EXAMPLE|yourname|\{[a-z_]+\}|<[a-z0-9_-]+>)/|AKIAIOSFODNN7EXAMPLE)$'
+
+# Files that name wiring/companion tokens as part of doing their job. LOW severity only — HIGH/MED
+# block everywhere, including here. Kept as a function so the list has exactly one definition.
+psa_low_allowlisted() {
+  case "$1" in
+    .gitignore|scripts/sync-to-be.sh|.claude/rules/local_fh_context.md|templates/local_fh_context.md|templates/.claude/rules/*|templates/.git-hooks/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# psa_load <defaults_path> <override_path>
+# Prints diagnostics for every degraded state; sets the flags above. NEVER exits — the caller owns
+# the degrade direction, because it differs by surface (see the header).
+psa_load() {
+  local defaults="$1" override="$2" raw ov
+  PSA_STREAM=""; PSA_DEFAULTS_OK=0; PSA_OVERRIDE_PRESENT=0; PSA_BAD_ROWS=0
+
+  # Layer 1 — committed defaults. This file ships with the repo, so missing/unreadable/empty is a
+  # BROKEN INSTRUMENT, not a configuration choice. A valid override used to mask its absence, and the
+  # scan then reported a clean "full pattern set" with every universal pattern silently gone.
+  if [ -f "$defaults" ] && [ -r "$defaults" ]; then
+    raw=$(cat "$defaults" 2>/dev/null || true)
+    if [ -n "$(printf '%s' "$raw" | grep -vE '^[[:space:]]*(#|$)' || true)" ]; then
+      PSA_STREAM="$raw"; PSA_DEFAULTS_OK=1
+    fi
+  fi
+  [ "$PSA_DEFAULTS_OK" -eq 0 ] && \
+    echo "  ❌ committed pattern defaults missing/unreadable/empty — universal patterns NOT loaded ($defaults)"
+
+  # Layer 2 — the gitignored operator literals. Present ONLY when a readable, non-empty read actually
+  # contributed patterns: an empty file must not masquerade as a configured gate.
+  if [ -f "$override" ]; then
+    if [ -r "$override" ]; then
+      ov=$(cat "$override" 2>/dev/null || true)
+      if [ -n "$(printf '%s' "$ov" | grep -vE '^[[:space:]]*(#|$)' || true)" ]; then
+        PSA_STREAM="$PSA_STREAM
+$ov"; PSA_OVERRIDE_PRESENT=1
+      else
+        echo "  ⚠️  operator pattern override is EMPTY — treated as absent."
+      fi
+    else
+      echo "  ⚠️  operator pattern override exists but is UNREADABLE — treated as absent."
+    fi
+  fi
+
+  # Row validation. Two ways a row can be present and still protect nothing, both previously silent:
+  #   • no TAB  → the whole line lands in the severity field and no detector is defined
+  #   • bad ERE → grep exits >=2 and the error is swallowed downstream as a no-match
+  # Both are DROPPED and COUNTED here so the caller can fail closed on an incomplete instrument.
+  local valid="" line re rc
+  while IFS= read -r line; do
+    line="${line%$'\r'}"                 # CRLF: a trailing CR welds onto the regex and it matches nothing
+    case "$line" in ''|\#*) continue;; esac
+    re="${line#*$'\t'}"
+    if [ "$re" = "$line" ]; then
+      echo "  ❌ unusable pattern row (no TAB between severity and regex): ${line%%$'\t'*}"
+      PSA_BAD_ROWS=$((PSA_BAD_ROWS+1)); continue
+    fi
+    printf '' | grep -E "$re" >/dev/null 2>&1; rc=$?    # 0/1 = compiled; >=2 = regex error
+    if [ "$rc" -ge 2 ]; then
+      echo "  ❌ unusable pattern (invalid regex) — this detector would match nothing: [${line%%$'\t'*}]"
+      PSA_BAD_ROWS=$((PSA_BAD_ROWS+1)); continue
+    fi
+    valid="$valid
+$line"
+  done <<PSA_ROWS
+$PSA_STREAM
+PSA_ROWS
+  PSA_STREAM="$valid"
+}
+
+# psa_scan_tagged  — reads "path<TAB>content" lines on stdin, prints one line per reportable hit.
+# Returns 0 = nothing reportable, 1 = at least one hit.
+#
+# Why path-tagged input: the LOW allowlist is per FILE, so a scanner that flattens content loses the
+# only information needed to apply it. The push copy did exactly that and blocked its own first real
+# push on a companion-store name inside the script whose job is to sync to the companion store.
+psa_scan_tagged() {
+  local input hit=0 row sev re path body tok
+  input=$(cat)
+  [ -n "$input" ] || return 0
+  while IFS= read -r row; do
+    case "$row" in ''|\#*) continue;; esac
+    re="${row#*$'\t'}"; [ "$re" = "$row" ] && continue
+    sev="${row%%$'\t'*}"
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      path="${line%%$'\t'*}"; body="${line#*$'\t'}"
+      # EVERY match on the line. Taking only the first let a documented placeholder earlier on the
+      # line shield a real token later on it.
+      while IFS= read -r tok; do
+        [ -z "$tok" ] && continue
+        printf '%s' "$tok" | grep -qiE "$PSA_PLACEHOLDER" && continue
+        if [ "$sev" = "LOW" ] && psa_low_allowlisted "$path"; then continue; fi
+        echo "  ❌ $sev leak — ${path}: '$tok'"
+        hit=1
+      done <<PSA_TOK
+$(printf '%s' "$body" | grep -oiE "$re" 2>/dev/null || true)
+PSA_TOK
+    done <<PSA_LINES
+$(printf '%s\n' "$input" | grep -iE "$re" 2>/dev/null || true)
+PSA_LINES
+  done <<PSA_PAT
+$PSA_STREAM
+PSA_PAT
+  return $hit
+}

--- a/scripts/public_surface_scan_files.sh
+++ b/scripts/public_surface_scan_files.sh
@@ -27,14 +27,36 @@ set -uo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 PSA_DEFAULTS="$REPO_ROOT/.claude/rules/.public-surface-patterns.defaults"
 PSA_OVERRIDE="${PSA_PATTERNS:-$REPO_ROOT/.claude/rules/.public-surface-patterns}"
-# Placeholder/example shapes that must PASS (documented example paths, not real literals).
-PSA_PLACEHOLDER='^(<[a-z0-9_-]+>|\{[a-z_]+\}|EXAMPLE|dummy|changeme|REDACTED|xxxx|/Users/(EXAMPLE|yourname|\{[a-z_]+\}|<[a-z0-9_-]+>)/|AKIAIOSFODNN7EXAMPLE)$'
+# PSA_PLACEHOLDER and the default psa_low_allowlisted now come from scripts/psa_scan_lib.sh.
+# A second copy here is exactly the divergence this refactor removed; do not reintroduce one.
 
 # LOW-severity allowlist by file (HIGH/MED still block). For the PUBLISH scan this is nearly vacuous:
 # a published file should carry NO operator-private token at all. Deliberately names no operator-private
 # file literal here (the pre-commit copy of this list does, but it lives in a git-hooks-allowlisted path;
 # THIS script is public-tracked, so hardcoding e.g. a companion-script name would itself be a LOW leak —
 # caught by the pre-commit confidentiality scan, 2026-06-27). Generic template paths only.
+
+echo "[Pre-Publish] public-surface scan (npm-published file content)..."
+
+# ── Load patterns via the shared library (scripts/psa_scan_lib.sh) ──
+# One implementation of loading + row validation + exemption decisions, shared with pre-commit and
+# pre-push. What this file KEEPS for itself, deliberately:
+#   • the file-level `grep -a` scan. It forces every published file to be read as TEXT; the library's
+#     line-stream interface would drop back to text-only handling and re-open the hole a challenger
+#     found earlier — a token inside an SVG / null-byte file (docs/pillars.svg ships) scanning clean.
+#   • a STRICTER LOW allowlist (below). A published artifact should carry no operator-private token
+#     at all, so the commit-time list of files that legitimately name wiring tokens does not apply.
+#     Sourcing the library and then redefining the function is how that difference stays visible
+#     instead of being buried as a divergence.
+PSA_LIB="$REPO_ROOT/scripts/psa_scan_lib.sh"
+if [ ! -r "$PSA_LIB" ]; then
+  echo "  ❌ scripts/psa_scan_lib.sh missing — the confidentiality scanner cannot run."
+  [ "${PUBLIC_SURFACE_OK:-0}" = "1" ] || { echo "     Fail-closed on the publish boundary."; exit 1; }
+else
+  . "$PSA_LIB"
+fi
+
+# Stricter than the library default — see the note above. Named here so the difference is legible.
 psa_low_allowlisted() {
   case "$1" in
     templates/*) return 0 ;;
@@ -42,71 +64,27 @@ psa_low_allowlisted() {
   esac
 }
 
-echo "[Pre-Publish] public-surface scan (npm-published file content)..."
+psa_load "$PSA_DEFAULTS" "$PSA_OVERRIDE"
 
-# ── Load patterns (single source, shared with pre-commit) ──
-PSA_STREAM=""
-# The defaults file is COMMITTED — missing/unreadable/empty is a BROKEN INSTRUMENT, not a config
-# choice. Without this, a valid operator override masked its absence and the scan reported a clean
-# "full pattern set" while every universal home-path and credential-shape pattern was silently gone
-# (cross-family audit R3, 2026-07-26 — same hole in both copies, found and fixed in both at once).
-PSA_DEFAULTS_OK=0
-if [ -f "$PSA_DEFAULTS" ] && [ -r "$PSA_DEFAULTS" ]; then
-  PSA_STREAM=$(cat "$PSA_DEFAULTS" 2>/dev/null || true)
-  [ -n "$(printf '%s' "$PSA_STREAM" | grep -vE '^[[:space:]]*(#|$)' || true)" ] && PSA_DEFAULTS_OK=1
-fi
-if [ "$PSA_DEFAULTS_OK" -eq 0 ]; then
-  echo "  ❌ committed pattern defaults missing/unreadable/empty — universal patterns NOT loaded."
-  echo "     Expected: $PSA_DEFAULTS"
-  [ "${PUBLIC_SURFACE_OK:-0}" = "1" ] && echo "  ⚠️  proceeding by PUBLIC_SURFACE_OK=1 (partial pattern set)" || {
-    echo "     Fail-closed: a partial pattern set cannot certify a clean surface."
-    exit 1
-  }
-fi
-OVERRIDE_PRESENT=0
-if [ -f "$PSA_OVERRIDE" ]; then
-  # Fail-OPEN guard (cross-family audit 2026-06-27): an override that EXISTS but is unreadable, or reads
-  # empty, must NOT set OVERRIDE_PRESENT=1 — otherwise the absent-override fail-closed block below is
-  # skipped while cat contributed nothing, and HIGH operator literals scan clean. Only count the override
-  # as present when a readable, non-empty read actually contributed patterns.
-  if [ -r "$PSA_OVERRIDE" ]; then
-    _ov="$(cat "$PSA_OVERRIDE" 2>/dev/null || true)"
-    if [ -n "$(printf '%s' "$_ov" | grep -vE '^[[:space:]]*(#|$)' || true)" ]; then
-      PSA_STREAM="$PSA_STREAM"$'\n'"$_ov"
-      OVERRIDE_PRESENT=1
-    fi
-  else
-    echo "  ⚠️  override exists but is UNREADABLE — treated as absent (fail-closed below)."
-  fi
-fi
-if [ -z "$(printf '%s' "$PSA_STREAM" | grep -vE '^[[:space:]]*(#|$)' || true)" ]; then
-  # No patterns at all on an irreversible surface → fail-closed (unless override).
-  echo "  ❌ no public-surface patterns loaded — confidentiality gate cannot run."
+# Publish is an irreversible surface: EVERY incomplete-instrument state blocks, including the merely
+# absent operator override (which only warns at commit time — see the library header for why the two
+# surfaces degrade differently).
+_psa_why=""
+[ "$PSA_DEFAULTS_OK" -eq 0 ]      && _psa_why="committed pattern defaults missing/unreadable/empty"
+[ "$PSA_BAD_ROWS" -gt 0 ]         && _psa_why="${_psa_why:+$_psa_why; }$PSA_BAD_ROWS unusable pattern row(s)"
+[ "$PSA_OVERRIDE_PRESENT" -eq 0 ] && _psa_why="${_psa_why:+$_psa_why; }operator-literal override absent/empty (HIGH company/companion literals NOT scanned)"
+if [ -n "$_psa_why" ]; then
+  echo "  ❌ incomplete confidentiality instrument — $_psa_why"
   if [ "${PUBLIC_SURFACE_OK:-0}" = "1" ]; then
-    echo "  ⚠️  proceeding by PUBLIC_SURFACE_OK=1 (no scan performed — conscious override)"
-    exit 0
-  fi
-  echo "     Populate .claude/rules/.public-surface-patterns.defaults (or the gitignored override),"
-  echo "     or publish with PUBLIC_SURFACE_OK=1 to override. Fail-closed on an irreversible surface."
-  exit 1
-fi
-# Override absent = INCOMPLETE INSTRUMENT on an irreversible surface (challenger S5): the gitignored
-# operator-literal patterns (HIGH company/companion names) are absent — true on EVERY fresh clone / CI
-# runner by construction. The committed .defaults only carries the universal home-path pattern, so a
-# HIGH company-name leak would scan-clean and print a green PASS. Per the Surface-Class Degrade
-# Invariant (irreversible → fail-CLOSED), an incomplete instrument BLOCKS rather than prints PASS.
-if [ "$OVERRIDE_PRESENT" -eq 0 ]; then
-  echo "  ❌ operator-literal pattern override absent (.claude/rules/.public-surface-patterns)."
-  echo "     Only the committed home-path defaults are active — HIGH company/companion literals are NOT scanned."
-  if [ "${PUBLIC_SURFACE_OK:-0}" = "1" ]; then
-    echo "  ⚠️  proceeding DEFAULTS-ONLY by PUBLIC_SURFACE_OK=1 (conscious — HIGH literals unscanned)"
-    echo "$(date +%Y-%m-%dT%H:%M:%S) PUBLIC_SURFACE_OK override (npm publish, DEFAULTS-ONLY scan)" \
+    echo "  ⚠️  proceeding by PUBLIC_SURFACE_OK=1 (conscious — the scan is incomplete)"
+    echo "$(date +%Y-%m-%dT%H:%M:%S) PUBLIC_SURFACE_OK override (npm publish, incomplete instrument)" \
       >> "$REPO_ROOT/tracks/_meta/.psa_override_log" 2>/dev/null || true
   else
-    echo "     Fail-closed on an irreversible surface: populate the override, or PUBLIC_SURFACE_OK=1 to publish defaults-only."
+    echo "     Fail-closed on an irreversible surface: an incomplete instrument cannot certify clean."
     exit 1
   fi
 fi
+
 
 # Named residual (cross-family audit 2026-06-27, deferred): this scans the WORKING-TREE content of the
 # packed file list, not the final tarball bytes. A content-generating publish lifecycle (prepack/prepare
@@ -123,6 +101,7 @@ if [ -z "$FILES" ]; then
   echo "     Fail-closed on an irreversible surface. Fix npm pack or override with PUBLIC_SURFACE_OK=1."
   exit 1
 fi
+
 # Wrong-set guard (challenger M6): a future npm --json shape change could yield a NON-empty but PARTIAL
 # file list (forEach iterates a renamed/nested structure without throwing) → files silently unscanned.
 # npm always ships package.json in the tarball; its absence means the parse got a wrong set → fail-closed.
@@ -132,32 +111,6 @@ if ! printf '%s\n' "$FILES" | grep -qx "package.json"; then
   echo "     Fail-closed (possible npm --json shape change). Verify npm pack output or PUBLIC_SURFACE_OK=1."
   exit 1
 fi
-
-# ── Validate every regex BEFORE scanning (cross-family audit 2026-06-27) ──
-# A malformed ERE makes `grep -E` exit ≥2 (error), which the scan's `2>/dev/null || true` swallows as a
-# silent no-hit — that detector is then disabled and LEAK stays 0 (fail-OPEN). On an irreversible surface
-# a broken detector is NOT "clean": fail-closed unless explicitly overridden.
-while IFS=$'\t' read -r sev regex; do
-  sev="${sev%$'\r'}"; regex="${regex%$'\r'}"   # CRLF: a trailing CR welds onto the regex → matches nothing
-  case "$sev" in \#*|'') continue;; esac
-  if [ -z "$regex" ]; then
-    # A row with no TAB puts the whole line in $sev and leaves $regex empty. This used to `continue`
-    # SILENTLY — so `HIGH zzz` (space instead of tab) was a detector the author believed in and the
-    # scanner never had, and the publish scan certified clean. Same hole as the commit-time copy;
-    # fixed in both at once, because these two are the pair whose leniency already diverged once.
-    echo "  ❌ unusable pattern row (no TAB between severity and regex): '$sev'"
-    [ "${PUBLIC_SURFACE_OK:-0}" = "1" ] && { echo "  ⚠️  proceeding by PUBLIC_SURFACE_OK=1 (a row is unusable)"; break; }
-    echo "     Fail-closed: a row that defines no detector cannot certify clean."
-    exit 1
-  fi
-  printf '' | grep -aoiE "$regex" >/dev/null 2>&1
-  if [ "$?" -ge 2 ]; then
-    echo "  ❌ invalid pattern (regex error) — detector disabled: [$sev] '$regex'"
-    [ "${PUBLIC_SURFACE_OK:-0}" = "1" ] && { echo "  ⚠️  proceeding by PUBLIC_SURFACE_OK=1 (a detector is broken)"; break; }
-    echo "     Fail-closed: a broken detector cannot certify clean. Fix the pattern or PUBLIC_SURFACE_OK=1."
-    exit 1
-  fi
-done <<< "$PSA_STREAM"
 
 # ── Scan full content of each published file ──
 LEAK=0
@@ -192,7 +145,9 @@ if [ "$LEAK" -eq 1 ]; then
   exit 1
 fi
 
-if [ "$OVERRIDE_PRESENT" -eq 0 ]; then
+# Renamed with the refactor: the flag is PSA_OVERRIDE_PRESENT, set by psa_load. The bare name was a
+# leftover that referenced nothing under `set -u` and aborted the scan at its final line.
+if [ "$PSA_OVERRIDE_PRESENT" -eq 0 ]; then
   echo "  ⚠️  PASS (DEFAULTS-ONLY) — no home-path leak, but HIGH operator literals were NOT scanned (override absent)."
 else
   echo "  ✅ PASS — no operator-private token in the published file set (full pattern set)."

--- a/scripts/test_fh_gate_regressions.sh
+++ b/scripts/test_fh_gate_regressions.sh
@@ -34,7 +34,7 @@ while [ $# -gt 0 ]; do
   esac
 done
 cat >/dev/null   # consume the prompt on stdin
-[ -n "$out" ] && printf '%s' "$FAKE_PAYLOAD" > "$out"
+[ -n "$out" ] && printf '%s' "${FAKE_PAYLOAD_CODEX:-$FAKE_PAYLOAD}" > "$out"
 exit 0
 FAKE
 chmod +x "$FAKEBIN/codex"
@@ -47,7 +47,7 @@ cat > "$FAKEBIN/claude" <<'FAKE'
 #!/usr/bin/env bash
 cat >/dev/null   # consume the prompt on stdin
 if [ -n "${FAKE_ENVELOPE:-}" ]; then printf '%s\n' "$FAKE_ENVELOPE"; exit 0; fi
-printf '{"is_error":false,"subtype":"success","structured_output":%s}\n' "$FAKE_PAYLOAD"
+printf '{"is_error":false,"subtype":"success","structured_output":%s}\n' "${FAKE_PAYLOAD_CLAUDE:-$FAKE_PAYLOAD}"
 exit 0
 FAKE
 chmod +x "$FAKEBIN/claude"
@@ -200,6 +200,50 @@ printf '#!/usr/bin/env bash\nexit 1\n' > "$NOENT/openssl"; chmod +x "$NOENT/open
 printf '#!/usr/bin/env bash\nexit 1\n' > "$NOENT/od";      chmod +x "$NOENT/od"
 check "no CSPRNG (openssl+od stubbed to fail) → fails closed" 10 \
   env PATH="$NOENT:$PATH" FH_DRY_RUN=1 bash "$GATE" "package.json" quick test
+
+echo
+echo "── FH_BACKEND=cross (decorrelated review) ──"
+# cross runs BOTH families and UNIONs. `auto` is fallback SELECTION and runs one leg; conflating the
+# two would let a single-family verdict read as decorrelated, which is the defect class this mode
+# exists to remove. These pairs pin: the union verdict, the leg accounting, and — most importantly —
+# that a degraded (single-leg) run says so in machine-readable form.
+CROSS_PASS='{"status":"SUCCESS","verdict":"PASS","findings_count":0,"findings_a":0,"findings_b":0,"findings":[]}'
+CROSS_BLOCK='{"status":"SUCCESS","verdict":"BLOCKED","findings_count":1,"findings_a":1,"findings_b":0,"findings":[{"grade":"A","location":"x:1","title":"t","evidence":"e","fix":"f"}]}'
+
+check_out() {  # <name> <expected-exit> <grep-ere that MUST appear> -- <cmd...>
+  local name="$1" expect="$2" want="$3"; shift 3
+  local got
+  "$@" >"$TMPROOT/out" 2>"$TMPROOT/err"; got=$?
+  if [ "$got" -eq "$expect" ] && grep -qE "$want" "$TMPROOT/out"; then
+    printf 'PASS  %-58s (exit %s)\n' "$name" "$got"; pass=$((pass + 1))
+  else
+    printf 'FAIL  %-58s expected %s + /%s/, got %s\n' "$name" "$expect" "$want" "$got"
+    sed 's/^/        /' "$TMPROOT/out" | head -4; sed 's/^/        /' "$TMPROOT/err" | head -2
+    fail=$((fail + 1))
+  fi
+}
+run_cross() {  # <claude-payload> <codex-payload>
+  env PATH="$FAKEBIN:$PATH" FH_BACKEND=cross FH_MODEL=fake \
+      FAKE_PAYLOAD_CLAUDE="$1" FAKE_PAYLOAD_CODEX="$2" FAKE_PAYLOAD="$1" \
+      bash "$GATE" "package.json" quick test
+}
+
+check_out "cross: both PASS → PASS, decorrelated" 0 'FH_GATE_DECORRELATED: yes' \
+  run_cross "$CROSS_PASS" "$CROSS_PASS"
+# UNION, not vote: one leg blocking is enough. A majority rule would discard precisely the finding
+# only the other family saw, which is the entire point of running two.
+check_out "cross: one leg BLOCKED → union BLOCKED" 2 'FH_GATE_VERDICT: BLOCKED' \
+  run_cross "$CROSS_PASS" "$CROSS_BLOCK"
+check_out "cross: both legs' findings survive the union" 2 'FH_GATE_LEGS: claude,codex' \
+  run_cross "$CROSS_BLOCK" "$CROSS_BLOCK"
+# A machine with only one family is the COMMON case, not an edge case. It must not be silent.
+ONELEG="$TMPROOT/oneleg"; mkdir -p "$ONELEG"; cp "$FAKEBIN/claude" "$ONELEG/claude"
+check_out "cross: codex absent → single leg, DECORRELATED: no" 0 'FH_GATE_DECORRELATED: no' \
+  env PATH="$ONELEG:/usr/bin:/bin" FH_BACKEND=cross FH_MODEL=fake \
+      FAKE_PAYLOAD_CLAUDE="$CROSS_PASS" FAKE_PAYLOAD="$CROSS_PASS" \
+      bash "$GATE" "package.json" quick test
+check "cross: no family available → fails closed" 10 \
+  env PATH="/usr/bin:/bin" FH_BACKEND=cross bash "$GATE" "package.json" quick test
 
 echo
 echo "────────────────────────────────────────────────────────────────────"

--- a/scripts/universal_guard_check.sh
+++ b/scripts/universal_guard_check.sh
@@ -73,8 +73,13 @@ DEFAULTS="$SANDBOX/.defaults-under-test"
 git -C "$SANDBOX" init -q 2>/dev/null
 git -C "$SANDBOX" config user.email "test@example.com"
 git -C "$SANDBOX" config user.name "test"
-mkdir -p "$SANDBOX/.claude/rules"
+mkdir -p "$SANDBOX/.claude/rules" "$SANDBOX/scripts"
 cp "$DEFAULTS" "$SANDBOX/.claude/rules/.public-surface-patterns.defaults"
+# The hook now sources the shared scan library, so the sandbox needs it too. When it was missing,
+# the gate correctly failed closed — and 3 of the "clean" pairs still scored PASS because the oracle
+# below did not recognise "scanner cannot run" as a not-armed state. Both were fixed together.
+cp "$REPO_ROOT/scripts/psa_scan_lib.sh" "$SANDBOX/scripts/psa_scan_lib.sh" 2>/dev/null \
+  || { echo "❌ FAIL — scripts/psa_scan_lib.sh missing — fail-closed."; exit 1; }
 # An initial commit so the hook's staged-vs-HEAD steps have a HEAD to diff against. Without it
 # they emit "fatal: ambiguous argument 'HEAD'" — harmless to the verdicts here, but noise in a
 # check whose whole job is to make a real signal legible.
@@ -108,7 +113,7 @@ run_case() {
     # hook to have actually blocked.
     if [ "$rc" -ne 0 ]; then hasleak=leak; else hasleak=leak-printed-but-NOT-blocked; fi
   elif printf '%s' "$out" | grep -qF '[Confidentiality] public-surface scan'; then
-    if printf '%s' "$out" | grep -qE '(INACTIVE|INCOMPLETE|unusable pattern)'; then
+    if printf '%s' "$out" | grep -qE '(INACTIVE|INCOMPLETE|unusable pattern|cannot run|scanner cannot)'; then
       hasleak=inconclusive-gate-not-armed
     else
       hasleak=clean
@@ -228,6 +233,14 @@ run_case "non-ASCII filename, credential  → BLOCK" \
          "유출.md" "aws = $AWS_FIXTURE" "leak"
 run_case "non-ASCII filename, clean       → PASS " \
          "유출.md" "평범한 문서, 비밀 없음" "clean"
+
+# ── Pair 8-b: a C-QUOTED path (backslash in the name). `core.quotePath=false` handles non-ASCII,
+# but git still C-quotes a backslash, and a quoted spelling matches no real file — so the file was
+# never scanned. R5 closed this with NUL-delimited iteration; a later refactor silently reverted the
+# loop to a line-oriented read and reopened it, which its own cross-family pass caught. Pinned so the
+# next refactor cannot revert it quietly.
+run_case "backslash in filename, credential → BLOCK" \
+         'back\slash.md' "aws = $AWS_FIXTURE" "leak"
 
 # ── Pair 9: rename-AWAY of the protected file. `git mv`-ing the hook out of its gated path used to
 # report only the DESTINATION, so the classifier saw no gate edit and the anchor fell back to the

--- a/templates/.git-hooks/pre-commit
+++ b/templates/.git-hooks/pre-commit
@@ -227,214 +227,85 @@ else
 fi
 
 # ── Confidentiality guard — public-surface scan on staged tracked content ─────
-# A commit to a PUBLIC repo is an effective PUBLISH of its content. The 4 axes above
-# verify STRUCTURAL integrity, not the confidentiality boundary — that is
-# public-surface-audit's job, and the prose trigger to run it was historically missed
-# on weaker-tier sessions (PR #109: a companion-store name + corp-context framing reached
-# a public PR; the Sonnet session's self-check trusted a PR comment over the file content).
-# This makes the confidentiality axis MECHANICAL *wherever the pattern source is configured*.
+# A commit to a PUBLIC repo is an effective PUBLISH of its content, so the confidentiality boundary is
+# checked here as well as at push/publish. Pattern loading and matching come from
+# scripts/psa_scan_lib.sh — the single implementation shared with pre-push and the publish scanner.
+# (Three near-duplicate copies used to exist; every confidentiality defect found in the 2026-07-26
+# cross-family audit was a divergence between them, so the duplication was removed rather than
+# repaired a fourth time.)
 #
-# Two-layer, mirroring public-surface-audit's own design: operator-private LITERALS live ONLY
-# in the GITIGNORED override; THIS SCRIPT NAMES NONE OF THEM. A COMMITTED *.defaults file carries
-# only universal, non-private patterns (absolute home paths) so the gate is NEVER fully blind even
-# before the operator populates the override. Scans the ADDED lines of staged TRACKED files
-# (gitignored paths are never staged → the public surface is exactly what is scanned).
-#
-# Honest scope: plaintext added lines only — encoded/obfuscated tokens are out of scope (weekly-audit
-# + operator residual). HIGH/MED substring patterns match WITHOUT word boundaries — author the gitignored
-# source with specific phrases to avoid in-word false matches. The '+++ b/<path>' diff header degrades to
-# '++ b/<path>' and is kept in the scanned body on purpose (also catches a leak in a new FILENAME).
+# DEGRADE DIRECTION HERE IS DELIBERATELY GENTLER THAN AT PUSH — do not "unify" it:
+#   • no usable patterns at all, or unusable rows → FAIL (an instrument that cannot run cannot certify)
+#   • operator override merely ABSENT            → WARN only. It is gitignored, so it is absent on
+#     every fresh clone and CI runner by construction; blocking each of their first commits would
+#     train PUBLIC_SURFACE_OK into a reflex and disarm the same channel the publish gate depends on.
+#     The push-time gate blocks that state instead, which is the boundary that actually publishes.
 echo "[Confidentiality] public-surface scan (staged tracked content)..."
-PSA_DEFAULTS="$REPO_ROOT/.claude/rules/.public-surface-patterns.defaults"        # committed, universal
-PSA_OVERRIDE="${PSA_PATTERNS:-$REPO_ROOT/.claude/rules/.public-surface-patterns}" # gitignored, operator literals
-# Placeholder/example shapes — incl. path-embedded (documented example paths must pass, not block).
-PSA_PLACEHOLDER='^(<[a-z0-9_-]+>|\{[a-z_]+\}|EXAMPLE|dummy|changeme|REDACTED|xxxx|/Users/(EXAMPLE|yourname|\{[a-z_]+\}|<[a-z0-9_-]+>)/|AKIAIOSFODNN7EXAMPLE)$'
-psa_low_allowlisted() {  # files that legitimately name companion/wiring tokens (LOW only; HIGH/MED still block)
-  case "$1" in
-    .gitignore|scripts/sync-to-be.sh|.claude/rules/local_fh_context.md|templates/local_fh_context.md|templates/.claude/rules/*|templates/.git-hooks/*) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-# Active patterns = committed defaults + gitignored override (if present).
-#
-# DIVERGENT-LENIENCY REPAIR (2026-07-26, cross-family audit): this block used to be the LENIENT twin
-# of the same logic in scripts/public_surface_scan_files.sh. That copy was hardened on 2026-06-27
-# (readable-and-non-empty override check + fail-CLOSED when no patterns load); THIS copy never
-# received the same fix, so three states that BLOCK at publish time passed silently at commit time:
-#   (a) override exists but is empty/unreadable → counted as present, contributed nothing
-#   (b) no patterns loaded at all → printed "gate INACTIVE" and PASSED
-#   (c) a malformed regex → grep exits 2, the error is swallowed, that detector silently does nothing
-# A commit to a public repo IS a publish of its content, so the two copies must degrade the same way.
-# Same defect shape as the confidentiality-scope hole above: the fix landed on one surface only.
-PSA_BAD=0
-PSA_STREAM=""
-PSA_DEFAULTS_OK=0
-if [ -f "$PSA_DEFAULTS" ] && [ -r "$PSA_DEFAULTS" ]; then
-  PSA_STREAM=$(cat "$PSA_DEFAULTS" 2>/dev/null || true)
-  [ -n "$(printf '%s' "$PSA_STREAM" | grep -vE '^[[:space:]]*(#|$)' || true)" ] && PSA_DEFAULTS_OK=1
-fi
-if [ "$PSA_DEFAULTS_OK" -eq 0 ]; then
-  # The defaults file is COMMITTED — its absence is not a configuration choice, it is a broken
-  # instrument. Previously a present-but-unrelated override masked this: the universal home-path and
-  # credential-shape patterns silently vanished while the gate reported a clean full scan (R3 audit,
-  # 2026-07-26). A partial pattern set must never certify a clean surface.
-  echo "  ❌ committed pattern defaults missing/unreadable/empty — universal patterns NOT loaded."
-  echo "     Expected: $PSA_DEFAULTS"
-  PSA_BAD=1
-fi
-PSA_OVERRIDE_PRESENT=0
-if [ -f "$PSA_OVERRIDE" ]; then
-  if [ -r "$PSA_OVERRIDE" ]; then
-    _psa_ov="$(cat "$PSA_OVERRIDE" 2>/dev/null || true)"
-    # Only count the override as PRESENT when a readable, non-empty read actually contributed
-    # patterns — an empty file must not masquerade as a configured gate.
-    if [ -n "$(printf '%s' "$_psa_ov" | grep -vE '^[[:space:]]*(#|$)' || true)" ]; then
-      PSA_STREAM="$PSA_STREAM"$'\n'"$_psa_ov"
-      PSA_OVERRIDE_PRESENT=1
-    else
-      echo "  ⚠️  operator pattern override is EMPTY — treated as absent."
-    fi
-  else
-    echo "  ⚠️  operator pattern override exists but is UNREADABLE — treated as absent."
-  fi
-fi
-if [ "$PSA_OVERRIDE_PRESENT" -eq 0 ]; then
-  # INTENTIONAL ASYMMETRY vs scripts/public_surface_scan_files.sh — do NOT "fix" this to match.
-  # There, an absent override BLOCKS; here it only warns. The two surfaces are not the same surface:
-  # `npm publish` is rare, deliberate, and irreversible outward, so an incomplete instrument must
-  # stop it. A commit happens constantly, and the override is gitignored — so it is absent on EVERY
-  # fresh clone and CI runner by construction. Blocking here would block every such environment on
-  # its first commit and train PUBLIC_SURFACE_OK into a reflex, which disarms the override channel
-  # for the publish gate too. The defaults still load, so the gate is ARMED (home paths + credential
-  # shapes); what is missing is operator literals, which a fresh clone cannot have anyway.
-  # (Raised as a leniency divergence by a cross-family audit R3, 2026-07-26, and REFUTED on these
-  # grounds. Recorded here so the next audit reads the reasoning instead of re-raising it — and so
-  # nobody closes it in the over-blocking direction.)
-  echo "  ⚠️  operator pattern override absent — only committed defaults active (home paths)."
-  echo "     Populate .claude/rules/.public-surface-patterns (gitignored) for company-specific tokens"
-  echo "     (esp. the company env, where company-origin public PRs are authored)."
-fi
-# Regex validity — a pattern grep cannot compile is a detector that silently does NOTHING. grep exits
-# >=2 on an invalid ERE; that error was previously swallowed by `|| true` downstream, so a single typo
-# in the gitignored override disabled its detector with no signal. Drop invalid patterns loudly and
-# treat their presence as an instrument fault (fail-closed below), never as a clean scan.
-PSA_VALID=""
-while IFS= read -r _psa_line; do
-  _psa_line="${_psa_line%$'\r'}"   # CRLF: a trailing CR welds onto the regex and it matches nothing
-  case "$_psa_line" in ''|\#*) continue;; esac
-  _psa_re="${_psa_line#*$'\t'}"
-  if [ "$_psa_re" = "$_psa_line" ]; then
-    # No TAB → this row is not a pattern at all. It used to be skipped SILENTLY, so writing
-    # "HIGH zzz" with a space instead of a tab produced a detector that never existed and a scan
-    # that reported clean (cross-family audit R2, 2026-07-26). A row the author believes is
-    # protecting them, that protects nothing, is the worst state of the three — louder than absent.
-    echo "  ❌ unusable pattern row (no TAB between severity and regex):"
-    echo "       ${_psa_line}"
-    PSA_BAD=1
-    continue
-  fi
-  # grep exit codes: 0 = matched, 1 = no match (both mean the regex COMPILED), >=2 = usage/regex error.
-  # Checked against empty input so only compilability is under test, never content.
-  printf '' | grep -E "$_psa_re" >/dev/null 2>&1
-  _psa_rc=$?
-  if [ "$_psa_rc" -lt 2 ]; then
-    PSA_VALID="$PSA_VALID"$'\n'"$_psa_line"
-  else
-    echo "  ❌ unusable pattern (invalid regex) — this detector would silently match nothing:"
-    echo "       ${_psa_line%%$'\t'*}<TAB>${_psa_re}"
-    PSA_BAD=1
-  fi
-done <<PSA_VALID_EOF
-$PSA_STREAM
-PSA_VALID_EOF
-PSA_STREAM="$PSA_VALID"
-if [ -z "$(printf '%s' "$PSA_STREAM" | grep -vE '^[[:space:]]*(#|$)' || true)" ] || [ "$PSA_BAD" -eq 1 ]; then
-  # FAIL-CLOSED. Per CLAUDE.md §Irreversibility Gates — Surface-Class Degrade Invariant, an
-  # applicable check whose instrument is unavailable BLOCKS on a publish surface; it never
-  # degrades to a printed warning plus PASS. Escape hatch is the same explicit, logged channel
-  # used everywhere else — never a silent proceed.
-  if [ "$PSA_BAD" -eq 1 ]; then
-    echo "  ❌ confidentiality gate INCOMPLETE — at least one pattern row is unusable (see above)."
-  else
-    echo "  ❌ confidentiality gate INACTIVE — no usable patterns loaded in this env."
-    echo "     Expected: $PSA_DEFAULTS (committed) and/or the gitignored override."
-  fi
-  if [ "${PUBLIC_SURFACE_OK:-0}" = "1" ]; then
-    echo "  ⚠️  proceeding with an INACTIVE/INCOMPLETE gate by PUBLIC_SURFACE_OK=1 (conscious)"
-    echo "$(date +%Y-%m-%dT%H:%M:%S) PUBLIC_SURFACE_OK override — branch $BRANCH — gate inactive/incomplete" \
-      >> "$REPO_ROOT/tracks/_meta/.psa_override_log" 2>/dev/null || true
-  else
-    echo "     Restore the pattern source, or PUBLIC_SURFACE_OK=1 git commit … to proceed unscanned."
-    FAILED=1
-  fi
+PSA_LIB="$REPO_ROOT/scripts/psa_scan_lib.sh"
+if [ ! -r "$PSA_LIB" ]; then
+  echo "  ❌ FAIL — scripts/psa_scan_lib.sh missing; the confidentiality scanner cannot run."
+  FAILED=1
 else
-  PSA_LEAK=0
-  while IFS= read -r -d '' f; do
-    [ -z "$f" ] && continue
-    added=$(git diff --cached -- "$f" 2>/dev/null | grep -E '^\+' | sed 's/^\+//' || true)
-    [ -z "$added" ] && continue
-    # Split-token backstop: TIGHT-join (no separator) so a token wrapped mid-word across added
-    # lines (e.g. "fh-\nbe" → "fh-be") is caught. Accepted residual (verified, not a missed fix):
-    # two whitespace-separated words can RARELY fuse into a spurious match — safe-direction (over-block)
-    # + PUBLIC_SURFACE_OK escape. A sentinel separator would close that fusion but RE-OPEN the split-catch
-    # (the more important case: real literals have no internal whitespace), so tight-join is deliberate.
-    joined=$(printf '%s' "$added" | tr -d '\n\r')
-    while IFS=$'\t' read -r sev regex; do
-      [ -z "$regex" ] && continue
-      case "$sev" in \#*) continue;; esac
-      per_line_hit=0
-      while IFS= read -r h; do
-        [ -z "$h" ] && continue
-        # EVERY match on the line, not just the first (propagation sweep, R7 audit 2026-07-26).
-        # `head -1` meant a documented placeholder earlier on a line SHIELDED a real token later on
-        # the same line: the first match was exempt, the loop moved on, and the line scanned clean.
-        # The same defect was fixed in the pre-push copy first and NOT propagated here — the exact
-        # half-fix-propagation class this session kept re-finding, committed once more while
-        # documenting it. The sweep that caught it: grep for `grep -oiE` across all three copies.
-        while IFS= read -r tok; do
-          [ -z "$tok" ] && continue
-          printf '%s' "$tok" | grep -qiE "$PSA_PLACEHOLDER" && continue
-          if [ "$sev" = "LOW" ] && psa_low_allowlisted "$f"; then continue; fi
-          echo "  ❌ $sev leak — $f: '$tok' on the public surface"
-          PSA_LEAK=1; per_line_hit=1
-        done <<PSATOK
-$(printf '%s' "$h" | grep -oiE "$regex" 2>/dev/null || true)
-PSATOK
-      done <<< "$(printf '%s\n' "$added" | grep -nIE "$regex" 2>/dev/null || true)"
-      # Split-token backstop: catch a token line-wrapped across added lines — only if the per-line
-      # pass found nothing for this pattern (avoids double-reporting the common single-line case).
-      if [ "$per_line_hit" -eq 0 ]; then
-        jtok=$(printf '%s' "$joined" | grep -oiE "$regex" 2>/dev/null | head -1 || true)
-        if [ -n "$jtok" ] && ! printf '%s' "$jtok" | grep -qiE "$PSA_PLACEHOLDER" \
-           && ! { [ "$sev" = "LOW" ] && psa_low_allowlisted "$f"; }; then
-          echo "  ❌ $sev leak (line-split) — $f: '$jtok' on the public surface"
-          PSA_LEAK=1
-        fi
-      fi
-    done <<< "$PSA_STREAM"
-  # NUL-delimited (R3, 2026-07-26): `core.quotePath=false` stops git quoting NON-ASCII names, but a
-  # path holding a backslash or a newline is STILL C-quoted, and a newline in a name breaks a
-  # line-oriented read outright. `-z` emits raw bytes with a NUL separator, which no filename can
-  # contain — the only spelling of a path that is always exact. Process substitution keeps the loop
-  # in THIS shell so PSA_LEAK survives it (a pipe would run the loop in a subshell and lose the flag,
-  # which would be a fail-open).
-  done < <(git -c core.quotePath=false diff --cached --name-only --no-renames --diff-filter=ACMR -z 2>/dev/null || true)
-  if [ "$PSA_LEAK" -eq 1 ]; then
+  . "$PSA_LIB"
+  psa_load "$REPO_ROOT/.claude/rules/.public-surface-patterns.defaults" \
+           "${PSA_PATTERNS:-$REPO_ROOT/.claude/rules/.public-surface-patterns}"
+  if [ "$PSA_OVERRIDE_PRESENT" -eq 0 ]; then
+    echo "  ⚠️  operator pattern override absent — only committed defaults active (home paths)."
+    echo "     Populate .claude/rules/.public-surface-patterns (gitignored) for company-specific tokens."
+  fi
+  if [ "$PSA_DEFAULTS_OK" -eq 0 ] || [ "$PSA_BAD_ROWS" -gt 0 ] \
+     || [ -z "$(printf '%s' "$PSA_STREAM" | grep -vE '^[[:space:]]*(#|$)' || true)" ]; then
+    echo "  ❌ confidentiality gate INACTIVE/INCOMPLETE — cannot certify a clean surface."
     if [ "${PUBLIC_SURFACE_OK:-0}" = "1" ]; then
-      echo "  ⚠️  public-surface hit(s) allowed by PUBLIC_SURFACE_OK=1 (conscious, reviewed intent)"
-      # Audit trail (parity with below-floor-ack): record the override event (NOT the token) so the
-      # weekly audit can re-queue it. Gitignored log → no token re-leak into committed history.
-      echo "$(date +%Y-%m-%dT%H:%M:%S) PUBLIC_SURFACE_OK override — branch $BRANCH — review suppressed hit(s) above" \
+      echo "  ⚠️  proceeding with an incomplete gate by PUBLIC_SURFACE_OK=1 (conscious)"
+      echo "$(date +%Y-%m-%dT%H:%M:%S) PUBLIC_SURFACE_OK override — branch $BRANCH — gate inactive/incomplete" \
         >> "$REPO_ROOT/tracks/_meta/.psa_override_log" 2>/dev/null || true
     else
-      echo "  Operator-private token reached the public surface. Generalize it"
-      echo "  (companion-store name → 'a private companion store'; corp-context → 'restricted/corp env';"
-      echo "   absolute home path → '~' or '{project}'), or PUBLIC_SURFACE_OK=1 git commit … for a"
-      echo "  deliberate, reviewed mention. Literal mapping lives in the gitignored pattern source."
       FAILED=1
     fi
   else
-    echo "  ✅ PASS"
+    PSA_LEAK=0
+    # NUL-delimited (regression caught by the refactor's own cross-family review): the pre-refactor
+    # loop read this list with `read -r -d ''`, and the rewrite dropped back to a line-oriented read.
+    # `core.quotePath=false` stops git quoting NON-ASCII names, but a path holding a backslash or a
+    # newline is still C-quoted or unsplittable, and the quoted spelling matches no real file — so the
+    # file scanned clean. Exactly the hole R5 closed, reopened by a refactor that claimed to change no
+    # behavior. This is why the refactor got its own adversarial pass instead of riding the earlier one.
+    while IFS= read -r -d '' f; do
+      [ -z "$f" ] && continue
+      added=$(git diff --cached -- "$f" 2>/dev/null | grep -E '^\+' | sed 's/^\+//' || true)
+      [ -z "$added" ] && continue
+      # Per-line pass, path-tagged so the LOW file allowlist applies.
+      if ! printf '%s\n' "$added" | sed "s|^|$f	|" | psa_scan_tagged; then PSA_LEAK=1; fi
+      # Split-token backstop (pre-commit ONLY — this surface is a DIFF, so a literal can be wrapped
+      # mid-word across two added lines and neither line matches). TIGHT-join, no separator, so
+      # "fh-\nbe" becomes "fh-be". Accepted residual, verified not a missed fix: two whitespace-
+      # separated words can RARELY fuse into a spurious match — safe direction (over-block) with the
+      # PUBLIC_SURFACE_OK escape. A sentinel separator would close the fusion but RE-OPEN the split
+      # catch, which is the more important case since real literals have no internal whitespace.
+      joined=$(printf '%s' "$added" | tr -d '\n\r')
+      if ! printf '%s\t%s\n' "$f" "$joined" | psa_scan_tagged >/dev/null 2>&1; then
+        # Only report if the per-line pass did not already flag this file, to avoid double-reporting.
+        if ! printf '%s\n' "$added" | sed "s|^|$f	|" | psa_scan_tagged >/dev/null 2>&1; then :; else
+          printf '%s\t%s\n' "$f" "$joined" | psa_scan_tagged | sed 's/leak —/leak (line-split) —/'
+          PSA_LEAK=1
+        fi
+      fi
+    done < <(git -c core.quotePath=false diff --cached --name-only --no-renames --diff-filter=ACMR -z 2>/dev/null || true)
+    if [ "$PSA_LEAK" -eq 1 ]; then
+      if [ "${PUBLIC_SURFACE_OK:-0}" = "1" ]; then
+        echo "  ⚠️  public-surface hit(s) allowed by PUBLIC_SURFACE_OK=1 (conscious, reviewed intent)"
+        echo "$(date +%Y-%m-%dT%H:%M:%S) PUBLIC_SURFACE_OK override — branch $BRANCH — review suppressed hit(s) above" \
+          >> "$REPO_ROOT/tracks/_meta/.psa_override_log" 2>/dev/null || true
+      else
+        echo "  Operator-private token reached the public surface. Generalize it (companion-store name"
+        echo "  → 'a private companion store'; corp-context → 'restricted/corp env'; absolute home path"
+        echo "  → '~' or '{project}'), or PUBLIC_SURFACE_OK=1 git commit … for a reviewed mention."
+        FAILED=1
+      fi
+    else
+      echo "  ✅ PASS"
+    fi
   fi
 fi
 }

--- a/templates/.git-hooks/pre-push
+++ b/templates/.git-hooks/pre-push
@@ -107,190 +107,100 @@ while read -r local_ref local_sha remote_ref remote_sha; do
   # remote_sha == ZERO → creating a new branch (not destructive) → ignore
 done
 
-# ── Confidentiality instrument completeness — at the PUBLISH boundary ─────────────
-# WHY HERE AND NOT AT COMMIT (cross-family audit R4, 2026-07-26 — a REFUTATION that was itself
-# refuted, and the correction is the interesting part):
-#   The pre-commit confidentiality scan only WARNS when the gitignored operator-literal override is
-#   absent, while the npm publish scan BLOCKS on the same state. That asymmetry was defended on the
-#   grounds that the override is absent on every fresh clone and CI runner by construction, so
-#   blocking at commit would block every such environment's first commit and train the override
-#   into a reflex. That part still holds. What the defence MISSED: it named `npm publish` as the
-#   backstop, but this repo is PUBLIC — `git push` is the moment content becomes public, and the
-#   npm gate never sees it. So a contributor with their own private tokens and no override could
-#   push a HIGH literal to a public repo with nothing downstream to catch it.
-#   The resolution is neither "warn forever" nor "block every commit": put the fail-closed at the
-#   boundary that actually publishes. A push is rare and deliberate; a commit is constant and local.
-# Scope honesty: this checks the INSTRUMENT is complete, not that the content is clean — the content
-# scan itself runs per-commit. An incomplete instrument cannot certify a clean surface.
-PSA_DEFAULTS_PP="$REPO_ROOT/.claude/rules/.public-surface-patterns.defaults"
-PSA_OVERRIDE_PP="${PSA_PATTERNS:-$REPO_ROOT/.claude/rules/.public-surface-patterns}"
-_pp_ok=1
-if [ ! -r "$PSA_DEFAULTS_PP" ] \
-   || [ -z "$(grep -vE '^[[:space:]]*(#|$)' "$PSA_DEFAULTS_PP" 2>/dev/null || true)" ]; then
-  _pp_ok=0; _pp_why="committed pattern defaults missing/unreadable/empty"
-elif [ ! -r "$PSA_OVERRIDE_PP" ] \
-   || [ -z "$(grep -vE '^[[:space:]]*(#|$)' "$PSA_OVERRIDE_PP" 2>/dev/null || true)" ]; then
-  _pp_ok=0; _pp_why="operator-literal override absent/empty (HIGH company/companion literals unscanned)"
-fi
-if [ "$_pp_ok" -eq 0 ]; then
-  if [ "${PUBLIC_SURFACE_OK:-0}" = "1" ]; then
-    echo "  ⚠️  FH Pre-Publish: pushing with an INCOMPLETE confidentiality instrument by PUBLIC_SURFACE_OK=1"
-    echo "      ($_pp_why)"
-    printf '%s PUBLIC_SURFACE_OK override (git push, incomplete instrument: %s)\n' \
-      "$(date +%Y-%m-%dT%H:%M:%S)" "$_pp_why" \
-      >> "$REPO_ROOT/tracks/_meta/.psa_override_log" 2>/dev/null || true
-  else
-    echo ""
-    echo "══════════════════════════════════════════════"
-    echo " ⛔ FH Pre-Publish Gate (pre-push) — incomplete confidentiality instrument"
-    echo "══════════════════════════════════════════════"
-    echo "  $_pp_why"
-    echo ""
-    echo "  A push makes content public. The per-commit scan only WARNED about this state, and the"
-    echo "  npm publish scan never sees a git push — so this is the boundary that must hold."
-    echo ""
-    echo "  Populate .claude/rules/.public-surface-patterns (gitignored, operator literals),"
-    echo "  or push consciously:  PUBLIC_SURFACE_OK=1 git push …"
-    echo "══════════════════════════════════════════════"
-    exit 1
-  fi
-fi
+# ── Confidentiality at the PUBLISH boundary — instrument completeness + content ───
+# Pattern loading and matching come from scripts/psa_scan_lib.sh, the single implementation shared
+# with pre-commit and the publish scanner. Every confidentiality defect found in the 2026-07-26
+# cross-family audit was a divergence between three near-duplicate copies of that logic, so the
+# copies were removed. What stays HERE is the part that genuinely differs by surface: the degrade
+# direction. A push is the act that makes content public and is not undoable, so an incomplete
+# instrument BLOCKS here, whereas the same state only warns at commit time (a commit is local and
+# re-committable, and the operator override is gitignored — absent on every fresh clone by
+# construction, so blocking there would train the override into a reflex).
+PSA_LIB="$REPO_ROOT/scripts/psa_scan_lib.sh"
+if [ ! -r "$PSA_LIB" ]; then
+  echo "  ❌ scripts/psa_scan_lib.sh missing — the confidentiality scanner cannot run."
+  [ "${PUBLIC_SURFACE_OK:-0}" = "1" ] || { echo "     Fail-closed on the publish boundary."; exit 1; }
+else
+  . "$PSA_LIB"
+  psa_load "$REPO_ROOT/.claude/rules/.public-surface-patterns.defaults" \
+           "${PSA_PATTERNS:-$REPO_ROOT/.claude/rules/.public-surface-patterns}"
 
-# ── Confidentiality CONTENT scan on exactly what this push publishes ──────────────
-# The block above verifies the INSTRUMENT is complete. It does not look at the content, and the
-# per-commit scan is not a backstop for a push: pre-commit may never have been installed, may have
-# been bypassed with --no-verify, or the commits may predate the scan entirely. Measured (R5 audit,
-# 2026-07-26): a `ghp_…` committed into README.md pushed to a new public branch exited 0 with both
-# pattern layers present. The commit gate is per-commit; the PUSH is the act that publishes, so the
-# content check has to exist here too — the same reasoning that moved the instrument check here.
-# Scans ADDED lines of every commit this push would publish (not the net diff: a token added and
-# later removed still ships in the pushed history).
-if [ -n "$PUSH_RANGES" ] && [ "$_pp_ok" -eq 1 ]; then
-  _pp_stream=$(cat "$PSA_DEFAULTS_PP" 2>/dev/null; cat "$PSA_OVERRIDE_PP" 2>/dev/null)
-  _pp_placeholder='^(<[a-z0-9_-]+>|\{[a-z_]+\}|EXAMPLE|dummy|changeme|REDACTED|xxxx|/Users/(EXAMPLE|yourname|\{[a-z_]+\}|<[a-z0-9_-]+>)/|AKIAIOSFODNN7EXAMPLE)$'
-  # ONE REF AT A TIME. Passing every range as one flat arg list let `--not` from ref A flip polarity
-  # for ref B, so `git push origin a b` could return an empty or wrong commit set (R6 audit). Newline-
-  # separating them is not enough on its own — the consumer has to iterate, or word-splitting folds
-  # them straight back into one arg list. Counts and diffs are accumulated per range.
-  _pp_count=0; _pp_added=""; _pp_err=0
-  while IFS= read -r _rg; do
-    [ -z "$_rg" ] && continue
-    _c=$(git rev-list --count $_rg 2>/dev/null) || { _pp_err=1; continue; }
-    _pp_count=$(( _pp_count + ${_c:-0} ))
-    _d=$(git -c core.quotePath=false log --format= --unified=0 $_rg 2>/dev/null) || { _pp_err=1; continue; }
-    _pp_added="$_pp_added$SEP$_d"
-  done <<PPRANGES
+  # Instrument completeness. Three distinct incomplete states, all blocking here.
+  _pp_why=""
+  [ "$PSA_DEFAULTS_OK" -eq 0 ]      && _pp_why="committed pattern defaults missing/unreadable/empty"
+  [ "$PSA_BAD_ROWS" -gt 0 ]         && _pp_why="${_pp_why:+$_pp_why; }$PSA_BAD_ROWS unusable pattern row(s)"
+  [ "$PSA_OVERRIDE_PRESENT" -eq 0 ] && _pp_why="${_pp_why:+$_pp_why; }operator-literal override absent/empty (HIGH company/companion literals unscanned)"
+  if [ -n "$_pp_why" ]; then
+    if [ "${PUBLIC_SURFACE_OK:-0}" = "1" ]; then
+      echo "  ⚠️  FH Pre-Publish: INCOMPLETE confidentiality instrument allowed by PUBLIC_SURFACE_OK=1"
+      echo "      ($_pp_why)"
+      printf '%s PUBLIC_SURFACE_OK override (git push, incomplete instrument: %s)\n' \
+        "$(date +%Y-%m-%dT%H:%M:%S)" "$_pp_why" \
+        >> "$REPO_ROOT/tracks/_meta/.psa_override_log" 2>/dev/null || true
+    else
+      echo ""
+      echo "══════════════════════════════════════════════"
+      echo " ⛔ FH Pre-Publish Gate (pre-push) — incomplete confidentiality instrument"
+      echo "══════════════════════════════════════════════"
+      echo "  $_pp_why"
+      echo ""
+      echo "  A push makes content public. The per-commit scan only WARNS about the missing override,"
+      echo "  and the npm publish scan never sees a git push — so this is the boundary that must hold."
+      echo "  Populate .claude/rules/.public-surface-patterns (gitignored), or push consciously:"
+      echo "      PUBLIC_SURFACE_OK=1 git push …"
+      echo "══════════════════════════════════════════════"
+      exit 1
+    fi
+  fi
+
+  # Content. Scans the ADDED lines of every commit this push publishes — per commit, not the net
+  # diff: a token added and later removed still ships inside the pushed history. Lines are tagged
+  # with their path so the LOW file allowlist can apply (flattening them is what made this leg block
+  # its own first real push on a companion-store name inside the sync script itself).
+  if [ -n "$PUSH_RANGES" ]; then
+    _pp_count=0; _pp_added=""; _pp_err=0
+    while IFS= read -r _rg; do
+      [ -z "$_rg" ] && continue
+      _c=$(git rev-list --count $_rg 2>/dev/null) || { _pp_err=1; continue; }
+      _pp_count=$(( _pp_count + ${_c:-0} ))
+      _d=$(git -c core.quotePath=false log --format= --unified=0 $_rg 2>/dev/null) || { _pp_err=1; continue; }
+      _pp_added="$_pp_added$SEP$_d"
+    done <<PPRANGES
 $PUSH_RANGES
 PPRANGES
-  if [ "$_pp_err" -eq 1 ]; then
-    echo "  ❌ could not read part of the push range — refusing to certify unscanned history."
-    [ "${PUBLIC_SURFACE_OK:-0}" = "1" ] || exit 1
-  fi
-  if [ "${_pp_count:-0}" -gt 0 ]; then
-    # RANGES, not an expanded commit list. The first version ran `git show $(git rev-list …)`, which
-    # expands every SHA into argv — on a large first push that hits ARG_MAX, git dies, the capture is
-    # empty, and an empty capture reads as "no hits" → a printed PASS. Self-caught before shipping;
-    # it is the same degrade-toward-PASS shape this whole gate exists to stop, authored into the gate
-    # itself. `git log` takes the range directly, so nothing is expanded and there is no size ceiling.
-    # rc is checked explicitly: a git failure must not be readable as a clean scan.
-    # Keep FILE CONTEXT: the added lines are prefixed with the path they came from, so the LOW
-    # allowlist can be applied per file. Without it this leg had no file context at all and could
-    # only ever treat every hit as unexempt — which is exactly how it blocked its own first real
-    # push on `fh-be` inside scripts/sync-to-be.sh, a file that names the companion store BY DESIGN
-    # and is LOW-allowlisted in the pre-commit copy. Seven adversarial rounds did not find this;
-    # the first genuine `git push` did. (2026-07-26)
-    _pp_added=$(printf '%s\n' "$_pp_added" | awk '
-      /^\+\+\+ b\// { f = substr($0, 7); next }
-      /^\+/            { print f "\t" substr($0, 2) }
-    ' || true)
-    _pp_hit=0
-    while IFS= read -r _row; do
-      _row="${_row%$'\r'}"
-      case "$_row" in ''|\#*) continue;; esac
-      _re="${_row#*$'\t'}"
-      if [ "$_re" = "$_row" ]; then
-        # No TAB → the row defines no detector. Silently skipping it (what this copy did until the
-        # R7 propagation sweep) means the author believes a pattern is protecting them while the
-        # scanner never had it, and the push is certified clean. pre-commit and the publish scanner
-        # were already fail-closed here; this copy was missed when that fix was written.
-        echo "  ❌ unusable pattern row (no TAB between severity and regex) — cannot certify clean."
-        [ "${PUBLIC_SURFACE_OK:-0}" = "1" ] || exit 1
-        continue
-      fi
-      _sev="${_row%%$'\t'*}"
-      # A row that cannot compile disables its own detector. Skipping it silently would let the scan
-      # certify clean on a surface it never actually examined — fail closed, same as pre-commit.
-      printf '' | grep -E "$_re" >/dev/null 2>&1
-      if [ "$?" -ge 2 ]; then
-        echo "  ❌ unusable pattern (invalid regex) — detector disabled: [$_sev]"
-        [ "${PUBLIC_SURFACE_OK:-0}" = "1" ] || exit 1
-        continue
-      fi
-      # EVERY match on EVERY matching line (R6 audit, 2026-07-26). The first version took only the
-      # FIRST match per line and only the first 20 matching lines, so twenty documented example keys
-      # ahead of one real key — or a placeholder earlier on the same line — produced zero hits and a
-      # printed "no operator-private token". A gate that truncates its own evidence and then makes an
-      # affirmative clean claim is worse than one that does not scan: it is wrong out loud.
-      # Display is capped separately from DETECTION: _pp_hit is set by any match, the cap only limits
-      # how many lines are echoed.
-      _shown=0
-      while IFS= read -r _h; do
-        [ -z "$_h" ] && continue
-        _pf="${_h%%$'\t'*}"
-        while IFS= read -r _tok; do
-          [ -z "$_tok" ] && continue
-          printf '%s' "$_tok" | grep -qiE "$_pp_placeholder" && continue
-          # LOW allowlist by file — same list as the pre-commit copy. These files name the wiring
-          # tokens as part of doing their job; HIGH/MED still block everywhere.
-          if [ "$_sev" = "LOW" ]; then
-            case "$_pf" in
-              .gitignore|scripts/sync-to-be.sh|.claude/rules/local_fh_context.md|templates/local_fh_context.md|templates/.claude/rules/*|templates/.git-hooks/*) continue ;;
-            esac
-          fi
-          _pp_hit=1
-          if [ "$_shown" -lt 20 ]; then
-            echo "  ❌ $_sev leak in pushed history — $_pf: '$_tok'"
-            _shown=$((_shown+1))
-          fi
-        done <<PPTOK
-$(printf '%s' "${_h#*$'\t'}" | grep -oiE "$_re" 2>/dev/null || true)
-PPTOK
-      done <<PPEOF
-$(printf '%s\n' "$_pp_added" | grep -iE "$_re" 2>/dev/null || true)
-PPEOF
-    done <<PPROWS
-$_pp_stream
-PPROWS
-    if [ "$_pp_hit" -eq 1 ]; then
-      if [ "${PUBLIC_SURFACE_OK:-0}" = "1" ]; then
-        echo "  ⚠️  pushing a flagged token by PUBLIC_SURFACE_OK=1 (conscious, reviewed)"
-        printf '%s PUBLIC_SURFACE_OK override (git push, content hit in pushed history)\n' \
-          "$(date +%Y-%m-%dT%H:%M:%S)" >> "$REPO_ROOT/tracks/_meta/.psa_override_log" 2>/dev/null || true
+    if [ "$_pp_err" -eq 1 ]; then
+      echo "  ❌ could not read part of the push range — an unread history is not a clean one."
+      [ "${PUBLIC_SURFACE_OK:-0}" = "1" ] || exit 1
+    fi
+    if [ "${_pp_count:-0}" -gt 0 ]; then
+      if printf '%s\n' "$_pp_added" | awk '
+           /^\+\+\+ b\// { f = substr($0, 7); next }
+           /^\+/         { print f "\t" substr($0, 2) }
+         ' | psa_scan_tagged; then
+        echo "  ✅ FH Pre-Publish: no operator-private token in the TEXT added by ${_pp_count} commit(s)"
+        echo "     (not covered: annotated-tag messages · binary blobs — named residuals)"
       else
-        echo ""
-        echo "══════════════════════════════════════════════"
-        echo " ⛔ FH Pre-Publish Gate (pre-push) — token in the history being pushed"
-        echo "══════════════════════════════════════════════"
-        echo "  A push publishes every commit in the range, not just the tip. Rewrite the offending"
-        echo "  commit(s) (git rebase -i / filter-repo) — removing the line in a NEW commit does not"
-        echo "  un-publish it once pushed."
-        echo "  Deliberate mention:  PUBLIC_SURFACE_OK=1 git push …  (logged)"
-        echo "══════════════════════════════════════════════"
-        exit 1
+        if [ "${PUBLIC_SURFACE_OK:-0}" = "1" ]; then
+          echo "  ⚠️  pushing a flagged token by PUBLIC_SURFACE_OK=1 (conscious, reviewed)"
+          printf '%s PUBLIC_SURFACE_OK override (git push, content hit in pushed history)\n' \
+            "$(date +%Y-%m-%dT%H:%M:%S)" >> "$REPO_ROOT/tracks/_meta/.psa_override_log" 2>/dev/null || true
+        else
+          echo ""
+          echo "══════════════════════════════════════════════"
+          echo " ⛔ FH Pre-Publish Gate (pre-push) — token in the history being pushed"
+          echo "══════════════════════════════════════════════"
+          echo "  A push publishes every commit in the range, not just the tip. Rewrite the offending"
+          echo "  commit(s) (git rebase -i / filter-repo) — removing the line in a NEW commit does not"
+          echo "  un-publish it once pushed."
+          echo "  Deliberate mention:  PUBLIC_SURFACE_OK=1 git push …  (logged)"
+          echo "══════════════════════════════════════════════"
+          exit 1
+        fi
       fi
-    else
-      # SCOPE-HONEST success line. Named residuals this leg does NOT cover (R6 audit, 2026-07-26,
-      # accepted as residuals rather than silently implied away):
-      #   • annotated TAG object messages — a tag-only push whose commits are already remote yields
-      #     an empty commit range, so a token in the tag message is unscanned.
-      #   • BINARY blobs — `git log -p` emits no textual added lines for them, so an ASCII token
-      #     inside a binary file is invisible here.
-      # The claim below is therefore about TEXT in commits, and says so. It is not "this push is clean".
-      echo "  ✅ FH Pre-Publish: no operator-private token in the TEXT added by ${_pp_count} commit(s)"
-      echo "     (not covered: annotated-tag messages · binary blobs — named residuals)"
     fi
   fi
 fi
+
 
 # ── Load-bearing change: the cross-family leg must have RUN, not just been stated ─────────────
 # The commit hook requires a `crossfamily:` line to EXIST (it blocks silence, not a 'none'), because


### PR DESCRIPTION
> **Stacked on #185.** Base is `digest-0726-context-rules-agentsmith`; merge that first.

## ① 단일 소스화 — #185 이 명시 잔여로 남긴 그 항목

#185 은 7라운드 cross-family 로 30건을 닫았지만, 마지막 라운드에서 **지적 4건 중 3건이 같은 클래스**였다: 수리가 세 사본 중 하나에만 착지. 그 라운드에서 멈추고 잔여로 적은 이유가 이거였다 — **라운드로는 안 닫힌다.**

세 벌(`pre-commit` · `pre-push` · `public_surface_scan_files.sh`)에서 실제로 갈렸던 것들:

| 항목 | 갈림 |
|---|---|
| override readable/non-empty 검사 | publish 에만 있었음 |
| 패턴 전무 시 fail-closed | 커밋·publish 만, push 는 따로 넣어야 했음 |
| no-TAB 행 거부 | 셋 중 둘 |
| 라인당 첫 매치만 보는 버그 수리 | 한 곳만 (→ 플레이스홀더가 진짜 토큰을 가림) |
| per-file LOW 허용목록 | **정확히 한 곳** — 그래서 push 게이트가 자기 첫 push 를 막았다 |

`scripts/psa_scan_lib.sh` 로 통합. **`psa_load` 는 절대 exit 하지 않고 상태만 노출한다** (`PSA_DEFAULTS_OK` / `PSA_OVERRIDE_PRESENT` / `PSA_BAD_ROWS`) — 판정은 호출자가 한다.

**일부러 통합하지 않은 것** (각각 파일 내 근거 주석 있음):
- **degrade 방향** — 커밋은 override 부재를 *경고*(gitignored 라 신선한 클론엔 구조적으로 항상 없다; 여기서 차단하면 `PUBLIC_SURFACE_OK` 가 반사가 되어 publish 게이트의 override 채널까지 무력화된다), push·publish 는 *차단*
- **publish 의 `grep -a` 파일단위 스캔** — 바이너리를 텍스트로 강제한다(SVG 가 출하됨). 라이브러리의 라인 스트림 인터페이스로 넘기면 과거 challenger 가 지적한 구멍이 재개방된다
- **publish 의 더 엄격한 LOW 목록** — 출하물엔 운영자 토큰이 아예 없어야 한다. 함수 재정의로 차이를 **눈에 보이게** 뒀다

**중복 제거 실측** (주장 아님): `PSA_PLACEHOLDER` 정의 **3→1**, `psa_low_allowlisted` **3→2**(라이브러리 기본 + 문서화된 엄격 오버라이드). 두 호출자에 남은 `unusable pattern row` 문자열은 라이브러리의 `PSA_BAD_ROWS` **상태를 소비**하는 쪽이지 재구현이 아니다.

## ② `FH_BACKEND=cross` — 탈상관을 이식 가능한 층에

`auto` 는 폴백 **선택**이다(`codex` 있으면 codex, 없으면 claude, **하나만** 실행). 탈상관이 아니다.

`cross` 는 두 패밀리를 실행하고 findings 를 **UNION** 한다. 투표가 아니라 union인 이유: 한쪽만 본 지적도 지적이고, 다수결은 **정확히 탈상관 신호만 버린다.** 판정은 레그 중 최중.

**가장 중요한 불변식**: 출력이 실제로 돈 레그를 선언한다.
```
FH_GATE_LEGS: claude,codex
FH_GATE_DECORRELATED: yes
```
한 패밀리만 설치된 머신에서는 단일 레그로 내려가되 `FH_GATE_DECORRELATED: no` + `FH_GATE_DEGRADED: <이유>` + stderr 경고를 낸다. **단일 패밀리 결과가 교차검증된 것처럼 읽히는 건, 안 돈 검사가 PASS 로 읽히는 것과 같은 클래스다.** 무레그면 fail-closed(10).

재귀 self-invocation 래퍼로 구현해 **npm 으로 나가는 단일 백엔드 경로는 한 줄도 안 건드렸다**(주간 2600+).

검증 중 실버그 1건: `set -e` 하에서 `_legout=$(child)` 가 자식 종료코드를 물고, 자식은 **설계상** non-PASS 에 non-zero 를 낸다 → **뭔가 찾은 첫 레그에서 스크립트가 통째로 죽었다.** 즉 *찾을 게 없을 때만 동작하는 리뷰 도구*가 될 뻔했다.

## 검증

리팩터에 **자체 cross-family 라운드**를 붙였다(#185 의 7라운드를 물려받지 않음). 공격축: *"안 바뀐다고 주장한 곳이 바뀌었나"*. 결과 **Med 2건 — 둘 다 이 리팩터가 만든 회귀**, 수용·수리·앵커 고정:

1. pre-commit 파일 루프가 NUL 반복 → 라인 읽기로 되돌아가 **C-quoted 경로 구멍 재개방**(#185 R5 수리 소실)
2. publish 스캐너가 `npm pack` **부분 파일셋 가드 소실**(FILES 블록 재삽입 시 범위 누락)

기존 앵커 어느 것도 이 둘을 못 잡았다 — 그래서 리팩터가 별도 적대 패스를 받은 것이고, 지금은 둘 다 고정돼 있다.

```
universal_guard_check   22쌍  ✅
prepush_guard_check     10쌍  ✅
test_fh_gate_regressions 31건 ✅ (cross 5쌍 신규, 기존 FAKEBIN 인프라 재사용)
gate_pathspec_check           ✅
validate_yaml                 ✅
```

앵커 자체도 이번에 두 번 고쳤다: 샌드박스가 새 라이브러리 의존을 안 가져서(올바르게 fail-closed 했으나) *clean* 쌍 3개가 "스캐너가 못 돈다" 상태에서 통과했고, prepush 쪽은 **BLOCK 이 옳은 이유로 난 건지 안 봤다** — 라이브러리 도입 직후 8쌍 중 6쌍이 *하네스 오류로* 차단되면서 초록이었다.

## 잔여

1. **cross 실모델 end-to-end 미검증** — 결정론적 fake 5케이스로만 검증했다. 배관은 확인됐고 실모델 거동은 미확인
2. **union 은 합집합이지 화해가 아니다** — 양쪽이 같은 결함을 보면 두 번 나온다. 중복 제거는 시도 안 함(가짜 중복은 싸고, 누락된 지적은 안 싸다)
3. `fh-gate.sh` 는 npm 출하물 — CLAUDE.md §④-b lockstep 버전 범프 + 재퍼블리시 필요. **여기선 안 했다**, 운영자 결정
4. 라이브러리가 서로 다른 `set` 옵션의 셸 셋에 source 된다. bash 3.2(이 머신의 유일 bash)에서 검증, 다른 셸/버전 미검증
5. 네 번째 호출자가 `PSA_BAD_ROWS>0` 을 clean 으로 취급할 수 있다 — 계약은 헤더에 문서화, 기계 강제는 아님

🤖 Generated with [Claude Code](https://claude.com/claude-code)