### PR TITLE
fix(sidecar): 대기 래퍼가 프롬프트를 자식에게 전달하지 못했다 (v1.4.76 출하 결함) + 앵커 배선

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "scripts/test_memory_link_check.sh",
     "scripts/memory_nearcheck.py",
     "scripts/sidecar_wait.sh",
+    "scripts/test_sidecar_wait_stdin.sh",
     "scripts/test_session_close_lanes.sh",
     "scripts/test_card_drift_probe.sh",
     "scripts/universal_guard_check.sh",

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -132,6 +132,21 @@ fi
 # prevent. test_card_drift_probe.sh had shipped with ZERO callers since it was written; wiring it
 # here closes that, and the anchors are added to files[] in the same change so package mode runs
 # them too rather than reporting a deleted anchor.
+# sidecar_wait stdin plumbing. Its subject is dispatched by auto-decorrelation / steel-quench /
+# sim-conductor / AGENTS.md as the REQUIRED wait form, so a regression there silently empties every
+# cross-family verification. The anchor's first version shipped in tests/ with ZERO callers — the
+# same defect the comment above records for test_card_drift_probe.sh, repeated one file later.
+if [ ! -f scripts/sidecar_wait.sh ]; then
+  echo "SKIP  test_sidecar_wait_stdin.sh (subject scripts/sidecar_wait.sh absent)"
+elif [ -f scripts/test_sidecar_wait_stdin.sh ]; then
+  if ! bash scripts/test_sidecar_wait_stdin.sh; then
+    fail=1
+  fi
+else
+  echo "FAIL  test_sidecar_wait_stdin.sh: sidecar_wait.sh present but its anchor is missing"
+  fail=1
+fi
+
 for _anchor in scripts/test_session_close_lanes.sh scripts/test_card_drift_probe.sh; do
   if [ ! -f scripts/session_close_check.sh ]; then
     echo "SKIP  ${_anchor##*/} (subject scripts/session_close_check.sh absent)"

