### PR TITLE
feat(sidecar): measure the cross-family panel before trusting it

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,8 @@
     "README.ja.md",
     "scripts/fh_node_check.sh",
     "templates/settings.SessionStart.snippet.json",
-    "scripts/test_node_check_lanes.sh"
+    "scripts/test_node_check_lanes.sh",
+    "scripts/sidecar_calibrate.sh",
+    "scripts/test_sidecar_calibrate_lanes.sh"
   ]
 }

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -152,6 +152,20 @@ fi
 # hooks counted as ours · the Mode D applicability gate silencing its own flagship case), and each
 # round's fix reverted a previous one because no anchor pinned it. Subject-present-but-anchor-absent
 # is a FAIL, not a skip — that is how an anchor gets quietly dropped.
+# Same treatment for the sidecar calibrator, same reason: its verdicts are all distinctions between
+# states that look identical from outside ("the sidecar ran" vs "the model I pinned answered",
+# "absent" vs "unmeasured"), and its lanes are hermetic stubs, so running them costs nothing.
+if [ ! -f scripts/sidecar_calibrate.sh ]; then
+  echo "SKIP  test_sidecar_calibrate_lanes.sh (subject scripts/sidecar_calibrate.sh absent)"
+elif [ -f scripts/test_sidecar_calibrate_lanes.sh ]; then
+  if ! bash scripts/test_sidecar_calibrate_lanes.sh; then
+    fail=1
+  fi
+else
+  echo "FAIL  test_sidecar_calibrate_lanes.sh: sidecar_calibrate.sh present but its anchor is missing"
+  fail=1
+fi
+
 if [ ! -f scripts/fh_node_check.sh ]; then
   echo "SKIP  test_node_check_lanes.sh (subject scripts/fh_node_check.sh absent)"
 elif [ -f scripts/test_node_check_lanes.sh ]; then

