### PR TITLE
docs(sidecar): OpenRouter Tier-2 verified-route promotion — model-echo discipline (harvest MED-1)

### DIFF
--- a/knowledge/shared/harness-core/multi_model_sidecar_strategy.md
+++ b/knowledge/shared/harness-core/multi_model_sidecar_strategy.md
@@ -303,7 +303,11 @@ command -v gh >/dev/null 2>&1 && gh copilot --help >/dev/null 2>&1 && echo "tier
 #    model-selectable, so pick a non-Claude model from a Claude host for genuine diversity)
 
 # Tier 2 — native API key (pay-per-use; only if no Tier-1 CLI)
-for k in GEMINI_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY; do
+#   OpenRouter is a VERIFIED Tier-2 route (2026-08-01: a GPT-family audit leg ran 4 calls to
+#   completion when the codex CLI was quota-exhausted — same model, API-shaped). Discipline when
+#   it binds: record the response's model-echo header PER CALL (server-side proof of which model
+#   answered — slug typos silently reroute, the measured agy failure mode; self-report is not it).
+for k in GEMINI_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY OPENROUTER_API_KEY; do
   [ -n "${!k:-}" ] && echo "tier2:$k"
 done
 


### PR DESCRIPTION
## Summary
- Promotes OpenRouter from unlisted to a **verified Tier-2 route** in `multi_model_sidecar_strategy.md`, grounded in the 2026-08-01 measurement: a GPT-family audit leg completed 4 calls via OpenRouter while the codex CLI was quota-exhausted (same model, API-shaped).
- Adds the binding discipline: record the **per-call model-echo header** (server-side proof of which model answered) — self-report is not it; slug typos silently reroute (the measured agy failure mode).
- Adds `OPENROUTER_API_KEY` to the Tier-2 discovery loop.

## Provenance
harvest-loop MED-1 promotion (2026-08-01 afternoon session). 4-axis gate PASS at commit time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rX7G1QR73sg9ajJiAvxvm