### PR TITLE
feat(hooks): 스택 브랜치 advisory 를 FH 템플릿 훅으로 전파 (필드 → 메타)

### DIFF
--- a/scripts/prepush_guard_check.sh
+++ b/scripts/prepush_guard_check.sh
@@ -225,6 +225,143 @@ check "LOW token in a NON-allowlisted file → BLOCK" "$R" block \
       "refs/heads/f $(cd "$R" && git rev-parse HEAD) refs/heads/f $B"
 rm -rf "$R"
 
+# ── Pair 10: stacked-branch ADVISORY. Unlike every pair above, the assertion is on the WARNING,
+# not on the verdict — this leg exists precisely because the advisory must never change the exit
+# code. Origin (2026-07-27, field harness PRs #38/#39): a branch cut off a feature branch produced a
+# child PR carrying the parent's three commits. Both ways out bill at parent-merge time — keeping the
+# integration base leaves the child CONFLICTING after the parent is squashed, and retargeting onto the
+# parent branch makes --delete-branch CLOSE the child. The observed run hit both (state=CLOSED,
+# mergeable=CONFLICTING), and the tempting recovery is a force-push — the irreversible surface this
+# hook guards.
+#
+# Assertions key on the STABLE MARKER `[fh-advisory:stacked-branch]`, not on the human prose around
+# it (Wave-1 B): a prose-coupled assertion silently desyncs the moment the message is reworded. ──
+SB_MARK='[fh-advisory:stacked-branch]'
+sb_check() {  # sb_check <name> <repo> <expect: warn|skip|none> <refline> [must-name]
+  # [must-name]: a branch the warning MUST name. "a warning appeared" is too weak an assertion —
+  # under a mutation that broke the self-exclusion, the advisory still warned, but about the
+  # pushed branch ITSELF. The leg went green while the defect was live (measured 2026-07-27).
+  local name="$1" repo="$2" expect="$3" refline="$4" mustname="${5:-}" out rc got
+  out=$(printf '%s\n' "$refline" | ( cd "$repo" && bash templates/.git-hooks/pre-push origin git@example:x/y.git 2>&1 )); rc=$?
+  if printf '%s' "$out" | grep -qiE 'bad substitution|unbound variable|syntax error|command not found'; then
+    echo "  ❌ $name — RUNTIME FAULT in the hook"; FAILED=1; return
+  fi
+  if printf '%s' "$out" | grep -qF "$SB_MARK"; then
+    # Key on a machine token, not prose. Measured 2026-07-27: this classifier first grepped the
+    # phrase "skipped —", and a one-word rewording of the hook's message silently reclassified a
+    # correct SKIP as a WARN — the same prose-coupling defect Wave-1 flagged in the leg assertions.
+    if printf '%s' "$out" | grep -qF "$SB_MARK SKIPPED"; then got=skip; else got=warn; fi
+  else
+    got=none
+  fi
+  if [ "$got" != "$expect" ]; then
+    echo "  ❌ $name — expected $expect, got $got"
+    printf '%s\n' "$out" | sed 's/^/       | /' | head -8
+    FAILED=1; return
+  fi
+  # The advisory must not move the verdict. These legs are otherwise-clean pushes, so a non-zero
+  # exit means the advisory (or something it perturbed) started blocking.
+  if [ "$rc" -ne 0 ]; then
+    echo "  ❌ $name — advisory changed the verdict (exit $rc); it must be advisory only"
+    printf '%s\n' "$out" | sed 's/^/       | /' | head -6
+    FAILED=1; return
+  fi
+  if [ -n "$mustname" ] && ! printf '%s' "$out" | grep -qF "$mustname"; then
+    echo "  ❌ $name — warned, but never named '$mustname' (warning for the wrong reason)"
+    printf '%s\n' "$out" | grep -F "$SB_MARK" -A5 | sed 's/^/       | /' | head -8
+    FAILED=1; return
+  fi
+  echo "  ✅ $name ($expect, verdict unchanged${mustname:+, named $mustname})"
+}
+# ⚠️ 계기 주의 (실측): 처음엔 remote_sha 를 all-zero(=신규 브랜치)로 줬는데, 그러면 push 범위에
+# 샌드박스의 base 커밋(= templates/.git-hooks/pre-push 사본을 담고 있다)이 들어가 이 훅의 **기존**
+# load-bearing cross-family 가드가 발화해 차단됐다. sb_check 은 그 rc!=0 을 "advisory 가 verdict 를
+# 바꿨다"로 오귀속했다 — 다른 가드의 차단을 이 기능 탓으로 읽는 계기 결함이다.
+# base 커밋을 remote_sha 로 주면 범위가 픽스처 커밋만으로 좁혀져 그 혼선이 사라진다.
+
+# 10-a known-positive: cut off a REMOTE feature branch.
+R=$(newrepo); B=$(cd "$R" && git rev-parse HEAD)
+( cd "$R" && git update-ref refs/remotes/origin/main "$(git rev-parse HEAD)" \
+  && git switch -q -c feat/parent && printf 'p\n' > p.md && git add p.md && git commit -qm parent >/dev/null \
+  && git update-ref refs/remotes/origin/feat/parent "$(git rev-parse HEAD)" \
+  && git switch -q -c feat/child && printf 'c\n' > c.md && git add c.md && git commit -qm child >/dev/null )
+sb_check "cut off a REMOTE feature branch     → warn" "$R" warn \
+      "refs/heads/feat/child $(cd "$R" && git rev-parse feat/child) refs/heads/feat/child $B"
+rm -rf "$R"
+
+# 10-b known-positive (Wave-1 A): the parent was never pushed. A remote-only check misses exactly
+# the most likely moment for this mistake — before the parent's first push.
+R=$(newrepo); B=$(cd "$R" && git rev-parse HEAD)
+( cd "$R" && git update-ref refs/remotes/origin/main "$(git rev-parse HEAD)" \
+  && git switch -q -c feat/localparent && printf 'p\n' > p.md && git add p.md && git commit -qm parent >/dev/null \
+  && git switch -q -c feat/child2 && printf 'c\n' > c.md && git add c.md && git commit -qm child >/dev/null )
+sb_check "cut off a LOCAL-only feature branch → warn" "$R" warn \
+      "refs/heads/feat/child2 $(cd "$R" && git rev-parse feat/child2) refs/heads/feat/child2 $B"
+rm -rf "$R"
+
+# 10-c known-positive (Wave-1 S, live-reproduced): a branch name carrying a regex metacharacter.
+# The first draft interpolated the name into `grep -vE ".../${self}$"`, so `feat/a.b`'s `.` also
+# matched a genuinely different branch `feat/aXb` — grep -v dropped the REAL hit and the advisory
+# silently no-opped on a true positive. Exclusion is exact-name now; this leg pins that.
+R=$(newrepo); B=$(cd "$R" && git rev-parse HEAD)
+( cd "$R" && git update-ref refs/remotes/origin/main "$(git rev-parse HEAD)" \
+  && git switch -q -c feat/aXb && printf 'p\n' > p.md && git add p.md && git commit -qm parent >/dev/null \
+  && git update-ref refs/remotes/origin/feat/aXb "$(git rev-parse HEAD)" \
+  && git switch -q -c 'feat/a.b' \
+  && git branch -q -D feat/aXb )
+# ⚠️ the local `feat/aXb` is DELETED on purpose. Left in place, the local listing line
+# (`local  feat/aXb`, no `/` before `feat`) dodges the vulnerable pattern `/feat/a.b$` and the leg
+# goes green even with the bug restored — i.e. it would pass for the wrong reason. Measured: the
+# first version of this fixture did exactly that under a mutation test.
+sb_check "regex-metachar branch name          → warn" "$R" warn \
+      "refs/heads/feat/a.b $(cd "$R" && git rev-parse 'feat/a.b') refs/heads/feat/a.b $B" \
+      "origin/feat/aXb"
+rm -rf "$R"
+
+# 10-d (Wave-1 A): base unresolvable → must SAY it did not scan. A silent return is
+# indistinguishable from "scanned, nothing found" — 부재는 통과가 아니다.
+R=$(newrepo); B=$(cd "$R" && git rev-parse HEAD)
+( cd "$R" && git switch -q -c feat/nobase && printf 'n\n' > n.md && git add n.md && git commit -qm x >/dev/null )
+sb_check "base unresolvable                   → skip announced" "$R" skip \
+      "refs/heads/feat/nobase $(cd "$R" && git rev-parse feat/nobase) refs/heads/feat/nobase $B"
+rm -rf "$R"
+
+# 10-e (cross-family LOW-7): parser edge cases. The first draft parsed human `git branch -r`
+# output, where `origin/HEAD -> origin/main` parses as ref="HEAD" and a branch name with a space is
+# truncated. for-each-ref emits refs, not a listing — this leg pins that the symbolic HEAD ref does
+# not manufacture a warning and does not mask a real one.
+R=$(newrepo); B=$(cd "$R" && git rev-parse HEAD)
+( cd "$R" && git update-ref refs/remotes/origin/main "$(git rev-parse HEAD)" \
+  && git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main \
+  && git switch -q -c feat/parent2 && printf 'p\n' > p.md && git add p.md && git commit -qm parent >/dev/null \
+  && git update-ref refs/remotes/origin/feat/parent2 "$(git rev-parse HEAD)" \
+  && git switch -q -c feat/child3 && printf 'c\n' > c.md && git add c.md && git commit -qm child >/dev/null )
+sb_check "origin/HEAD symref present         → warn" "$R" warn \
+      "refs/heads/feat/child3 $(cd "$R" && git rev-parse feat/child3) refs/heads/feat/child3 $B" \
+      "origin/feat/parent2"
+rm -rf "$R"
+
+# 10-f (cross-family MED-2): the integration branch is excluded by its RESOLVED name, not by a
+# hard-coded main/master. A stack built on a LOCAL branch merely named `master` in a repo whose base
+# is origin/main must still warn — hard-coding hid exactly that case.
+R=$(newrepo); B=$(cd "$R" && git rev-parse HEAD)
+( cd "$R" && git update-ref refs/remotes/origin/main "$(git rev-parse HEAD)" \
+  && git switch -q -c master && printf 'p\n' > p.md && git add p.md && git commit -qm onmaster >/dev/null \
+  && git switch -q -c feat/child4 && printf 'c\n' > c.md && git add c.md && git commit -qm child >/dev/null )
+sb_check "stack on a local 'master' branch   → warn" "$R" warn \
+      "refs/heads/feat/child4 $(cd "$R" && git rev-parse feat/child4) refs/heads/feat/child4 $B" \
+      "master"
+rm -rf "$R"
+
+# 10-g CONTROL: cut off the integration branch. Without this leg an advisory that fired
+# unconditionally would score green on every positive leg above while being useless.
+R=$(newrepo); B=$(cd "$R" && git rev-parse HEAD)
+( cd "$R" && git update-ref refs/remotes/origin/main "$(git rev-parse HEAD)" \
+  && git switch -q -c feat/clean && printf 'w\n' > w.md && git add w.md && git commit -qm clean >/dev/null )
+sb_check "control: cut off main               → no warn" "$R" none \
+      "refs/heads/feat/clean $(cd "$R" && git rev-parse feat/clean) refs/heads/feat/clean $B"
+rm -rf "$R"
+
 echo
 if [ "$FAILED" -eq 0 ]; then
   echo "[prepush-guard] ✅ all known pairs hold"

