### PR TITLE
feat(guard): 파이프 반대쪽 끝에서 verdict 를 읽는 걸 그 자리에서 잡는다 — 그리고 표면을 바꿨다

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,9 @@
     "templates/settings.SessionStart.snippet.json",
     "scripts/test_node_check_lanes.sh",
     "scripts/sidecar_calibrate.sh",
-    "scripts/test_sidecar_calibrate_lanes.sh"
+    "scripts/test_sidecar_calibrate_lanes.sh",
+    "scripts/pipe_verdict_guard.sh",
+    "scripts/test_pipe_verdict_guard_lanes.sh",
+    "templates/settings.PreToolUse.snippet.json"
   ]
 }

--- a/scripts/pipe_verdict_guard.sh
+++ b/scripts/pipe_verdict_guard.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# pipe_verdict_guard.sh — PreToolUse(Bash) advisory: a verdict read from the wrong end of a pipe.
+#
+# THE DEFECT
+#   `cmd | tail -5; echo "exit=$?"` reports TAIL's status, not cmd's. A gate that FAILED reads as
+#   exit 0. The degrade direction is toward PASS, which is the direction that never announces
+#   itself. Measured 6× in this project between 2026-07-29 and 2026-07-31.
+#
+# WHY A HOOK AND NOT A FILE LINTER (measured 2026-07-31, and it reversed the plan on record)
+#   The session card prescribed "add an S6 class to scripts/degrade_direction_scan.sh". Every
+#   `pipe + $?` occurrence in this repo's shell scripts was then hand-verified: 7 hits, 7 correct
+#   — in all 7 the final stage WAS the command under test. True positives in shipped files: 0.
+#   All 6 recurrences lived in interactively-composed commands, which a repo scanner never reads.
+#   S6 would have shipped a probe with no true positives, the exact failure mode S5 records in
+#   its own comment ("100% FP trains dismissal of the one hit that will matter"). So the guard
+#   moved to the surface where the defect actually occurs: the Bash tool call itself.
+#
+# TWO RULES, DELIBERATELY UNEQUAL IN CONFIDENCE
+#   R1 — deterministic, zero-FP. `${PIPESTATUS[…]}` is bash-only. This project's Bash tool runs
+#        zsh, where that expands to the EMPTY STRING (zsh spells it `$pipestatus[1]`, 1-indexed).
+#        A verdict read from it is not wrong, it is ABSENT. No judgment involved.
+#   R2 — heuristic, narrowed to DISPLAY FILTERS as the final stage (tail/head/cat/less/more).
+#        A final `grep -q`, a script, or a subshell is usually the thing whose status is wanted —
+#        those are the 7 correct shapes above and are not flagged. Narrowing costs recall; the
+#        alternative is a probe nobody reads.
+#
+# DEGRADE DIRECTION: advisory. This guard WARNS and exits 0 — it never blocks a Bash call, because
+#   a mis-read verdict is re-runnable and a false block on a developer's shell trains --no-verify
+#   reflexes on hooks that DO guard irreversible surfaces. Set FH_PIPE_VERDICT_BLOCK=1 to escalate.
+#   If the command cannot be extracted, it stays silent: an unparsed input is not a finding.
+#
+# Usage:
+#   hook:  PreToolUse matcher "Bash" → bash scripts/pipe_verdict_guard.sh
+#   test:  printf '%s' "<command>" | bash scripts/pipe_verdict_guard.sh --stdin-raw
+# Opt out on a single command with a trailing `# noqa: pipe-verdict`.
+
+set -u
+
+CMD=""
+if [ "${1:-}" = "--stdin-raw" ]; then
+  CMD=$(cat)
+else
+  RAW=$(cat)
+  # PreToolUse payload. Absent/!Bash/unparseable → stay silent (see degrade direction above).
+  CMD=$(printf '%s' "$RAW" | python3 -c '
+import json,sys
+try: d = json.load(sys.stdin)
+except Exception: sys.exit(0)
+if d.get("tool_name") != "Bash": sys.exit(0)
+sys.stdout.write(d.get("tool_input", {}).get("command", "") or "")
+' 2>/dev/null) || CMD=""
+fi
+[ -n "$CMD" ] || exit 0
+
+# Explicit opt-outs, checked before any rule.
+printf '%s' "$CMD" | grep -qE '#[[:space:]]*noqa:?[[:space:]]*pipe-verdict' && exit 0
+
+hits=""
+add() { hits="${hits}  ⚠️  PIPE-VERDICT $1
+      $2
+"; }
+
+# Flatten to ONE line before any matching. grep is line-oriented, so `.*` never spans a newline and
+# every multi-line command missed — which is the worse half, because the invocations that actually
+# recur here are multi-line. A newline is a statement separator, so `; ` is the faithful substitute.
+# (Found by the Axis-2 adversarial pass on this guard, 2026-07-31; lanes A* pin it.)
+FLAT=$(printf '%s' "$CMD" | tr '\n' ';' | sed 's/;/; /g')
+
+# ── R1 — PIPESTATUS under zsh: the value is empty, so the verdict is absent. ──────────────────
+# Brace-optional: zsh accepts `$PIPESTATUS[0]` as well, and the brace-anchored form missed it (lane B*).
+if printf '%s' "$FLAT" | grep -qE '\$\{?PIPESTATUS[[{]' ; then
+  add "R1 \${PIPESTATUS[…]} is empty in zsh" \
+      "This shell is zsh; the bash array does not exist here, so the verdict expands to \"\". Use zsh's \`\$pipestatus[1]\` (1-indexed), or drop the pipe and read \$? directly."
+fi
+
+# ── R2 — display filter as the final stage, then a read of $?. ────────────────────────────────
+# `||` is neutralized first: `a || b || echo 0` contains no pipeline, and reading it as one is
+# how the sibling S5 probe produced 9 false positives before it was narrowed (2026-07-28).
+# `set -o pipefail` in the same command makes `$?` after a pipeline correct — not a finding.
+NORM=$(printf '%s' "$FLAT" | sed 's/||/__OR__/g')
+if ! printf '%s' "$NORM" | grep -qE 'set -o pipefail|set -[a-zA-Z]*o[a-zA-Z]* pipefail'; then
+  if printf '%s' "$NORM" \
+     | grep -qE '\|[[:space:]]*(tail|head|cat|less|more)([[:space:]][^|;&]*)?[[:space:]]*[;&].*\$\?'; then
+    add "R2 \$? after a display filter" \
+        "\$? holds the filter's status (tail/head/cat almost always succeed), not the command's — a FAILED check reads as 0. Capture first: \`out=\$(cmd 2>&1); rc=\$?\` then print \"\$out\" | tail."
+  fi
+fi
+
+[ -n "$hits" ] || exit 0
+
+printf '%s' "$hits" >&2
+if [ "${FH_PIPE_VERDICT_BLOCK:-0}" = "1" ]; then exit 2; fi
+exit 0

--- a/scripts/test_pipe_verdict_guard_lanes.sh
+++ b/scripts/test_pipe_verdict_guard_lanes.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# test_pipe_verdict_guard_lanes.sh — known pairs for scripts/pipe_verdict_guard.sh
+#
+# WHY THIS FILE EXISTS, AND WHY IT IS WRITTEN BEFORE THE DETECTOR
+#   2026-07-30 harvest #1: across a 5-round challenger run, three rounds contained a fix that
+#   reverted an earlier fix — and the rounds that wrote the lane BEFORE touching the code had
+#   zero such regressions. Convergence came from the ORDER, not the patch. So: lanes first.
+#
+# WHAT IS BEING GUARDED
+#   Reading a verdict from `$?`/`${PIPESTATUS[…]}` after a pipeline, which yields the status of
+#   the LAST stage. When the last stage is a display filter (`tail`, `head`, `cat`), that status
+#   is the filter's — a FAILING gate reads as exit 0. Degrade direction: toward PASS.
+#
+#   R1 (deterministic, zero-FP): `${PIPESTATUS[...]}` under zsh. zsh spells it `$pipestatus[1]`
+#       and 1-indexes it; the bash array expands to the EMPTY STRING. Any verdict read from it is
+#       not merely wrong, it is absent. Measured 6× in this project's ad-hoc invocations.
+#   R2 (heuristic, narrowed): pipeline whose FINAL stage is a display filter, followed by a read
+#       of `$?`. Narrowed to display filters on purpose — see the FP lanes below.
+#
+# WHY A REPO-FILE LINTER IS THE WRONG SURFACE (measured 2026-07-31)
+#   The prescription on the session card was "add an S6 class to degrade_direction_scan.sh".
+#   Hand-verifying every `pipe + $?` hit in this repo's scripts returned 7 hits, 7 of them correct
+#   (the last stage WAS the command under test in all 7). True positives in shipped files: 0.
+#   All 6 measured recurrences were in interactively-composed commands, which no file scanner
+#   reads. Shipping S6 would have been a 0-true-positive probe — exactly the failure S5's own
+#   comment records ("100% FP trains dismissal of the one hit that will matter").
+
+set -u
+G="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/pipe_verdict_guard.sh"
+pass=0; fail=0
+
+# expect <label> <expected: HIT|CLEAN> <command-string>
+expect() {
+  local label="$1" want="$2" cmd="$3" out got
+  out=$(printf '%s' "$cmd" | bash "$G" --stdin-raw 2>&1)
+  if printf '%s' "$out" | grep -q 'PIPE-VERDICT'; then got=HIT; else got=CLEAN; fi
+  if [ "$got" = "$want" ]; then
+    printf '  ✅ %-52s %s (expected %s)\n' "$label" "$got" "$want"; pass=$((pass+1))
+  else
+    printf '  ❌ %-52s %s (expected %s)\n' "$label" "$got" "$want"; fail=$((fail+1))
+    printf '     cmd: %s\n     out: %s\n' "$cmd" "$out"
+  fi
+}
+
+echo "[pipe-verdict-guard] known pairs"
+echo "-- R1: PIPESTATUS under zsh (deterministic) --"
+# The exact shape emitted 6× in this project, including twice on 2026-07-31.
+expect "R1 the measured shape"            HIT   'bash x.sh | tail -5; echo "exit=${PIPESTATUS[0]}"'
+expect "R1 any index"                     HIT   'a | b; rc=${PIPESTATUS[1]}'
+expect "R1 inside a larger command"       HIT   'cd /r && npm t | tail; E=${PIPESTATUS[0]}; echo $E'
+# zsh's own spelling is correct here and must never be flagged.
+expect "R1 zsh spelling is CLEAN"         CLEAN 'a | b; rc=$pipestatus[1]'
+
+echo "-- R2: display-filter final stage, then \$? --"
+expect "R2 tail then \$?"                  HIT   'bash gate.sh | tail -20; echo "exit=$?"'
+expect "R2 head then \$?"                  HIT   'make test | head -40; rc=$?'
+expect "R2 cat then \$?"                   HIT   'run.sh | cat; if [ $? -ne 0 ]; then echo bad; fi'
+
+echo "-- R2 false-positive lanes: the 7 shapes this repo actually ships --"
+# Every one of these was hand-verified on 2026-07-31 as CORRECT: the final stage IS the command
+# whose status is wanted. A detector that flags these is noise, and noise trains dismissal.
+expect "FP grep -q is the test itself"    CLEAN 'echo "$pos" | grep -qE "$re"; rc=$?'
+expect "FP grep compiles the regex"       CLEAN "printf '' | grep -E \"\$re\" >/dev/null 2>&1; rc=\$?"
+# Path deliberately generic: naming a real unshipped script here would make this lane a shipped
+# doc pointing at a file the package omits (caught by selfcheck's package-coverage rule).
+expect "FP last stage is the script"      CLEAN "printf '%s' \"\$S\" | bash some-filter.sh - ; echo EXIT:\$?"
+expect "FP command substitution assign"   CLEAN 'out=$(printf x | ( cd "$r" && bash hook 2>&1 )); rc=$?'
+expect "FP no pipe at all"                CLEAN 'bash gate.sh; echo "exit=$?"'
+expect "FP || fallback, not a pipe"       CLEAN 'stat -c %Y f || stat -f %m f || echo 0'
+expect "FP pipefail set, explicit"        CLEAN 'set -o pipefail; bash gate.sh | tail -5; rc=$?'
+
+echo "-- adversarial (found by the Axis-2 pass on this guard, 2026-07-31) --"
+# A: grep is line-oriented, so `.*` never spanned a newline and every MULTI-LINE command missed.
+#    This mattered more than the single-line case: the invocations that actually recur in this
+#    project are multi-line. Caught by attacking the guard, not by the happy-path lanes.
+expect "A multi-line pipe then \$?"        HIT   'bash gate.sh | tail -20
+echo "exit=$?"'
+expect "A multi-line, three statements"   HIT   'cd /r
+make test | head -40
+rc=$?'
+expect "A multi-line stays CLEAN if legit" CLEAN 'cd /r
+echo x | grep -q y
+rc=$?'
+# B: zsh accepts `$PIPESTATUS[0]` without braces; the brace-anchored regex missed it.
+expect "B PIPESTATUS without braces"      HIT   'a | b; rc=$PIPESTATUS[0]'
+expect "B braced form still caught"       HIT   'a | b; rc=${PIPESTATUS[0]}'
+
+echo "-- opt-out --"
+expect "noqa suppresses"                  CLEAN 'bash g.sh | tail; rc=$?  # noqa: pipe-verdict'
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "[pipe-verdict-guard] ✅ all $pass known pairs hold"; exit 0
+else
+  echo "[pipe-verdict-guard] ❌ $fail/$((pass+fail)) lanes failed"; exit 1
+fi

--- a/templates/settings.PreToolUse.snippet.json
+++ b/templates/settings.PreToolUse.snippet.json
@@ -1,0 +1,49 @@
+{
+  "_README": [
+    "PreToolUse(Bash) hook snippet — TRACKED, so it arrives with a clone. Every .claude/settings*.json",
+    "path in this repo is gitignored (confirm with `git check-ignore -v .claude/settings.json`), so a",
+    "hook registration cannot itself be tracked. This is the tracked SOURCE that install-wizard merges",
+    "into the user's local settings. Shipping the file is not the same proposition as wiring it — that",
+    "gap is exactly what #204 found (the SessionStart hook existed from 07-05 and the wizard had never",
+    "installed it, for every new user).",
+    "",
+    "WHAT IT GUARDS: reading a verdict from the wrong end of a pipe. `cmd | tail -5; echo $?` reports",
+    "TAIL's status, so a FAILED gate reads as 0 — a degrade toward PASS, the direction that never",
+    "announces itself. Measured 6x in this project 2026-07-29..07-31.",
+    "",
+    "WHY A HOOK AND NOT A FILE LINTER: the plan of record was an S6 class in degrade_direction_scan.sh.",
+    "Hand-verifying every `pipe + $?` in this repo's scripts returned 7 hits, 7 of them CORRECT. True",
+    "positives in shipped files: 0. All 6 recurrences were in interactively-composed commands, which no",
+    "repo scanner reads. The guard belongs where the defect occurs — the Bash call itself.",
+    "",
+    "ADVISORY BY DESIGN: it warns and exits 0. It never blocks a Bash call, because a mis-read verdict",
+    "is re-runnable, and a false block on a developer's own shell trains the --no-verify reflex on the",
+    "hooks that DO guard irreversible surfaces (pre-push destructive-op, pre-commit confidentiality).",
+    "Escalate deliberately with FH_PIPE_VERDICT_BLOCK=1 if a project wants it to bite.",
+    "",
+    "Carries no private path, so it belongs in .claude/settings.json (project-local), not settings.local.json.",
+    "Merge, do not overwrite: preserve any PreToolUse entries the user already has; replace only the FH",
+    "one, keyed by script name.",
+    "",
+    "Verify after wiring (known pair, both directions):",
+    "  bash scripts/test_pipe_verdict_guard_lanes.sh          # 15 pairs, expect all hold",
+    "  printf '%s' '{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"g.sh | tail; rc=$?\"}}' \\",
+    "    | bash scripts/pipe_verdict_guard.sh                 # expect a PIPE-VERDICT R2 warning"
+  ],
+  "project_settings_json": {
+    "hooks": {
+      "PreToolUse": [
+        {
+          "matcher": "Bash",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/pipe_verdict_guard.sh\"",
+              "timeout": 5
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## 결함

`cmd | tail -5; echo $?` 는 **tail 의 상태**를 보고한다. 실패한 게이트가 `exit 0` 으로 읽힌다 — degrade 방향이 PASS 쪽이고, 그 방향은 스스로를 알리지 않는다. 2026-07-29~07-31 사이 **6회 실측**.

## 본론: 계획된 표면이 틀렸다

세션 카드의 처방(N=3 기계화 부채 #2)은 **`scripts/degrade_direction_scan.sh` 에 S6 클래스 추가**였다. 짓기 전에 쟀다.

| 측정 | 결과 |
|---|---|
| 레포 셸 스크립트의 `pipe + $?` 전수 | **7건** |
| 손검증 결과 정상 | **7건** (7건 모두 마지막 단이 검사 대상 그 자체) |
| **출하 파일의 진양성** | **0** |
| 6회 재발이 실제로 산 곳 | **즉석 조립된 Bash 툴 명령** |
| 레포 파일 스캐너가 그중 잡았을 수 | **0 / 6** |

S6 은 진양성 0짜리 프로브가 됐을 것이다. 그건 바로 옆 S5 가 **9/9 오탐** 끝에 자기 주석에 남긴 실패 — *"100% FP 는 정작 중요한 한 건을 무시하도록 훈련시킨다"* — 의 재연이다. 그래서 결함이 실제로 사는 표면인 **Bash 호출 자체**(`PreToolUse`)로 옮겼다. `PreToolUse` 훅은 이 레포에 **아예 없던** 표면이다.

## 규칙 2개, 확신도가 일부러 다르다

- **R1 — 결정론적, 오탐 0.** `$PIPESTATUS[…]` 는 bash 전용. 이 프로젝트 셸은 zsh 라 **빈 문자열**로 전개된다(zsh 는 `$pipestatus[1]`, 1-인덱스). verdict 가 *틀린* 게 아니라 **부재**한다. 판단 개입 없음.
- **R2 — 휴리스틱, 좁힘.** 마지막 단이 **표시 필터**(`tail|head|cat|less|more`)일 때만. 마지막이 `grep -q`·스크립트·서브셸이면 보통 그게 원하는 verdict — 위 7건이 정확히 그 모양이라 **오탐 레인으로 고정**했다.

## advisory 인 이유 (설계 결정)

경고 후 `exit 0`. Bash 호출을 막지 않는다 — 오독된 verdict 는 재실행 가능하고, 개발자 자기 셸에서의 오탐 차단은 **비가역 표면을 지키는 훅**(pre-push Destructive-Op, pre-commit 기밀 스캔)에 `--no-verify` 반사를 훈련시킨다. 의도적 격상은 `FH_PIPE_VERDICT_BLOCK=1`.

---

## 증거 캡슐 (4축)

- **Axis 1** — `regression_guard`: **SKIP**. 게이트 pathspec 에 걸린 파일 없음. **검사 안 함 ≠ 통과** — 카운트하지 않고 명시한다.
- **Axis 2** — ⚠️ **자기검토였다. cross-family 아님.** 이 세션에서 독립 challenger 디스패치가 불가했다. 합의 대신 **기계로 앵커**했다: 적대 패스가 찾은 결함 2건이 **둘 다 회귀 레인으로 고정**돼 있고, 수정 없이는 실패한다.
  - (a) **grep 이 줄 단위**라 **다중행 명령을 전부 놓쳤다** — 재발하는 실제 명령이 다중행이라 이쪽이 더 나쁜 절반이었다
  - (b) zsh 는 **중괄호 없는 `$PIPESTATUS[0]`** 도 받는데 중괄호 앵커 정규식이 놓쳤다
  - 레인 **15 → 20**, **레드 선행 확인**(수정 전 3건 실패), 수정 후 **20/20**. 다중행 형태는 실물 JSON 경로로 재확인.
- **Axis 3** — 근거: 이 세션에서 **전부 재측정**(인용 아님). 레포 7/7 손검증 · S5 의 9/9 오탐 좁힘은 소스 주석에서 직독 · zsh 의 빈 `PIPESTATUS` 는 라이브 실측 · python3 fail-open 은 스텁으로 실측. **phantom 0**.
- **Axis 4** — `edit_manifest.yaml` 2026-07-31 항목.
- **타깃-티어 sim — 면제.** 게이트 자체의 enforcement-column 기준상 훅+스크립트는 **기계적 강제 = 티어 독립**.
- 레포 게이트: `test_pipe_verdict_guard_lanes` · `selfcheck` · `degrade_direction_scan` **전부 exit 0** — 파이프 통하지 않고 직독(이 PR 의 주제가 바로 그거다).

> 마커는 gitignored 로컬 산출물이라 붙여넣지 않았다. 위는 정제된 캡슐이다.

## 명시 잔여

1. **`python3` 고장/부재 → 침묵 (fail-open)** — 스텁으로 실측(`rc=0`, 출력 없음). advisory 라 수용 가능하지만, **`FH_PIPE_VERDICT_BLOCK=1` 로 격상하기 전에 반드시 먼저 닫아야 한다.**
2. **배선은 로컬 전용** — `.claude/settings.json` 이 gitignored 라 등록이 추적되지 않는다. 추적되는 건 스니펫뿐이고 **install-wizard 가 머지해야** 돈다. 이건 #204 가 찾은 갭의 재진술이지 해소가 아니다.
3. **Axis 2 가 same-family** — 위 참조.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CTFuQcRf9i4inv5oTxsMa