--- a/scripts/sidecar_calibrate.sh
+++ b/scripts/sidecar_calibrate.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# sidecar_calibrate.sh — measure the cross-family sidecar panel before trusting it.
+#
+# WHY: `auto-decorrelation` and the load-bearing cross-family gate both ask "is a different-family
+# auditor reachable?" — and until now that question was answered from memory. Two measured failures
+# on 2026-07-30, one in each direction:
+#   · A marker was written claiming `cross-family unavailable this session`. Probed later in the same
+#     session, codex ran fine. Unavailability was DECLARED, never measured.
+#   · agy pinned with the slug `gemini-3.1-pro-high` answered as **Gemini 3.6 Flash** — silently, with
+#     no error. "The sidecar ran" and "the model I pinned answered" are different propositions, and
+#     only the second one licenses a claim about model-family diversity.
+# A panel you have not probed is not a panel; it is an assumption with a hostname.
+#
+# WHAT IT MEASURES, per runtime — four legs, because each catches a different lie:
+#   REACHABLE          the binary exists and runs at all
+#   PIN-OK / UNTRUSTED-PIN
+#                      a discriminating identity probe: does the answer NAME the model that was
+#                      pinned? A generic "OK" proves nothing — any model returns it. This is the only
+#                      anchor for a runtime that falls back silently.
+#   control: rejects-bogus / accepts-bogus
+#                      pin a model that cannot exist. This measures ONE thing only: whether unknown
+#                      names are validated. It does NOT mean known names are served faithfully, and
+#                      the gap between those is where the real trap lives — agy REJECTS nonsense yet
+#                      silently served Flash for `gemini-3.1-pro-high`, a slug from its own
+#                      catalogue (measured 2026-07-30). So `rejects-bogus` must never be read as
+#                      "the pin is safe": the identity probe still decides. `accepts-bogus` is the
+#                      stronger warning — there, the identity probe is the ONLY evidence at all.
+#   VERDICT-OK / VERDICT-UNPARSEABLE
+#                      ask for one bare token. A runtime that answers with agentic prose cannot carry
+#                      a machine-read verdict. Measured for agy at 1.0.14 (2026-07-04) and NOT
+#                      inherited here: the version has moved, and this file re-measures rather than
+#                      quoting. Fitness is a per-run measurement, not a property.
+#
+# Detector, never a gate: ALWAYS exits 0. It reports; the caller decides. A calibration run that
+# could block would make callers stop running it, which is the failure this exists to prevent.
+#
+# Cost: real API calls (3 short probes per runtime). Use --only to scope. `--stub-model` exists for
+# the lane harness so it can drive stub CLIs without touching a real catalogue.
+#
+# Usage:  bash scripts/sidecar_calibrate.sh [--only codex|agy] [--stub-model NAME] [--quiet]
+# Output: one block per runtime, then a PANEL line — the line a marker's `crossfamily:` leg quotes.
+
+set -uo pipefail
+
+ONLY=""; STUB_MODEL=""; QUIET=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --only) ONLY="${2:-}"; shift 2 ;;
+    --stub-model) STUB_MODEL="${2:-}"; shift 2 ;;
+    --quiet) QUIET=1; shift ;;
+    *) shift ;;
+  esac
+done
+
+TIMEOUT_BIN=""
+command -v timeout >/dev/null 2>&1 && TIMEOUT_BIN="timeout"
+command -v gtimeout >/dev/null 2>&1 && TIMEOUT_BIN="gtimeout"
+# No coreutils timeout on stock macOS. perl's alarm is the portable watchdog; if perl is missing too,
+# run WITHOUT a deadline rather than skipping the probe — a missing watchdog must never become a
+# silently skipped measurement reported as absence (the same rule fh_session_load.sh applies).
+_run() {
+  local secs="$1"; shift
+  if [ -n "$TIMEOUT_BIN" ]; then "$TIMEOUT_BIN" "$secs" "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm shift @ARGV; exec @ARGV' "$secs" "$@"
+  else "$@"; fi
+}
+
+# _answer — reduce a runtime's stdout to THE MODEL'S ANSWER.
+# Measured on the first real run (2026-07-30): matching against whole stdout is unsound, because a
+# real CLI prints a session banner that REPEATS the pinned model back (`codex exec` emits its
+# version, workdir and model config before the reply). Under a whole-stdout match, a runtime that
+# merely echoes its own configuration passes the identity probe — the transport layer supplying the
+# very evidence the probe exists to obtain from the model. So: take the last non-empty line, skipping
+# trailing telemetry (`tokens used`, bare numbers, rule lines).
+# RESIDUAL, named: this is a heuristic on line position. A runtime that prints its answer and then
+# unrecognised trailing chatter would be mis-read. It is checked by the banner-echo lane, not proven
+# in general; a structured output mode (JSON) would replace the heuristic and none is used here yet.
+_answer() {
+  awk 'BEGIN{last=""}
+       {line=$0
+        gsub(/\r/,"",line)
+        gsub(/^[[:space:]]+|[[:space:]]+$/,"",line)
+        if (line=="") next
+        if (line ~ /^[-=_]{3,}$/) next
+        if (tolower(line) ~ /^tokens? used/) next
+        if (line ~ /^[0-9,.]+$/) next
+        last=line}
+       END{print last}'
+}
+
+IDENTITY_PROMPT="Answer with one line only: your exact model name and version."
+VERDICT_PROMPT="Reply with exactly one word, PASS or FAIL, and nothing else. The word is PASS."
+BOGUS_MODEL="zzz-nonexistent-model-9.9"
+
+PANEL=""
+
+# build_cmd <runtime> <model> <prompt> — fills CMD as an argv array.
+# NOT a shell function passed to the watchdog: `timeout`/`gtimeout` exec a BINARY and cannot see
+# shell functions, so an earlier revision fed them a function name and every probe came back as the
+# runtime failing to run (caught by lane 3/4b/5b, not by reading).
+build_cmd() {
+  case "$1" in
+    codex) CMD=(codex exec -m "$2" -c model_reasoning_effort=high --skip-git-repo-check "$3") ;;
+    agy)   CMD=(agy -p "$3" --model "$2" --print-timeout 170s) ;;
+    *)     CMD=("$1" "$3") ;;
+  esac
+}
+
+# probe_runtime <name> <real-model-pin>
+probe_runtime() {
+  local rt="$1" model="$2"
+  [ -n "$ONLY" ] && [ "$ONLY" != "$rt" ] && return 0
+  [ -n "$STUB_MODEL" ] && model="$STUB_MODEL"
+
+  if ! command -v "$rt" >/dev/null 2>&1; then
+    printf '%-6s ABSENT — not installed on this machine (absence measured, not assumed)\n' "$rt"
+    return 0
+  fi
+
+  local id_out pin_state ctl_out ctl_state v_out v_state
+  build_cmd "$rt" "$model" "$IDENTITY_PROMPT"
+  id_out="$(_run 200 "${CMD[@]}" 2>&1 | _answer)"
+
+  # Discriminating check — the answer must be the MODEL's self-report naming the model that was
+  # pinned. What counts as "naming it" is the VERSION token, not every token of the pin slug:
+  # vendors answer with a product name (`gpt-5.6-sol` → "GPT-5.6 Codex"), and demanding the suffix
+  # made this report UNTRUSTED-PIN for a pin that had actually held (measured 2026-07-30). The
+  # version is also exactly where the real failures differ — 3.1 asked, 3.6 answered. If a pin
+  # carries no version token at all, fall back to requiring the name words, since then there is
+  # nothing sharper to test.
+  local ver name_words hit=0
+  ver="$(printf '%s' "$model" | grep -oE '[0-9]+\.[0-9]+' | head -1)"
+  name_words="$(printf '%s' "$model" | tr 'A-Z' 'a-z' | sed -E 's/[^a-z]+/ /g' \
+        | tr ' ' '\n' | grep -E '^[a-z]{3,}$' \
+        | grep -vE '^(high|low|medium|thinking|the|exec)$' | head -1)"
+  if [ -n "$id_out" ]; then
+    if [ -n "$ver" ]; then
+      printf '%s' "$id_out" | grep -qF "$ver" && hit=1
+    elif [ -n "$name_words" ]; then
+      printf '%s' "$id_out" | tr 'A-Z' 'a-z' | grep -qF "$name_words" && hit=1
+    fi
+  fi
+  if [ "$hit" -eq 1 ]; then pin_state="PIN-OK"; else pin_state="UNTRUSTED-PIN"; fi
+
+  build_cmd "$rt" "$BOGUS_MODEL" "$IDENTITY_PROMPT"
+  ctl_out="$(_run 120 "${CMD[@]}" 2>&1)"
+  if [ $? -ne 0 ] || printf '%s' "$ctl_out" | grep -qiE 'not supported|invalid|unknown model|error'; then
+    ctl_state="rejects-bogus"
+  else
+    ctl_state="accepts-bogus"
+  fi
+
+  build_cmd "$rt" "$model" "$VERDICT_PROMPT"
+  v_out="$(_run 200 "${CMD[@]}" 2>&1 | _answer)"
+  # Parseable = a bare verdict token is recoverable from a short answer. Prose that merely CONTAINS
+  # the word does not qualify: a verdict channel must be readable without a human deciding what the
+  # runtime meant.
+  local v_compact
+  v_compact="$(printf '%s' "$v_out" | tr -s '[:space:]' ' ' | sed 's/^ *//; s/ *$//')"
+  if [ "${#v_compact}" -le 12 ] && printf '%s' "$v_compact" | grep -qiE '^(pass|fail)[.!]?$'; then
+    v_state="VERDICT-OK"
+  else
+    v_state="VERDICT-UNPARSEABLE"
+  fi
+
+  printf '%-6s REACHABLE · %s · control: %s · %s\n' "$rt" "$pin_state" "$ctl_state" "$v_state"
+  [ -z "$QUIET" ] && printf '       pinned: %s\n       identity said: %s\n' "$model" "$(printf '%s' "$id_out" | cut -c1-100)"
+  if [ "$ctl_state" = "accepts-bogus" ]; then
+    printf '       ⚠️  this runtime does not validate the pin at all, so the identity probe is the ONLY\n'
+    printf '           evidence that the intended model answered — a clean run proves nothing here.\n'
+  elif [ "$pin_state" = "UNTRUSTED-PIN" ]; then
+    printf '       ⚠️  it rejects UNKNOWN names, which says nothing about serving KNOWN ones faithfully.\n'
+    printf '           The identity probe disagreed with the pin — treat this runtime as substituting.\n'
+  fi
+  # Only a runtime whose pin is trustworthy counts toward the panel. A reachable runtime answering as
+  # some other model contributes no family diversity, which is the entire point of the panel.
+  [ "$pin_state" = "PIN-OK" ] && PANEL="${PANEL:+$PANEL, }$rt"
+  return 0
+}
+
+probe_runtime codex "gpt-5.6-sol"
+probe_runtime agy   "Gemini 3.1 Pro (High)"
+
+if [ -n "$PANEL" ]; then
+  echo "PANEL: $PANEL — usable different-family auditor(s), pin verified this run"
+else
+  echo "PANEL: none — no runtime passed the identity probe on this machine, this run"
+  echo "       State this, do not infer it: a marker's crossfamily leg may say 'none' but never stay silent."
+fi
+exit 0