--- a/templates/.git-hooks/pre-push
+++ b/templates/.git-hooks/pre-push
@@ -59,8 +59,108 @@ SEP=$'\n'   # ranges are newline-separated and evaluated ONE REF AT A TIME: conc
             # multi-ref push could return an empty or wrong commit set (R6 audit 2026-07-26).
 PUSH_RANGES=""    # rev-list args for exactly the commits this push would publish (R5 audit 2026-07-26)
 
+# --- stacked-branch advisory (ADVISORY — never changes the verdict) --------------------------
+# Warns when the branch being pushed carries commits that already live on ANOTHER unmerged remote
+# branch. That is the signature of a branch cut while standing on a feature branch instead of on
+# the integration branch.
+#
+# Measured origin (2026-07-27, a field harness, PRs #38/#39): a branch was cut off a feature branch
+# by accident, so the child PR carried the parent's three commits (parent PR = 3 commits, measured).
+# From there BOTH available routes cost something, and both bills arrive at parent-merge time:
+#   (a) leave the child based on the integration branch → its diff shows the parent's changes too,
+#       and once the parent is squash-merged the SHAs no longer match, so the child goes CONFLICTING;
+#   (b) retarget the child onto the parent branch to clean the diff → merging the parent with
+#       `--delete-branch` deletes that base and GitHub **CLOSES** the child rather than retargeting it.
+# The observed run took (b) and ended CLOSED + CONFLICTING (`state=CLOSED`, `mergeable=CONFLICTING`).
+# In both routes the tempting recovery is `git push -f`, which walks straight into the irreversible
+# surface THIS HOOK exists to guard. (Clean recovery: re-cut from the integration branch and
+# cherry-pick — no history rewrite.)
+#
+# Why it is worth a line in a destructive-op hook: the mistake happens at branch-cut time but only
+# bites at parent-merge time, so the two are hard to connect — and its natural "fix" is a history
+# rewrite. Surfacing it at push time removes the pressure before it reaches the force-push path.
+#
+# ADVISORY on purpose (Surface-Class Degrade Invariant, reversible half): intentional stacked PRs
+# are a legitimate workflow, so blocking would be pure over-blocking — and over-blocking trains
+# `--no-verify`, which disarms the IRREVERSIBLE guards in this same hook. What this closes is
+# silence, not permission.
+fh_stacked_branch_advisory() {
+  _sb_ref="$1"; _sb_sha="$2"
+  case "$_sb_ref" in refs/heads/*) ;; *) return 0 ;; esac
+  _sb_self="${_sb_ref#refs/heads/}"; _sb_hit=""
+
+  # Single baseline — this hook already resolved one at the top (BASE). Wave-1 caught the first
+  # draft inventing a 4-candidate fallback chain while its own comment claimed it reused BASE:
+  # comment and code disagreed, and the extra candidates existed nowhere else in the file.
+  if ! git rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null 2>&1; then
+    # 부재는 통과가 아니다 — a silent `return` here is indistinguishable from "scanned, nothing
+    # found". Say that the scan did not happen. (Advisory, so it still does not block.)
+    printf '  ℹ️  [fh-advisory:stacked-branch] SKIPPED (all refs) — base %s does not resolve (FH_DESTRUCTIVE_BASE or default origin/main; shallow clone / unfetched remote). Not scanned. Fix: git fetch origin, or set FH_DESTRUCTIVE_BASE.\n' "$BASE" >&2
+    return 0
+  fi
+  # Orphan / unrelated history has no merge-base, so `BASE..HEAD` would enumerate the branch's
+  # ENTIRE history — none of which is "cut off the wrong base". Different situation, not this one.
+  if ! git merge-base "$BASE" "$_sb_sha" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  # Ref enumeration uses for-each-ref with an explicit TAB-delimited format — never the human
+  # `git branch` output. Cross-family review (codex, 2026-07-27) named three defects that all
+  # traced to that one choice: `origin/HEAD -> origin/main` parses as ref="HEAD", branch names
+  # containing spaces get truncated (so self-exclusion can fail), and `* `/`+ ` prefixes leak in.
+  # for-each-ref emits refs, not a display listing, so the input grammar is actually what the
+  # parser assumes.
+  #
+  # Self-exclusion is by EXACT name comparison, never by interpolating the branch name into a
+  # regex. Wave-1 reproduced that bug: a branch named `feat/a.b` built the pattern `/feat/a.b$`,
+  # whose `.` also matched a genuinely different branch `origin/feat/aXb` — grep -v dropped the
+  # REAL hit and the advisory silently no-opped on a true positive.
+  #
+  # The integration branch is excluded by its RESOLVED name (from BASE), not by hard-coded
+  # `main`/`master` (cross-family MED-2): hard-coding hides a genuine stack built on a local
+  # branch that merely happens to be called `main` in a repo whose base is something else.
+  _sb_base_name="${BASE##*/}"
+  #
+  # ⚠️ Each commit in the range is checked, NOT just the tip. Wave-2 briefly rewrote this to test
+  # `$_sb_sha` alone and the anchors caught it immediately: a child branch that adds its own commit
+  # has a tip nobody else carries — the parent's commits are the evidence, and they sit BELOW the
+  # tip. Bound: newest 50, stated in the message (a bounded best-effort advisory, not a proof).
+  _sb_others=""
+  for _sb_c in $(git rev-list "${BASE}..${_sb_sha}" 2>/dev/null | head -50); do
+    _sb_others=$(
+      { git for-each-ref --contains "$_sb_c" --format='remote	%(refname:short)' refs/remotes 2>/dev/null
+        # Local refs too: the mistake is made BEFORE the parent is ever pushed, which is the most
+        # likely moment for it. A remote-only check structurally misses that case (Wave-1 A).
+        git for-each-ref --contains "$_sb_c" --format='local	%(refname:short)' refs/heads 2>/dev/null
+      } | awk -F'\t' -v self="$_sb_self" -v basename="$_sb_base_name" -v base="$BASE" '
+          { kind=$1; ref=$2
+            name=ref
+            if (kind == "remote") sub(/^[^\/]*\//, "", name)   # drop the remote segment only
+            if (name == self || name == "HEAD" || name == basename) next
+            if (ref == base) next
+            print kind "  " ref }' | head -3
+    )
+    [ -n "$_sb_others" ] && { _sb_hit="$_sb_c"; break; }
+  done
+  [ -n "$_sb_others" ] || return 0
+
+  printf '\n  ⚠️  [fh-advisory:stacked-branch] %s carries commit(s) that already live on another branch.\n' "$_sb_self" >&2
+  printf '     shared commit example: %s\n' "$(git log -1 --format='%h %s' "$_sb_hit" 2>/dev/null | cut -c1-72)" >&2
+  printf '     also on:\n' >&2
+  printf '%s\n' "$_sb_others" | sed 's/^/       - /' >&2
+  printf '     Intentional stack? Ignore this. Otherwise the branch was cut off a feature branch\n' >&2
+  printf '     instead of %s — re-cut from %s and cherry-pick BEFORE opening the PR.\n' "$BASE" "$BASE" >&2
+  printf '     Merging the parent with --squash --delete-branch CLOSES the child PR rather than\n' >&2
+  printf '     retargeting it, and `git push -f` to recover is the surface this hook guards.\n' >&2
+  printf '     (Advisory only — does not block. Scanned the NEWEST 50 commits of %s..%s.)\n\n' "$BASE" "$_sb_self" >&2
+  return 0
+}
+
 while read -r local_ref local_sha remote_ref remote_sha; do
   [ -z "${remote_ref:-}" ] && continue
