### PR TITLE
fix(scan): degrade-scan 셸 표면 거짓 클린 3종 폐쇄 + 계기-캘리브레이션 제약 Codex 진입점 이식

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,11 +104,11 @@ For complex multi-step tasks, run `/agent-composer` first to plan which agents t
 
 The methodology layer (`tracks/`, `knowledge/`, `SKILL.md` docs) is Codex-compatible beta. Any AI model can follow skill workflows by reading SKILL.md files directly; the automation layer (hooks, plugin-channel agents under `plugins/*/agents/`, `/model`) is Claude Code-native and requires manual adaptation. FH's own agents are auto-loaded via the plugin channel when the plugin is enabled — `.claude/agents/` is the field-project override slot, not where FH ships its agents. Non-Claude runtimes use this `AGENTS.md`, `plugins/*/agents/*.md`, and `scripts/fh-run.sh` to apply the same methodology via adapter.
 
-### Non-Claude runtimes: four things CLAUDE.md holds that you will not auto-load
+### Non-Claude runtimes: five things CLAUDE.md holds that you will not auto-load
 
 `.claude/rules/*.md` with `paths:` frontmatter is a **Claude Code platform feature** — those files are
 auto-loaded into a Claude Code session when it reads a matching file, and **your runtime has no equivalent**.
-So four things that govern behavior are not going to reach you on their own. Read them explicitly:
+So five things that govern behavior are not going to reach you on their own. Read them explicitly:
 
 1. **FH asset changes run a mandatory 4-axis verification chain before the session's first commit.**
    Detail (axis definitions · marker required fields · lightweight exception · substantive carve-out):
@@ -166,6 +166,30 @@ So four things that govern behavior are not going to reach you on their own. Rea
 > **Detail**: See `knowledge/shared/harness-core/intent_marshaling_general_work.md` — the 5-step loop,
 > the gate-routing table, the Sonnet-floor boundaries, and the origin defect — **open it directly**
 > before applying the ladder or when a gap appears.
+
+5. **A scan, checker, or metric in this repo is not evidence until it has been shown to work on the
+   target you are pointing it at.** This one is easy to skip because the tooling looks finished, so it
+   is worth two cheap steps before you rely on a number it produces:
+
+   - **Run it against one case you already know the answer to, and one you know is clean.** A tool that
+     cannot separate those two has not been shown to measure anything, so its output cannot ground a
+     claim about the target — it may still be right, you just have no way to tell. This
+     repo has produced that exact result more than once — an ASCII-token scanner run over a Korean
+     corpus scored ~96% false positives, and a shell-shape scanner reported a fail-open script as
+     "clean" because every one of its probes was written for Python syntax.
+   - **Open one hit by hand before you state a count anywhere** — including in chat, not only in a file.
+     An unverified figure is anchored the moment it is said, and then has to be corrected everywhere it
+     travelled.
+
+   Two conventions that follow from this, and that the rest of the repo assumes you are using:
+   *an empty result is not a zero* — a scan that found no target files, or died mid-run, reports
+   `UNMEASURED`, never `0` — and *an extreme result (everything passed, everything failed) is a reason
+   to suspect the instrument before the target.*
+
+   Nothing enforces this mechanically; the trigger is your own intent to trust an output, which no hook
+   can see. Detail, including the known-pair procedure and the failure catalogue:
+   `knowledge/shared/harness-core/measurement-integrity-checklist.md` — **open it directly** before
+   running a scan whose count you will report.
 
 The irreversible-surface gates (Pre-Publish · Destructive-Op) likewise live in CLAUDE.md and fire on
 **intent**, not on a file — read them before any publish, delete, or history-rewrite. `pre-push` enforces

--- a/knowledge/shared/harness-core/measurement-integrity-checklist.md
+++ b/knowledge/shared/harness-core/measurement-integrity-checklist.md
@@ -120,6 +120,8 @@ here.** Three shapes, all observed 2026-07-20 in a single session:
 | n+7 | **Instrument sees only part of its own declared surface** | An "always-loaded footprint" scan summed files rooted at `$TARGET`, silently omitting the auto-loaded memory index living outside it — **61% of the real resident surface** | A known-positive (a file you *know* is resident) fails to appear in the sum |
 | n+8 | **A cheap proxy substituted for the real property** | Index-line/topic-file **size ratio** used as a proxy for *content coverage*; minimum ratio 3.7× read as "safe" — while an entry whose file was 3.7× larger still lacked every fact the index carried | One known case checked by content, not size, inverts the verdict immediately |
 | n+9 | **Language / encoding assumption mismatch** | An **ASCII-token scanner run over a Korean corpus**: the index wrote `catch`, `MERGED`, `expert-system`; the files wrote `잡았다`, `머지`, `케이스크래프트` → every token scored as missing. **~96% false positives** | One known-negative (an entry you know is fully covered) scores as "missing" → mismatch exposed |
