### PR TITLE
docs: split AGENTS runtime details by salience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,283 +1,119 @@
-# AGENTS.md — forge-harness Sub-Agent Specs
+# AGENTS.md — forge-harness Runtime Entry Point
 
-> **This file is the runtime agent specification registry for forge-harness.**
-> For session rules and orchestration protocol, see `CLAUDE.md`.
-> For skill descriptions and natural language triggers, see `plugins/fh-meta/` and `plugins/fh-commons/`.
-
----
+> **Always-loaded layer.** Keep agent selection and rules that must govern every runtime here.
+> Load execution examples, compatibility history, and conditional procedures only through the
+> imperative pointers below.
 
 ## Relationship to CLAUDE.md
 
 | File | Scope | Audience |
 |---|---|---|
-| `CLAUDE.md` | Session rules, protocols, orchestration flow | AI (Claude Code) — operational ruleset |
-| `AGENTS.md` | Runtime agent specs — roles, tools, invocation | AI + humans — agent registry |
+| `CLAUDE.md` | Session rules, protocols, orchestration flow | Claude Code |
+| `AGENTS.md` | Portable runtime rules, agent roles, dispatch boundaries | AI runtimes + humans |
 
-CLAUDE.md governs *how* the session runs. AGENTS.md defines *what each agent does* when dispatched.
-
----
+`CLAUDE.md` governs Claude-native automation. This file is the portable entry point for Codex and
+other non-Claude runtimes, which do not auto-load `.claude/rules/*.md`.
 
 ## Agent Registry
 
-forge-harness ships 8 tracked agents across plugin `agents/` directories. The **user-mastery spectrum** (`beginner` · `main-player` · `expert`) plus `challenger` (adversarial axis) supply multi-persona review; `fact-checker`, `hub-persona-auditor`, and `persona-innovator` serve general harness operations; `quench-challenger` is steel-quench-dedicated.
+forge-harness ships 8 tracked agents. The user-mastery spectrum (`beginner` · `main-player` ·
+`expert`) plus `challenger` supplies multi-persona review; the remaining agents serve harness
+operations or steel-quench.
 
 | Agent | File | Role | Invoked by |
 |---|---|---|---|
-| `beginner` | `plugins/fh-meta/agents/beginner.md` | First-contact cold-read standpoint (spectrum entry tier) — onboarding friction a fluent author cannot feel; constructive, not adversarial | `sim-conductor` Area A, `marketplace-gate`, `install-wizard`, or direct dispatch |
-| `main-player` | `plugins/fh-meta/agents/main-player.md` | Engaged-user standpoint (spectrum core tier) — intelligently scopes Light/Midcore/Heavy; Heavy = classic power-user edge/limit lens | `sim-conductor` Area A/D-code, or direct dispatch |
-| `expert` | `plugins/fh-meta/agents/expert.md` | Domain-authority standpoint (spectrum frontier tier) — web-grounded accuracy + SOTA currency, citation-enforced | `sim-conductor` Area E/D, paper review, or direct dispatch |
-| `challenger` | `plugins/fh-meta/agents/challenger.md` | Frontier-grade adversarial evaluator — adapts attack vectors to artifact type, enforces evidence citation, models its own information asymmetry; U1 absorbs the skeptic "why not just X?" lens | `steel-quench`, `harvest-loop`, `sim-conductor`, or direct dispatch |
-| `fact-checker` | `plugins/fh-meta/agents/fact-checker.md` | Pre-recommendation deduplication — greps hub assets for existing skills/agents/patterns before main agent commits to a new recommendation; catches stale facts and duplicate work | Main agent before any new asset creation or recommendation |
-| `hub-persona-auditor` | `plugins/fh-meta/agents/hub-persona-auditor.md` | Pre-publication audit of external-facing assets — 3+ persona simulation, 4-axis review (resonance/confusion/resistance/supplement), 3-tier revision proposals | `hub-cc-pr-reviewer`, `sim-conductor`, or direct dispatch |
-| `quench-challenger` | `plugins/fh-commons/agents/quench-challenger.md` | Steel-quench dedicated adversary — 3-DNA synthesis of Devil + Innovator + Prescriber; every attack paired with a concrete fix direction | `steel-quench` Wave 1 (primary), `install-doctor`, `marketplace-gate` |
-| `persona-innovator` | `plugins/fh-meta/agents/persona-innovator.md` | Naming gap detection + frame proposals + external frontier absorption signals | `sim-conductor` Area A, `harvest-loop`, or direct dispatch |
+| `beginner` | `plugins/fh-meta/agents/beginner.md` | First-contact cold read; finds onboarding friction | `sim-conductor` Area A, `marketplace-gate`, `install-wizard`, direct |
+| `main-player` | `plugins/fh-meta/agents/main-player.md` | Engaged-user view; scopes Light/Midcore/Heavy usage | `sim-conductor` Area A/D-code, direct |
+| `expert` | `plugins/fh-meta/agents/expert.md` | Web-grounded domain accuracy and current practice | `sim-conductor` Area E/D, paper review, direct |
+| `challenger` | `plugins/fh-meta/agents/challenger.md` | Evidence-cited adversarial evaluation | `steel-quench`, `harvest-loop`, `sim-conductor`, direct |
+| `fact-checker` | `plugins/fh-meta/agents/fact-checker.md` | Pre-recommendation duplicate and stale-fact search | Before new asset creation or recommendation |
+| `hub-persona-auditor` | `plugins/fh-meta/agents/hub-persona-auditor.md` | External-facing pre-publication persona audit | `hub-cc-pr-reviewer`, `sim-conductor`, direct |
+| `quench-challenger` | `plugins/fh-commons/agents/quench-challenger.md` | Steel-quench attack plus concrete fix direction | `steel-quench` Wave 1, `install-doctor`, `marketplace-gate` |
+| `persona-innovator` | `plugins/fh-meta/agents/persona-innovator.md` | Naming gaps, frame proposals, frontier signals | `sim-conductor` Area A, `harvest-loop`, direct |
 