+  # Advisory first — it can never alter the verdict, and it must be visible even when a guard
+  # below blocks (the two findings are independent and the operator wants both at once).
+  [ "$local_sha" = "$ZERO" ] || fh_stacked_branch_advisory "$local_ref" "$local_sha"
   if [ "$local_sha" = "$ZERO" ]; then
     # local side zero → this refspec DELETES remote_ref
     case "$remote_ref" in


### PR DESCRIPTION
필드 하네스(qasp-dev)에서 실측된 실수를 FH `templates/.git-hooks/pre-push` 로 올린다.
새 브랜치가 **다른 미머지 브랜치에도 존재하는 커밋**을 싣고 있으면 push 시점에 경고한다.

## 왜 비가역 게이트가 있는 훅에 advisory 를 넣나

실수는 브랜치를 자르는 **순간** 벌어지는데 대가는 **부모 머지 때** 온다. 둘의 연결이 안 보이고,
그때의 자연스러운 복구 시도가 **force-push** — 바로 이 훅이 지키는 비가역 표면이다.
신호를 push 시점으로 당겨 그 압력이 생기기 전에 없앤다.

실측(2026-07-27): 자식 PR 이 부모 커밋 3개를 물었고, 부모를 `--squash --delete-branch` 로
머지하자 **재타깃이 아니라 CLOSED**(+SHA 불일치로 CONFLICTING). 복구는 force-push 대신
`main` 에서 재절단 + cherry-pick 으로 했다.