+| n+10 | **Accepted into the scanned set, but no probe matches that shape** — the instrument counts the file as covered and reports it *clean* | `degrade_direction_scan.sh` collected `.sh` files while every probe was Python-shaped (`except:` / `.get(k, True)` / `if not x:`). A known-positive bash file with four default-toward-PASS constructs scored **0/4**, and the output read `no default-toward-PASS smells in 1 scanned py/sh file` (2026-07-28) | The known-positive of *that shape* scores 0 while the summary says "scanned" — the tell is coverage claimed without detection demonstrated |
+| n+11 | **The collection predicate, not the probe, is what silently drops the target** | Same scan: git hooks are named `pre-push` (no extension) under `.git-hooks` (dotted directory), and the extension test ran against the **full path**, so FH's own mechanical floor reported `no scannable (py/sh) target files`, exit 0 | Point the instrument at a directory you *know* holds a positive; an empty file list is the finding, not a clean result |
 
 Secondary false-positive sources in the same run, worth checking explicitly: **whitespace/hyphen
 variants** (`3주새` vs `3주 새`), and treating a line's **navigational annotation** (`(detail …, archive)`)
@@ -134,6 +136,14 @@ as a factual claim.
   `UNMEASURED`, never `0`.
 - An instrument that produces an **impossible value** (all-pass, all-fail, or a self-scan in which the
   running tool does not detect itself) is suspect **before** its target is. Suspect the instrument first.
+- **"Scanned" is a claim, and it is separate from "covered."** A scanner that admits a file type into its
+  scanned set owes a known-positive *of that type*; without one, its clean message is a false clean, which
+  is strictly worse than an honest "not covered" (n+10). Same for the collection step: an empty file list
+  is a calibration failure to report, never a clean run (n+11).
+- **A probe that flags the prescribed remedy is a defect in the probe.** Measured 2026-07-28: flagging
+  `${count:-0}` — the integer sanitization that closes the `pipefail`-fallback class — would push an author
+  to delete the fix. Hand-check a sample of hits before shipping a probe; on this corpus 6/6 sampled hits
+  were false positives and the scoping that followed cut the load from 73 to 14.
 
 ### Done When
 

--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -542,3 +542,13 @@
   findings: "R1 5문항 중 #5(유니코드 표기 변형으로 같은-계열 차단 우회) 수용·수리(NFKC+Cf 제거, 앵커 5종). #1 소스 실행으로 기각(자기모순), #2~#4 사이드카 자인 no-finding. R2 CONVERGED"
   verdict_holder: governor (소스 실행 대조)
   note: "적대 검증이 실사용을 대체 못 함 — 5문항이 못 잡은 '리뷰 존재≠통과' 구멍은 실운영 1호가 잡았다. qasp-dev PR#32"
+
+- date: 2026-07-28
+  agent: fh-commons:quench-challenger (NOT invoked)
+  model: n/a
+  purpose: "Axis 2 adversarial pass on the degrade-scan shell-probe change (load-bearing: a verdict pre-screen)"
+  prompt_summary: "Would have been: attack the S1~S5 probes + the FP scoping; verify no default-toward-PASS class is hidden by the scoping itself."
+  outcome: sustained
+  finding: "Ran the adversarial pass INLINE instead. It did find a HIGH (S1 scope-exclusion swallowed `[ -f lib ] || exit 0` dependency guards — the fail-open class), closed with a regression anchor. But inline review is same-context by construction, so the isolation property the gate asks for was NOT obtained."
+  note: "Recorded as `sustained` (decided NOT to invoke) because the session carries a standing instruction: no Agent tool unless the user requests it. FIRST `sustained` entry in this log — and directly relevant to fh_signal_2026-07-28_decorrelation-log-uncalibrated, which measured 0 rejected / 0 sustained across 74 entries and argued the log is written selectively toward optimistic outcomes. Operator decision pending on dispatching before merge."
+

--- a/scripts/degrade_direction_scan.sh
+++ b/scripts/degrade_direction_scan.sh
@@ -16,6 +16,14 @@
 # (Irreversibility-gate note: because it is advisory, a degraded/empty run is a no-op,
 #  not a free pass — the cross-family review is the load-bearing check it feeds.)
 #