--- a/scripts/test_sidecar_calibrate_lanes.sh
+++ b/scripts/test_sidecar_calibrate_lanes.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# test_sidecar_calibrate_lanes.sh — regression lanes for scripts/sidecar_calibrate.sh.
+#
+# WHY LANES FIRST: the calibrator's whole job is to distinguish states that LOOK the same from the
+# outside — "the sidecar ran" vs "the model I asked for answered", "absent" vs "unmeasured". Those
+# are negative legs, and negative legs are what three adversarial rounds on the node check showed
+# nobody tests until a lane forces it. Each lane below drives the calibrator with a STUB CLI whose
+# behaviour is known, so the calibrator's verdict can be checked against ground truth.
+#
+# No network, no API spend: every sidecar binary is replaced by a stub on PATH.
+#
+# Usage:  bash scripts/test_sidecar_calibrate_lanes.sh
+# Exit:   0 = all lanes pass; 1 = at least one failed.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CAL="$REPO/scripts/sidecar_calibrate.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '  ✅ %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  ❌ %s\n     got: %s\n' "$1" "$(printf '%s' "$2" | tr '\n' '|' | cut -c1-240)"; }
+
+# stub <name> <behaviour> — write a fake sidecar CLI onto the lane PATH.
+#   honest        : echoes back the model it was pinned to (a truthful runtime)
+#   silent-fallback: ALWAYS answers as one fixed model, whatever the pin (the agy trap)
+#   loud-reject   : exits non-zero on an unknown pin (the codex behaviour)
+#   chatty        : answers with agentic prose instead of the requested token (unparseable verdict)
+#   banner-echo   : prints a session banner that REPEATS the pinned model, then answers as a
+#                   different model — the real shape of `codex exec` stdout (measured 2026-07-30)
+#   listed-substitute: REJECTS an unknown name (so the bogus control says "rejects-bogus") yet
+#                   silently serves a different model for a name that IS in its own catalogue —
+#                   the measured agy shape (`gemini-3.1-pro-high` answered as 3.6 Flash, no error)
+#   alias-name    : answers with the vendor's PRODUCT name carrying the right version but not every
+#                   token of the pin slug — measured: pin `gpt-5.6-sol` → "GPT-5.6 Codex"
+#   absent        : not created at all
+mkstub() {
+  local name="$1" mode="$2" bin="$TMP/bin"
+  mkdir -p "$bin"
+  case "$mode" in
+    absent) rm -f "$bin/$name"; return ;;
+  esac
+  cat > "$bin/$name" <<STUB
+#!/usr/bin/env bash
+mode="$mode"
+pin=""
+prev=""
+for a in "\$@"; do
+  case "\$prev" in -m|--model) pin="\$a" ;; esac
+  prev="\$a"
+done
+case "\$1" in --version) echo "stub 9.9.9"; exit 0 ;; esac
+# Scan ALL arguments for the verdict prompt — it is NOT always last. codex puts the prompt at the
+# end; agy puts it after -p with `--print-timeout 170s` trailing. A first draft read only the last
+# argument, so the agy-shaped call never looked like a verdict request and lane5b failed against a
+# correct script. An honest runtime ANSWERS THE QUESTION ASKED: a one-token request gets one token.
+is_verdict=0
+for a in "\$@"; do case "\$a" in *"PASS or FAIL"*) is_verdict=1 ;; esac; done
+case "\$mode" in
+  loud-reject)
+     case "\$pin" in *nonexistent*|*bogus*) echo "ERROR: model '\$pin' is not supported" >&2; exit 1 ;; esac
+     if [ "\$is_verdict" -eq 1 ]; then echo "PASS"; else echo "I am \$pin, by StubCorp."; fi ;;
+  silent-fallback)
+     if [ "\$is_verdict" -eq 1 ]; then echo "PASS"; else echo "I am stub-flash-3.6, by StubCorp."; fi ;;
+  alias-name)
+     if [ "\$is_verdict" -eq 1 ]; then echo "PASS"; else echo "StubGPT-3.1 Coder"; fi ;;
+  listed-substitute)
+     case "\$pin" in *nonexistent*|*bogus*) echo "ERROR: model '\$pin' is not supported" >&2; exit 1 ;; esac
+     if [ "\$is_verdict" -eq 1 ]; then echo "PASS"; else echo "I am stub-flash-3.6, by StubCorp."; fi ;;
+  banner-echo)
+     echo "Reading additional input from stdin... CLI v0.0.0"
+     echo "--------"
+     echo "model: \$pin   workdir: /tmp   approval: never"
+     echo "--------"
+     if [ "\$is_verdict" -eq 1 ]; then echo "PASS"; else echo "I am stub-flash-3.6, by StubCorp."; fi ;;
+  chatty)
+     printf 'Summary of Work\n- considered the request\n- the answer is probably PASS\n' ;;
+  honest|*)
+     if [ "\$is_verdict" -eq 1 ]; then echo "PASS"; else echo "I am \$pin, by StubCorp."; fi ;;
+esac
+exit 0
+STUB
+  chmod +x "$bin/$name"
+}
+
+# HERMETIC PATH — system paths only, plus the stub dir. Inheriting $PATH looked harmless and was
+# not: "absent" is simulated by NOT creating a stub, so the real codex/agy further down $PATH were
+# found instead and the lanes fired REAL, billed API calls (measured: a lane run hung past 120s
+# against live runtimes). A test that can reach production is not a test.
+run_cal() { PATH="$TMP/bin:/usr/bin:/bin:/usr/sbin:/sbin" bash "$CAL" --stub-model "stub-pro-3.1" "$@" 2>&1; }
+
+echo "── sidecar-calibrate lanes ──"
+
+# LANE 1 — absent runtime must read as ABSENT, never as a failure of the panel and never as "fine".
+mkstub codex absent; mkstub agy absent
+out="$(run_cal --only codex)"
+case "$out" in
+  *"codex"*ABSENT*) ok "lane1 absent runtime reported ABSENT" ;;
+  *) bad "lane1 absent runtime not reported as ABSENT" "$out" ;;
+esac
+
+# LANE 2 — THE POINT OF THE WHOLE SCRIPT. A runtime that silently answers as a different model must
+# be reported as UNTRUSTED-PIN, not as reachable. "The sidecar ran" and "the model I pinned answered"
+# are different propositions; agy's slug fallback is the measured instance (2026-07-30).
+mkstub agy silent-fallback
+out="$(run_cal --only agy)"
+case "$out" in
+  *UNTRUSTED-PIN*) ok "lane2 silent fallback caught (pinned model did not answer)" ;;
+  *) bad "lane2 silent fallback passed as a healthy sidecar" "$out" ;;
+esac
+
+# LANE 3 — an honest runtime that echoes its pin is PIN-OK.
+mkstub agy honest
+out="$(run_cal --only agy)"
+case "$out" in
+  *PIN-OK*) ok "lane3 honest runtime reported PIN-OK" ;;
+  *) bad "lane3 honest runtime not reported PIN-OK" "$out" ;;
+esac
+
+# LANE 4 — the negative control must actually control. A runtime that ACCEPTS a bogus model pin has
+# no server-side validation, so "it ran without error" proves nothing about which model answered;
+# that must be visible in the report rather than inferred.
+mkstub codex loud-reject
+out="$(run_cal --only codex)"
+case "$out" in
+  *"control: rejects-bogus"*) ok "lane4 bogus-pin control observed (runtime validates pins)" ;;
+  *) bad "lane4 bogus-pin control not reported" "$out" ;;
+esac
+mkstub codex honest      # honest stub answers ANY pin, including a bogus one
+out="$(run_cal --only codex)"
+case "$out" in
+  *"control: accepts-bogus"*) ok "lane4b runtime accepting a bogus pin is flagged" ;;
+  *) bad "lane4b runtime accepting a bogus pin was not flagged" "$out" ;;
+esac
+
+# LANE 5 — verdict fitness is MEASURED, not assumed. A runtime that answers a one-token request with
+# agentic prose cannot carry a machine-read verdict. The recorded 2026-07-04 finding said exactly
+# this about agy at 1.0.14; the version has moved since, so the answer must be re-measured, never
+# inherited.
+mkstub agy chatty
+out="$(run_cal --only agy)"
+case "$out" in
+  *VERDICT-UNPARSEABLE*) ok "lane5 prose-answering runtime flagged VERDICT-UNPARSEABLE" ;;
+  *) bad "lane5 prose answer accepted as a usable verdict channel" "$out" ;;
+esac
+mkstub agy honest
+out="$(run_cal --only agy)"
+case "$out" in
+  *VERDICT-OK*) ok "lane5b token-answering runtime reported VERDICT-OK" ;;
+  *) bad "lane5b clean token answer not reported VERDICT-OK" "$out" ;;
+esac
+
+# LANE 8 (measured on the first real run) — BANNER ECHO MUST NOT SATISFY THE IDENTITY PROBE.
+# Real CLIs print a session banner before the answer, and that banner repeats the pinned model name
+# back (`codex exec` prints its version and config header). Matching against whole stdout therefore
+# passes any runtime that merely echoes its own configuration — which is precisely the lie this
+# script exists to catch, re-entering through the transport layer instead of the model.
+mkstub agy banner-echo
+out="$(run_cal --only agy)"
+case "$out" in
+  *UNTRUSTED-PIN*) ok "lane8 banner echo rejected (config echo is not a self-report)" ;;
+  *) bad "lane8 banner echoing the pin passed the identity probe" "$out" ;;
+esac
+
+# LANE 10 (measured 2026-07-30) — a vendor product alias carrying the RIGHT VERSION is not a pin
+# failure. Pinning `gpt-5.6-sol` returned "GPT-5.6 Codex": same family, same version, different
+# product suffix. Requiring every token of the pin slug to appear made the calibrator report
+# UNTRUSTED-PIN on a runtime whose pin had actually held — and that runtime also validates pins
+# server-side, so the corroborating evidence was there to read. The version token is the
+# discriminator that matters; the fallback cases (3.1 asked, 3.6 answered) differ exactly there.
+mkstub agy alias-name
+out="$(run_cal --only agy)"
+case "$out" in
+  *PIN-OK*) ok "lane10 product alias with matching version accepted as PIN-OK" ;;
+  *) bad "lane10 matching version rejected because a suffix token was absent" "$out" ;;
+esac
+
+# LANE 9 (measured 2026-07-30) — "rejects unknown names" does NOT imply "serves known names
+# faithfully", and the gap between them is where the real trap lives. agy rejects a nonsense model
+# yet silently substituted Flash for `gemini-3.1-pro-high`, a slug from its OWN catalogue. A control
+# that only probes nonsense therefore returns reassuring evidence about the wrong question: the
+# identity probe must still decide, and the report must not let `rejects-bogus` read as "pin safe".
+mkstub agy listed-substitute
+out="$(run_cal --only agy)"
+case "$out" in
+  *"control: rejects-bogus"*UNTRUSTED-PIN*|*UNTRUSTED-PIN*"control: rejects-bogus"*)
+      ok "lane9 validates unknown names yet substitutes a known one → still UNTRUSTED-PIN" ;;
+  *) bad "lane9 pin substitution masked by a passing bogus-control" "$out" ;;
+esac
+
+# LANE 6 — panel verdict. With no usable different-family sidecar the script must say so explicitly:
+# this is the line a marker's `crossfamily:` leg quotes, and the 2026-07-30 defect was asserting
+# "cross-family unavailable" without ever probing.
+mkstub codex absent; mkstub agy absent
+out="$(run_cal)"
+case "$out" in
+  *"PANEL: none"*) ok "lane6 empty panel stated explicitly (not silence)" ;;
+  *) bad "lane6 empty panel not stated" "$out" ;;
+esac
+mkstub codex honest
+out="$(run_cal)"
+case "$out" in
+  *"PANEL: "*codex*) ok "lane6b populated panel names the usable runtime" ;;
+  *) bad "lane6b populated panel not named" "$out" ;;
+esac
+
+# LANE 7 — detector, not gate: always exit 0, so a calibration run can never block a caller. The
+# caller reads the verdict; the script does not decide for it.
+mkstub codex absent; mkstub agy absent
+PATH="$TMP/bin:/usr/bin:/bin:/usr/sbin:/sbin" bash "$CAL" >/dev/null 2>&1
+[ $? -eq 0 ] && ok "lane7 exits 0 even with an empty panel (detector, not gate)" \
+             || bad "lane7 non-zero exit on empty panel" "exit=$?"
+
+printf '\nsidecar-calibrate lanes: %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
## Why