## 차단하지 않는다 (의도적)

의도적 스택 PR 은 정당한 워크플로다. 과차단은 `--no-verify` 를 습관화하고, 그 습관이
**같은 훅의 비가역 가드**를 무장해제한다. 닫는 것은 차단이 아니라 **침묵**이다.

## 4축 게이트

| 축 | 결과 |
|---|---|
| Axis 1 | **SKIP (검사 안 함 ≠ 통과)** — `GUARD_PATHSPEC` 는 마크다운 자산 언어검사라 셸 훅이 대상 아님. 기계 등가물은 앵커 19쌍 |
| Axis 2 | quench-challenger Wave1 → **S1 / A4 / B5**, Wave3 수렴 0 S, Wave-T **τ-PASS** |
| Axis 3 | phantom-quench **PASS** (청구 5건 역추적 · Phantom 0 · Partial 1 수리 후 재감사) |
| Axis 4 | edit_manifest 기록 |
| cross-family | codex/gpt-5.5 — **HIGH 0 / MED 4 / LOW 3**, 전부 반영 → CONVERGED |

## 적대 검증이 실제로 잡은 것

**Wave 1 [S] — 브랜치명 정규식 메타문자.** `feat/a.b` 가 `/feat/a.b$` 패턴을 만들어 진짜 다른
브랜치 `origin/feat/aXb` 까지 자기제외에 먹혔다 = **참 양성에서 무발화**. 로컬 재현 후
정확일치 비교로 교체.