+# NAMED RECALL RESIDUALS (cross-family audit, gpt-5.5, 2026-07-28 — accepted, not closed):
+#   * Indirection defeats every probe. `allow() { exit 0; }` … `check || allow` is the same
+#     fail-open shape one function call away, and a line-oriented grep cannot follow it. This is
+#     inherent to the heuristic, not a bug to patch — it is why the terminal verdict is the
+#     cross-family review, and why a clean run is never evidence of safety.
+#   * The regression anchor proves the probes on the fixture GRAMMAR it ships, not on every
+#     spelling of each class (e.g. `if ! cmd; then :; fi`, arithmetic-context defaults).
+#
 # Usage:
 #   bash scripts/degrade_direction_scan.sh [path ...]        # scan dirs/files (default: .)
 #   git diff --name-only main..HEAD -- '*.py' | xargs bash scripts/degrade_direction_scan.sh
@@ -36,13 +44,21 @@ FILES=(); UNSCANNABLE=()
 for t in "${TARGETS[@]}"; do
   if [ -d "$t" ]; then
     while IFS= read -r f; do FILES+=("$f"); done < <(find "$t" -type f \( -name '*.py' -o -name '*.sh' \) 2>/dev/null)
-    # Extensionless shell files (git hooks are named `pre-push` / `pre-commit`, never `*.sh`).
-    # Measured 2026-07-28: `templates/.git-hooks` — FH's own mechanical floor — reported
-    # "no scannable (py/sh) target files", exit 0. The most load-bearing bash in the repo was
-    # invisible AND read as clean. Collect by shebang when the name carries no extension.
+    # Shebang pass — this is what makes git hooks visible at all. Measured 2026-07-28:
+    # `templates/.git-hooks` (files named `pre-push`, no extension, under a dotted directory) —
+    # FH's own mechanical floor — reported "no scannable (py/sh) target files", exit 0.
+    # Shebang pass. Deliberately NOT restricted to extensionless names: a cross-family audit
+    # (2026-07-28, gpt-5.5) found that an earlier draft skipped any dotted basename, so a shell
+    # file named `helper.bash` carrying an identical known-positive was dropped from a DIRECTORY
+    # target in silence — while the explicit-file branch reported the same file as UNSCANNABLE.
+    # Silent-drop on one path and honest-report on the other is the fail-open half. Confirmed by
+    # running both paths on the same fixture before accepting the finding.
     while IFS= read -r f; do
       b="${f##*/}"                      # basename — a dotted DIRECTORY (.git-hooks) is not an extension
-      case "$b" in *.*) continue ;; esac
+      case "$b" in
+        *.py|*.sh) continue ;;          # already collected above
+        *.md|*.json|*.yaml|*.yml|*.txt|*.lock|*.png|*.jpg|*.svg|*.pdf|*.zip) continue ;;
+      esac
       head -n1 "$f" 2>/dev/null | grep -qE '^#!.*\b(ba|z|k)?sh\b' && FILES+=("$f")
     done < <(find "$t" -type f 2>/dev/null)
   elif [ -f "$t" ]; then
@@ -73,11 +89,16 @@ for f in "${FILES[@]}"; do
   # (`except:` / `.get(k, True)` / `if not x:` / `.split()`), none of which exist in bash. A .sh file
   # was still COLLECTED and counted, so a fail-open shell gate printed "no smells in 1 scanned py/sh
   # file" — a FALSE CLEAN, which is worse than honest non-coverage. A known-positive .sh carrying four
-  # distinct default-toward-PASS shapes scored 0/4. These probes close that; they run on .sh only.
+  # distinct default-toward-PASS shapes scored 0/4. These probes close that; they run on any file
+  # whose basename ends in .sh OR that carries a shell shebang (see the is_sh test below).
   is_sh=""; fb="${f##*/}"
   case "$fb" in
     *.sh) is_sh=1 ;;
-    *.*) ;;
+    *.py) ;;
+    # Any other collected file reached FILES only via the shebang pass, or is a dotted shell name
+    # like `helper.bash`. Re-check the shebang rather than keying on the extension — keying on the
+    # extension is what produced the collect-but-never-probe false clean this whole block exists to
+    # close (n+10). Collected-but-unprobed must not be reachable again.
     *) head -n1 "$f" 2>/dev/null | grep -qE '^#!.*\b(ba|z|k)?sh\b' && is_sh=1 ;;
   esac
   if [ -n "$is_sh" ]; then

--- a/scripts/degrade_direction_scan.sh
+++ b/scripts/degrade_direction_scan.sh
@@ -36,10 +36,21 @@ FILES=(); UNSCANNABLE=()
 for t in "${TARGETS[@]}"; do
   if [ -d "$t" ]; then
     while IFS= read -r f; do FILES+=("$f"); done < <(find "$t" -type f \( -name '*.py' -o -name '*.sh' \) 2>/dev/null)
