### PR TITLE
fix(agents): 사이드카 대기 규칙을 Codex 진입점에 이식 (gate-locality)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,24 @@ Agents in this registry belong to the **Automation layer**. Skills (in `plugins/
 
 > **Multi-model sidecar (validated)**: Any FH user can delegate to other models via sidecar — Gemini CLI, OpenAI/Codex CLI, or Copilot CLI's model catalog — invoked with `Bash` from within the Claude Code session. FH is the orchestrating harness; the sidecar is a routing/access layer (not a second harness — different layer entirely). Validated empirically: `echo "prompt" | gemini` works inside a CC session and produces usable output. Sidecar calls are Bash invocations, not agent dispatches — they bypass this registry and are coordinated inline by the skill. Capability routing matters too: Gemini/Antigravity is the natural breadth/multimodal sidecar, while Codex's primary cast is the **repo-grounded audit** sidecar (file reads · grep/source-close · diff & patch · gate execution · phantom/backtrace) — **not** discovery/design-depth; a Codex session with Browser/Chrome connectors mounted can additionally take live web-flow automation as a capability-routed handoff. In a local FH workspace that pairs the public methodology mirror with a private companion store (the `*-be` pattern), route by workspace capability while preserving each repository's ownership boundary. See `knowledge/shared/harness-core/multi_model_sidecar_strategy.md §Runtime Authority` for the authority model and the full pattern.
 
+> **Waiting on a sidecar — mechanical, not by eye (2026-07-29).** A sidecar you dispatched is judged
+> ONLY by the typed verdict line from `scripts/sidecar_wait.sh`:
+>
+> ```bash
+> printf '%s' "$prompt" | bash scripts/sidecar_wait.sh out.txt 900 -- codex exec -m gpt-5.5 -
+> #   SIDECAR_VERDICT=COMPLETE exit=0 bytes=48489   → read out.txt
+> #   SIDECAR_VERDICT=TIMEOUT  waited=900s bytes=0  → STILL ALIVE, not a result
+> #   SIDECAR_VERDICT=EMPTY    exit=0               → the only state meaning "it said nothing"
+> ```
+>
+> **Never judge a sidecar by looking at its output file.** A live process and a dead one produce the
+> same zero bytes, and only process state separates them. Measured here: a session backgrounded two
+> sidecars, read their files after 1 s and 30 s, recorded *"both returned 0-output"* into five
+> records — and both had answered, with four real findings, one of which showed the change under
+> review was over-applied. The mis-read nearly retired a working mechanism. This rule is repeated in
+> this file because line 71 tells you to invoke sidecars with `Bash`; a runtime reading only that
+> would dispatch with no waiting discipline at all. Canonical: `auto-decorrelation` SKILL.md §S-1b.
+
 > **Runtime authority — hard stop line (Codex / non-Claude runtimes):** your findings are **evidence candidates, not terminal verdicts**. They are not final until the governor source-closes them against a **mechanical anchor** (a local file hit · a literal source span · a passing check) — **never governor agreement alone**. You are a capability-routed **sidecar**, not a co-governor: there is one explicit governor per context. Full doctrine: `knowledge/shared/harness-core/multi_model_sidecar_strategy.md §Runtime Authority`.
 
 ---


### PR DESCRIPTION
마감 체인의 **④-b drift 프로브가 잡았다** — 의도가 아니라 게이트가 찾았다.

## 왜 이게 진짜 drift 인가

`AGENTS.md:71` 이 non-Claude 런타임에 **"사이드카는 Bash 호출"** 이라고 안내한다(sidecar 관련 히트 10). 그런데 어제 만든 대기 규칙은 CC 쪽 스킬에만 들어갔다.

→ 자기 진입점만 읽는 Codex 런타임은 **대기 규율 없이 사이드카를 띄운다.** 안전규칙을 행위자가 안 읽는 곳에 둔 전형(`feedback_gate_locality_principle`: 그런 규칙은 장식이다).

## 판정이 매번 달라야 하는 이유

같은 세션에서 ⑤ 원자화 건은 **두 번 다 `drift:none`** 으로 판정했고 그건 맞았다 — AGENTS.md 에 마감체인 히트가 0이라 stale half 가 생길 수 없었다. 프로브가 쓸모 있는 건 판정을 **매 변경마다** 하고 기본값으로 때우지 않기 때문이다.

## 검증

```
fh-codex-doctor --strict   exit 0
Axis 1                     M-tier 0 / S-tier 0
```

## 부수 — 내 계기 오탐 1건

④-c 에서 GHE 핸드오프가 '이미 스탬프됨'으로 나왔는데, grep 이 §5 의 **지시문**(`STATUS: DONE 을 찍어라`)을 스탬프로 오인한 것이었다. 핸드오프는 정상적으로 열려 있다.

## 잔여

규칙이 이제 **5곳**에 있다(정본 + 포인터 3 + AGENTS.md). 각기 다른 독자 진입점이라 수용했지만 **정본과 드리프트할 수 있고 미완화 상태**다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)