**Wave 1 [A] ×4** — 자체 baseline 4후보 체인 발명(주석은 "BASE 재사용"이라 주장) · 원격
브랜치만 검사(정작 이 실수는 부모를 **푸시하기 전**이 가장 흔하다) · base 미해결 시 **무음
return**(부재는 통과가 아니다) · 앵커가 프로즈에 결합.

**cross-family [MED×4 / LOW×3]** — MED-1·LOW-6·LOW-7 의 뿌리가 하나였다: **사람용
`git branch` 출력을 파싱**(`origin/HEAD -> origin/main` 이 `ref=HEAD` 로 파싱, 공백 포함
브랜치명 절단). `git for-each-ref --format`(TAB 구분)으로 교체하니 셋이 함께 닫혔다.
MED-2 하드코딩 `main`/`master` 제외 → **해석된 BASE 이름**으로 제외.

## 앵커가 잡은 내 자기회귀 2건

1. Wave2 수리 중 커밋 루프를 없애고 **팁 커밋만** 검사하게 만들었다(자식이 자기 커밋을
   얹으면 무발화) → 새 레그가 즉시 빨간불.
2. 분류기가 `"skipped —"` 프로즈에 결합돼 있어, 훅 메시지 한 단어를 고치자 **정상 SKIP 을
   WARN 으로 오분류**했다 → 기계 토큰(`[fh-advisory:stacked-branch] SKIPPED`)으로 교체.