+    # Extensionless shell files (git hooks are named `pre-push` / `pre-commit`, never `*.sh`).
+    # Measured 2026-07-28: `templates/.git-hooks` — FH's own mechanical floor — reported
+    # "no scannable (py/sh) target files", exit 0. The most load-bearing bash in the repo was
+    # invisible AND read as clean. Collect by shebang when the name carries no extension.
+    while IFS= read -r f; do
+      b="${f##*/}"                      # basename — a dotted DIRECTORY (.git-hooks) is not an extension
+      case "$b" in *.*) continue ;; esac
+      head -n1 "$f" 2>/dev/null | grep -qE '^#!.*\b(ba|z|k)?sh\b' && FILES+=("$f")
+    done < <(find "$t" -type f 2>/dev/null)
   elif [ -f "$t" ]; then
-    case "$t" in
+    tb="${t##*/}"
+    case "$tb" in
       *.py|*.sh) FILES+=("$t") ;;
-      *) UNSCANNABLE+=("$t") ;;
+      *.*) UNSCANNABLE+=("$t") ;;
+      *) if head -n1 "$t" 2>/dev/null | grep -qE '^#!.*\b(ba|z|k)?sh\b'; then FILES+=("$t"); else UNSCANNABLE+=("$t"); fi ;;
     esac
   fi
 done
@@ -57,6 +68,73 @@ hits=0
 emit() { printf '  %s:%s\n    [%s] %s\n' "$1" "$2" "$3" "$4"; hits=$((hits+1)); }
 
 for f in "${FILES[@]}"; do
