### PR TITLE
docs(gate): reviewer-visible axis evidence — without punching through residency

### DIFF
--- a/.claude/rules/fh_4axis_gate.md
+++ b/.claude/rules/fh_4axis_gate.md
@@ -114,6 +114,69 @@ no runnable path exists (run-first, ask-last — sonnet_floor_doctrine.md §Auto
 
 Record sim results in the Axes 2–3 marker + sub-agent invocation log.
 
+### Reviewer-visible evidence — the marker is not readable from the other side
+
+**Rule**: a PR touching FH assets carries a **sanitized evidence capsule** in its body — what was
+run, what it returned, what was found and closed — plus, for any verdict reported as a **grade, tier
+or code**, both the **inline expansion** and the **canonical definition's location**
+(`sim grade F = Functional/PASS — scale: sim-conductor SKILL.md §Area-D`). A bare letter is not a
+verdict to anyone outside the author's vocabulary, and a decoded letter is still only *semantics* —
+it says what the grade means, never that the run produced it. Keep those two separate.
+
+**Never paste the raw marker.** Write the capsule; do not copy the file. The marker is a local
+artifact that may quote paths, hostnames, internal asset names, or unredacted findings, and
+**§Company residency forbids those reaching a log, comment, or paste** (`CLAUDE.md` — "not into a
+log, comment, or paste"). A PR body is a paste on a public surface. This matters mechanically, not
+just in principle: the pre-commit confidentiality guard scans **staged tracked content** and has no
+view of PR-body text, so a body is *outside* the repo's mechanical privacy floor. Run the
+public-surface scan over the capsule text before creating or editing the body. (Cross-family review
+2026-07-30 caught this: the first draft of this rule said "inline the evidence itself", which pointed
+authors straight through that gap — the residency floor and the reviewer-visibility goal were pulling
+in opposite directions and only one of them had a hook.)
+
+**Why this is structural, not politeness**: the marker file itself is **gitignored by design**
+(`.gitignore` `tracks/**` — verify per file with `git check-ignore -v <marker>`; a couple of
+force-added files elsewhere under `tracks/_meta/` do not change it for markers). So the
+machine-checkable evidence for a change exists only on the author's machine — a reviewer on another
+session, another worktree, or another runtime **cannot reach it**.
+The gate is satisfied and the reviewer still has nothing but prose. This is the same shape as the
+gate-locality defect (a gate placed where the actor that needs it cannot read it), one layer over:
+**evidence placed where the reviewer cannot read it**.
+
+**Measured 2026-07-30 (PR #205, a Codex-authored change reviewed by Claude)**: the PR body reported
+`salience cold-start simulation: grade F`. The reviewer could not resolve it — the marker was in a
+gitignored path inside the author's worktree — and recorded it as UNVERIFIED. `F` in fact meant
+**Functional**, the PASS grade of sim-conductor's Area-D consumer scale
+(`plugins/fh-meta/skills/sim-conductor/SKILL.md` §Area-D — `F` functional / `P` partial / `B` broken),
+i.e. the sim had *passed*. Two failures, one on each side, and the rule addresses both: the author
+reported a coded verdict without its scale, and the reviewer's own grep surfaced the defining file
+and the reviewer did not open it. **A pointer your instrument hands you is not optional reading.**
+
+**Degrade direction — and it does NOT satisfy the rule.** Evidence that cannot be sanitized into a
+capsule is declared, never dropped, and never silently counted as met:
+
+```
+LOCAL-ONLY ATTESTATION — UNVERIFIED: <one-line result> (record: local marker <name>)
+```
+
+That line is **an author's claim, not reviewer-visible evidence**. It leaves the requirement
+*unmet*, and the PR proceeds only by one of: a sanitized reproducible capsule · an authorized
+independent review on a machine that can read the record · explicit operator acceptance of the
+unverified state. Silence reads as verified, which is why the label is mandatory — but the label is
+an honest gap, not a way to close one. **Never restate a local-only result as though the reviewer
+confirmed it**, and note that inlining a marker field proves nothing about provenance either: the
+marker's own scope is form + non-vacuity + auditability, **not** that the run happened (see the
+marker-scope note above).
+
+**Enforcement boundary — say which half is mechanical.** An earlier draft of this rule claimed no
+hook could enforce any of it. That was overbroad: **presence and syntax are mechanizable** — a
+`pull_request` CI status can check that an applicable PR carries a capsule, that graded verdicts are
+expanded, and that a local-only attestation is labelled; a local `gh pr create/edit` wrapper can run
+the private-pattern scan that public CI cannot (public CI must never hold the private patterns).
+What stays un-mechanizable is **truth and provenance** — whether the capsule describes a run that
+actually happened. Neither anchor is built today; that is a named residual, and a rule that
+over-claims its own floor is the defect this file exists to prevent.
+
 > **Detail**: See `knowledge/shared/harness-core/claude_md_gate_details.md §Sim-Dispatch-Fallback` — the
 > headless `claude -p --model` fallback when in-session model-pin is unavailable, the saturation-disguise
 > retry (compact-then-retry once), and the credit-pool caveat — read when a model-pinned dispatch fails.


### PR DESCRIPTION
## Rule added

An FH-asset PR carries a **sanitized evidence capsule** in its body — what was run, what it returned,
what was found and closed — and any graded verdict is given **both** its inline expansion and its
canonical scale location (`sim grade F = Functional/PASS — scale: sim-conductor SKILL.md §Area-D`).

## Why it is structural

The marker holding a change's machine-checkable evidence is **gitignored by design** (`tracks/**`).
So that evidence exists only on the author's machine, and a reviewer on another session, worktree or
runtime cannot reach it. The gate is satisfied and the reviewer still has only prose. This is the
gate-locality defect one layer up: **evidence placed where the reviewer cannot read it**.

## Origin — measured today, and both sides were wrong

In PR #205 (Codex-authored, Claude-reviewed) the body reported `salience cold-start simulation:
grade F`. The reviewer could not resolve it and recorded UNVERIFIED — then overreached and asserted
the scale was "defined nowhere". It is defined in a shipped skill spec (`sim-conductor` Area-D:
`F` functional / `P` partial / `B` broken), so `F` meant **PASS**, and the reviewer's own grep had
returned that file unopened. The rule closes both sides: name the scale (author), treat a pointer
your instrument hands you as required reading (reviewer).

## Cross-family review returned BLOCK on the first draft — all 4 findings accepted

`codex/gpt-5.6-sol`, reasoning high. Every finding was source-grounded before acceptance.

| # | Finding | Resolution |
|---|---|---|
| **Critical** | "Inline the evidence itself" opened a **residency exfiltration path** — it directed authors to paste local marker content (paths, hostnames, internal names, unredacted findings) into a public PR body. `CLAUDE.md` forbids exactly that ("not into a log, comment, or paste"), and the pre-commit confidentiality guard scans **staged tracked content only** — a PR body sits outside the mechanical privacy floor. | Rewritten to a sanitized capsule; never paste the raw marker; run the public-surface scan over the body first. |
| **High** | The degrade path let a named-but-unreadable attestation keep satisfying the requirement. | Now labelled `LOCAL-ONLY ATTESTATION — UNVERIFIED`, explicitly **does not** satisfy the rule, with three named exits. |
| **High** | The draft claimed no hook could enforce any of this — overbroad. | Corrected: presence/syntax **is** mechanizable (a `pull_request` status + a local `gh` wrapper for the private-pattern scan); only truth/provenance is not. Both anchors named as unbuilt residuals. |
| **Medium** | Internal contradictions: "the evidence itself" vs the permitted one-line form; inlining a marker field treated as provenance when the marker's own scope excludes it; decoding a grade confused with verifying it. | Verdict semantics and run evidence now explicitly separated. |

The same-family review (mine) had **no residency angle at all**. That is what cross-family is for.

## Verification

Axis 1 `regression_guard --staged` PASS (M 0 / S 0) · Axis 2 cross-family as above · Axis 3 every
cited path and literal verified before commit, including one overbroad `gitignore` claim caught and
narrowed mid-pass · Axis 4 manifest entry · the load-bearing `crossfamily:` gate leg recorded.

## Residual

No hook enforces the PR-body requirement today. Presence/syntax anchors are described but **not
built** — and a rule that over-claims its own floor is the defect this file exists to prevent, so it
says so in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)