`auto-decorrelation` and the load-bearing cross-family gate both ask *"is a different-family auditor
reachable?"* — and until now that question was answered from memory. It was wrong in both directions
today, in one session:

- A marker was written claiming `cross-family unavailable this session`. Probed later in the same
  session, **codex ran fine**. Unavailability was declared, never measured.
- agy pinned with `gemini-3.1-pro-high` answered as **Gemini 3.6 Flash** — silently, no error.
  *"The sidecar ran"* and *"the model I pinned answered"* are different propositions, and only the
  second licenses a claim about family diversity.

## What it measures — four legs, each catching a different lie

| Leg | Question |
|---|---|
| `REACHABLE` | does the binary exist and run |
| `PIN-OK` / `UNTRUSTED-PIN` | **discriminating** identity probe — does the answer name the pinned model? A generic "OK" proves nothing |
| `control: rejects-bogus` / `accepts-bogus` | does the runtime validate *unknown* names — i.e. how much the other legs are worth |
| `VERDICT-OK` / `VERDICT-UNPARSEABLE` | can it carry a machine-read verdict at all |

It ends with a `PANEL:` line — the line a marker's `crossfamily:` leg can quote instead of asserting
availability. **Detector, never a gate: always exits 0.** A calibration that could block is one
people stop running.

