### PR TITLE
fix(hooks): advisory 경고를 버려지는 채널에서 모델 컨텍스트로 옮긴다 (N=8 봉인)

### DIFF
--- a/scripts/pipe_verdict_guard.sh
+++ b/scripts/pipe_verdict_guard.sh
@@ -29,6 +29,26 @@
 #   reflexes on hooks that DO guard irreversible surfaces. Set FH_PIPE_VERDICT_BLOCK=1 to escalate.
 #   If the command cannot be extracted, it stays silent: an unparsed input is not a finding.
 #
+# DELIVERY CHANNEL (added 2026-07-31 — closes N=8: detection 100%, delivery 0%)
+#   The first shipped version wrote its warning to stderr and exited 0. Per the hook contract
+#   (code.claude.com/docs/en/hooks), on exit 0 stderr is IGNORED and stdout is parsed for JSON —
+#   so the warning reached the transcript, never the model. The actor making the mistake never saw
+#   the guard fire (measured: the guard's own author repeated the guarded mistake twice the day
+#   after shipping it, N=7/N=8).
+#   Advisory now emits JSON on stdout: `hookSpecificOutput.additionalContext` (wrapped by CC in a
+#   system-reminder and injected into MODEL context) + top-level `systemMessage` (shown to the
+#   USER). Two audiences, two fields, one emission.
+#   ⚠️ `permissionDecision` is DELIBERATELY ABSENT: emitting "allow" alongside the warning would
+#   auto-approve the flagged command past the permission system — the guard must never grant what
+#   it exists to question. Block mode keeps the exit-2 path (stderr → fed to Claude, call blocked);
+#   on exit 2 stdout/JSON is ignored by contract, so stderr is the correct channel there.
+#   NAMED RESIDUAL (cross-family, 2026-07-31): with python3 broken/absent, payload extraction
+#   yields CMD="" and the guard exits 0 even under FH_PIPE_VERDICT_BLOCK=1 — block mode fails
+#   open on a dead interpreter. Accepted, not fixed: the Bash-call surface is re-runnable
+#   (reversible → degrade-to-advisory per the Surface-Class Degrade Invariant), and the
+#   alternative — exit 2 whenever python3 is missing — would block EVERY Bash call on such a
+#   machine, the exact false-block storm the advisory design exists to avoid.
+#
 # Usage:
 #   hook:  PreToolUse matcher "Bash" → bash scripts/pipe_verdict_guard.sh
 #   test:  printf '%s' "<command>" | bash scripts/pipe_verdict_guard.sh --stdin-raw
@@ -88,6 +108,32 @@ fi
 
 [ -n "$hits" ] || exit 0
 
+if [ "${FH_PIPE_VERDICT_BLOCK:-0}" = "1" ]; then
+  # Block mode: exit 2 = stderr fed to the model as the blocking reason; stdout ignored by contract.
+  printf '%s' "$hits" >&2
+  exit 2
+fi
+
+# Advisory mode: JSON on stdout, exit 0. additionalContext → model, systemMessage → user.
+# NO permissionDecision — see DELIVERY CHANNEL header. python3 owns the JSON escaping; if it
+# fails, degrade to the old stderr emission (delivery lost, but the call is never disturbed).
+# Capture-then-emit, not stream: a producer that prints partial output and dies must never leave
+# half a JSON object on the hook's stdout (cross-family finding, 2026-07-31). The codec pin must
+# be PYTHONIOENCODING itself — the hits text carries non-ASCII (⚠️), an inherited
+# PYTHONIOENCODING=ascii was measured to kill the emission (silently restoring the exact delivery
+# loss this rewrite closes), and PYTHONUTF8=1 does NOT win over an explicit PYTHONIOENCODING
+# (measured by lane C4: the UTF8-mode pin still emitted 0 bytes under the ascii env).
+json_out=$(printf '%s' "$hits" | PYTHONIOENCODING=utf-8 python3 -c '
+import json, sys
+h = sys.stdin.read()
+print(json.dumps({
+    "systemMessage": h,
+    "hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": h},
+}))
+' 2>/dev/null)
+if [ -n "$json_out" ]; then
+  printf '%s\n' "$json_out"
+  exit 0
+fi
 printf '%s' "$hits" >&2
