### PR TITLE
fix(guards): codex leg-C HIGH 3 — option-before-pathspec bypass, advisory-timing honesty, input-extraction utf-8 pin

### DIFF
--- a/scripts/destructive_pre_gate.sh
+++ b/scripts/destructive_pre_gate.sh
@@ -75,7 +75,7 @@ import json,sys
 try: d = json.load(sys.stdin)
 except Exception: sys.exit(0)
 if d.get("tool_name") != "Bash": sys.exit(0)
-sys.stdout.write(d.get("tool_input", {}).get("command", "") or "")
+sys.stdout.buffer.write((d.get("tool_input", {}).get("command", "") or "").encode("utf-8"))
 ' 2>/dev/null) || CMD=""
 fi
 [ -n "$CMD" ] || exit 0
@@ -124,6 +124,16 @@ FLAT=$(printf '%s' "$FLAT" | sed -E 's/git clean( +--?[a-zA-Z][a-zA-Z=-]*)* +(-[
 # alternation sees the canonical spelling (GPT-round; brace-expansion globs stay a residual).
 FLAT=$(printf '%s' "$FLAT" | sed -E 's/(\.\/)+/.\//g')
 
+# Staged-only restore neutralizer (GPT leg-C round, 2026-08-01): `git restore --staged .` only
+# unstages (worktree untouched, re-addable) — the broadened restore-dot row below would FP on it.
+# Neutralize ONLY when --staged is present AND no worktree flag is (staged+worktree IS destructive
+# and the -W/--worktree row catches it). Whole-payload rewrite: a compound payload mixing a
+# staged-only restore with a plain destructive restore is a named residual (rare shape).
+if printf '%s' "$FLAT" | LC_ALL=C grep -qE 'git restore [^|;&]*--staged' \
+   && ! printf '%s' "$FLAT" | LC_ALL=C grep -qE 'git restore [^|;&]*(--worktree|-[a-zA-Z]*W)'; then
+  FLAT=$(printf '%s' "$FLAT" | sed -E 's/git restore /git restore_stagedonly /g')
+fi
+
 # ── Destructive pattern table: regex@@description ─────────────────────────────────────────────
 # Delimiter is @@ because the regexes themselves carry `|` (alternation) — a `|` delimiter
 # truncated every alternation-bearing pattern at split time (caught by the known-pair lanes on
@@ -138,9 +148,9 @@ FLAT=$(printf '%s' "$FLAT" | sed -E 's/(\.\/)+/.\//g')
 PATTERNS=(
   '[ (/]git reset ([^|;&]* )?--hard[ ;]@@git reset --hard discards ALL uncommitted changes irreversibly'
   '[ (/]git clean ([^|;&]* )?(--force[ ;]|-[a-zA-Z]*[fxX][a-zA-Z]*[ ;])@@git clean -f/-x permanently deletes untracked files'
-  '[ (/]git checkout ([^|;&]*-- )?\.\/? @@git checkout . reverts every local modification'
+  '[ (/]git checkout ([^|;&]* )?\.\/? @@git checkout . reverts every local modification'
   '[ (/]git restore ([^|;&]* )?(--worktree|-[a-zA-Z]*W[a-zA-Z]*[ ;])@@git restore --worktree reverts working-tree changes'
-  '[ (/]git restore \.\/? @@git restore . reverts every local modification'
+  '[ (/]git restore ([^|;&]* )?\.\/? @@git restore . reverts every local modification'
   '[ (/]git push ([^|;&]* )?(--force(-with-lease(=[^ ;]+)?)?[ ;]|-[a-zA-Z]*f[a-zA-Z]*[ ;]|\+[^ ;]+[ ;])@@force push rewrites remote history (pre-push hook will also gate this — enumerate first)'
   '[ (/]git branch ([^|;&]* )?(-[a-zA-Z]*D[ ;]|--delete( [^|;&]*)? --force[ ;]|--force( [^|;&]*)? --delete[ ;])@@git branch -D force-deletes a branch without merge check'
   '[ (/]git stash (drop|clear)[ ;]@@git stash drop/clear permanently discards stashed work'
@@ -162,7 +172,9 @@ for entry in "${PATTERNS[@]}"; do
 done
 [ -n "$hits" ] || exit 0
 
-hits="${hits}      Before running: is uncommitted/stashed state enumerated (git status / predelete_check.sh)?
+hits="${hits}      Advisory timing: this context reaches the model on the NEXT turn — the call may have
+      already run (pre-action blocking = FH_DESTRUCTIVE_BLOCK=1). If it ran un-enumerated,
+      recover FIRST: git status / git stash list / git reflog / predelete_check.sh.
       Destructive-Op Gate order: enumerate → recover → destroy — never destroy-then-check.
       Intentional and reviewed → re-run with trailing \`# noqa: destructive-op\`."
 

--- a/scripts/pipe_verdict_guard.sh
+++ b/scripts/pipe_verdict_guard.sh
@@ -67,7 +67,7 @@ import json,sys
 try: d = json.load(sys.stdin)
 except Exception: sys.exit(0)
 if d.get("tool_name") != "Bash": sys.exit(0)
-sys.stdout.write(d.get("tool_input", {}).get("command", "") or "")
+sys.stdout.buffer.write((d.get("tool_input", {}).get("command", "") or "").encode("utf-8"))
 ' 2>/dev/null) || CMD=""
 fi
 [ -n "$CMD" ] || exit 0

--- a/scripts/stale_clone_guard.sh
+++ b/scripts/stale_clone_guard.sh
@@ -41,7 +41,7 @@ import json,sys
 try: d = json.load(sys.stdin)
 except Exception: sys.exit(0)
 if d.get("tool_name") != "Write": sys.exit(0)
-sys.stdout.write(d.get("tool_input", {}).get("file_path", "") or "")
+sys.stdout.buffer.write((d.get("tool_input", {}).get("file_path", "") or "").encode("utf-8"))
 ' 2>/dev/null) || FILE=""
 [ -n "$FILE" ] || exit 0
 
@@ -85,7 +85,8 @@ case "$BEHIND" in ''|*[!0-9]*) exit 0 ;; esac
 MSG="  ⚠️  STALE-CLONE $ROOT is behind $UPSTREAM by $BEHIND commit(s).
       Building on a stale clone manufactures duplicates of work that already exists upstream
       (measured: a 46-PR-behind clone rebuilt an existing lane, 2026-07-31).
-      Before creating new files here: git -C $ROOT pull --ff-only  (or rebase your branch).
+      Advisory timing: this notice arrives with the Write already evaluated — reconcile NOW,
+      before the next file: git -C '$ROOT' pull --ff-only  (or rebase your branch).
       found→extend applies at repo level too — check what upstream already has."
 
 if json_out=$(printf '%s' "$MSG" | PYTHONIOENCODING=utf-8 python3 -c '

--- a/scripts/test_destructive_pre_gate_lanes.sh
+++ b/scripts/test_destructive_pre_gate_lanes.sh
@@ -218,6 +218,28 @@ else
   printf '  ❌ %-52s rc=%s out=%s\n' "C5 non-Bash payload: silent" "$c_rc" "$c_out"; fail=$((fail+1))
 fi
 
+echo "-- GPT leg-C round (2026-08-01): option-before-pathspec + staged-only + unicode-input --"
+expect "checkout -f . (leg-C bypass)"              HIT   'git checkout -f .'
+expect "restore --source=HEAD . (leg-C bypass)"    HIT   'git restore --source=HEAD .'
+expect "restore -s HEAD ."                         HIT   'git restore -s HEAD .'
+expect "restore --staged . is CLEAN (unstage only)" CLEAN 'git restore --staged .'
+expect "restore --staged --worktree ."             HIT   'git restore --staged --worktree .'
+expect "checkout .gitignore still CLEAN"           CLEAN 'git checkout .gitignore'
+
+# C6 — unicode command + ascii-codec env: the INPUT extractor must survive (leg-C HIGH #8 —
+# output encoder was pinned, input was not; a non-ASCII char anywhere in the payload emptied CMD
+# and the guard failed CLEAN-open).
+c_out=$(python3 -c 'import json;print(json.dumps({"tool_name":"Bash","tool_input":{"command":"git reset --hard # 한글 주석"}}))' | PYTHONIOENCODING=ascii bash "$G" 2>/dev/null); c_rc=$?
+if [ "$c_rc" -eq 0 ] && printf '%s' "$c_out" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+assert "DESTRUCTIVE-OP" in d["hookSpecificOutput"]["additionalContext"]
+' 2>/dev/null; then
+  printf '  ✅ %-52s %s\n' "C6 unicode cmd + ascii env: still HIT" OK; pass=$((pass+1))
+else
+  printf '  ❌ %-52s rc=%s out=%s\n' "C6 unicode cmd + ascii env: still HIT" "$c_rc" "$c_out"; fail=$((fail+1))
+fi
+
 echo
 if [ "$fail" -eq 0 ]; then
   echo "[destructive-pre-gate] ✅ all $pass known pairs hold"; exit 0


### PR DESCRIPTION
## What

Cross-family (GPT leg) audit of the three shipped PreToolUse/Write guards reopened a 133-lane-green surface with 3 HIGH findings; this PR closes all three, each with mechanical regression lanes.

1. **Option-before-pathspec bypass** — `git checkout -f .` and `git restore --source=HEAD .` returned CLEAN (rows only allowed a `-- ` prefix / no prefix). Rows broadened to allow option tokens; a **staged-only neutralizer** keeps `git restore --staged .` CLEAN (unstage is re-addable — FP precision guard), while `--staged --worktree .` still HITs via the worktree row. Compound payload mixing staged-only + destructive restore = named residual in-file.
2. **Advisory-timing honesty** — both guard messages said "Before running/creating", but PreToolUse `additionalContext` reaches the model on the NEXT turn; an allowlisted destructive command completes before the warning arrives. Messages now state the real contract and route to recovery first (`FH_DESTRUCTIVE_BLOCK=1` remains the pre-action option).
3. **Input-extraction encoding fail-open** — output encoders were utf-8-pinned but the stdin extractors were not: under `PYTHONIOENCODING=ascii`, any non-ASCII char in the payload emptied `CMD` and the guard exited CLEAN. All three extractors now use `sys.stdout.buffer.write(...encode("utf-8"))`.

## Evidence capsule

- Finder: codex (session-header `gpt-5.6-sol`, reasoning high), missed-by-both pass with named residuals excluded; verdict "reopen CONVERGED" (HIGH 3 / MED 5 / LOW 1).
- Governor reproduced HIGH #1 by known-pair **before** fixing: `checkout -f .` = CLEAN (bug), `checkout -- .` = HIT (control).
- Every fix ships a regression lane (7 new pairs, incl. CLEAN-direction pairs and a unicode-command × ascii-env lane). Suites: destructive 106, pipe 24, stale 10 — all green, exit codes captured directly.
- MED 5 + LOW 1 registered in the session signal backlog (not in scope here, per operator instruction).

LOCAL-ONLY ATTESTATION — UNVERIFIED: axes marker + signal records live in gitignored tracks/_meta on the author machine (record: axes marker fix_guard-high3-codex-legc 2026-08-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)