## Measured, this machine, this session

```
codex  REACHABLE · PIN-OK · control: rejects-bogus · VERDICT-OK
agy    REACHABLE · PIN-OK · control: rejects-bogus · VERDICT-OK
PANEL: codex, agy
```

## Lanes first — and they earned it

13 hermetic lanes (stub CLIs, no network, no spend), wired into `selfcheck.sh`. Four defects were
caught by the lanes or by the first live run, none by reading:

1. `timeout`/`gtimeout` **cannot exec a shell function**, so every probe returned "runtime failed to
   run". Caught by lanes 3/4b/5b. Fixed with argv arrays.
2. **The lanes were not hermetic.** "Absent" was simulated by deleting a stub, so the real
   `codex`/`agy` further down `$PATH` were found and the suite fired **real, billed API calls**
   (observed as a lane run exceeding 120s against live runtimes). Fixed with a system-only `PATH`.
3. **First live run**: the identity probe matched against *whole stdout*, and `codex exec` prints a
   session banner that repeats the pinned model back — so a runtime echoing its own configuration
   satisfied the probe. The transport layer was supplying the evidence the probe exists to obtain
   from the model. Lane 8 reproduces it; an `_answer` extractor now reduces stdout to the reply.
4. **Second live run**: reported `UNTRUSTED-PIN` on a pin that had actually held — pinned
   `gpt-5.6-sol`, self-reported `GPT-5.6 Codex`. Same family and version, different product suffix.
   The matcher now keys on the **version token**, which is also exactly where genuine substitution
   differs (3.1 asked, 3.6 answered). Lane 10 pins it.

