### PR TITLE
fix(spec-sync): reverse-verification pilot S-tier fixes — count-free lane refs, noqa whole-payload semantics, ⑤-b spec presence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -728,6 +728,10 @@ it is the **first half of** ⑤. A close-time finding has exactly one landing or
 and there is no remaining moment where appending is the natural move. *Honest scope*: this removes
 the ordering ambiguity, not the reflex; the pre-push gate stays the floor, and on a violation it now
 **names the offending files and prints their last lines** so re-running ⑤ is a delta, not a re-read.
+The check also carries a **⑤-b card-drift probe** (advisory, never blocks): it cross-checks the
+card's *absence claims* against on-disk reality (`session_close_check.sh` ⑤-b block) — surfaced
+here because an implemented-and-lane-tested step that no spec document names is exactly the
+orphan-implementation class the 2026-08-01 reverse-verification pilot flagged (P2-08).
 
 **Mid-session card writes are drafts**: If a task (e.g., a calibration run) internally updates
 the card, that is a draft. The close chain always re-runs ⑤ to capture post-draft activities.

--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -608,3 +608,17 @@
   outcome: accepted
   evidence: "Guard R1: 7 bypass + 3 FP classes, JSON-contract violations 0; 3 findings overlapped challenger = independent convergence; 1 suggestion (start-anchoring) refuted with recorded reason, later PARTIALLY vindicated by live prose FPs — resolved with leading-separator class instead of command-position anchor. qasp R1: HIGH status-enum hole independently converged with governor read; core_override_flag requiredness grounded in contract §105 before acting. R2: 5/5 CLOSED, CONVERGED."
   note: "codex unavailable (~8/6); agy carried the cross-family leg for both FH and qasp reviews, mirroring the 07-31 panel precedent."
+- date: 2026-08-01
+  agent: headless claude -p (scratchpad cwd — context-decorrelated audit leg)
+  task: "qasp reverse-verification Run #1: Protocol #2/#4/#5 audit of FH guard+close-chain slice, 21 black-box TCs executed"
+  mode: headless -p, workspace-confined, FH CLAUDE.md not loaded (decorrelation by cwd)
+  outcome: accepted
+  evidence: "CALIBRATED (KP4 re-derived AND executed via TC-DG-03; known-negative FP 0; self-FP-tagged 1). 10 findings -> governor source-ground: 7 novel-grounded (3 S fixed same-evening 2711e0a), 2 rejected as governor corpus-feeding artifacts (agent itself marked both 미확인 — honest). Dynamic leg 17/21 PASS."
+  note: "First field->meta reverse verification. Rejection cause was the governor's slice construction, not the instrument — lesson registered in run report."
+- date: 2026-08-01
+  agent: fh-meta:challenger (in-session isolated)
+  task: "Axis-2 adversarial pass on spec-sync diff (3 fixes from Run #1)"
+  mode: sync Agent dispatch, read-only, 4 attack angles
+  outcome: accepted
+  evidence: "M0/S1/R3. S = same-class stale phrasing in destructive_pre_gate.sh:63 usage comment ('single command') that the diff itself existed to eliminate — fixed same branch. All 4 angles returned evidence, not assertion (grep :83, 3 suite counter prints, JSON tool, ⑤-b never-FAIL)."
+  note: "Angle ④ surfaced an accepted trade: count-free refs lose lane-deletion detection — mechanical suite-internal floor named as the right home if wanted."

--- a/scripts/destructive_pre_gate.sh
+++ b/scripts/destructive_pre_gate.sh
@@ -60,7 +60,8 @@
 # Usage:
 #   hook:  PreToolUse matcher "Bash" → bash scripts/destructive_pre_gate.sh
 #   test:  printf '%s' "<command>" | bash scripts/destructive_pre_gate.sh --stdin-raw
-# Opt out on a single command with a trailing `# noqa: destructive-op`.
+# Opt out with `# noqa: destructive-op` — exempts the ENTIRE Bash payload (whole-command match,
+# see PRECISION OVER RECALL above), not a single line.
 
 set -u
 

