### PR TITLE
chore(release): 1.4.79 — files[] 변경분 출하 정렬 (lockstep)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,13 @@
   "plugins": [
     {
       "name": "fh-meta",
-      "version": "1.4.78",
+      "version": "1.4.79",
       "description": "Hub meta-operations toolkit — 35 skills + 7 agents. New in 1.4.53: `fh-codex-doctor` (npm bin) — Codex adapter drift scanner; reads the documented M1/M2/M3 skill tier map + skill/agent source and reports codex-native/adapter-required/claude-native/unclassified per unit, wired into `npm test`/`prepublishOnly` (fail-closed on unclassified Claude-native primitives). New in 1.4.49: steel-quench gains Step 0.6 Verdict-Invariance Probe (groundedness axis — a load-bearing judged gate's verdict must track behavior, not rubric phrasing; measured flip-count over cross-family paraphrases; arXiv:2605.06161 Policy Invariance anchor); multi_model_sidecar_strategy §Vendor-native harness (a model is strongest in its own vendor CLI — Claude/CC, GPT/codex, Gemini/Antigravity; a universal router degrades all of them, so it stays an autocomplete/QA sidecar, never orchestration); predelete_check.sh fail-closed rewrite; memory-hygiene A-TMA anchor. New in 1.4.48: phantom-quench + steel-quench gain external frontier anchors (arXiv:2607.02052 package-hallucination; arXiv:2607.02057 prompt-coverage-adequacy); README model-flat claim reframed from a per-release point-curve to structural invariants (operation flattens across tiers; depth tier-order fixed within a generation). New in 1.4.47: onboarding step ① surfaces the Mode D companion-store session-start load in the auto-read salience anchor (previously only in the local binding + rules, so a greeting could skip the load). New in 1.4.46: context-doctor command-output axis (route to rtk/proxy for verbose CLI stdout, complementing .claudeignore; risk-gated to token-scarce envs). New in 1.4.41: context-doctor 2026 trigger vocab (context engineering/rot/collapse) + phantom-citation hardening; hub measurement-integrity-checklist (cross-model measurement pre-flight: display-name pin/reps≥3/discriminating probe). New in 1.4.40: install-wizard queryable-wiki scaffold (INDEX + session-start read + R/W/C ingest). New in 1.4.39: auto-decorrelation (cross-family verifier sidecar recruitment) + video-ingest (capability-routed video ingestion). New in 1.4.x: verify-axis check-class taxonomy (mandatory-pass/measured/judged), no-reinvention Tier-0 inventory, 7-class failure taxonomy, Destructive-Op Gate, Wave-T (Temper), tier-floor governance, Mode D Model Notice, FC consent lane, default-Sonnet guidance. New in 1.3.0: public-surface-audit, field-harvest Mode B auto-trigger, 4-axis gate scope ext. Validated cross-CLI: Claude Code, Codex, Gemini.",
       "source": "./plugins/fh-meta"
     },
     {
       "name": "fh-commons",
-      "version": "1.4.78",
+      "version": "1.4.79",
       "description": "Project-agnostic utility skills — 4 skills (convergence-loop · deliberation · mcp-circuit-breaker · token-budget-gate) + 1 agent (quench-challenger). Domain-independent utilities transplantable into any project.",
       "source": "./plugins/fh-commons"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrono-meta/fh-gate",
-  "version": "1.4.78",
+  "version": "1.4.79",
   "description": "FH runtime adapters — run FH governance, skills, and agents via Claude or Codex with machine-parseable gates.",
   "license": "MIT",
   "keywords": [

--- a/plugins/fh-commons/.claude-plugin/plugin.json
+++ b/plugins/fh-commons/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-commons",
-  "version": "1.4.78",
+  "version": "1.4.79",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/.claude-plugin/plugin.json
+++ b/plugins/fh-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-meta",
-  "version": "1.4.78",
+  "version": "1.4.79",
   "engines": {
     "claudeCode": ">=1.0.0"
   },


### PR DESCRIPTION
## 왜

머지된 #213 이 `scripts/test_package_coverage_lanes.sh` 를 `package.json` `files[]` 에 추가했다.
버전을 안 올리면 **레지스트리 출하본과 레포가 갈라진다**.

## lockstep 4처 (단일 소스 = `package.json`)

| 파일 | 1.4.78 → |
|---|---|
| `package.json` | 1.4.79 |
| `plugins/fh-meta/.claude-plugin/plugin.json` | 1.4.79 |
| `plugins/fh-commons/.claude-plugin/plugin.json` | 1.4.79 |
| `.claude-plugin/marketplace.json` (plugins[] 2개) | 1.4.79 |

**왜 lockstep 이어야 하나**: Codex 는 `plugin.json` 버전으로 캐시한다. 한쪽만 올리면
한쪽 진입점만 갱신된 상태로 출하된다.

## 검증

- Pre-Publish `public_surface_scan_files.sh` (실제 `npm pack` 출하 파일셋 **전체 내용**) → **PASS, full pattern set**
- 출하 파일셋 202개, 신규 `test_package_coverage_lanes.sh` **포함 확인**
- 잔여 `1.4.78` 문자열 4파일 모두 **0건**

머지 후: `npm publish` → `git tag v1.4.79`

🤖 Generated with [Claude Code](https://claude.com/claude-code)