Mutation-verified: disabling the identity verdict makes lane 2 fail and the suite exit 1.

## Two recorded beliefs overturned by measurement

- **agy's verdict channel.** The 2026-07-04 record says agy answers with agentic "Summary of Work"
  prose and is unusable for machine-read verdicts. At **1.1.8 it returns a clean one-token verdict**.
  That record's own warning — *version regression possible, re-probe every time* — is what made
  re-measuring mandatory rather than optional.
- **`rejects-bogus` is not a reassurance.** It measures only whether *unknown* names are validated,
  and says nothing about whether *known* names are served faithfully. agy rejects nonsense yet
  silently served Flash for `gemini-3.1-pro-high`, a slug from its **own catalogue**. Lane 9 pins
  that gap; the report now warns where it used to reassure.

Also observed: codex's self-report is **not deterministic** across runs (`GPT-5.6 Codex`, then
`GPT-5.6 Codex (gpt-5.6-sol)`) — itself the argument for keying on the stable version token.

## Residuals (named, not closed)

1. `_answer` is a **heuristic on line position** — a runtime printing unrecognised chatter after its
   reply would be misread. The banner-echo lane checks the known shape, not the general case; a
   structured (JSON) output mode would remove the heuristic.
2. The bogus-pin control cannot see the *listed-but-substituted* class generically. Only the identity
   probe can, and only for a pin whose expected answer is known.
3. Each run costs three real API calls per runtime, **uncached on purpose** — a cached calibration is
   precisely the stale assumption this replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)