+  # ---- Shell-shaped probes (S*) -------------------------------------------------------------
+  # Calibration finding (2026-07-28, known-pair): every probe below the S-block is PYTHON-shaped
+  # (`except:` / `.get(k, True)` / `if not x:` / `.split()`), none of which exist in bash. A .sh file
+  # was still COLLECTED and counted, so a fail-open shell gate printed "no smells in 1 scanned py/sh
+  # file" — a FALSE CLEAN, which is worse than honest non-coverage. A known-positive .sh carrying four
+  # distinct default-toward-PASS shapes scored 0/4. These probes close that; they run on .sh only.
+  is_sh=""; fb="${f##*/}"
+  case "$fb" in
+    *.sh) is_sh=1 ;;
+    *.*) ;;
+    *) head -n1 "$f" 2>/dev/null | grep -qE '^#!.*\b(ba|z|k)?sh\b' && is_sh=1 ;;
+  esac
+  if [ -n "$is_sh" ]; then
+    # S1 — permissive short-circuit on a FAILING CHECK: `scan=$(...) || return 0`, `verify … || exit 0`.
+    #   The check errored and the surface reports success. Safe-fail is `|| return 1` / `|| exit 1`.
+    #   SCOPED to check-shaped left-hand sides (command substitution, or a verb like
+    #   scan/check/verify/grep/audit/validate/gate). A PRECONDITION guard — `[ -d x ] || exit 0`,
+    #   `[[ $d =~ … ]] || return 0` — is deliberately excluded: "this run does not apply here" is not
+    #   the same claim as "this check passed". Hand-measured 2026-07-28: unscoped, 6/6 sampled hits
+    #   were false positives, 4 of them precondition guards.
+    #   EXCEPTION, re-added after an adversarial pass on this very scoping: a `-f`/`-x` test is a
+    #   DEPENDENCY check, not a scope check. `[ -f "$GUARD_LIB" ] || exit 0` means "my guard library
+    #   is missing, therefore allow" — the fail-open shape that bit qasp on 2026-07-28. Excluding it
+    #   with the scope guards would have hidden exactly the class this scan exists to find.
+    while IFS= read -r m; do
+      emit "$f" "${m%%:*}" "S1:||→PASS(sh)" "failing check short-circuits to a permissive result (\`|| return 0\` / \`|| exit 0\` / \`|| true\`) — an errored check must fail closed, not report success"
+    done < <(grep -nE '\|\|[[:space:]]*(return[[:space:]]+0|exit[[:space:]]+0|true)([[:space:]]*(#|;|$))' "$f" 2>/dev/null \
+             | grep -vE '#[[:space:]]*noqa[:[:space:]]*degrade' \
+             | grep -vE '^[0-9]+:[[:space:]]*(if[[:space:]]+)?\[\[?[[:space:]]*(-[dznN][[:space:]]|[^]]*=~)' \
+             | grep -E '(\$\(|`|\[[[:space:]]*-[fx][[:space:]]|\b(scan|check|verify|validate|audit|grep|gate|assert|lint|test_)[A-Za-z_]*[[:space:](])')
+
+    # S2 — `else` fall-through to a permissive exit/return within 2 lines (unenumerated case → allow).
+    while IFS= read -r ln; do
+      emit "$f" "$ln" "S2:else→PASS(sh)" "else/fall-through branch exits permissively — the unenumerated case should fail closed"
+    done < <(grep -nE -A2 '^[[:space:]]*else[[:space:]]*$' "$f" 2>/dev/null \
+             | grep -E '^[0-9]+[-:][[:space:]]*(exit[[:space:]]+0|return[[:space:]]+0)[[:space:]]*(#.*)?$' \
+             | grep -oE '^[0-9]+' | sort -u)
+
+    # S3 — empty/unset defaulted to a permissive VERDICT: `${V:-PASS}` / `V="PASS"` after a failed read.
+    #   "the value never arrived" must not be spelled the same way as "the value said PASS".
+    #   `${V:-0}` and `${V:-true}` are NOT flagged: numeric defaulting is the prescribed integer
+    #   sanitization against the pipefail-fallback class (see S5), and flagging it would push an
+    #   author to delete the remedy. Measured 2026-07-28 — `${PRS:-0}` in session_close_check.sh is
+    #   the fix, not the defect. Only explicit verdict words count.
+    while IFS= read -r m; do
+      emit "$f" "${m%%:*}" "S3:default→PASS(sh)" "unset/empty defaults to a permissive verdict — absent is not clean (\`not found\` ≠ \`0\`); default to the blocking value"
+    done < <(grep -nE "(\\$\{[A-Za-z_][A-Za-z0-9_]*:?-[[:space:]]*(PASS|OK|ALLOW|GRANTED|VALID|PASSED)\}|\|\|[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=[\"']?(PASS|OK|ALLOW|GRANTED|VALID))" "$f" 2>/dev/null \
+             | grep -vE '#[[:space:]]*noqa[:[:space:]]*degrade')
+
+    # S4 — empty-output guard treated as clean: `if [ -z "$out" ]; then return 0/exit 0`.
+    #   Identical to Probe E's falsy-sentinel class, in shell spelling: an errored scan produces empty
+    #   output, so "found nothing" and "never ran" become indistinguishable.
+    while IFS= read -r ln; do
+      emit "$f" "$ln" "S4:empty→PASS(sh)" "empty output treated as clean — a scan that errored also produces empty output; distinguish 'errored/absent' from 'verified clean'"
+    done < <(grep -nE -A2 '^[[:space:]]*(if|elif)[[:space:]]+\[+[[:space:]]*-z[[:space:]]' "$f" 2>/dev/null \
+             | grep -E '^[0-9]+[-:][[:space:]]*(exit[[:space:]]+0|return[[:space:]]+0)[[:space:]]*(#.*)?$' \
+             | grep -oE '^[0-9]+' | sort -u)
+
+    # S5 — the pipefail-fallback disarm: `... | grep -c ... || echo 0` appends a SECOND line under
+    #   `set -o pipefail`, so the later `-gt` integer test becomes a bash error (= false) and the guard
+    #   passes silently, with the error going only to stderr. Measured class, 2026-07-26.
+    while IFS= read -r m; do
+      emit "$f" "${m%%:*}" "S5:pipefail-fallback(sh)" "\`|| echo 0\` fallback on a pipeline — under \`set -o pipefail\` this yields a multi-line value whose integer comparison errors out and silently passes the guard; split the pipeline and sanitize to an integer"
+    done < <(grep -nE '\|[^|]+\|\|[[:space:]]*echo[[:space:]]+[\"'"'"']?0' "$f" 2>/dev/null \
+             | grep -vE '#[[:space:]]*noqa[:[:space:]]*degrade')
+  fi
+
   # Probe A — except/else/finally block returning a permissive value within 2 lines.
   #   The classic "swallow the error → report success". A safe-fail returns BLOCK/None/raise.
   while IFS= read -r line; do

--- a/scripts/test_degrade_scan_shell_probes.sh
+++ b/scripts/test_degrade_scan_shell_probes.sh
@@ -134,6 +134,23 @@ n=$(s_hits "$TMP/non_detections.sh")
 [ "$n" -eq 0 ] && ok "non-detections stay silent (\${v:-0} sanitization + precondition guards)" \
                 || bad "non-detections fired $n time(s) — flagging the remedy trains authors to delete it"
 