-> Machine-readable mirror: `.claude/registry/agent_cards.json` (canonical capability cards, count-synced to tracked agent files — A2A Agent Card pattern).
+Machine-readable mirror: `.claude/registry/agent_cards.json`.
 
-### Tool restrictions per agent
+### Tool restrictions
 
-| Agent | Allowed tools | Rationale |
-|---|---|---|
-| `challenger` | Read, Grep, Glob, WebSearch, WebFetch | Needs external evidence; no writes |
-| `fact-checker` | Read, Grep, Glob | Deduplication grep only — no modification |
-| `hub-persona-auditor` | Read, Grep, Glob | Audit only — no modification |
-| `quench-challenger` | Read, Grep, Glob | Attack+prescription only — no modification |
-| `persona-innovator` | Read, Grep, Glob, WebSearch, WebFetch | Frontier scanning requires web access |
-
----
-
-## 2-Layer Architecture Context
-
-forge-harness is structured as two distinct layers:
-
-| Layer | Contents | AI compatibility |
-|---|---|---|
-| **Methodology layer** (model-agnostic) | `tracks/`, `knowledge/`, `SKILL.md` documents, session protocols | Any AI model |
-| **Automation layer** (Claude-native) | `plugins/*/agents/` (plugin channel — FH's own agents, auto-loaded when the plugin is enabled), hooks, slash commands, `CLAUDE.md` rules; `.claude/agents/` is the field-project local/override slot, unused by FH itself | Claude Code only |
-
-Agents in this registry belong to the **Automation layer**. Skills (in `plugins/`) straddle both layers — their methodology is model-agnostic, but their invocation mechanism is Claude Code-native.
-
-> **Codex-compatible beta**: The Methodology layer (`tracks/`, `knowledge/`, skill documentation) is designated Codex-compatible beta. Gemini, Codex, and other AI users can apply FH methodology without the Automation layer — manual invocation replaces hook/agent dispatch.
-
-> **Directory → destination routing (where your outputs belong)**: not everything in the methodology layer is public-shareable. `knowledge/` and `SKILL.md` docs are the **public, reusable** methodology. `tracks/` is **local / private by convention** — work history, session records, `fh_signal_*`, audit logs — and is gitignored on the public mirror. An AI working in a local workspace that pairs the public mirror with a private companion store (the `*-be` pattern) must **not** infer "same folder ⇒ same repository"; route by content type:
->
-> | Content | Default destination |
-> |---|---|
-> | reusable methodology · docs · skills · public guidance · polished external-facing conclusions | public mirror (`knowledge/`, `plugins/`, `docs/`) |
-> | raw signal · operator observation · private validation · handoff · paper draft · PR-background reasoning log | private companion store (`*-be` pattern) — or keep local; do **not** commit to the public mirror |
->
-> When unsure, treat raw / observational / operator-specific material as **private-first** and promote only the polished result to public. (Concrete per-operator bindings — exact companion-store path, sync mechanism — live in the operator's local config, not here.)
-
-> **Multi-model sidecar (validated)**: Any FH user can delegate to other models via sidecar — Gemini CLI, OpenAI/Codex CLI, or Copilot CLI's model catalog — invoked with `Bash` from within the Claude Code session. FH is the orchestrating harness; the sidecar is a routing/access layer (not a second harness — different layer entirely). Validated empirically: `echo "prompt" | gemini` works inside a CC session and produces usable output. Sidecar calls are Bash invocations, not agent dispatches — they bypass this registry and are coordinated inline by the skill. Capability routing matters too: Gemini/Antigravity is the natural breadth/multimodal sidecar, while Codex's primary cast is the **repo-grounded audit** sidecar (file reads · grep/source-close · diff & patch · gate execution · phantom/backtrace) — **not** discovery/design-depth; a Codex session with Browser/Chrome connectors mounted can additionally take live web-flow automation as a capability-routed handoff. In a local FH workspace that pairs the public methodology mirror with a private companion store (the `*-be` pattern), route by workspace capability while preserving each repository's ownership boundary. See `knowledge/shared/harness-core/multi_model_sidecar_strategy.md §Runtime Authority` for the authority model and the full pattern.
-
-> **Waiting on a sidecar — mechanical, not by eye (2026-07-29).** A sidecar you dispatched is judged
-> ONLY by the typed verdict line from `scripts/sidecar_wait.sh`:
->
-> ```bash
-> printf '%s' "$prompt" | bash scripts/sidecar_wait.sh out.txt 900 -- codex exec -m gpt-5.5 -
-> #   SIDECAR_VERDICT=COMPLETE exit=0 bytes=48489   → read out.txt
-> #   SIDECAR_VERDICT=TIMEOUT  waited=900s bytes=0  → STILL ALIVE, not a result
-> #   SIDECAR_VERDICT=EMPTY    exit=0               → the only state meaning "it said nothing"
-> ```
->
-> **Never judge a sidecar by looking at its output file.** A live process and a dead one produce the
-> same zero bytes, and only process state separates them. Measured here: a session backgrounded two
-> sidecars, read their files after 1 s and 30 s, recorded *"both returned 0-output"* into five
-> records — and both had answered, with four real findings, one of which showed the change under
-> review was over-applied. The mis-read nearly retired a working mechanism. This rule is repeated in
-> this file because line 71 tells you to invoke sidecars with `Bash`; a runtime reading only that
-> would dispatch with no waiting discipline at all. Canonical: `auto-decorrelation` SKILL.md §S-1b.
-
-> **Runtime authority — hard stop line (Codex / non-Claude runtimes):** your findings are **evidence candidates, not terminal verdicts**. They are not final until the governor source-closes them against a **mechanical anchor** (a local file hit · a literal source span · a passing check) — **never governor agreement alone**. You are a capability-routed **sidecar**, not a co-governor: there is one explicit governor per context. Full doctrine: `knowledge/shared/harness-core/multi_model_sidecar_strategy.md §Runtime Authority`.
-
----
-
-## Invocation patterns
-
-### Single agent dispatch
-
-```
-Analyze this SKILL.md for structural flaws before I commit it.
-```
-
-→ Claude dispatches `quench-challenger` automatically (description-triggered).
-
-### Parallel dispatch (2+ independent tasks)
-
-```
-Run fact-checker and persona-innovator in parallel.
-  First: check [asset path] for duplicates
-  Second: scan for naming gaps in the current harness
-```
-
-→ Both agents run concurrently in Agent View; results are integrated by the orchestrator.
-
-### Wave-based composition (via agent-composer)
-
-For complex multi-step tasks, run `/agent-composer` first to plan which agents to dispatch in which order (Wave 0 reconnaissance → Wave 1 execution → Wave 2 synthesis).
-
----
-
-## Codex Compatibility (beta)
-
-The methodology layer (`tracks/`, `knowledge/`, `SKILL.md` docs) is Codex-compatible beta. Any AI model can follow skill workflows by reading SKILL.md files directly; the automation layer (hooks, plugin-channel agents under `plugins/*/agents/`, `/model`) is Claude Code-native and requires manual adaptation. FH's own agents are auto-loaded via the plugin channel when the plugin is enabled — `.claude/agents/` is the field-project override slot, not where FH ships its agents. Non-Claude runtimes use this `AGENTS.md`, `plugins/*/agents/*.md`, and `scripts/fh-run.sh` to apply the same methodology via adapter.
-
-### Non-Claude runtimes: five things CLAUDE.md holds that you will not auto-load
-
-`.claude/rules/*.md` with `paths:` frontmatter is a **Claude Code platform feature** — those files are
-auto-loaded into a Claude Code session when it reads a matching file, and **your runtime has no equivalent**.
-So five things that govern behavior are not going to reach you on their own. Read them explicitly:
-
-1. **FH asset changes run a mandatory 4-axis verification chain before the session's first commit.**
-   Detail (axis definitions · marker required fields · lightweight exception · substantive carve-out):
-   `.claude/rules/fh_4axis_gate.md` — **open it directly**; nothing will load it for you. The commit is
-   hard-blocked by `templates/.git-hooks/pre-commit` regardless of runtime, so skipping the read does not
-   skip the gate — it just means you meet the block without knowing what it wants.
-   ⚠️ If you run `templates/regression_guard.sh` (Axis 1) yourself, **`exit 0` means PASS *or* SKIP** —
-   SKIP being "no staged file matched the gate's pathspec", which is *not checked*, not *checked and
-   clean*. Prefer the typed file channel — set `REGRESSION_GUARD_RESULT_FILE=<path>` and read
-   `result=pass|review|block|skip|error` from that file (stdout's `REGRESSION_GUARD_RESULT=` line is
-   the no-env fallback). Judging by exit code
-   alone lets an unexamined change report as a pass (measured 2026-07-22: that is exactly what the
-   commit hook did until it was fixed).
-2. **Company residency is absolute** (CLAUDE.md §Field-Harness Diagnostic): raw company source, secrets,
-   hostnames, internal repo/asset names, stack traces, and unredacted findings **never leave the local
-   machine** — not to an external *or same-family* cloud model, not through a browser/API tool, not into a
-   log, comment, or paste. Outbound gets a **sanitized summary only**; exceptions need explicit operator
-   approval plus a gitignored audit note. This binds every runtime, not just Claude Code — a leak does not
-   un-happen, and the guard is worth nothing if it only lives where one runtime reads.
-
-3. **Before calling a material work product done, name what you are blind to.** CLAUDE.md routes the
-   everyday "commit and merge this" moment to `agent-composer` **§Author-Exposure Table** — a review
-   pass keyed on *what the author cannot self-detect* (cold entry → `beginner` · everyday friction →
-   `main-player` · outside currency → `expert` · optimistic self-verification → `challenger` +
-   cross-family · rebuilding what exists → `fact-checker` · ungrounded numbers → `phantom-quench`),
-   with a materiality gate and an `Exposure-unclear → challenger` default so "no row applies" is not
-   an exit. **This row exists because the triggering utterance names no agent** — nothing will fire it
-   for you. Your runtime *can* run these lenses: substitute `Agent(subagent_type=...)` per §M2 above
-   (`fh-run`, or `codex exec` reading the agent spec). The lens returns evidence, never the verdict.
-
-4. **General work is in scope here, and the mechanism for serving it is to marshal installed
-   capability.** CLAUDE.md §Intent Marshaling makes this the runtime default. It settles a *category*
-   question only — whether non-harness work belongs in this environment at all. Every ordinary check
-   about a specific request (is it safe, sensible, well-formed, worth doing) is yours and is unaffected.
-
-   The category answer is yes, for a concrete reason: the skill registry, the mapped field harnesses,
-   and the memory store exist **only** in this environment. So when the operator states a work intent in
-   plain language (write this doc, build this wiki page, organize this material — **any work-shaped ask,
-   not only harness building**), the scan below is what tells you whether capability for it is actually
-   present. An empty scan, reported with the scan cited, is a correct answer — see the third bullet.
-
-   Three constraints carry over unchanged to your runtime:
-   - **Enumerate rather than recall.** List the available skills, `LOCAL_SKILL_REGISTRY`, and the mapped
-     project assets. Recall under-reports what is installed, which is why the scan is a listing step.
-   - **Marshaling never upgrades a trust tier.** Run-first autonomy covers **FH-native capability whose
-     steps are per-action reversible**. A non-FH sibling capability stays at its registry `ask-tier`
-     (propose only), and an outward-mutating action (send · post · deploy · delete) keeps its own gate.
-   - **A capability gap is declared by citing the scan result**, not as a bare "nothing fits" — then
-     route at request scale (internal scan → external search → in-session synthesis). *Persist* routes
-     to the New-Skill gate; *install* routes to plugin-recommender's HITL. No new gates.
-
-   **This item exists because the triggering utterance is ordinary work language that names no skill and
-   no agent** — like item 3, no automatic trigger covers it; read it explicitly.
-
-> **Detail**: See `knowledge/shared/harness-core/intent_marshaling_general_work.md` — the 5-step loop,
-> the gate-routing table, the Sonnet-floor boundaries, and the origin defect — **open it directly**
-> before applying the ladder or when a gap appears.
-
-5. **A scan, checker, or metric in this repo is not evidence until it has been shown to work on the
-   target you are pointing it at.** This one is easy to skip because the tooling looks finished, so it
-   is worth two cheap steps before you rely on a number it produces:
-
-   - **Run it against one case you already know the answer to, and one you know is clean.** A tool that
-     cannot separate those two has not been shown to measure anything, so its output cannot ground a
-     claim about the target — it may still be right, you just have no way to tell. This
-     repo has produced that exact result more than once — an ASCII-token scanner run over a Korean
-     corpus scored ~96% false positives, and a shell-shape scanner reported a fail-open script as
-     "clean" because every one of its probes was written for Python syntax.
-   - **Open one hit by hand before you state a count anywhere** — including in chat, not only in a file.
-     An unverified figure is anchored the moment it is said, and then has to be corrected everywhere it
-     travelled.
-
-   Two conventions that follow from this, and that the rest of the repo assumes you are using:
-   *an empty result is not a zero* — a scan that found no target files, or died mid-run, reports
-   `UNMEASURED`, never `0` — and *an extreme result (everything passed, everything failed) is a reason
-   to suspect the instrument before the target.*
-
-   Nothing enforces this mechanically; the trigger is your own intent to trust an output, which no hook
-   can see. Detail, including the known-pair procedure and the failure catalogue:
-   `knowledge/shared/harness-core/measurement-integrity-checklist.md` — **open it directly** before
-   running a scan whose count you will report.
-
-The irreversible-surface gates (Pre-Publish · Destructive-Op) likewise live in CLAUDE.md and fire on
-**intent**, not on a file — read them before any publish, delete, or history-rewrite. `pre-push` enforces
-the git-side destructive surface mechanically for every runtime.
-
-### Entry point for Codex users
-
-AGENTS.md is your starting point. Navigate from here to skill workflows:
-
-```bash
-# Read a skill's full workflow
-cat plugins/fh-meta/skills/steel-quench/SKILL.md
-
-# Apply via codex exec (validated pattern — codex-cli ≥ 0.135.0)
-cat plugins/fh-meta/skills/steel-quench/SKILL.md path/to/artifact.md \
-  | codex exec -m gpt-5.5 -
-
-# Or use FH's runtime adapter (preferred for Codex-primary workflows)
-FH_BACKEND=codex npx --package @chrono-meta/fh-gate fh-run \
-  --skill steel-quench \
-  --file path/to/artifact.md
-
-# Agent substitution for Claude Code Agent(...) calls
-FH_BACKEND=codex npx --package @chrono-meta/fh-gate fh-run \
-  --agent fh-commons:quench-challenger \
-  --file path/to/artifact.md
-
-# Or pipe explicitly
-echo "Apply the following skill to the artifact below." | \
-  cat - plugins/fh-meta/skills/{skill}/SKILL.md target.md \
-  | codex exec -m gpt-5.5 -
-```
-
-`codex exec -m gpt-5.5 -` reads from stdin in headless mode. `npx @openai/codex` (interactive) is not suitable — it requires TTY.
-
-### Skill compatibility tiers
-
-| Tier | Definition | Examples |
-|---|---|---|
-| **M1 — Full** | All phases run without CC-native dependencies — no Stop hook, no `.claude/agents/` dispatch, no `/model` | `token-budget-gate`, `asset-placement-gate`, `phantom-quench`, `deep-clarify`, `convergence-loop` |
-| **M2 — Partial** | Core workflow runs; CC-native phases require manual adaptation or skip | `deliberation` (Mediator/Jury Agent steps = manual), `steel-quench` (Wave 1–3 ✅; quench-challenger agent = manual), `harness-doctor`, `context-doctor`, `sim-conductor`, `harvest-loop` (git scan phase ✅; PR auto-proposal = manual) |
-| **M3 — CC-only** | Requires CC Stop hook or session-scoped agent dispatch; methodology reference only | `goal-quench` (Phase 3 Stop hook), `hub-cc-pr-reviewer` (CC session context), `install-wizard` (settings.json write) |
-
-**M2 adaptation pattern**: when a step references `Agent(subagent_type=...)` or a slash command, substitute with `fh-run` (preferred) or a direct `codex exec` call reading the sub-agent's SKILL.md — same workflow, different runtime.
-
-**Goal handling under Codex**: use Codex's native goal/session feature when available. FH's portable role is the quality gate after the goal completes: `FH_BACKEND=codex npx --package @chrono-meta/fh-gate fh-gate ...`. `fh-goal` exists only for non-interactive one-shot runs that should be followed automatically by `fh-gate`; it is not a replacement for Codex-native goal control.
-
-### Beta removal conditions
-
-| Condition | Status |
+| Agent | Allowed tools |
 |---|---|
-| Known limitation list published (`docs/codex-compat.md`) | ✅ done (2026-06-04) |
-| 5+ externally validated M1 skill runs (not FH author) | ⬜ pending — needs external users |
-| At least 1 external Codex user confirms methodology reproduces | ⬜ pending — needs external users |
-| README badge updated (`Codex-compatible` without `beta`) | ⬜ blocked on above |
+| `challenger` | Read, Grep, Glob, WebSearch, WebFetch |
+| `fact-checker` | Read, Grep, Glob |
+| `hub-persona-auditor` | Read, Grep, Glob |
+| `quench-challenger` | Read, Grep, Glob |
+| `persona-innovator` | Read, Grep, Glob, WebSearch, WebFetch |
 
-**Author M1 validation (2026-06-04, internal — does not satisfy the external conditions above):** `phantom-quench` (4/4 on a phantom-seeded fixture) and `asset-placement-gate` (correct Drop routing on a duplicate-skill proposal) ran end-to-end via `codex exec -m gpt-5.5 -` with no CC-native dependency, confirming the M1 tier assignments. Limitations observed (CC-native hook noise, no token accounting, etc.) are documented in `docs/codex-compat.md`.
+## Runtime Boundaries
 
-Tracking: open an issue at `chrono-meta/forge-harness` with label `codex-validation` to report a validated run.
+- **Two layers:** `tracks/`, `knowledge/`, and skill methodology are model-agnostic. Plugin agents,
+  hooks, slash commands, and `.claude/rules/` automation are Claude-native.
+- **Output residency:** reusable methodology and polished public guidance belong in `knowledge/`,
+  `plugins/`, or `docs/`. Raw signals, operator observations, handoffs, audit logs, and private
+  reasoning are private-first; do not infer that colocated directories share a repository.
+- **Runtime authority:** a non-Claude sidecar returns evidence candidates, never the terminal verdict.
+  The governor must source-close each finding against a local file hit, literal source span, or
+  passing check. Governor agreement alone is not an anchor.
+- **Sidecar completion:** judge a sidecar only by the typed verdict from `scripts/sidecar_wait.sh`.
+  Never infer completion or emptiness by looking at its output file.
 
----
+> **Detail**: See `knowledge/shared/harness-core/agents_md_runtime_details.md §Architecture-and-output-routing`
+> — layer ownership and destination routing — read before routing work across a public/private workspace pair.
 
-## Adding new agents
+> **Detail**: See `knowledge/shared/harness-core/agents_md_runtime_details.md §Sidecar-routing-and-waiting`
+> — capability routing, the required wait command, and typed verdict meanings — read before dispatching a sidecar.
 
-New agents must pass the **New Skill Creation Pre-Commit Gate** defined in `CLAUDE.md` before committing. Key requirements:
+## Mandatory Non-Claude Checklist
 
-1. Role duplication check via `/asset-placement-gate`
-2. Plain description — no self-marketing language
-3. At least 1 explicit `Done When` condition
-4. At least 3 natural language trigger examples
-5. Independently executable (or dependencies explicitly documented)
+Because non-Claude runtimes do not auto-load Claude path rules, apply these rules explicitly:
 
-After 2+ weeks of use: if `accepted ≥ 60%` of invocations → strengthen; if `rejected ≥ 40%` → redefine scope or deprecate. See `CLAUDE.md > Sub-agent Operations`.
+1. **FH asset change:** before editing, read `.claude/rules/fh_4axis_gate.md`; before the first commit,
+   run its required axes. Treat `templates/regression_guard.sh` exit 0 as PASS or SKIP; use its typed
+   result channel and never report SKIP as checked.
+2. **Company residency:** raw company source, secrets, hostnames, internal names, stack traces, and
+   unredacted findings never leave the local machine, including to same-family cloud models. Only a
+   sanitized summary may leave; exceptions require explicit operator approval and a gitignored note.
+3. **Author exposure:** before calling a material work product done, identify the author's blind spot
+   and run the matching `agent-composer` Author-Exposure lens. The lens supplies evidence, not a verdict;
+   unclear exposure defaults to `challenger`.
+4. **Intent marshaling:** general work is in scope. Enumerate installed skills, `LOCAL_SKILL_REGISTRY`,
+   and mapped project assets before composing capability. Preserve each trust tier and each outward
+   action gate. Declare a gap only with the scan cited, then route through internal registry search,
+   external search, and in-session synthesis. Persist and install retain their existing gates.
+5. **Measurement integrity:** before trusting a scan or count, run a known-positive and known-clean
+   pair, then open one hit manually. An empty or failed scan is `UNMEASURED`, not zero; extreme results
+   require instrument suspicion.
+6. **Irreversible intent:** before publish, delete, or history rewrite, read and apply the
+   Pre-Publish or Destructive-Op gate in `CLAUDE.md`. `pre-push` is only the git-side backstop.
+
+> **Detail**: See `knowledge/shared/harness-core/agents_md_runtime_details.md §Mandatory-checklist-procedures`
+> — exact supporting procedures and canonical doctrine links — read when any checklist trigger fires.
+
+## Invocation
+
+Non-Claude runtimes apply methodology manually. Prefer `FH_BACKEND=codex ... fh-run` for skills and
+agents. When a workflow references `Agent(subagent_type=...)` or a slash command, replace that step
+with `fh-run` or a direct `codex exec` call that reads the relevant spec. Use Codex native goal/session
+control; FH supplies the quality gate after goal completion.
+
+| Tier | Definition | Skills |
+|---|---|---|
+| **M1 — Full** | No Claude-native dependency | `token-budget-gate`, `asset-placement-gate`, `phantom-quench`, `deep-clarify`, `convergence-loop` |
+| **M2 — Partial** | Core works; native agent or slash-command steps need adaptation | `deliberation`, `steel-quench`, `harness-doctor`, `context-doctor`, `sim-conductor`, `harvest-loop` |
+| **M3 — Claude-only** | Requires a Claude hook or session-scoped dispatch | `goal-quench`, `hub-cc-pr-reviewer`, `install-wizard` |
+
+> **Detail**: See `knowledge/shared/harness-core/agents_md_runtime_details.md §Invocation-patterns`
+> — single, parallel, and wave composition examples — read when choosing a dispatch shape.
+
+> **Detail**: See `knowledge/shared/harness-core/agents_md_runtime_details.md §Codex-entry-points`
+> — runnable `fh-run` and `codex exec` forms — read before invoking FH from Codex.
+
+> **Detail**: See `knowledge/shared/harness-core/agents_md_runtime_details.md §Compatibility-tiers`
+> — tier constraints and goal-handling limits — read before adapting an M2/M3 workflow.
+
+## Conditional Procedures
+
+> **Detail**: See `knowledge/shared/harness-core/agents_md_runtime_details.md §Beta-removal`
+> — external-validation conditions and reporting route — read when evaluating or changing beta status.
+
+> **Detail**: See `knowledge/shared/harness-core/agents_md_runtime_details.md §Adding-agents`
+> — creation gate, registry synchronization, and post-use thresholds — read before adding an agent.

--- a/docs/codex-compat.md
+++ b/docs/codex-compat.md
@@ -1,6 +1,9 @@
 # Codex Compatibility — Known Limitations & Validated Patterns
 
-> Status: **beta**. This document is beta-removal condition #2 (see `AGENTS.md` → Codex Compatibility → Beta removal conditions). It lists what works, what breaks, and what to expect when applying forge-harness (FH) methodology through OpenAI Codex (`codex exec`) instead of Claude Code.
+> Status: **beta**. This document is a beta-removal condition (see
+> `knowledge/shared/harness-core/agents_md_runtime_details.md §Beta-removal`). It lists what works,
+> what breaks, and what to expect when applying forge-harness (FH) methodology through OpenAI Codex
+> (`codex exec`) instead of Claude Code.
 
 FH is a 2-layer system: a **methodology layer** (`tracks/`, `knowledge/`, `SKILL.md` docs) that is model-agnostic, and an **automation layer** (Claude Code hooks, plugin-channel agents under `plugins/*/agents/`, field-project overrides under `.claude/agents/`, `/model`, settings.json) that is Claude-native. Codex users run the methodology layer by reading `SKILL.md` files directly; automation steps either run through runtime adapters (`fh-gate`, `fh-run`) or require manual substitution.
 

--- a/knowledge/shared/harness-core/agents_md_runtime_details.md
+++ b/knowledge/shared/harness-core/agents_md_runtime_details.md
@@ -178,6 +178,20 @@ is not the headless substitute.
 | **M2 — Partial** | Core works; native agent/slash-command steps need adaptation | `deliberation`, `steel-quench`, `harness-doctor`, `context-doctor`, `sim-conductor`, `harvest-loop` |
 | **M3 — Claude-only** | Requires a Claude hook or session-scoped dispatch | `goal-quench`, `hub-cc-pr-reviewer`, `install-wizard` |
 
+**Which phase needs adapting** — the operative half of the M2/M3 rows. Without this a tier label
+tells a non-Claude runtime that a skill is "partial" but not *where* to intervene, which is the only
+thing it can act on. (Restored 2026-07-30 during review of the salience split: the rows survived the
+move, these per-skill cues did not, and they existed in no other file.)
+
+| Skill | Runs unchanged | Needs substitution |
+|---|---|---|
+| `steel-quench` | Waves 1–3 | the `quench-challenger` agent step |
+| `harvest-loop` | the git-scan phase | PR auto-proposal |
+| `deliberation` | proposal/synthesis structure | Mediator and Jury agent steps |
+| `goal-quench` (M3) | — | Phase 3 depends on a Claude Stop hook |
+| `hub-cc-pr-reviewer` (M3) | — | needs Claude session context |
+| `install-wizard` (M3) | — | writes `settings.json` |
+
 For M2, replace `Agent(subagent_type=...)` and slash-command steps with `fh-run` or direct
 `codex exec` reading the relevant spec.
 

--- a/knowledge/shared/harness-core/agents_md_runtime_details.md
+++ b/knowledge/shared/harness-core/agents_md_runtime_details.md
@@ -1,0 +1,219 @@
+# AGENTS.md Runtime Details
+
+> **Load: on demand.** `AGENTS.md` is the always-loaded runtime entry point. Read only the section
+> named by its imperative pointer.
+
+## §Architecture-and-output-routing
+
+forge-harness has two distinct layers:
+
+| Layer | Contents | Compatibility |
+|---|---|---|
+| **Methodology** | `tracks/`, `knowledge/`, `SKILL.md` documents, session protocols | Model-agnostic |
+| **Automation** | Plugin agents, hooks, slash commands, `CLAUDE.md` rules | Claude Code-native |
+
+FH agents ship under `plugins/*/agents/` through the plugin channel. `.claude/agents/` is the
+field-project local/override slot, not FH's shipping location. Skills straddle both layers: their
+methodology is portable, while their automatic invocation is Claude-native.
+
+The methodology layer is Codex-compatible beta. Gemini, Codex, and other runtimes can apply it by
+replacing hooks and native dispatch with manual invocation.
+
+Directory names do not determine publication residency:
+
+| Content | Default destination |
+|---|---|
+| Reusable methodology, docs, skills, public guidance, polished external conclusions | Public mirror: `knowledge/`, `plugins/`, `docs/` |
+| Raw signals, operator observations, private validation, handoffs, paper drafts, PR-background reasoning | Private companion store or local-only |
+
+In a workspace pairing a public mirror with a private companion store, preserve repository ownership
+even when both are locally available. Treat observational or operator-specific material as
+private-first and promote only the polished result.
+
+## §Sidecar-routing-and-waiting
+
+A sidecar is a capability-routing layer, not a second harness or co-governor. Gemini/Antigravity is
+suited to breadth and multimodal work. Codex's primary FH role is repo-grounded audit: file reads,
+source-close grep, diff/patch review, gate execution, and phantom/backtrace. A Codex session with
+Browser or Chrome connectors may also take live web-flow automation.
+
+Sidecars are Bash/adapter invocations coordinated inline; they bypass plugin agent dispatch and this
+registry. Route Codex to repo-grounded audit by default, not breadth, discovery, or design-depth work.
+
+After dispatch, wait mechanically:
+
+```bash
+printf '%s' "$prompt" | bash scripts/sidecar_wait.sh out.txt 900 -- codex exec -m gpt-5.5 -
+```
+
+Interpret only the typed verdict:
+
+| Verdict | Meaning |
+|---|---|
+| `SIDECAR_VERDICT=COMPLETE exit=0 bytes=N` | The process completed; read the output file |
+| `SIDECAR_VERDICT=TIMEOUT waited=Ns bytes=N` | The process is still alive; this is not a result |
+| `SIDECAR_VERDICT=EMPTY exit=0` | The completed process returned no content |
+
+A live process and a completed empty process can both show a zero-byte file. Never judge state by
+file inspection. Canonical authority and waiting doctrine:
+`knowledge/shared/harness-core/multi_model_sidecar_strategy.md §Runtime Authority` and
+`plugins/fh-meta/skills/auto-decorrelation/SKILL.md §S-1b`.
+
+## §Mandatory-checklist-procedures
+
+### FH asset changes
+
+Read `.claude/rules/fh_4axis_gate.md` before changing an FH asset. It defines the mandatory
+Backward, Adversarial, Forward, and Record axes, marker fields, lightweight exception, and
+substantive carve-out. The pre-commit hook blocks commits that lack required evidence.
+
+When running `templates/regression_guard.sh`, prefer `REGRESSION_GUARD_RESULT_FILE=<path>` and read
+`result=pass|review|block|skip|error`. Without that environment variable, read the typed
+`REGRESSION_GUARD_RESULT=` stdout line. Exit 0 alone cannot distinguish PASS from SKIP.
+
+### Company residency
+
+Keep raw company source, secrets, hostnames, internal names, stack traces, and unredacted findings
+local. Outbound requests may contain only a sanitized summary. An exception requires explicit
+operator approval plus a gitignored audit note. Canonical procedure:
+`CLAUDE.md §Field-Harness Diagnostic`.
+
+### Author exposure
+
+Before completing a material deliverable, use `agent-composer §Author-Exposure Table`:
+
+| Blind spot | Lens |
+|---|---|
+| Cold entry | `beginner` |
+| Everyday friction | `main-player` |
+| Outside currency | `expert` |
+| Optimistic self-verification | `challenger` plus cross-family evidence |
+| Rebuilding an existing asset | `fact-checker` |
+| Ungrounded numbers or references | `phantom-quench` |
+| Unclear | `challenger` |
+
+Run an agent lens through `fh-run` or a direct `codex exec` reading the agent spec. The result remains
+evidence for the governor to source-close.
+
+### Intent marshaling
+
+For ordinary work requests, read
+`knowledge/shared/harness-core/intent_marshaling_general_work.md` before applying its ladder or when a
+capability gap appears. The required loop is: restate deliverable and doneness; enumerate installed
+and mapped capability with trust tiers; compose and run reversible FH-native work; cite the scan
+before declaring a gap; search the internal registry, then external capability, then synthesize
+in-session; apply the Author-Exposure check to material output.
+
+Marshaling never upgrades trust. Non-FH sibling `ask-tier` capability remains propose-only.
+Send, post, deploy, delete, and payment retain their own gates. Installing external capability routes
+to `plugin-recommender` HITL; persisting a synthesized skill routes to the New-Skill gate.
+
+### Measurement integrity
+
+Read `knowledge/shared/harness-core/measurement-integrity-checklist.md` before relying on a scan,
+checker, or metric. Demonstrate that the instrument separates one known-positive target from one
+known-clean target, and inspect at least one hit before stating a count. Report no-target and
+mid-run failure as `UNMEASURED`. Treat all-pass or all-fail output as an instrument warning.
+
+### Irreversible surfaces
+
+The Pre-Publish and Destructive-Op gates in `CLAUDE.md` fire on intent rather than file paths.
+Read the relevant gate before any publish, delete, or history rewrite. The pre-push hook provides
+only the git-side mechanical backstop.
+
+## §Invocation-patterns
+
+### Single agent
+
+Ask for the required lens directly, for example: "Analyze this SKILL.md for structural flaws before
+I commit it." Claude may description-dispatch `quench-challenger`; a non-Claude runtime invokes the
+agent through the adapter.
+
+### Parallel independent work
+
+Dispatch two or more agents concurrently only when their tasks are independent, such as a
+`fact-checker` duplicate scan and a `persona-innovator` naming-gap scan. The orchestrator integrates
+their evidence after both finish.
+
+### Wave composition
+
+For complex dependent work, use `agent-composer`: Wave 0 reconnaissance, Wave 1 execution, then
+Wave 2 synthesis.
+
+## §Codex-entry-points
+
+Read a skill workflow directly:
+
+```bash
+cat plugins/fh-meta/skills/steel-quench/SKILL.md
+```
+
+Prefer the runtime adapter:
+
+```bash
+FH_BACKEND=codex npx --package @chrono-meta/fh-gate fh-run \
+  --skill steel-quench \
+  --file path/to/artifact.md
+
+FH_BACKEND=codex npx --package @chrono-meta/fh-gate fh-run \
+  --agent fh-commons:quench-challenger \
+  --file path/to/artifact.md
+```
+
+Direct headless fallback:
+
+```bash
+cat plugins/fh-meta/skills/steel-quench/SKILL.md path/to/artifact.md \
+  | codex exec -m gpt-5.5 -
+```
+
+`codex exec -m gpt-5.5 -` reads stdin headlessly. Interactive `npx @openai/codex` requires a TTY and
+is not the headless substitute.
+
+## §Compatibility-tiers
+
+| Tier | Definition | Examples |
+|---|---|---|
+| **M1 — Full** | No Claude-native dependency | `token-budget-gate`, `asset-placement-gate`, `phantom-quench`, `deep-clarify`, `convergence-loop` |
+| **M2 — Partial** | Core works; native agent/slash-command steps need adaptation | `deliberation`, `steel-quench`, `harness-doctor`, `context-doctor`, `sim-conductor`, `harvest-loop` |
+| **M3 — Claude-only** | Requires a Claude hook or session-scoped dispatch | `goal-quench`, `hub-cc-pr-reviewer`, `install-wizard` |
+
+For M2, replace `Agent(subagent_type=...)` and slash-command steps with `fh-run` or direct
+`codex exec` reading the relevant spec.
+
+Use Codex native goal/session control when available. FH's portable role is the post-goal quality
+gate (`fh-gate`). `fh-goal` is for non-interactive one-shot runs followed automatically by
+`fh-gate`; it does not replace native goal control.
+
+## §Beta-removal
+
+| Condition | Status |
+|---|---|
+| Known-limitations document published at `docs/codex-compat.md` | Done |
+| At least 5 externally validated M1 skill runs from non-authors | Pending |
+| At least 1 external Codex user confirms methodology reproduction | Pending |
+| README badge removes `beta` | Blocked on the external conditions |
+
+Internal author validation does not satisfy the external conditions. The author validated
+`phantom-quench` against a phantom-seeded fixture and `asset-placement-gate` against a duplicate-skill
+proposal on 2026-06-04. See `docs/codex-compat.md` for limitations and validation details.
+
+Report external validation through an issue on `chrono-meta/forge-harness` with the
+`codex-validation` label.
+
+## §Adding-agents
+
+Before adding an agent:
+
+1. Run `asset-placement-gate` and confirm the role does not duplicate an existing asset.
+2. Use a plain description with no self-marketing language.
+3. Define at least one explicit `Done When` condition.
+4. Provide at least three natural-language trigger examples.
+5. Make the agent independently executable or document its dependencies.
+6. Add the canonical spec under the correct `plugins/*/agents/` directory.
+7. Synchronize `AGENTS.md` and `.claude/registry/agent_cards.json`.
+
+Before commit, apply `.claude/rules/fh_4axis_gate.md §FH Improvement 4-Axis Auto-Gate` and read
+`knowledge/shared/rules/operations.md §Sub-agent Operations`. After at least two weeks of use,
+strengthen an agent when accepted invocations are at least 60%; redefine or deprecate it when
+rejected invocations are at least 40%.

--- a/knowledge/shared/harness-core/multi_model_sidecar_strategy.md
+++ b/knowledge/shared/harness-core/multi_model_sidecar_strategy.md
@@ -716,7 +716,7 @@ Missing any layer = compression risk. (Path conventions adapt per project — se
 ## References
 
 - `README.md §Architecture — 2-layer design` — sidecar note in Automation layer section
-- `AGENTS.md §2-Layer Architecture Context` — sidecar note distinguishing Bash invocation from agent dispatch
+- `knowledge/shared/harness-core/agents_md_runtime_details.md §Sidecar-routing-and-waiting` — sidecar note distinguishing adapter invocation from agent dispatch
 - FH paper (Zenodo DOI: 10.5281/zenodo.20397566, arXiv: submit/7657304) — harness-as-durable-layer thesis
 - A sister-harness `sidecar-orchestrator` SKILL.md (2026-06-01) — gh copilot + corporate endpoint + 3-tier fallback + 3-layer persistence
 - arXiv:2605.26302 AgingBench — compression aging defense rationale


### PR DESCRIPTION
## Summary

- reduce the always-loaded `AGENTS.md` from 3,113 to 969 words while retaining agent selection, runtime authority, safety gates, intent marshaling, and the machine-parsed M1/M2/M3 table
- move execution examples, compatibility history, and conditional procedures into `knowledge/shared/harness-core/agents_md_runtime_details.md` behind eight imperative on-demand pointers
- update inbound references in the Codex compatibility and sidecar strategy docs

## Verification

- `bash scripts/selfcheck.sh`: PASS
- `node bin/fh-codex-doctor.js --strict`: OK
- salience cold-start simulation: grade F
- pointer audit: 8 forward / 8 reverse, 0 broken, 0 orphan
- Axis 2 challenger: converged, 0 A/B findings after fixes
- Axis 3 phantom-quench: 29 grounded claim clusters, 0 phantom, 0 unverifiable
- pre-commit 4-axis hook: ALL AXES PASSED

## Notes

The regression guard reported 0 M-tier blockers and 5 S-tier review signals. Each signal was source-closed as an intentional relocation of code blocks, Wave labels, Done When text, or overall line count into the on-demand detail layer.