--- a/scripts/sidecar_wait.sh
+++ b/scripts/sidecar_wait.sh
@@ -41,12 +41,59 @@ shift 2
 [ "${1:-}" = "--" ] && shift
 [ $# -gt 0 ] || { echo "sidecar_wait: no command given" >&2; exit 2; }
 
-: > "$OUT"
-"$@" > "$OUT" 2>&1 &
+# Forward stdin to the child with an explicit fd dup.
+#
+# The hole (measured 2026-07-29, known-pair): `"$@" > "$OUT" 2>&1 &` gave the child /dev/null for
+# stdin in a non-interactive shell, so the documented pipe form reached codex with NO prompt, codex
+# answered "No prompt provided via stdin", and this wrapper reported COMPLETE — the exact 0-output
+# misjudgment it exists to prevent, produced by itself.
+#
+# `<&0` is the whole fix: POSIX substitutes /dev/null ONLY when stdin is not explicitly redirected.
+# The first repair spooled stdin to a tempfile instead, and adversarial review (Axis 2) showed that
+# mechanism was both unnecessary AND strictly worse than the bug — reproduced, not argued:
+#   - the unbounded `cat` ran BEFORE the child, so an inherited never-EOF stdin hung the wrapper
+#     forever and the timeout budget never applied (`-- true` with inherited stdin → rc=124);
+#   - it CONSUMED the caller's stdin, so a caller reading 3 lines after the call read 0.
+# A bounded-wait wrapper with an unbounded pre-step, and an input-preserving tool that eats input.
+# The lesson is kept in the file: the simplest correct fix was one token, and the machinery built
+# around it introduced two S-grade defects the original bug did not have.
+: > "$OUT" || { echo "SIDECAR_VERDICT=OUTFILE_UNWRITABLE path=$OUT" >&2; exit 2; }
+set -m   # own process group per child, so the TIMEOUT kill can reach grandchildren
+if [ -t 0 ]; then
+  # On a controlling tty, a child that READS stdin raises SIGTTIN and stops the whole process
+  # group — the wrapper with it — so the budget never fires and no verdict is emitted (measured:
+  # `cat` under a tty gave rc=124 and zero verdict lines, while `sleep 30` correctly TIMEOUTed).
+  # Interactive callers have no prompt to pipe anyway; the documented pipe form is never a tty.
+  "$@" < /dev/null > "$OUT" 2>&1 &
+else
+  "$@" <&0 > "$OUT" 2>&1 &
+fi
 PID=$!
 
 waited=0
 last_size=0
+# Poll interval is overridable so the regression anchor is not charged the 5s floor per
+# invocation (a 25s anchor is an anchor people skip).
+POLL="${SIDECAR_POLL:-5}"
+# Validate it. Caller-controlled and unvalidated, this knob RESTORED the very failure the wrapper
+# exists to prevent (measured 2026-07-29, budget 3s under an external timeout 10):
+#   SIDECAR_POLL=0    -> rc=124, `waited` never advances, TIMEOUT never fires, zero typed verdicts
+#   SIDECAR_POLL=0.5  -> rc=124, arithmetic error each iteration, assignment never lands
+#   SIDECAR_POLL=abc  -> exits 1 (the documented TIMEOUT code) with NO verdict line and a live child
+# The file's own "a 25s anchor is an anchor people skip" comment invites tuning this, and `0.5` is
+# the obvious next step for someone doing that. An unbounded wait must not be reachable by typo.
+# `10#` forces base 10: `test` reads 08 as decimal-8 and PASSES it, then $((waited + 08)) dies with
+# "value too great for base" every iteration, waited never advances, and the wait is unbounded again
+# — the first guard did not close its own finding (measured: 08/09 -> rc=124, zero verdicts).
+# The ceiling matters just as much: the budget is checked at the TOP of the loop, so any POLL above
+# it makes the effective wait POLL, not BUDGET (SIDECAR_POLL=600 -> rc=124). 600 is exactly what
+# someone copying the budget argument into the knob writes.
+_poll_raw="$POLL"
+case "$POLL" in ''|*[!0-9]*) POLL=5 ;; *) POLL=$((10#$POLL)) 2>/dev/null || POLL=5 ;; esac
+{ [ "$POLL" -ge 1 ] && [ "$POLL" -le 60 ]; } 2>/dev/null || POLL=5
+# Never coerce silently on a script whose whole thesis is a typed channel.
+[ "$POLL" = "$_poll_raw" ] || [ -z "${SIDECAR_POLL:-}" ] || \
+  echo "sidecar_wait: ignoring SIDECAR_POLL='$_poll_raw' (not an integer in 1..60); using $POLL" >&2
 # Poll rather than `wait`, so a live-but-quiet process is distinguishable from a dead one and the
 # caller can SEE progress. A silent minute on a reasoning model is normal; the earlier misreading
 # happened precisely because silence was treated as termination.
@@ -54,11 +101,14 @@ while kill -0 "$PID" 2>/dev/null; do
   if [ "$waited" -ge "$BUDGET" ]; then
     size=$(wc -c < "$OUT" 2>/dev/null | tr -d ' ')
     echo "SIDECAR_VERDICT=TIMEOUT waited=${BUDGET}s bytes=${size:-0} pid=$PID"
-    echo "  the process is STILL RUNNING — this is not 'no output'. Raise the budget, or kill $PID" >&2
+    echo "  the process is STILL RUNNING — this is not 'no output'. Raise the budget if it needs longer." >&2
+    # Kill the GROUP. `kill "$PID"` reaches only the direct child, so `sh -c 'sleep N & wait'`
+    # left a live grandchild behind while the lane stayed green (measured wave 4).
+    kill -- -"$PID" 2>/dev/null || kill "$PID" 2>/dev/null
     exit 1
   fi
-  sleep 5
-  waited=$((waited + 5))
+  sleep "$POLL"
+  waited=$((waited + POLL))
   size=$(wc -c < "$OUT" 2>/dev/null | tr -d ' ')
   if [ "${size:-0}" -ne "$last_size" ]; then
     echo "  … ${waited}s elapsed, ${size} bytes so far (alive)" >&2

--- a/scripts/test_sidecar_wait_stdin.sh
+++ b/scripts/test_sidecar_wait_stdin.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# test_sidecar_wait_stdin.sh — known-pair anchor for scripts/sidecar_wait.sh's stdin plumbing.
+#
+# WHY (measured 2026-07-29)
+#   `sidecar_wait.sh` shipped in v1.4.76 documenting this invocation in its own header:
+#       printf '%s' "$prompt" | bash scripts/sidecar_wait.sh out.txt 600 -- codex exec -m gpt-5.5 -
+#   It did not work. `"$@" > "$OUT" 2>&1 &` gives the child /dev/null for stdin in a
+#   non-interactive shell, so codex received no prompt, answered "No prompt provided via stdin",
+#   and the wrapper reported SIDECAR_VERDICT=COMPLETE — a sidecar that never ran, reported as
+#   complete. That is the exact misjudgment the script exists to prevent, produced by the script.
+#
+#   The FIRST repair was worse than the bug, and adversarial review caught it before it shipped.
+#   It spooled stdin to a tempfile; reproduced consequences:
+#     - the unbounded `cat` ran BEFORE the child, so an inherited never-EOF stdin hung the wrapper
+#       forever and the timeout budget never applied (`-- true` with inherited stdin → rc=124);
+#     - it CONSUMED the caller's stdin (a caller reading 3 lines afterwards read 0).
+#   The correct fix is one token: `<&0`. POSIX substitutes /dev/null only when stdin is NOT
+#   explicitly redirected. Lanes P2/P3 exist because the anchor's first version reported 4/4 green
+#   in the same shell where the argv form returned rc=124 — it bound only P1.
+#
+# Lanes
+#   P1  piped stdin REACHES the child                        (the original hole)
+#   P2  argv-form with an inherited never-EOF stdin does NOT hang   (spool regression)
+#   P3  the caller's own stdin is NOT consumed by the wrapper       (spool regression)
+#   P4  verdict codes: TIMEOUT=1 · EMPTY=0 · COMPLETE=0, and EMPTY/COMPLETE are distinguished
+#   P5  an unwritable outfile is exit 2, not "EMPTY" (a false clean on the typed channel)
+#
+# Verdicts are read by running the wrapper DIRECTLY — piping it into `tail` and reading `$?`
+# answers with tail's status and turns a real exit 1 green.
+#
+# Exit 0 = all lanes correct. Exit 1 = the plumbing regressed.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SW="$ROOT/scripts/sidecar_wait.sh"
+[ -f "$SW" ] || { echo "FAIL: $SW not found"; exit 1; }
+# NOTE: SIDECAR_POLL is set PER LANE, never exported globally. A global export pinned the knob for
+# every lane and thereby MASKED a bad default — a regression to `SIDECAR_POLL:-0` passed 5/5.
+FAST="SIDECAR_POLL=1"
+
+pass=0; fail=0
+ok()  { printf '  ✅ %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  ❌ %s\n' "$1"; fail=$((fail+1)); }
+TD="$(mktemp -d)"; trap 'rm -rf "$TD"' EXIT
+
+# P1 — `cat` echoes whatever it receives; an empty outfile means stdin was swallowed, which is
+# exactly what the shipped version did.
+printf 'MARKER_STDIN_ARRIVED' | SIDECAR_POLL=1 bash "$SW" "$TD/p1.out" 20 -- cat >/dev/null 2>&1
+if grep -q 'MARKER_STDIN_ARRIVED' "$TD/p1.out" 2>/dev/null; then
+  ok "P1 piped stdin reaches the child process"
+else
+  bad "P1 STDIN HOLE IS BACK — child saw no stdin (got: '$(head -c 60 "$TD/p1.out" 2>/dev/null)')"
+fi
+
+# P2 — the lane the first anchor lacked. A never-EOF stdin must not block the wrapper: the child is
+# launched immediately and the budget governs. `sleep 20 |` keeps the pipe open with no data.
+( sleep 6 | SIDECAR_POLL=1 timeout 5 bash "$SW" "$TD/p2.out" 3 -- echo ARGV_OK ) >/dev/null 2>&1
+rc_hang=$?
+if [ "$rc_hang" -ne 124 ] && grep -q 'ARGV_OK' "$TD/p2.out" 2>/dev/null; then
+  ok "P2 an inherited never-EOF stdin does not hang the wrapper (child still runs)"
+else
+  bad "P2 the wrapper HUNG or never ran the child on inherited stdin (rc=$rc_hang, out='$(head -c 40 "$TD/p2.out" 2>/dev/null)')"
+fi
+
+# P3 — the wrapper must not eat the caller's stream. `echo` reads nothing, so all three lines must
+# remain readable afterwards. The spool version left zero.
+n=$(printf 'l1\nl2\nl3\n' | { SIDECAR_POLL=1 bash "$SW" "$TD/p3.out" 20 -- echo x >/dev/null 2>&1
+                              c=0; while read -r _; do c=$((c+1)); done; echo "$c"; })
+if [ "$n" = "3" ]; then
+  ok "P3 the caller's own stdin survives the call (3/3 lines still readable)"
+else
+  bad "P3 the wrapper consumed the caller's stdin ($n of 3 lines left)"
+fi
+
+# P4 — verdict channel. `-- true` writes nothing and is EMPTY, NOT COMPLETE; the first anchor
+# labelled that lane "COMPLETE" and so never exercised COMPLETE at all.
+SIDECAR_POLL=1 bash "$SW" "$TD/p4t.out" 2 -- sleep 30 >"$TD/p4t.txt" 2>&1 </dev/null; rc_t=$?
+SIDECAR_POLL=1 bash "$SW" "$TD/p4e.out" 20 -- true      >"$TD/p4e.txt" 2>&1 </dev/null; rc_e=$?
+SIDECAR_POLL=1 bash "$SW" "$TD/p4c.out" 20 -- echo hi   >"$TD/p4c.txt" 2>&1 </dev/null; rc_c=$?
+if [ "$rc_t" -eq 1 ] && [ "$rc_e" -eq 0 ] && [ "$rc_c" -eq 0 ] \
+   && grep -q 'SIDECAR_VERDICT=TIMEOUT'  "$TD/p4t.txt" \
+   && grep -q 'SIDECAR_VERDICT=EMPTY'    "$TD/p4e.txt" \
+   && grep -q 'SIDECAR_VERDICT=COMPLETE' "$TD/p4c.txt"; then
+  ok "P4 verdicts intact and distinguished (TIMEOUT=1 · EMPTY=0 · COMPLETE=0)"
+else
+  bad "P4 verdict channel drifted (timeout rc=$rc_t, empty rc=$rc_e, complete rc=$rc_c)"
+  head -1 "$TD/p4t.txt" "$TD/p4e.txt" "$TD/p4c.txt" 2>/dev/null | sed 's/^/     /'
+fi
+
+# P5 — an outfile that cannot be written made `wc -c` fail, `${size:-0}` read 0, and the wrapper
+# announce EMPTY with exit 0. The sidecar had in fact produced output. Same false-clean class as
+# the bug this file anchors, on the typed channel itself.
+SIDECAR_POLL=1 bash "$SW" "$TD/nodir/x.out" 10 -- echo hi >/dev/null 2>&1 </dev/null
+rc_w=$?
+if [ "$rc_w" -eq 2 ]; then
+  ok "P5 an unwritable outfile fails closed (exit 2), never 'EMPTY'"
+else
+  bad "P5 an unwritable outfile returned rc=$rc_w — a sidecar that ran reported as saying nothing"
+fi
+
+# P6 — the knob added while making this anchor cheap re-opened the unbounded wait. Each bad value
+# must still produce a bounded TIMEOUT. Deliberately NOT using $FAST: the point is a bad POLL.
+p6=0
+for badpoll in 0 0.5 abc 08 09 600; do
+  SIDECAR_POLL="$badpoll" timeout 12 bash "$SW" "$TD/p6.out" 2 -- sleep 30 >"$TD/p6.txt" 2>&1
+  rc6=$?
+  if [ "$rc6" -eq 1 ] && grep -q 'SIDECAR_VERDICT=TIMEOUT' "$TD/p6.txt"; then p6=$((p6+1)); fi
+done
+if [ "$p6" -eq 6 ]; then
+  ok "P6 a malformed SIDECAR_POLL (0·0.5·abc·08·09·600) still times out — the budget is not disarmable"
+else
+  bad "P6 only $p6/6 malformed poll values produced a bounded TIMEOUT (unbounded wait is reachable)"
+fi
+
+# P7 — TIMEOUT must not orphan the sidecar, INCLUDING grandchildren: `kill "$PID"` reached only the
+# direct child, so `sh -c 'sleep N & wait'` survived while this lane stayed green. The marker is
+# per-run: a machine-global `pgrep -f 'sleep 25'` false-FAILs on any concurrent sleep and its
+# failure branch would kill unrelated host processes.
+MARK="p7_$$_$(date +%s 2>/dev/null || echo x)"
+SIDECAR_POLL=1 bash "$SW" "$TD/p7.out" 2 -- sh -c "sleep 25 & wait # $MARK" >"$TD/p7.txt" 2>&1 </dev/null
+sleep 1
+if ! pgrep -f "$MARK" >/dev/null 2>&1; then
+  ok "P7 a timed-out sidecar is killed with its grandchildren, not orphaned past our exit"
+else
+  bad "P7 a grandchild survived TIMEOUT (orphan restored)"; pkill -f "$MARK" 2>/dev/null
+fi
+
+# P9 — the tty path. HONEST SCOPE, do not read this lane as more than it is.
+#
+# It asserts that a stdin-reading child under an allocated pty still produces a bounded verdict. It
+# does NOT bind the `if [ -t 0 ]` branch: removing that branch entirely leaves this lane GREEN
+# (measured 2026-07-29). Cross-family review reproduced a SIGTTIN stop (rc=124, no verdict) under a
+# pty before `set -m` was added for the group-kill; this harness cannot reproduce that condition,
+# so whether the branch is still load-bearing is UNMEASURED — the branch is kept as defensive, not
+# as something this anchor proves.
+#
+# A lane that cannot separate a known-positive from a known-negative is not measuring; it is
+# generating. Shipping it as a plain green would manufacture exactly the false confidence this
+# file exists to prevent, so it is labelled instead of silently counted.
+if command -v script >/dev/null 2>&1; then
+  # `< /dev/null` on `script` itself: with the harness's inherited stdin it could not allocate a pty
+  # at all and wrote no rc file, so the lane failed identically with AND without the fix under test
+  # — it discriminated nothing. The pty it allocates for the inner command is what matters.
+  # The inner shell writes its rc to a FILE. Parsing `script`'s own stdout fails: it emits ^D and
+  # CRLF, and the first version of this lane read rc as empty and reported a defect that did not
+  # exist — the target was fine, the instrument was not.
+  script -q /dev/null bash -c "SIDECAR_POLL=1 timeout 12 bash '$SW' '$TD/p9.out' 3 -- cat >'$TD/p9.txt' 2>&1; echo \$? > '$TD/p9rc'" >/dev/null 2>&1 < /dev/null
+  rc9=$(tr -dc '0-9' < "$TD/p9rc" 2>/dev/null)
+  if [ -n "$rc9" ] && [ "$rc9" != "124" ] && grep -q 'SIDECAR_VERDICT=' "$TD/p9.txt" 2>/dev/null; then
+    ok "P9 the tty path runs and emits a verdict (UNCALIBRATED — see note; does NOT bind the branch)"
+  else
+    bad "P9 tty case rc='${rc9:-<unread>}' verdict='$(head -1 "$TD/p9.txt" 2>/dev/null)'"
+  fi
+else
+  bad "P9 UNCALIBRATED — \`script\` unavailable, the tty branch cannot be exercised here"
+fi
+
+# P8 — the child's stderr AND its exit code must reach the typed channel. Dropping `2>&1` or
+# hardcoding rc=0 both passed the earlier anchor: it grepped the verdict WORD and the wrapper's
+# own rc, never the child's.
+SIDECAR_POLL=1 bash "$SW" "$TD/p8.out" 20 -- sh -c 'echo STDERR_MARK >&2; exit 3' >"$TD/p8.txt" 2>&1 </dev/null
+if grep -q 'STDERR_MARK' "$TD/p8.out" 2>/dev/null && grep -q 'exit=3' "$TD/p8.txt"; then
+  ok "P8 child stderr is captured and its exit code reaches the verdict line"
+else
+  bad "P8 stderr or child exit code lost (out='$(head -c 40 "$TD/p8.out" 2>/dev/null)' verdict='$(head -1 "$TD/p8.txt")')"
+fi
+
+echo "----"
+echo "sidecar_wait stdin anchor: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
## 무엇이 깨져 있었나

`scripts/sidecar_wait.sh` 는 **v1.4.76 으로 출하됐고**, 자기 헤더에 적어둔 사용법대로 동작하지 않았다:

```
printf '%s' "$prompt" | bash scripts/sidecar_wait.sh out.txt 600 -- codex exec -m gpt-5.5 -
```

`"$@" > "$OUT" 2>&1 &` 로 백그라운드하면 비대화형 셸이 자식의 stdin 을 `/dev/null` 로 재부착한다. codex 는 프롬프트를 **한 번도 받지 못한 채** `No prompt provided via stdin` 을 냈고, 래퍼는 그것을 `SIDECAR_VERDICT=COMPLETE` 로 보고했다.

**사이드카 0-output 오판을 막으려고 만든 스크립트가 정확히 그 오판을 스스로 생산했다.**

노출면은 스킬 하나가 아니다 — `AGENTS.md:77` · `auto-decorrelation/SKILL.md:132,:143` · `sim-conductor` · `steel-quench` **네 진입점이 이 폼을 필수 형식으로 지정한다.** 해당 버전을 받아 cross-family 검증을 돌린 소비자는 빈 사이드카를 COMPLETE 로 받는다.

**검증 방식**: known-pair. 동일 프롬프트를 `codex exec -` 에 직접 파이프하면 응답했고(`DIRECT_OK`), 래퍼를 거치면 30바이트 오류만 나왔다. 수리 후 1267바이트 실응답. `git show v1.4.76:scripts/sidecar_wait.sh` 로 결함 형태가 **출하된 태그 안에 실재**함을 확인했다.

## 수리

**한 토큰이다: `<&0`.** POSIX 는 stdin 이 명시적으로 리다이렉트되지 **않은** 경우에만 `/dev/null` 로 치환한다.

⚠️ **첫 수리본은 버그보다 나빴고, 적대 검증이 출하 전에 잡았다.** stdin 을 tempfile 로 스풀했는데:
- 언바운드 `cat` 이 자식보다 **먼저** 돌아, 상속된 non-EOF stdin 에서 래퍼가 무한 행에 빠졌다 — **타임아웃 예산이 아예 적용되지 않는다**(`rc=124`)
- **호출자의 stdin 을 통째로 삼켰다** (3줄 → 0줄)

바운드 대기가 목적인 래퍼에 언바운드 선행 단계를, 입력 보존이 목적인 도구에 입력 소비를 넣은 셈이다.

### 같이 닫은 것

| 결함 | 수리 |
|---|---|
| outfile 쓰기 불가 시 `wc -c` 실패를 `${size:-0}` 이 0으로 읽어 **실행된** 사이드카를 `EMPTY`/exit 0 으로 보고 | `: > "$OUT" \|\|` → exit 2 (typed 채널 위의 같은 거짓-클린 클래스) |
| TIMEOUT 시 `kill "$PID"` 가 직계 자식만 닿아 `sh -c 'sleep N & wait'` 손자가 생존 | `set -m` + 프로세스 **그룹** kill |
| `SIDECAR_POLL`(앵커 가속용 손잡이)이 무검증이라 `0`/`0.5`/비숫자가 예산 무효화 | base-10 강제 + `1..60` 클램프 + 무음 아닌 통지 |
| 1차 POLL 가드도 부족 — `08`/`09` 는 `test` 통과 후 **8진수 산술**에서 죽고, 상한이 없어 `POLL>BUDGET` 이면 실효 대기가 예산이 아님(`600` → `rc=124`) | 위와 동일. **12/12 bounded TIMEOUT 실측** (`08 09 010 600 99999999 0 0.5 abc "" " " 1 5`) |

## 앵커

`scripts/test_sidecar_wait_stdin.sh` — 9레인. 모델이 아니라 `cat`/`sh -c` 로 검증한다(결함이 셸 배관이므로, 네트워크 사이드카가 필요한 앵커였다면 조용히 N/A 가 된다).

**첫 버전은 `tests/` 에 있었고 호출자가 0이었다** — `selfcheck.sh:132` 가 다른 앵커에 대해 *"shipped with ZERO callers"* 를 기록해둔 자리 바로 옆에서 같은 결함을 재현했다. 지금은 `selfcheck.sh` 에 배선했고 `package.json` `files[]` 에 실어 패키지 모드에서도 돈다.

**뮤테이션 9종이 각각 자기 레인에 걸린다** (격리 사본):
`<&0` 제거→P1 · 스풀 복귀→P2+P3 · outfile 가드 제거→P5 · EMPTY/COMPLETE 붕괴→P4 · TIMEOUT exit 1→0→P4 · POLL 가드 삭제→P6 · kill 제거→P7 · `2>&1` 제거→P8 · 자식 rc 위조→P8

**검증은 worktree 가 아니라 index 내용으로 돌렸다** — 스테이징이 실물과 갈려 있던 것(index 에 폐기한 스풀이 남아 있었다)을 적대 검증이 잡았다.

## 명시 잔여 (닫혔다고 하지 않음)

- **P9(tty 분기) UNCALIBRATED** — `[ -t 0 ]` 분기를 제거해도 레인이 초록이라, 이 하네스는 SIGTTIN 수리를 **결속하지 못한다**. 파일에 그대로 표기했고 방어적으로 유지한다. *가르지 못하는 레인을 초록으로 세면 이 파일이 막으려는 바로 그 거짓 확신을 만든다.*
- 적대 검증 **4웨이브**(S 3 → 1 → 1 → 0 known). **웨이브 5는 안 돌렸다** — "0 known S" 이지 "proven 0" 이 아니다.

## 게이트

4축 전부 PASS. Axis 1 = SKIP(게이트 pathspec 밖, 검사 안 함 ≠ 통과) · Axis 2 = quench-challenger 4웨이브 · Axis 3 = 8/8 GROUNDED, 팬텀 0 · Axis 4 = edit-manifest.

## 후속 (이 PR 아님)

**재퍼블리시가 선행 조건이다.** 머지 후 `v1.4.77` lockstep → Pre-Publish 게이트 → publish → tag. 그전까지 v1.4.76 소비자의 cross-family 검증 레그는 비어 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7rGfDXm5xnSaGLNF5D2sc