--- a/templates/settings.PreToolUse.snippet.json
+++ b/templates/settings.PreToolUse.snippet.json
@@ -26,7 +26,7 @@
     "one, keyed by script name.",
     "",
     "Verify after wiring (known pair, both directions):",
-    "  bash scripts/test_pipe_verdict_guard_lanes.sh          # 15 pairs, expect all hold",
+    "  bash scripts/test_pipe_verdict_guard_lanes.sh          # expect: all known pairs hold (count is self-reported by the suite — do not pin it here, it rots)",
     "  printf '%s' '{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"g.sh | tail; rc=$?\"}}' \\",
     "    | bash scripts/pipe_verdict_guard.sh                 # expect a PIPE-VERDICT R2 warning",
     "",
@@ -38,9 +38,11 @@
     "counterweight is mechanical. Net-new coverage is the LOCAL destructive ops no git hook sees;",
     "the pre-push hook remains the hard floor for the push-time surface (role deconfliction in the",
     "script header). Advisory by design, same contract as pipe_verdict_guard (additionalContext +",
-    "systemMessage, no permissionDecision); escalate with FH_DESTRUCTIVE_BLOCK=1. Opt out per",
-    "command with `# noqa: destructive-op`.",
-    "  bash scripts/test_destructive_pre_gate_lanes.sh        # 99 pairs, expect all hold",
+    "systemMessage, no permissionDecision); escalate with FH_DESTRUCTIVE_BLOCK=1. Opt out with",
+    "`# noqa: destructive-op` — the opt-out exempts the ENTIRE Bash payload (whole-command match),",
+    "not a single line: a multi-statement payload with a destructive line 1 and a noqa on line 2 is",
+    "fully exempt (accepted advisory-surface residual — see the script header's PRECISION OVER RECALL list).",
+    "  bash scripts/test_destructive_pre_gate_lanes.sh        # expect: all known pairs hold (count self-reported)",
     "",
     "THIRD GUARD, Write matcher — stale_clone_guard.sh (added 2026-08-01, fh_signal_2026-07-31):",
     "advisory when a NEW file is created inside a git clone that is behind its upstream (fetch +",
@@ -48,7 +50,7 @@
     "built on a 46-PR-behind clone and manufactured a duplicate of an upstream lane. found→extend",
     "applies at repo level; this is its mechanical layer. Same advisory contract; fail-open on",
     "every uncertainty (non-repo, no upstream, fetch failure).",
-    "  bash scripts/test_stale_clone_guard_lanes.sh           # 10 pairs, expect all hold"
+    "  bash scripts/test_stale_clone_guard_lanes.sh           # expect: all known pairs hold (count self-reported)"
   ],
   "project_settings_json": {
     "hooks": {


### PR DESCRIPTION
## Summary
S-tier fixes from the 2026-08-01 qasp reverse-verification Run #1 (field→meta pilot, CALIBRATED, 7 novel-grounded findings), plus the session's subagent invocation log entries.

- **CLAUDE.md**: names the ⑤-b card-drift probe in the close-chain spec — an implemented-and-lane-tested step no spec document named (orphan-implementation class, finding P2-08).
- **destructive_pre_gate.sh**: usage comment corrected — `# noqa: destructive-op` exempts the **entire Bash payload** (whole-command match), not a single line. Includes the challenger's same-class catch at :63.
- **settings.PreToolUse.snippet.json**: lane-suite counts un-pinned (`15/99/10 pairs` → "count self-reported by the suite — pinned counts rot") + noqa whole-payload semantics spelled out with the accepted advisory-surface residual.
- **subagent_invocations_log.yaml**: 2 entries — headless decorrelated audit leg (Run #1) + Axis-2 challenger pass (M0/S1/R3).

## Provenance
Run #1 report: fh-be `tracks-meta/qasp_reverse_verification_run_2026-08-01.md`. 4-axis full gate PASS at commit time (2711e0a). Known trade (challenger angle ④): count-free refs lose lane-deletion detection — mechanical home named if wanted (suite-internal expected≥N floor), carried on the session card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rX7G1QR73sg9ajJiAvxvm