+# A DOTTED shell filename (`helper.bash`) must not be silently dropped from a directory walk.
+# Cross-family finding (gpt-5.5, 2026-07-28), reproduced before acceptance: the directory path
+# dropped it in silence while the explicit-file path reported the same file as UNSCANNABLE.
+# Silent on one path, honest on the other, is the fail-open half.
+mkdir -p "$TMP/dotted"
+cat > "$TMP/dotted/helper.bash" <<'EOF'
+#!/usr/bin/env bash
+scan=$(run_scanner "$1") || return 0
+EOF
+cat > "$TMP/dotted/gate.sh" <<'EOF'
+#!/usr/bin/env bash
+scan=$(run_scanner "$1") || return 0
+EOF
+n=$(s_hits "$TMP/dotted")
+[ "$n" -eq 2 ] && ok "dotted shell filename (helper.bash) scanned alongside gate.sh in a directory walk" \
+                || bad "dotted shell filename: expected 2 S-hits, got $n — a .bash/.zsh gate is silently dropped again"
+
 n=$(s_hits "$TMP/dependency_guards.sh")
 [ "$n" -eq 2 ] && ok "dependency guards (\`[ -f lib ] || exit 0\`) still detected — scope exclusion did not swallow them" \
                 || bad "dependency guards: expected 2 S-hits, got $n — 'guard library missing → allow' is hidden again"

