### PR TITLE
fix(gate): pre-push 과차단 정정 + chore(release): v1.4.72

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,13 @@
   "plugins": [
     {
       "name": "fh-meta",
-      "version": "1.4.71",
+      "version": "1.4.72",
       "description": "Hub meta-operations toolkit — 35 skills + 7 agents. New in 1.4.53: `fh-codex-doctor` (npm bin) — Codex adapter drift scanner; reads the documented M1/M2/M3 skill tier map + skill/agent source and reports codex-native/adapter-required/claude-native/unclassified per unit, wired into `npm test`/`prepublishOnly` (fail-closed on unclassified Claude-native primitives). New in 1.4.49: steel-quench gains Step 0.6 Verdict-Invariance Probe (groundedness axis — a load-bearing judged gate's verdict must track behavior, not rubric phrasing; measured flip-count over cross-family paraphrases; arXiv:2605.06161 Policy Invariance anchor); multi_model_sidecar_strategy §Vendor-native harness (a model is strongest in its own vendor CLI — Claude/CC, GPT/codex, Gemini/Antigravity; a universal router degrades all of them, so it stays an autocomplete/QA sidecar, never orchestration); predelete_check.sh fail-closed rewrite; memory-hygiene A-TMA anchor. New in 1.4.48: phantom-quench + steel-quench gain external frontier anchors (arXiv:2607.02052 package-hallucination; arXiv:2607.02057 prompt-coverage-adequacy); README model-flat claim reframed from a per-release point-curve to structural invariants (operation flattens across tiers; depth tier-order fixed within a generation). New in 1.4.47: onboarding step ① surfaces the Mode D companion-store session-start load in the auto-read salience anchor (previously only in the local binding + rules, so a greeting could skip the load). New in 1.4.46: context-doctor command-output axis (route to rtk/proxy for verbose CLI stdout, complementing .claudeignore; risk-gated to token-scarce envs). New in 1.4.41: context-doctor 2026 trigger vocab (context engineering/rot/collapse) + phantom-citation hardening; hub measurement-integrity-checklist (cross-model measurement pre-flight: display-name pin/reps≥3/discriminating probe). New in 1.4.40: install-wizard queryable-wiki scaffold (INDEX + session-start read + R/W/C ingest). New in 1.4.39: auto-decorrelation (cross-family verifier sidecar recruitment) + video-ingest (capability-routed video ingestion). New in 1.4.x: verify-axis check-class taxonomy (mandatory-pass/measured/judged), no-reinvention Tier-0 inventory, 7-class failure taxonomy, Destructive-Op Gate, Wave-T (Temper), tier-floor governance, Mode D Model Notice, FC consent lane, default-Sonnet guidance. New in 1.3.0: public-surface-audit, field-harvest Mode B auto-trigger, 4-axis gate scope ext. Validated cross-CLI: Claude Code, Codex, Gemini.",
       "source": "./plugins/fh-meta"
     },
     {
       "name": "fh-commons",
-      "version": "1.4.71",
+      "version": "1.4.72",
       "description": "Project-agnostic utility skills — 4 skills (convergence-loop · deliberation · mcp-circuit-breaker · token-budget-gate) + 1 agent (quench-challenger). Domain-independent utilities transplantable into any project.",
       "source": "./plugins/fh-commons"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrono-meta/fh-gate",
-  "version": "1.4.71",
+  "version": "1.4.72",
   "description": "FH runtime adapters — run FH governance, skills, and agents via Claude or Codex with machine-parseable gates.",
   "license": "MIT",
   "keywords": [

--- a/plugins/fh-commons/.claude-plugin/plugin.json
+++ b/plugins/fh-commons/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-commons",
-  "version": "1.4.71",
+  "version": "1.4.72",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/.claude-plugin/plugin.json
+++ b/plugins/fh-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-meta",
-  "version": "1.4.71",
+  "version": "1.4.72",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/scripts/prepush_guard_check.sh
+++ b/scripts/prepush_guard_check.sh
@@ -153,11 +153,33 @@ check "multi-ref push, token on 2nd ref    → BLOCK" "$R" block \
       "refs/heads/dirty2 $C2 refs/heads/dirty2 $B"
 rm -rf "$R"
 
-# ── Pair 6: instrument completeness. An absent operator override is fail-closed at the PUBLISH
-# boundary (it only warns at commit time — that asymmetry is deliberate, see the hook's comment). ──
+# ── Pair 6: instrument completeness, and the line between "not configured" and "broken".
+# CHANGED DELIBERATELY 2026-07-26 — this pair used to expect BLOCK on an absent operator override.
+# Two things overturned that: selfcheck flagged it as over-blocking (T7: "guard over-fires; that
+# trains the override"), and the reasoning did not hold — the override contains THIS operator's
+# literals, so another environment lacking it was never protected by it anyway. What protects a fresh
+# clone is the generic credential shapes in the COMMITTED layer. So an absent override now warns, and
+# what still blocks is a genuinely BROKEN pattern source, which affects everyone. Both pinned. ──
 R=$(newrepo); B=$(cd "$R" && git rev-parse HEAD)
 ( cd "$R" && echo ok > g.md && git add g.md && git commit -qm g >/dev/null && rm -f .claude/rules/.public-surface-patterns )
-check "operator override ABSENT            → BLOCK" "$R" block \
+check "operator override absent (per-operator) → PASS " "$R" pass \
+      "refs/heads/f $(cd "$R" && git rev-parse HEAD) refs/heads/f $B"
+rm -rf "$R"
+
+R=$(newrepo); B=$(cd "$R" && git rev-parse HEAD)
+( cd "$R" && echo ok > g.md && git add g.md && git commit -qm g >/dev/null \
+  && : > .claude/rules/.public-surface-patterns.defaults )   # present but EMPTY = broken, not unconfigured
+check "committed defaults EMPTY (broken)      → BLOCK" "$R" block \
+      "refs/heads/f $(cd "$R" && git rev-parse HEAD) refs/heads/f $B"
+rm -rf "$R"
+
+# Applicability is mechanical: no committed pattern source at all = not an FH checkout = legs N/A.
+# Without this the hook blocked every push in any bare repo it was copied into, which is how the
+# over-block was found in the first place.
+R=$(newrepo); B=$(cd "$R" && git rev-parse HEAD)
+( cd "$R" && echo ok > g.md && git add g.md && git commit -qm g >/dev/null \
+  && rm -f .claude/rules/.public-surface-patterns.defaults .claude/rules/.public-surface-patterns )
+check "no committed pattern source (not FH)   → PASS " "$R" pass \
       "refs/heads/f $(cd "$R" && git rev-parse HEAD) refs/heads/f $B"
 rm -rf "$R"
 

--- a/templates/.git-hooks/pre-push
+++ b/templates/.git-hooks/pre-push
@@ -116,8 +116,25 @@ done
 # instrument BLOCKS here, whereas the same state only warns at commit time (a commit is local and
 # re-committable, and the operator override is gitignored — absent on every fresh clone by
 # construction, so blocking there would train the override into a reflex).
+# APPLICABILITY FIRST, before anything is required to exist. The mechanical test for "is this an FH
+# checkout at all" is the COMMITTED pattern source; a bare repo with this hook copied into it (this
+# repo's own selfcheck fixture is exactly that) has neither the patterns nor the library, and demanding
+# them there is over-blocking, not fail-closed. Deleting the defaults to reach this state is not a free
+# bypass — it is a commit against a .claude/rules/ path, which the commit gate treats as HEAVY and
+# universal_guard_check pins in both directions.
 PSA_LIB="$REPO_ROOT/scripts/psa_scan_lib.sh"
-if [ ! -r "$PSA_LIB" ]; then
+_PP_APPLICABLE=1
+if [ ! -e "$REPO_ROOT/.claude/rules/.public-surface-patterns.defaults" ]; then
+  _PP_APPLICABLE=0
+fi
+if [ "$_PP_APPLICABLE" -eq 0 ]; then
+  # An inapplicable check must SAY it is inapplicable. A silent skip is indistinguishable from a
+  # check that aborted, and "skipped" reading as "passed" is the defect class this whole gate exists
+  # to remove — including when the skip is correct.
+  echo "  ⏭️  FH Pre-Publish: N/A — no committed pattern source in this repo (not an FH checkout)"
+elif [ ! -r "$PSA_LIB" ]; then
+  # The pattern source IS here, so this IS an FH checkout — a missing library is then a broken
+  # instrument on a publish surface, not an inapplicable one.
   echo "  ❌ scripts/psa_scan_lib.sh missing — the confidentiality scanner cannot run."
   [ "${PUBLIC_SURFACE_OK:-0}" = "1" ] || { echo "     Fail-closed on the publish boundary."; exit 1; }
 else
@@ -125,11 +142,31 @@ else
   psa_load "$REPO_ROOT/.claude/rules/.public-surface-patterns.defaults" \
            "${PSA_PATTERNS:-$REPO_ROOT/.claude/rules/.public-surface-patterns}"
 
-  # Instrument completeness. Three distinct incomplete states, all blocking here.
+  # Instrument completeness — and a CORRECTION to how this was first written (2026-07-26).
+  #
+  # The first version blocked on an absent operator override. Two things then showed that was wrong:
+  # this repo's own selfcheck flagged it as over-blocking (T7: a feature-branch push blocked → "guard
+  # over-fires; that trains the override"), and the reasoning did not survive re-examination. The
+  # override holds THIS operator's literals. Another environment lacking it is not thereby unprotected
+  # against ITS OWN leaks — those literals were never in the file. The earlier argument (npm publish is
+  # not a backstop for a public git push) was right about the gap and wrong about the fix: the thing
+  # that actually protects a fresh clone is GENERIC credential shapes in the COMMITTED layer, which is
+  # exactly what was added to the defaults in the same session. So:
+  #   override absent  → WARN (a per-operator configuration a fresh clone legitimately lacks)
+  #   defaults broken  → BLOCK (the shipped universal patterns are gone; that affects everyone)
+  #
+  # Applicability is mechanical, not self-judged (CLAUDE.md §Surface-Class Degrade Invariant): if the
+  # COMMITTED defaults file does not exist at all, this is not an FH repo and the confidentiality legs
+  # do not apply — a bare repo with this hook copied in is not a publish surface this gate knows how to
+  # reason about. Deleting the file to reach that state is not a free bypass: it is a commit against a
+  # .claude/rules/ path, which the commit gate treats as HEAVY and universal_guard_check pins.
   _pp_why=""
-  [ "$PSA_DEFAULTS_OK" -eq 0 ]      && _pp_why="committed pattern defaults missing/unreadable/empty"
-  [ "$PSA_BAD_ROWS" -gt 0 ]         && _pp_why="${_pp_why:+$_pp_why; }$PSA_BAD_ROWS unusable pattern row(s)"
-  [ "$PSA_OVERRIDE_PRESENT" -eq 0 ] && _pp_why="${_pp_why:+$_pp_why; }operator-literal override absent/empty (HIGH company/companion literals unscanned)"
+  [ "$_PP_APPLICABLE" -eq 1 ] && [ "$PSA_DEFAULTS_OK" -eq 0 ] && _pp_why="committed pattern defaults unreadable/empty"
+  [ "$_PP_APPLICABLE" -eq 1 ] && [ "$PSA_BAD_ROWS" -gt 0 ]    && _pp_why="${_pp_why:+$_pp_why; }$PSA_BAD_ROWS unusable pattern row(s)"
+  if [ "$_PP_APPLICABLE" -eq 1 ] && [ "$PSA_OVERRIDE_PRESENT" -eq 0 ]; then
+    echo "  ⚠️  operator-literal override absent — only the committed defaults (home paths + credential"
+    echo "     shapes) are active. Populate .claude/rules/.public-surface-patterns for company literals."
+  fi
   if [ -n "$_pp_why" ]; then
     if [ "${PUBLIC_SURFACE_OK:-0}" = "1" ]; then
       echo "  ⚠️  FH Pre-Publish: INCOMPLETE confidentiality instrument allowed by PUBLIC_SURFACE_OK=1"
@@ -157,7 +194,7 @@ else
   # diff: a token added and later removed still ships inside the pushed history. Lines are tagged
   # with their path so the LOW file allowlist can apply (flattening them is what made this leg block
   # its own first real push on a companion-store name inside the sync script itself).
-  if [ -n "$PUSH_RANGES" ]; then
+  if [ -n "$PUSH_RANGES" ] && [ "$_PP_APPLICABLE" -eq 1 ]; then
     _pp_count=0; _pp_added=""; _pp_err=0
     while IFS= read -r _rg; do
       [ -z "$_rg" ] && continue
@@ -223,7 +260,10 @@ LBR
 _LB_FILES=$(printf '%s\n' "$_LB_RAW" \
   | grep -E '(templates/\.git-hooks/|scripts/(fh-gate|degrade_direction_scan|universal_guard_check|public_surface_scan_files|gate_pathspec_check|predelete_check)\.sh|\.claude/rules/\.public-surface-patterns)' \
   | sort -u || true)
-if [ -n "$PUSH_RANGES" ] && [ -n "$_LB_FILES" ]; then
+# Also FH-dev-scoped: the marker this requires lives in tracks/_meta, which only an FH checkout has.
+# An outside contributor pushing a gate file cannot produce an FH marker, and blocking them would make
+# the repo hostile to contribution while protecting nothing they could act on.
+if [ -n "$PUSH_RANGES" ] && [ -n "$_LB_FILES" ] && [ -d "$REPO_ROOT/tracks/_meta" ]; then
   _cf_marker=$(ls -t "$REPO_ROOT"/tracks/_meta/.axes_23_passed_*.marker 2>/dev/null | head -1)
   _cf_line=$(grep -m1 -E '^[[:space:]]*crossfamily:[[:space:]]*[^[:space:]]' "$_cf_marker" 2>/dev/null || true)
   if [ -z "$_cf_line" ]; then


### PR DESCRIPTION
## ① 과차단 정정 — **자기 selfcheck 가 잡았다**

#185 에서 추가한 pre-push 기밀 레그가 두 경우에 과차단했다:
- 운영자 override(gitignored) 부재 → 신선한 클론·CI·외부 기여자의 push 전부 차단
- 커밋된 패턴 소스 자체가 없는 맨 리포 → 무조건 차단

`scripts/test_prepush_stdin_integrity.sh` T7/T8 이 검출했고, 그 체크가 쓰인 문구 그대로였다:

> `guard over-fires; that trains the override`

**그리고 근거가 성립하지 않았다.** override 는 *이 운영자의* 리터럴을 담는다. 다른 환경에 그게 없다고 막아봐야 **그들 자신의 유출은 애초에 그 파일로 못 잡는다.** 신선한 클론을 실제로 지키는 건 같은 세션에 커밋층에 넣은 **일반 자격증명 shape**(AWS/GitHub/Slack/OpenAI/Anthropic/PEM 등)이다.

#185 R4 에서 *"npm publish 는 공개 git push 의 백스톱이 아니다"* 라고 본 건 맞았다. 틀린 건 처방이었다 — 막을 게 아니라 커밋층 shape 을 넣는 것이었고, 그건 이미 했다.

**정정된 동작**

| 상태 | 이전 | 지금 |
|---|---|---|
| operator override 부재 | 차단 | **경고** (fresh clone 이 구조적으로 갖지 못하는 per-operator 설정) |
| 커밋된 defaults 존재하나 비어있음/읽기불가/불량행 | 차단 | 차단 (유지 — 모두에게 영향) |
| 커밋된 패턴 소스 전무 | 차단 | **N/A — 단, 한 줄로 공표** |
| 실제 토큰 검출 | 차단 | 차단 (유지) |

N/A 를 조용히 넘기지 않는 이유: **무음 skip 은 중단과 구별이 안 된다.** "skip 이 pass 로 읽히는 것"이 이 게이트가 없애려는 결함 클래스고, skip 이 *옳을 때조차* 그렇다.

적용가능성 판정은 **모든 의존성 요구보다 앞**으로 옮겼다 (§Surface-Class Degrade Invariant: *applicability is mechanical, not self-judged*). 그 상태에 도달하려고 defaults 를 지우는 건 공짜 우회가 아니다 — `.claude/rules/` 경로 커밋이라 commit 게이트가 HEAVY 로 잡고 `universal_guard_check` 가 양방향으로 고정한다.

**앵커 처리**: `override 부재 → BLOCK` 쌍을 **지우지 않고 새 의미로 재명세**했고, 여전히 막아야 하는 상태(defaults 존재하나 empty)와 막으면 안 되는 상태(패턴소스 전무)를 2쌍 추가했다. 앵커가 의도적 보안 동작 변경을 잡아 세운 것이고, 그게 앵커가 하는 일이다.

## ② v1.4.72 lockstep

4개 선언 5 occurrence 전부 갱신(`package.json` · `marketplace.json` ×2 · `plugin.json` ×2), 잔여 `1.4.71` 없음, `count_check` PASS.

**버전 관례 확인 후 결정**: v0.1.0 이후 **71연속 patch**, minor 태그 없음. `FH_BACKEND=cross` 는 semver 상 minor 감이지만 여기서 스킴을 혼자 바꾸면 일관성만 깨진다 → 관례 유지, 관찰만 기록.

**출하 전 확인**
- npm `files[]` ∩ 변경분 = **8파일** → 재퍼블리시 근거 있음(가정 아님)
- `psa_scan_lib.sh` 는 `files[]` **밖** → 출하되는 스크립트 전수 grep, 참조 **0** (깨진 패키지 아님)
- §④-b 진입점 drift **양방향**: CC측 1건이 `subagent_invocations_log.yaml`(규칙 아닌 기록) → **drift: none**. grep 이 깃발을 들고 판단이 내린다

## 검사

```
selfcheck                     ✅   (T7/T8 복구 — 이 PR 의 발단)
universal_guard_check   22쌍  ✅
prepush_guard_check     12쌍  ✅   (pair 6 재명세 + 2쌍 신규)
gate_pathspec_check           ✅
test_fh_gate_regressions 31건 ✅
validate_yaml                 ✅
```

## 잔여

- 이 델타엔 **cross-family 라운드를 안 돌렸다** — 오늘 8라운드를 받은 코드에 대한 정정이고, 게이트를 *덜* 막는 방향이며(보호하지 못하던 경우), 발견자가 리뷰가 아니라 자기 검사였다. 판단으로 생략했고 마커에 그렇게 기록했다(누락 아님)
- 정정이 좁힌 커버리지: override 없는 환경의 운영자-리터럴 유출은 이제 **커밋층 일반 shape 이 기술하는 범위까지만** 커버된다. denylist 지 범용 시크릿 탐지기가 아니다
- 신선한 클론 실물 첫 push 는 미검증(앵커 샌드박스로만 확인)
- pre-push 는 npm `files[]` 밖이라 **출하물엔 이 정정이 안 실린다** — 패키지 리스크는 `fh-gate.sh` 의 cross 모드에 한정되고, 그건 앞 브랜치에서 cross-family 라운드를 받았다

🤖 Generated with [Claude Code](https://claude.com/claude-code)