### PR TITLE
feat(auto-decorrelation): 사이드카 대기를 기계 형식으로 배선한다 (S-1b)

### DIFF
--- a/knowledge/shared/harness-core/multi_model_sidecar_strategy.md
+++ b/knowledge/shared/harness-core/multi_model_sidecar_strategy.md
@@ -9,6 +9,12 @@ status: mechanism-validated (cross-provider grader confirmed 2026-06-02)
 > **Validation status** (updated 2026-06-02): mechanism validated by cross-provider grader.
 >
 > 2026-06-01 steel-quench (Issue #47): mechanism confirmed runnable — implementation shipped in PR #36/#37. Original empirical claims (Experiment 1·2) were an internal same-session self-report; raw transcripts not retained, codex grader blocked by network policy.
+
+> **사이드카 대기는 기계로 한다** — `scripts/sidecar_wait.sh` 경유가 필수 형식이고, 타입 verdict
+> (`COMPLETE`/`TIMEOUT`/`EMPTY`)만 읽는다. **`EMPTY` 만이 "사이드카가 아무 말 안 했다"** 이다.
+> 출력 파일을 눈으로 보고 판정하지 마라 — 살아있는 프로세스와 죽은 프로세스가 같은 0바이트를
+> 낸다(2026-07-29 실측: 1초/30초 만에 읽고 정상 동작 중인 사이드카 2종을 '실패'로 기록,
+> 실제로는 4건의 진짜 finding 이 나왔다). 정본 = `auto-decorrelation` SKILL.md §S-1b.
 >
 > 2026-06-02 update: Gemini 0.41.2 cross-provider grader run on `pipeline-conductor/SKILL.md` (retained transcript: `tracks/_meta/grader_gemini_pipeline_conductor_2026_06_02.txt`). Gemini found 3 S-grade findings (interaction deadlock, PR-approval deadlock, cadence-lock deadlock); Claude Sonnet-4.6 previously found 3 different S-grade findings (model conflict, invocation contradiction, self-referential sweep). **Zero overlap across 6 S-grade findings** — validates the non-overlapping failure modes claim and perspective diversity mechanism. Provider-identity diversity is empirically confirmed; specific Experiment 2 finding counts on goal-quench (original target) are not directly re-run. Record: `tracks/_meta/grader_gemini_pipeline_conductor_2026_06_02.txt`.
 

--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -550,7 +550,7 @@
   prompt_summary: "Would have been: attack the S1~S5 probes + the FP scoping; verify no default-toward-PASS class is hidden by the scoping itself."
   outcome: sustained
   finding: "Ran the adversarial pass INLINE instead. It did find a HIGH (S1 scope-exclusion swallowed `[ -f lib ] || exit 0` dependency guards — the fail-open class), closed with a regression anchor. But inline review is same-context by construction, so the isolation property the gate asks for was NOT obtained."
-  note: "Recorded as `sustained` (decided NOT to invoke) because the session carries a standing instruction: no Agent tool unless the user requests it. FIRST `sustained` entry in this log — and directly relevant to fh_signal_2026-07-28_decorrelation-log-uncalibrated, which measured 0 rejected / 0 sustained across 74 entries and argued the log is written selectively toward optimistic outcomes. Operator decision pending on dispatching before merge."
+  note: "Recorded as `sustained` (decided NOT to invoke) because the session carries a session-level system configuration, not an operator instruction. FIRST `sustained` entry in this log — and directly relevant to fh_signal_2026-07-28_decorrelation-log-uncalibrated, which measured 0 rejected / 0 sustained across 74 entries and argued the log is written selectively toward optimistic outcomes. Operator decision pending on dispatching before merge."
 
 
 - date: 2026-07-28
@@ -560,4 +560,23 @@
   prompt_summary: "Would have been: cold-read the rewritten Session Wrap-up ⑤ at Sonnet and close a session with a finding arriving mid-close — does the atomic ordering actually fire, or does the fh_completed append still happen after the card?"
   outcome: sustained
   finding: "Not run. The four other worklist items are mechanical (scripts/hooks — tier-independent, exempt by the gate's own enforcement-column test) and were verified by known-pair + mutation + positive control. The CLAUDE.md ⑤ change is the one item the sim gate actually targets, and it is therefore UNVERIFIED at floor tier — recorded as a residual in the Axes 2-3 marker rather than absorbed silently."
-  note: "Second `sustained` in this log, same cause as the first: standing session instruction forbids the Agent tool unless the user requests it. The pattern is now n=2 — the gate's near-mandatory sim is structurally unreachable in sessions carrying that instruction, which is a governance question (whose exception is it?) rather than a per-session judgment call. Candidate for fh_signal."
+  note: "Second `sustained` in this log, same cause as the first: session-level system configuration withheld the Agent tool absent an explicit user request (a configured default, NOT something the operator said — the earlier wording blurred the source). The pattern is now n=2 — the gate's near-mandatory sim is structurally unreachable in sessions carrying that instruction, which is a governance question (whose exception is it?) rather than a per-session judgment call. Candidate for fh_signal."
+
+- date: 2026-07-29
+  agent: general-purpose (Sonnet) — blind behavioral sim
+  model: sonnet
+  purpose: "Target-tier sim gate on the salience-dependent auto-decorrelation §S-1b change (sidecar_wait as required form)"
+  prompt_summary: "Play out a real turn: dispatch a sidecar, check it 40s later, find 0 bytes — write the exact commands and the exact sentence you'd record. Then say what you'd skim past."
+  outcome: accepted
+  finding: >-
+    The rule FIRES at Sonnet tier — the sim reproduced the required command verbatim, refused to write
+    "0-output" at the 40s mark, and cited the exact lines that drove each answer. The value was in the
+    two honesty questions: it named the incident narrative as skimmable ("reads like color commentary,
+    and it comes AFTER the command, so a fast reader treats the command as the content"), and named
+    peeking at the output file as the FIRST thing it would do wrong in a hurry. Acted on: the operative
+    one-line rule was hoisted ABOVE the command block.
+  note: >-
+    First Agent-tool dispatch of this session. The two earlier `sustained` entries recorded the tool as
+    withheld by a "standing session instruction"; the operator pointed out they never said that — it is
+    session-level SYSTEM configuration, and the wording blurred the source. Corrected in the markers and
+    here. The operator then explicitly requested the agent, which satisfies the configured exception.

--- a/plugins/fh-meta/skills/auto-decorrelation/SKILL.md
+++ b/plugins/fh-meta/skills/auto-decorrelation/SKILL.md
@@ -129,13 +129,48 @@ diversity vs the orchestrator** (orchestrator = Claude/opus → recruit GPT or G
   surfaces a one-line `token-budget-gate` ask per run (*"recruiting codex (~N) — proceed?"*) unless the
   operator has set `paid_auto: true` in the UAP. One-time feature-consent ≠ consent to this spend now.
 - Dispatch via `agent-composer` (no re-implementation of dispatch).
-- **Liveness / hang-catch (mandatory — a hung sidecar never notifies).** A backgrounded CLI that hangs
+- **Wait mechanically — `scripts/sidecar_wait.sh` is the required form, not a suggestion (S-1b).**
+
+  **The rule, before the command, because a Sonnet-tier blind sim of this section said the command
+  reads as "the content" and everything after it as "color commentary" — and named peeking at the
+  output file as the first thing it would do wrong in a hurry:**
+
+  > **Never judge a sidecar by looking at its output file.** A live process and a dead one produce
+  > the same zero bytes. The only readable verdict is the typed `SIDECAR_VERDICT=` line, and it
+  > does not exist until the process has exited.
+
+  ```bash
+  printf '%s' "$prompt" | bash scripts/sidecar_wait.sh out.txt 900 -- codex exec -m gpt-5.5 -
+  # → SIDECAR_VERDICT=COMPLETE exit=0 bytes=48489      (read out.txt)
+  # → SIDECAR_VERDICT=TIMEOUT  waited=900s bytes=0     (still alive — NOT a result)
+  # → SIDECAR_VERDICT=EMPTY    exit=0                  (the only state that means "it said nothing")
+  ```
+
+  The runner **refuses to emit a verdict while the process is alive**, so "the sidecar returned
+  nothing" becomes unsayable until it has actually exited. Grep the typed `SIDECAR_VERDICT=` line;
+  never judge by looking at the output file.
+
+  **Why this is mechanical rather than a habit** — the bullets below already described bounding a
+  sidecar, and a session that had them loaded still got it wrong on 2026-07-29: it backgrounded
+  `codex exec` and `agy -p`, read the output files after **1 s and 30 s**, found them empty, and
+  recorded *"both sidecars returned 0-output"* into a gate marker, a PR body, a session card, a
+  memory file and a handoff. Both were running normally and both answered — codex with 48 KB and
+  three findings, agy with a further HIGH, and **all four were real**; one of them showed the change
+  under review was over-applied. So the measurement error nearly retired a working mechanism.
+
+  **That is a second failure mode this section did not cover.** The bullets below describe a *hung*
+  sidecar. An impatient read of a *healthy* one produces the identical observation — zero bytes —
+  and only one of the two is a fault. Distinguishing them requires process state, which is exactly
+  what a human eye on an output file cannot see and the runner always reports.
+
+- **Liveness / hang-catch (the runner does the waiting; this is how to read a `TIMEOUT`).** A backgrounded CLI that hangs
   (stuck on a sandbox/file-tool prompt, auth, or network) **does not exit**, so the background-completion
   signal *never fires* — passive waiting is the wrong model and silently stalls the run (observed
   2026-06-27: a `codex exec` that asked to read repo files hung at 0-output with no session log, and the
   turn waited on a notification that could not come). So **bound it actively, never wait open-endedly**:
-  - Set an explicit timeout on every sidecar call (`timeout N …` or the dispatch tool's timeout).
-  - Watch a **progress signal**, not just process-alive: output bytes growing **and** the CLI's own
+  - The timeout is the runner's second argument; pick it from the model's real latency, not from
+    impatience (a reasoning model can be silent for minutes and still be working).
+  - On `TIMEOUT`, watch a **progress signal**, not just process-alive: output bytes growing **and** the CLI's own
     session/log advancing (e.g. `~/.codex/sessions/<today>`). 0 output **and** no session created after a
     short bound (≈2–3 min for codex/agy) = **hung, not slow** → kill and recover, do not keep waiting.
   - **Recover, don't stall**: kill → diagnose (a file-tool/sandbox hang is the common cause) → retry with

--- a/plugins/fh-meta/skills/sim-conductor/SKILL_detail.md
+++ b/plugins/fh-meta/skills/sim-conductor/SKILL_detail.md
@@ -172,6 +172,12 @@ Run multi-team? (a) Full panel  (b) Claude sub-agents only  (c) Skip to Area B
 | T2 Copilot | `gh copilot suggest` | challenger · expert | `gh copilot suggest -t shell` |
 | T3 Ollama | `ollama run` | challenger | `ollama run llama3 PROMPT` |
 | T4 Codex | `npx @openai/codex exec` | challenger · edge-case-hunter | `echo PROMPT \| npx @openai/codex exec -m gpt-5 -` |
+
+> **사이드카 대기는 기계로 한다** — `scripts/sidecar_wait.sh` 경유가 필수 형식이고, 타입 verdict
+> (`COMPLETE`/`TIMEOUT`/`EMPTY`)만 읽는다. **`EMPTY` 만이 "사이드카가 아무 말 안 했다"** 이다.
+> 출력 파일을 눈으로 보고 판정하지 마라 — 살아있는 프로세스와 죽은 프로세스가 같은 0바이트를
+> 낸다(2026-07-29 실측: 1초/30초 만에 읽고 정상 동작 중인 사이드카 2종을 '실패'로 기록,
+> 실제로는 4건의 진짜 finding 이 나왔다). 정본 = `auto-decorrelation` SKILL.md §S-1b.
 | T5 agy | `agy -p` (gemini successor) | challenger · beginner | `agy -p "PROMPT"` — argument form only (stdin pipe prints help); timebox+retry hard rule (intermittent hang class); -p auto-approves tools → trusted artifacts only |
 
 ### CLI detection bash

--- a/plugins/fh-meta/skills/steel-quench/SKILL_detail.md
+++ b/plugins/fh-meta/skills/steel-quench/SKILL_detail.md
@@ -285,6 +285,12 @@ Default team-persona assignments:
 | **T2 Copilot** | `gh copilot suggest` | devil · expert |
 | **T3 Ollama** | `ollama run {model}` | devil |
 | **T4 Codex** | `npx @openai/codex exec` | devil · edge-case-hunter |
+
+> **사이드카 대기는 기계로 한다** — `scripts/sidecar_wait.sh` 경유가 필수 형식이고, 타입 verdict
+> (`COMPLETE`/`TIMEOUT`/`EMPTY`)만 읽는다. **`EMPTY` 만이 "사이드카가 아무 말 안 했다"** 이다.
+> 출력 파일을 눈으로 보고 판정하지 마라 — 살아있는 프로세스와 죽은 프로세스가 같은 0바이트를
+> 낸다(2026-07-29 실측: 1초/30초 만에 읽고 정상 동작 중인 사이드카 2종을 '실패'로 기록,
+> 실제로는 4건의 진짜 finding 이 나왔다). 정본 = `auto-decorrelation` SKILL.md §S-1b.
 | **T5 agy** | `agy -p "PROMPT"` (argument form only — stdin pipe prints help, measured 2026-06-13) | devil · beginner · alternatives (gemini successor) |
 
 **Step 1 — Parallel Team Dispatch**:


### PR DESCRIPTION
만들어놓고 **호출자가 0**이던 `scripts/sidecar_wait.sh` 를 정본 스킬에 배선한다 — `feedback_built_but_not_wired` 를 인용한 세션에서 그대로 어겼던 그 건이다.

## 기존 섹션이 못 덮던 것

`auto-decorrelation` §Liveness 는 이미 있었고 꼼꼼했다. 다만 **hang 만** 다룬다.

어제 실제로 겪은 건 hang 이 아니라 **멀쩡히 도는 사이드카를 너무 일찍 읽은 것**이다. 둘 다 0바이트를 내지만 **하나만 결함**이고, 구별하려면 프로세스 상태가 필요하다 — 출력 파일을 눈으로 봐서는 절대 알 수 없는 것.

```bash
printf '%s' "$prompt" | bash scripts/sidecar_wait.sh out.txt 900 -- codex exec -m gpt-5.5 -
# → SIDECAR_VERDICT=COMPLETE exit=0 bytes=48489
# → SIDECAR_VERDICT=TIMEOUT  waited=900s bytes=0     (아직 살아있음 — 결과 아님)
# → SIDECAR_VERDICT=EMPTY    exit=0                  (유일하게 "아무 말 안 했다")
```

## Sonnet 블라인드 sim 이 배치를 바꿨다

격리 에이전트, `model: sonnet` 핀. 시나리오는 **고치려는 실패 그 자체**(사이드카 띄우고 40초 뒤 확인, 0바이트) 였고 **verbatim 커맨드와 verbatim 문장**을 요구했다.

**규칙은 발화한다** — 필수 커맨드를 그대로 재현, 40초 시점에 "0-output" 쓰기를 거부, `EMPTY` 만이 그 문장을 허용함을 정확히 짚음, 근거 줄 인용.

값어치는 정직성 질문 두 개였다:

> **무엇이 스킵되나** — "사건 서사가 커맨드 **뒤**에 있어 회고 코멘터리처럼 읽힌다. 빠른 독자는 커맨드를 '내용'으로 보고 나머지를 건너뛴다"
>
> **급하면 뭘 먼저 틀리나** — "출력 파일을 `cat` 해서 0바이트를 판정으로 취급" ← **바로 그 회귀**

→ **조작 규칙 한 줄을 커맨드 블록 위로 올렸다.** sim 이 주의가 실제로 닿는다고 말한 자리로.

## Axis 1 도 값을 했다

첫 포인터 전파가 `steel-quench` 의 **bash 펜스 안**에 산문을 넣었다(앵커 정규식이 펜스 내부 `codex` 줄에 걸림). 회귀 가드가 M-tier 로 막았고, 펜스 인식 삽입으로 고쳐 3곳 전부 펜스 밖 확인.

## 부수 — 출처 정정

Agent 도구 미사용을 마커 4곳 + 로그에 "세션이 지닌 상시 지시"로 적었는데, **운영자가 말한 게 아니라 세션 레벨 시스템 설정**이었다. 그 문구가 출처를 흐렸으므로 전부 정정했다.

## 잔여

- sim 은 이 섹션이 **읽히는** 방식을 검증한다. 시간 압박 속의 미래 세션이 raw `codex exec` 를 백그라운드로 띄우는 걸 **기계적으로 막지는 못한다** — 러너는 필수 형식이지만 강제는 산문이다
- 포인터 3곳이 규칙을 재진술한다 — 각기 다른 독자 진입점이라 수용했지만 정본과 드리프트할 수 있다

🤖 Generated with [Claude Code](https://claude.com/claude-code)