--- a/scripts/test_degrade_scan_shell_probes.sh
+++ b/scripts/test_degrade_scan_shell_probes.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# test_degrade_scan_shell_probes.sh — regression anchor for the shell (S*) probes of
+# scripts/degrade_direction_scan.sh.
+#
+# WHY THIS EXISTS (measured 2026-07-28, known-pair calibration):
+#   The scan COLLECTED `.sh` files but every probe was Python-shaped (`except:` / `.get(k, True)` /
+#   `if not x:` / `.split()`). A known-positive bash file carrying four distinct default-toward-PASS
+#   shapes scored 0/4 and the scan printed "no default-toward-PASS smells in 1 scanned py/sh file".
+#   That is a FALSE CLEAN — strictly worse than honest non-coverage, because a caller keying on the
+#   message or exit code reads it as verified.
+#   A second, larger hole surfaced in the same run: git hooks are named `pre-push` / `pre-commit`
+#   (no extension) and live under a DOTTED directory, so `templates/.git-hooks` — FH's own mechanical
+#   floor — reported "no scannable (py/sh) target files", exit 0.
+#
+# The assertions below pin: (1) the S-probes separate a known pair, (2) extensionless shell files
+# under a dotted directory are collected, (3) the Python probes did not regress, and (4) two
+# deliberate NON-detections stay non-detections — flagging them would push an author to delete a
+# remedy or to silence a legitimate precondition guard.
+#
+# Usage:  bash scripts/test_degrade_scan_shell_probes.sh
+# Exit:   0 = all assertions pass; 1 = a regression.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN="$REPO_ROOT/scripts/degrade_direction_scan.sh"
+[ -f "$SCAN" ] || { echo "FAIL: $SCAN not found"; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0; fail=0
+ok()   { printf '  ✅ %s\n' "$1"; pass=$((pass+1)); }
+bad()  { printf '  ❌ %s\n' "$1"; fail=$((fail+1)); }
+
+# Count S-probe hit lines. Deliberately counts the probe TAG, not the summary line: a summary can say
+# "clean" for reasons unrelated to detection, and this anchor must not be satisfiable by prose.
+s_hits() { bash "$SCAN" "$@" 2>&1 | grep -cE '\[S[0-9]:'; }
+p_hits() { bash "$SCAN" "$@" 2>&1 | grep -cE '\[[A-F][0-9]?:'; }
+rc_of()  { bash "$SCAN" "$@" >/dev/null 2>&1; echo $?; }
+
+# ── Fixtures ────────────────────────────────────────────────────────────────────────
+# Known POSITIVE: four distinct shell-shaped default-toward-PASS constructs, one per probe.
+cat > "$TMP/known_positive.sh" <<'EOF'
+#!/usr/bin/env bash
+check_secret() {
+  scan_output=$(run_scanner "$1") || return 0        # S1: the check errored -> report success
+  if [ -z "$scan_output" ]; then
+    return 0                                          # S4: empty == errored == "clean"
+  fi
+  return 1
+}
+verdict=$(get_verdict) || verdict="PASS"              # S3: unresolved -> permissive verdict
+if [ "$verdict" = "BLOCK" ]; then
+  exit 1
+else
+  exit 0                                              # S2: unenumerated case -> allow
+fi
+EOF
+
+# Known NEGATIVE: the same logic written fail-closed. Must stay silent, or the probes are noise.
+cat > "$TMP/known_negative.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+check_secret() {
+  if ! scan_output=$(run_scanner "$1"); then
+    echo "scanner failed - fail closed" >&2; return 1
+  fi
+  [ -n "$scan_output" ] && return 1
+  return 0
+}
+EOF
+
+# Extensionless hook under a DOTTED directory — the collection bug's exact shape.
+mkdir -p "$TMP/.git-hooks"
+cat > "$TMP/.git-hooks/pre-push" <<'EOF'
+#!/usr/bin/env bash
+verdict=$(classify_refs) || verdict="ALLOW"
+EOF
+
+# Deliberate NON-detections.
+cat > "$TMP/non_detections.sh" <<'EOF'
+#!/usr/bin/env bash
+# (a) integer sanitization — the PRESCRIBED remedy for the pipefail-fallback class, not the defect.
+count=$(grep -c pattern file)
+if [ "${count:-0}" -gt 0 ]; then echo "found"; fi
+# (b) SCOPE guards — "this run does not apply here" is not a claim that a check passed.
+[ -d "$HOME/projects" ] || exit 0
+[[ "$1" =~ ^[0-9]{4}$ ]] || return 0
+EOF
+
+# DEPENDENCY guards must NOT be swept up by the scope-guard exclusion above. `[ -f lib ] || exit 0`
+# says "my guard library is missing, therefore allow" — the fail-open shape measured on qasp
+# 2026-07-28. An earlier draft of the scoping hid it; this fixture pins the distinction.
+cat > "$TMP/dependency_guards.sh" <<'EOF'
+#!/usr/bin/env bash
+[ -f "$GUARD_LIB" ] || exit 0
+[ -x "$SCANNER" ] || exit 0
+EOF
+
+# Python known-pair — the pre-existing probes must not have regressed.
+printf 'def f(x):\n    try:\n        return g(x)\n    except Exception:\n        return True\n' > "$TMP/kp.py"
+printf 'def f(x):\n    try:\n        return g(x)\n    except Exception:\n        raise\n' > "$TMP/kn.py"
+
+# ── Assertions ──────────────────────────────────────────────────────────────────────
+echo "degrade-scan shell-probe regression anchor"
+
+n=$(s_hits "$TMP/known_positive.sh")
+[ "$n" -eq 4 ] && ok "known-positive .sh: 4/4 shell smells detected" \
+                || bad "known-positive .sh: expected 4 S-hits, got $n (probes blind to bash again)"
+
+rc=$(rc_of "$TMP/known_positive.sh")
+[ "$rc" -eq 2 ] && ok "known-positive .sh: advisory exit 2" \
+                || bad "known-positive .sh: expected exit 2, got $rc"
+
+n=$(s_hits "$TMP/known_negative.sh")
+[ "$n" -eq 0 ] && ok "known-negative .sh: silent (probes discriminate, not just fire)" \
+                || bad "known-negative .sh: expected 0 S-hits, got $n"
+
+rc=$(rc_of "$TMP/known_negative.sh")
+[ "$rc" -eq 0 ] && ok "known-negative .sh: exit 0" \
+                || bad "known-negative .sh: expected exit 0, got $rc"
+
+# Directory walk must reach an extensionless shell file inside a dotted directory.
+n=$(s_hits "$TMP/.git-hooks")
+[ "$n" -ge 1 ] && ok "extensionless hook under a dotted dir: collected and scanned" \
+                || bad "extensionless hook under a dotted dir: not scanned ($n hits) — the git-hook floor is invisible again"
+
+# ...and so must an explicit file argument naming it.
+n=$(s_hits "$TMP/.git-hooks/pre-push")
+[ "$n" -ge 1 ] && ok "extensionless hook as a direct file argument: scanned" \
+                || bad "extensionless hook as a direct file argument: not scanned ($n hits)"
+
+n=$(s_hits "$TMP/non_detections.sh")
+[ "$n" -eq 0 ] && ok "non-detections stay silent (\${v:-0} sanitization + precondition guards)" \
+                || bad "non-detections fired $n time(s) — flagging the remedy trains authors to delete it"
+
+n=$(s_hits "$TMP/dependency_guards.sh")
+[ "$n" -eq 2 ] && ok "dependency guards (\`[ -f lib ] || exit 0\`) still detected — scope exclusion did not swallow them" \
+                || bad "dependency guards: expected 2 S-hits, got $n — 'guard library missing → allow' is hidden again"
+
+n=$(p_hits "$TMP/kp.py")
+[ "$n" -ge 1 ] && ok "python known-positive: pre-existing probes still fire" \
+                || bad "python known-positive: no hits — the Python probes regressed"
+
+n=$(p_hits "$TMP/kn.py")
+[ "$n" -eq 0 ] && ok "python known-negative: still silent" \
+                || bad "python known-negative: $n hit(s) — Python probes became noisy"
+
+echo "----"
+echo "degrade-scan shell probes: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
## 무엇을 고쳤나

`scripts/degrade_direction_scan.sh` 는 fail-open(default-toward-PASS) 코드 형태를 cross-family 리뷰 **전에** 걸러주는 advisory 프리스크린이다. known-pair 캘리브레이션을 돌려보니 셸 표면에서 **거짓 클린 3종**을 만들고 있었다.