## "옳은 이유로 초록인가" — 판별력 검증

metachar 레그는 처음엔 **취약한 상태에서도 통과**했다(로컬 브랜치 줄이 정규식을 피해가
다른 이유로 warn 이 떴다). 픽스처에서 로컬 브랜치를 지우고 **must-name 어서션**(경고가
`origin/feat/aXb` 를 실제로 지목해야 함)을 붙이니 뮤테이션에서 정확히 실패한다.
**"경고가 떴다"는 어서션은 이 클래스를 못 가른다.**

앵커 **12 → 19쌍**, 전부 통과.

## 잔여 (정직 표기)

- must-name 어서션은 metachar 레그에만 있다 — 나머지 레그는 여전히 "경고가 떴다"까지만 본다.
- stderr 를 `/dev/null` 로 버리는 CI 래퍼에선 advisory 가 보이지 않는다(advisory-only 설계의
  수용 비용 — 실행 기록이 남지 않는다).
- 커밋당 ref 조회라 브랜치가 많은 레포에서 비용이 선형 증가, **시간 상한 없음**.
- 범위는 **newest 50 커밋**(bounded best-effort, 메시지에 명시 — 무음 상한 아님).
- 필드 프로젝트에는 미전파(FH-internal 훅). qasp-dev 는 자체 사본으로 이미 보유.