-if [ "${FH_PIPE_VERDICT_BLOCK:-0}" = "1" ]; then exit 2; fi
 exit 0

--- a/scripts/test_pipe_verdict_guard_lanes.sh
+++ b/scripts/test_pipe_verdict_guard_lanes.sh
@@ -88,6 +88,73 @@ expect "B braced form still caught"       HIT   'a | b; rc=${PIPESTATUS[0]}'
 echo "-- opt-out --"
 expect "noqa suppresses"                  CLEAN 'bash g.sh | tail; rc=$?  # noqa: pipe-verdict'
 
+echo "-- C: delivery channel (closes N=8 — detection without delivery is decoration) --"
+# These lanes assert the CHANNEL, not the detection: per the hook contract, on exit 0 only stdout
+# JSON reaches anyone (additionalContext → model, systemMessage → user); stderr is discarded.
+# A lane that only greps merged output would stay green while the warning goes nowhere — which is
+# exactly the hole the 2026-07-31 rewrite closed. Verdicts are exit codes, not free-form stdout.
+# NAMED RESIDUAL (cross-family LOW, accepted): $(…) capture strips NUL bytes, so a mutant emitting
+# NUL+JSON would pass C1. The producer's hits text is static ASCII+⚠️ with no NUL source, so the
+# lane does not pay for a byte-exact harness; revisit only if the producer ever emits dynamic bytes.
+HIT_CMD='bash x.sh | tail -5; echo "exit=${PIPESTATUS[0]}"'
+payload() { python3 -c 'import json,sys; print(json.dumps({"tool_name":"Bash","tool_input":{"command":sys.argv[1]}}))' "$1"; }
+
+# All C lanes measure ONE invocation: stdout, stderr, and exit code from the same run (a pair of
+# runs can each satisfy half the contract while no single run satisfies it — cross-family finding).
+c_errf=$(mktemp)
+
+# C1 — advisory hit, full hook payload path: stdout must be one JSON object carrying
+#      additionalContext + systemMessage, with permissionDecision ABSENT (emitting "allow" would
+#      auto-approve the flagged command — the guard must never grant what it questions). exit 0.
+c_out=$(payload "$HIT_CMD" | bash "$G" 2>"$c_errf"); c_rc=$?
+c_err=$(cat "$c_errf")
+if [ "$c_rc" -eq 0 ] && printf '%s' "$c_out" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+h = d["hookSpecificOutput"]
+assert h["hookEventName"] == "PreToolUse"
+assert "PIPE-VERDICT" in h["additionalContext"]
+assert "PIPE-VERDICT" in d["systemMessage"]
+assert "permissionDecision" not in h and "permissionDecision" not in d
+' 2>/dev/null; then
+  printf '  ✅ %-52s %s\n' "C1 advisory: stdout JSON, no permissionDecision" OK; pass=$((pass+1))
+else
+  printf '  ❌ %-52s rc=%s out=%s err=%s\n' "C1 advisory: stdout JSON, no permissionDecision" "$c_rc" "$c_out" "$c_err"; fail=$((fail+1))
+fi
+
+# C2 — block mode: exit 2, warning on stderr (stdout JSON is ignored by contract on exit 2).
+c_out=$(payload "$HIT_CMD" | FH_PIPE_VERDICT_BLOCK=1 bash "$G" 2>"$c_errf"); c_rc=$?
+c_err=$(cat "$c_errf")
+if [ "$c_rc" -eq 2 ] && printf '%s' "$c_err" | grep -q 'PIPE-VERDICT' && [ -z "$c_out" ]; then
+  printf '  ✅ %-52s %s\n' "C2 block: exit 2, stderr carries the reason" OK; pass=$((pass+1))
+else
+  printf '  ❌ %-52s rc=%s out=%s err=%s\n' "C2 block: exit 2, stderr carries the reason" "$c_rc" "$c_out" "$c_err"; fail=$((fail+1))
+fi
+
+# C3 — clean command through the full payload path: NO JSON at all (an empty advisory would still
+#      inject an empty reminder every Bash call — silence must stay silent). exit 0.
+c_out=$(payload 'echo hello' | bash "$G" 2>"$c_errf"); c_rc=$?
+rm -f "$c_errf"
+if [ "$c_rc" -eq 0 ] && [ -z "$c_out" ]; then
+  printf '  ✅ %-52s %s\n' "C3 clean: no emission at all" OK; pass=$((pass+1))
+else
+  printf '  ❌ %-52s rc=%s out=%s\n' "C3 clean: no emission at all" "$c_rc" "$c_out"; fail=$((fail+1))
+fi
+
+# C4 — hostile inherited codec: the hits text is non-ASCII (⚠️), and an environment-inherited
+#      PYTHONIOENCODING=ascii was measured (2026-07-31) to abort json.dumps and silently restore
+#      the pre-fix delivery loss. The guard pins PYTHONUTF8=1; this lane keeps that pin honest.
+c_out=$(payload "$HIT_CMD" | PYTHONIOENCODING=ascii bash "$G" 2>/dev/null); c_rc=$?
+if [ "$c_rc" -eq 0 ] && printf '%s' "$c_out" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+assert "PIPE-VERDICT" in d["hookSpecificOutput"]["additionalContext"]
+' 2>/dev/null; then
+  printf '  ✅ %-52s %s\n' "C4 ascii-codec env: JSON still delivered" OK; pass=$((pass+1))
+else
+  printf '  ❌ %-52s rc=%s out=%s\n' "C4 ascii-codec env: JSON still delivered" "$c_rc" "$c_out"; fail=$((fail+1))
+fi
+
 echo
 if [ "$fail" -eq 0 ]; then
   echo "[pipe-verdict-guard] ✅ all $pass known pairs hold"; exit 0