| # | 결함 | 왜 거짓 클린인가 |
|---|---|---|
| 1 | 프로브가 전부 파이썬 문법(`except:` · `.get(k, True)` · `if not x:` · `.split()`) | `.sh` 를 **수집은 하고** 탐지는 0 → 출력이 `no smells in 1 scanned py/sh file`. 커버리지를 주장하면서 탐지가 없다 |
| 2 | 확장자 판정이 basename 이 아니라 **경로 전체** | `templates/.git-hooks/pre-push` (확장자 없음 + 점 있는 디렉터리) → `no scannable (py/sh) target files`, exit 0. **FH 자기 기계 floor 가 통째로 스캔 밖** |
| 3 | shebang 패스가 점 없는 이름에만 적용 | `helper.bash` 가 **디렉터리** 워크에선 무음 드롭. 같은 파일을 명시 파일로 주면 UNSCANNABLE 로 정직하게 보고 — 한쪽 무음/한쪽 정직에서 무음 쪽이 fail-open |

셸 프로브 `S1`~`S5` 신설: 단축평가→PASS · `else` 폴스루 · 판정 기본값 · 빈출력=클린 · pipefail 폴백.

## 계기 규율

- **known-pair**: 수리 전 known-positive `.sh` 4종 **0/4** 검출, positive/negative 구분 0. 수리 후 **4/4 · negative 0**, 파이썬 known-pair 무회귀.
- **FP 손검증**: 표본 **6/6 오탐**. 그중 `${count:-0}` 은 pipefail 클래스의 *처방*이다 — 처방을 결함으로 찍으면 저자가 처방을 지운다. 스코프 테스트(`-d`, `=~`)만 제외하고 **의존물 테스트(`-f`, `-x`)는 살렸다**: `[ -f "$GUARD_LIB" ] || exit 0` = "가드 라이브러리가 없으니 통과" 는 07-28 qasp 를 문 바로 그 형태다.
- `scripts/` 기준 S-히트 **73 → 22**.

## 검증

- 회귀 앵커 `scripts/test_degrade_scan_shell_probes.sh` — **11/11**
- 뮤테이션 배터리 **5/5 검출**: 원본 복귀 · basename 되돌림 · S3 가드 제거 · A1 스코핑 되돌림 · dotted 수집 되돌림
- **cross-family** (codex/gpt-5.5, CLI 사이드카): 1 MED 확인·폐쇄(위 #3 — **수용 전에 픽스처로 직접 재현**, 사이드카 동의가 아니라 소스 그라운딩). 잔여 2건은 **닫지 않고 명시 수용**하여 스크립트 헤더에 기록 — (a) 래퍼 함수 경유 간접화는 라인 단위 grep 으로 못 따라간다 (b) 앵커는 동봉 픽스처 문법을 증명하지 모든 철자를 증명하지 않는다
- 4축: Axis1 PASS · Axis2 인라인 + cross-family(**격리 dispatch 미실행 사실을 마커에 명시**) · Axis3 phantom 0 · Axis4 RECORD

## 진입점 이식 (gate-locality)

`CLAUDE.md` 는 Instrument-Calibration 을 상주로 들고 있는데 `AGENTS.md` · `docs/codex-compat.md` 에는 관련 문구가 **0건**이었다. 비-Claude 런타임은 `.claude/rules` 자동로드가 없어 이 규칙을 구조적으로 못 본다.

이식한 건 **제약**이지 문구가 아니다 — CLAUDE.md 의 단정형을 그대로 옮기면 무관계 서드파티 콜드리드에겐 강압으로 읽힌다는 게 기록된 실측이다. 청중(비-Claude 런타임)에 맞춰 다시 썼고, **콜드리드 sim 을 그 청중으로 돌렸다**(codex/gpt-5.5): `reasonable engineering constraint I would follow`, 강압 아님. 과장 1건 지적받아 수정.

## 문서

`measurement-integrity-checklist.md` 에 두 클래스를 명명: **n+10**(수집됐으나 그 형태를 볼 프로브가 없음 → 클린으로 보고) · **n+11**(프로브가 아니라 수집 술어가 대상을 떨어뜨림). degrade direction 절에 "scanned ≠ covered" · "처방을 찍는 프로브는 프로브의 결함" 추가.

## 범위 밖 (기록만)

`templates/.git-hooks` 와 `scripts/degrade_direction_scan.sh` 는 `package.json` `files[]` 에 없어 **npm 사용자에게 전달되지 않는다**. 이 PR 은 그 범위를 바꾸지 않는다 — 운영자 결정 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)