### PR DESCRIPTION
## What

`pipe_verdict_guard.sh`(PreToolUse/Bash 훅)는 탐지 100% · **전달 0%** 였다 — stderr+exit 0 은 훅 계약상 버려지는 채널이다(exit 0 에서는 stdout JSON 만 파싱됨, code.claude.com/docs/en/hooks 로 확인). 가드를 출하한 다음 날 저자 세션이 같은 실수를 두 번 반복(N=7/N=8)한 실측이 출발점.

- Advisory: stdout JSON 이중 채널 — `hookSpecificOutput.additionalContext` → 모델 컨텍스트(system-reminder), `systemMessage` → 운영자.
- `permissionDecision` **의도적 부재**: "allow"를 곁들이면 플래그한 명령을 퍼미션 시스템 너머로 자동 승인하는 역전 — 가드는 자기가 의심하는 것을 허가하면 안 된다. 뮤턴트로 핀.
- Block 모드(`FH_PIPE_VERDICT_BLOCK=1`)는 exit 2+stderr 유지(그 계약에선 stderr가 모델로 가는 정 채널).
- Emission은 capture-then-emit(부분 JSON 방지) + `PYTHONIOENCODING=utf-8` 핀.

## Evidence capsule

- **레인**: 24/24 PASS — 채널 단언 레인 C1–C4 신설 (C1 stdout JSON+permissionDecision 부재 · C2 블록 계약 · C3 침묵 유지 · C4 적대적 ascii 코덱 환경). 판정은 종료코드.
- **뮤턴트**: 3/3 KILLED — emission 비활성 / allow 주입 / 코덱 핀 제거.
- **라이브 실증 2회**: 알려진-양성 명령의 경고가 저작 세션의 모델 컨텍스트에 실제 도착; 이후 가드가 세션의 실제 R2 실수를 실시간 캐치(출하 후 첫 의도-청중 전달).
- **Cross-family (codex gpt-5.6-sol @ high)**: 1 MEDIUM + 4 LOW, 전건 소스검증 후 처리 — 3건 수정(ascii 코덱 킬은 로컬 재현 rc=0/0bytes 후 수정, **1차 수정 `PYTHONUTF8=1`은 레인 C4가 반증**해 `PYTHONIOENCODING`으로 재수정 · 비원자 emission · 레인 2회-호출 술어), 2건 잔여 명명(블록모드 python3-부재 fail-open — 가역 표면이라 Surface-Class Degrade Invariant 근거로 수용 · NUL 레인 맹점 — 정적 producer 텍스트).
- 4축 게이트 PASS (Axis1 훅 · Axis2 cross-family · Axis3 계약 소스검증+라이브파이어 · Axis4 manifest 엔트리).

🤖 Generated with [Claude Code](https://claude.com/claude-code)