### PR TITLE
fix(consent): 승인 게이트의 fail-open 을 닫는다 — 회수된 R9 리뷰를 실행으로 옮김

### DIFF
--- a/knowledge/shared/rules/operational_adaptation.md
+++ b/knowledge/shared/rules/operational_adaptation.md
@@ -75,10 +75,20 @@ referent. Record the human-readable grounds in the body, the value in the frontm
 
 **Mechanical floor**: `scripts/consent_registry_check.sh` — joins `standing_consent` against the
 registry and enforces schema, eligibility soundness (a class naming an irreversible or unlisted sink
-**cannot** declare itself promotable), registration, expiry, and recorded scope. Missing registry → N/A
-+ promotion disabled; unparseable → fail-closed. Run it before trusting any grant; the prose above is
+**cannot** declare itself promotable), registration, expiry, and the full recorded scope
+(owner · mode · target · effects · sinks).
+
+**Read the exit code, never the printed words** — the code is the only machine-readable channel, and
+prose that says "DISABLED" disables nothing: **`0` = VERIFIED** (a real grant was joined; the ONLY code
+on which a prompt may be skipped) · **`3` = UNMEASURED** (nothing to join — no registry, zero classes,
+no UAP, **or a UAP recording no active grant**: keep asking) · **`1` = BROKEN** (unparseable or invalid;
+cannot decide == not allowed). `if scripts/consent_registry_check.sh; then run_unprompted; fi` is
+**wrong** — it reads 3 as success. Test `-eq 0` explicitly.
+
+Run it before trusting any grant; the prose above is
 the salience layer over this check, not the enforcement. Anchor: `scripts/test_consent_registry.sh`
-(64 lanes, incl. the `F*` storage-form lanes). Four mutants were run against it — each false-clean
+(75 lanes, incl. the `F*` storage-form lanes and the round-9 `P-F3*`/`D3*` fingerprint + exit-channel
+lanes; each `P`/`D` lane was measured returning the fail-open verdict against the pre-fix script). Four mutants were run against it — each false-clean
 net, the fence regex, and the falsy-laundering guard — and each turned its lanes red, so the green is
 measured rather than assumed. Cross-family review found the first draft's green was partly vacuous
 (one lane called `ok` in both branches; three others passed via a path other than the one they named).
@@ -103,7 +113,17 @@ sessions from the UAP outcome log. Refinements that keep the count honest:
 The offer **quotes the three approvals and the exact scope**; a grant the user cannot audit is not
 consent. Then:
 
-- **granted** → write `standing_consent: <class>: {granted: <date>, expires: <date+N>, effects: [...]}`.
+- **granted** → write `standing_consent: <class>: {granted: <date>, expires: <date+N>, owner: <gate/skill>,
+  mode: <mode>, target: <target scope>, effects: [...], sinks: [...]}`.
+  **All five scope fields are mandatory, not illustrative** — they are the fingerprint §Consent binds to
+  the action's SHAPE requires, and `scripts/consent_registry_check.sh` R6 refuses a grant missing any of
+  them (a fingerprint that omits a field cannot detect drift in that field). `sinks: []` is a real
+  recorded fingerprint, not an omission. *Origin (cross-family round 9, 2026-07-31)*: this line listed
+  only `effects`, so the shape a grant was told to write did not contain the fields the same document's
+  fingerprint rule binds to — and the checker, written from this line, read only what it listed. A
+  class's `owner` or `mode` could then be swapped underneath a live grant and the required re-ask never
+  fired. When the write-instruction and the invariant disagree, the write-instruction wins in practice,
+  because it is the one someone follows.
   Later instances run unprompted, each **states in one line what it did**, and each **appends a durable
   entry to `tracks/_meta/consent_runs.log`**. *Post-action chat notice is not a control* (cross-family
   round 2): a line the user scrolls past has stopped the prompt without replacing it. The chat line is
@@ -139,10 +159,13 @@ Their cost is not the prompt, it is that the thing cannot be undone — grain-in
 answer "yes" to once, knowingly and in scope, which is why it does not contradict the "acceptance alone
 never auto-runs" rule above.
 
-**Degrade direction (fail-closed), three ways**: no UAP (ephemeral/cloud session, wiped profile) → **no
-promotion, keep asking**. No registry entry → **no promotion, keep asking**. Expired or unparseable
+**Degrade direction (fail-closed), four ways**: no UAP (ephemeral/cloud session, wiped profile) → **no
+promotion, keep asking**. No registry entry → **no promotion, keep asking**. A UAP that exists but
+records **no active grant** — empty, or holding only `declined`/`revoked`/`unset` — → **no promotion,
+keep asking** (this is the same state as the two above and gets the same answer; it was the one branch
+that used to report success). Expired or unparseable
 record → **`unset`, keep asking**. A missing consent record is never `granted` — an absent measurement is
-not a yes.
+not a yes, and a refusal is never the reason a prompt is skipped.
 
 **Named residual — the ledger is self-attested (cross-family, 2026-07-29, HIGH, NOT closed).** The UAP
 outcome log is written by the same agent that benefits from fewer prompts, and it is gitignored, so there
@@ -158,9 +181,12 @@ on the assumption the ledger is trustworthy.**
 a class name is a string, and the action behind it can change after consent is granted. A sim that
 merely returned a report when you said "stop asking" may, ten sessions later, write into shared memory
 and trigger a downstream commit — same label, different blast radius, HITL skipped. So a grant records
-**what it was granted for**: the owning gate/skill, and the set of **effect classes** the action had at
+**what it was granted for**: the owning gate/skill (`owner`) **and its `mode`** — the two fields that say
+*who* acts and *what it does* when it acts — and the set of **effect classes** the action had at
 grant time (reads · local writes · network · dispatch · repo-mutation) **plus the `target` scope and
-the `sinks` fingerprint**. On any later run whose fingerprint is **not a subset** of the granted one,
+the `sinks` fingerprint**. That is the same five-field scope the offer above quotes to the user, and the
+same five `consent_registry_check.sh` R6/R7 enforce; the three lists must not drift apart. On any later
+run whose fingerprint is **not a subset** of the granted one,
 standing consent **reverts to `unset` and asks again**, naming what widened. Effect classes alone are
 too coarse to be the whole test (cross-family round 2): "local write" stays "local write" whether the
 target is a scratch report or a policy file — the *target* is where that drift shows, which is why it

--- a/scripts/consent_registry_check.sh
+++ b/scripts/consent_registry_check.sh
@@ -16,8 +16,11 @@
 #   R3  join     — every standing_consent key resolves to a registered class
 #   R4  floor    — every standing_consent key resolves to a promotion_eligible class
 #   R5  lease    — every grant carries `expires` and is not past it
-#   R6  scope    — every grant records `effects` AND `target`, so the subset check has something to
+#   R6  scope    — every grant records the FULL fingerprint the rule binds consent to — `owner`,
+#                  `mode`, `effects`, `target`, `sinks` — so the subset check has something to
 #                  compare against (a grant whose scope was never recorded cannot be re-validated)
+#   R7  drift    — the recorded fingerprint still matches the registry: effects ⊆ capabilities,
+#                  target/owner/mode identical, and the class's current `sinks` ⊆ the granted ones
 #
 # WHAT IT DOES *NOT* CHECK (named, so the prose above it cannot over-claim)
 #   - the effect-SUBSET comparison itself. R6 proves a baseline was recorded; it does not compare a
@@ -70,7 +73,7 @@ REG="${1:-$ROOT/tracks/_meta/consent_classes.yaml}"
 UAP="${2:-$ROOT/tracks/_meta/user_adaptation_profile.md}"
 
 python3 - "$REG" "$UAP" <<'PY'
-import sys, os, re, datetime
+import sys, os, re, datetime, unicodedata
 reg_path, uap_path = sys.argv[1], sys.argv[2]
 
 def out(sym, msg): print(f"  {sym} {msg}")
@@ -98,9 +101,19 @@ def _no_dup(loader, node, deep=False):
     # a merge key exited 1 as an unregistered class). Over-blocking is not a safety win — it trains
     # the override reflex and turns the gate into decoration, so it counts as a defect like any
     # fail-open.
-    loader.flatten_mapping(node)
+    # ORDER MATTERS. Duplicates are detected over the node's OWN keys, BEFORE merge resolution —
+    # then the merge is resolved. Running flatten_mapping first put the anchor's keys and the
+    # explicit keys into one list, so a canonical YAML override (`<<: *d` then `target: t`) looked
+    # like a duplicate and a legitimate grant was refused. YAML merge semantics are explicit that
+    # the explicit key WINS; refusing it is us disagreeing with the format, not catching a defect.
+    # This is a reorder plus skipping the `<<` key itself — NOT the full-file parser rewrite that
+    # regressed 16 of 41 lanes and was reverted. A literal duplicate in one mapping still fails.
+    # (Pinned as K1 over-block for two rounds; closed 2026-08-02 once the lane count made the change
+    # verifiable — 85 lanes, both directions mutation-checked.)
     seen = set()
     for k, _ in node.value:
+        if getattr(k, "tag", "") == "tag:yaml.org,2002:merge":
+            continue                      # the `<<` key is a directive, not a data key
         key = loader.construct_object(k, deep=deep)
         try:
             if key in seen:
@@ -108,6 +121,7 @@ def _no_dup(loader, node, deep=False):
         except TypeError:
             pass
         seen.add(key)
+    loader.flatten_mapping(node)
     return yaml.SafeLoader.construct_mapping(loader, node, deep)
 
 NoDupLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_dup)
@@ -126,6 +140,17 @@ reg = load(open(reg_path), "registry")
 REQUIRED = ["name", "owner", "mode", "target", "capabilities", "sinks", "feeds", "promotion_eligible"]
 STR_FIELDS = ["name", "owner", "mode", "target"]
 IRREVERSIBLE = {"go-public", "publish", "delete", "history-rewrite", "unknown"}
+# The closed vocabulary. Anything outside it is UNKNOWN, and unknown is not reversible (the floor's
+# own words). Kept next to IRREVERSIBLE so the two cannot drift apart. All entries are pre-normalised
+# (lower-case) because _norm case-folds both sides.
+# READ FROM THE SOURCE, not invented: templates/consent_classes.yaml.example line 52 and
+# operational_adaptation.md line 51 both enumerate capabilities as
+# `read · local-write · network · dispatch · repo-mutation`. The irreversible names are unioned in
+# because they may legally APPEAR in a capabilities list — that is exactly what R2-b exists to catch,
+# so they must be recognised rather than flagged as unknown.
+# (First draft of this set was guessed and broke 61 of 76 lanes: it invented `write`/`publish` as
+# capabilities and omitted `repo-mutation`. The vocabulary lives in two files; read them.)
+KNOWN_EFFECTS = {"read", "local-write", "network", "dispatch", "repo-mutation"} | IRREVERSIBLE
 NON_GRANT = {"declined", "unset", "revoked"}
 MAX_LEASE_DAYS = 365
 
@@ -133,7 +158,34 @@ MAX_LEASE_DAYS = 365
 # an identifier, not prose) and whitespace-insensitive; the point is that one function decides, so
 # the two sides of a comparison can never drift apart.
 def _norm(s):
+    # IDENTITY / SCOPE comparison. Strip surrounding whitespace and NOTHING ELSE. Case, width and
+    # invisible characters are all REAL DIFFERENCES here: `OwnerOne` is not `ownerone`, and a target
+    # carrying a zero-width space is not the target without it. A difference the comparison cannot
+    # see is a re-ask that never fires.
+    #
+    # WHY THIS IS BACK TO STRIP-ONLY (2026-08-02): a previous session left a residual — "_norm does
+    # not case-fold, so `History-Rewrite` evades the irreversible floor" — and explicitly warned that
+    # case-folding would change R7's semantics and needed its own change. A cross-family round proved
+    # the fail-open was real, so I case-folded _norm — and the very next round measured the predicted
+    # consequence: owner/mode/target drift stopped being detected. The evidence was right and the
+    # warning was right; what was wrong was using ONE normalizer for two different questions.
     return str(s).strip()
+
+
+def _norm_vocab(s):
+    # VOCABULARY matching only — is this token one of the known / irreversible effect classes? Here
+    # case, width and invisible characters are NOISE, not signal: `History-Rewrite`, `history-rewrite`
+    # and a zero-width-suffixed variant all name the same irreversible surface, and treating them as
+    # distinct is what let a history-rewrite class declare itself promotable.
+    #
+    # TWO NORMALIZERS IS THE POINT, NOT A SLIP. The known trap is two normalizers for the SAME
+    # question drifting apart in leniency (one accepts what the other silently drops). These answer
+    # DIFFERENT questions — "are these the same identity?" vs "is this token in this closed set?" —
+    # and each is used for exactly one of them. Keep it that way: if a third call site appears, decide
+    # which question it is asking before picking.
+    t = unicodedata.normalize("NFKC", str(s))
+    t = "".join(ch for ch in t if unicodedata.category(ch) not in ("Cf", "Cc"))
+    return t.strip().casefold()
 
 # H1 FALSY CONTAINERS. `reg or {}` / `classes or []` laundered `false`, `0`, `[]` and a bare
 # `classes:` into a valid-empty registry that exited 0 — the same falsy-collapse defect already
@@ -151,9 +203,13 @@ if classes is None:
 if not isinstance(classes, list):
     print(f"consent-registry: FAIL — `classes` is {type(classes).__name__}, not a list; fail-closed")
     sys.exit(1)
-if not classes:
-    print("consent-registry: N/A — registry declares zero classes; promotion DISABLED (not a PASS)")
-    sys.exit(3)   # UNMEASURED, not verified — see EXIT CONTRACT
+ZERO_CLASSES = not classes
+# The zero-class verdict is DEFERRED, not decided here. Deciding it early required peeking at the
+# profile with a second, weaker parser (a bespoke frontmatter regex, a bare non-empty-dict test), and
+# two parsers for one file disagree by construction — measured: `--- # metadata` and
+# `standing_consent: []` and a declined-only profile each got the wrong code. One parser, one answer.
+# The main body below reads the profile properly; the verdict is taken at the end with everything
+# else. (cross-family round 2, 2026-08-02 — same lesson as collapsing three write paths into one.)
 
 by_name = {}
 for i, c in enumerate(classes):
@@ -219,7 +275,16 @@ for i, c in enumerate(classes):
     # floor into decoration. Residual, named rather than fixed here: _norm strips whitespace but
     # does NOT case-fold, so `History-Rewrite` still evades BOTH R2-b and R7 — case-folding would
     # change R7's semantics too and belongs in its own change with its own lanes.
-    cap_bad = {_norm(x) for x in (c["capabilities"] or [])} & IRREVERSIBLE
+    caps_n = {_norm_vocab(x) for x in (c["capabilities"] or [])}
+    cap_bad = caps_n & IRREVERSIBLE
+    # CLOSED vocabulary. An effect class nobody enumerated cannot be judged reversible, and the floor
+    # already says unknown is not reversible — so an unrecognised capability is treated as one.
+    # Without this, a typo (`local-wrtie`) or a novel string silently classified itself as safe.
+    unknown_caps = caps_n - KNOWN_EFFECTS
+    if c["promotion_eligible"] and unknown_caps:
+        out("❌", f"R2-c `{nm}` promotion_eligible:true with capabilities outside the declared "
+                  f"vocabulary {sorted(unknown_caps)} — unknown is not reversible")
+        fails += 1
     if c["promotion_eligible"] and bad:
         out("❌", f"R2 `{nm}` claims promotion_eligible:true but sinks/feeds include {sorted(bad)}")
         fails += 1
@@ -345,10 +410,23 @@ else:
                 out("❌", f"R3 standing_consent is not a mapping ({type(grants).__name__}); fail-closed")
                 fails += 1; grants = None
 
+no_active_grant = False
 if grants is None:
     pass
 elif not grants:
-    out("✅", "R3-R6 no standing consent recorded (nothing to validate)")
+    # F4-b (2026-07-31, same round, same principle, a path F4's fix did not reach). F4 gave
+    # "nothing to join" its own exit code for a MISSING registry, ZERO classes and a MISSING UAP —
+    # and left a present UAP holding ZERO grants returning 0. That is the identical state judged by
+    # two different codes: lane D1-d already asserts in its own name that "no grants is not a
+    # verified pass", and the EXIT CONTRACT at the top of this file already defines 3 as "there was
+    # nothing to join". The code disagreed with both. A caller writing the conventional
+    #     if scripts/consent_registry_check.sh; then run_unprompted; fi
+    # therefore ran unprompted against a UAP that had granted it nothing at all — the exact
+    # conversion of "keep asking" into "success" that F4 exists to stop, one branch over.
+    # Not a failure and not painted red: N/A, exit 3, keep asking.
+    print("consent-registry: N/A — registry is well-formed but NO standing consent is recorded; "
+          "nothing granted, keep asking (not a PASS)")
+    no_active_grant = True
 else:
     today = datetime.date.today()
     validated = 0
@@ -428,10 +506,71 @@ else:
         # caught (measured with that control, cross-family round 7). Half a fix propagated is a hole:
         # a baseline that is not a list-of-effects and a real target string cannot be compared against
         # anything later, which is the entire purpose of recording it.
-        eff, tgt = g.get("effects"), g.get("target")
-        if eff is None or tgt is None:
-            out("❌", f"R6 `{name}` grant records no `effects`+`target` — the subset check has no baseline")
+        # R6-c FINGERPRINT COMPLETENESS (cross-family round 9, finding F3, 2026-07-31).
+        # The rule says consent binds to the action's SHAPE and enumerates that shape:
+        #   "a grant records ... the owning gate/skill, and the set of effect classes ... plus the
+        #    `target` scope and the `sinks` fingerprint"  (operational_adaptation.md §Consent binds
+        #   to the action's SHAPE), and the offer quoted to the user is `<mode · target ·
+        #   capabilities · sinks>`.
+        # The baseline recorded here was `effects` + `target` ONLY. So a class could keep its name,
+        # target, capabilities and empty sinks while its `owner` (which gate/skill does the acting)
+        # or its `mode` (what it does when it acts) was swapped underneath the grant — R6 found its
+        # two fields present and R7 found the effects still a subset, and the checker returned 0.
+        # "The name is exactly what does not change when the danger does" — and so, it turned out,
+        # were the only two fields the floor was reading. A fingerprint missing the fields the rule
+        # names is not a fingerprint; it is a partial hash that collides on the dangerous case.
+        # Sentinel-then-type, never `or`: `sinks: []` is a REAL fingerprint ("crossed nothing at
+        # grant time") and must not be laundered into "not recorded" by a falsy test — the same
+        # falsy-collapse defect fixed twice above.
+        FP_STR = ("owner", "mode", "target")
+        missing_fp = [f for f in ("owner", "mode", "target", "effects", "sinks") if g.get(f) is None]
+        if missing_fp:
+            out("❌", f"R6 `{name}` grant records no {'+'.join(missing_fp)} — consent binds to the "
+                      f"action's SHAPE (owner·mode·target·effects·sinks), and a fingerprint missing "
+                      f"a field cannot detect drift in that field")
             fails += 1
+        eff, tgt = g.get("effects"), g.get("target")
+        for fld in FP_STR:
+            v = g.get(fld)
+            if v is not None and (not isinstance(v, str) or not v.strip()):
+                out("❌", f"R6 `{name}` `{fld}` must be a non-blank string, got "
+                          f"{type(v).__name__} {v!r} — an unreadable baseline is no baseline")
+                fails += 1
+        gs = g.get("sinks")
+        if gs is not None and (not isinstance(gs, list)
+                               or not all(isinstance(x, str) and x.strip() for x in gs)):
+            out("❌", f"R6 `{name}` `sinks` must be a list of non-blank strings, got "
+                      f"{type(gs).__name__} {gs!r} — an unreadable sink is an UNDECLARED sink")
+            fails += 1
+        else:
+            # R7-c SINK WIDENING. Rule: "on any later run whose fingerprint is not a subset of the
+            # granted one, standing consent reverts to unset and asks again ... widening is the
+            # trigger; narrowing is not." The class's CURRENT sinks are the later fingerprint.
+            # HONEST SCOPE — this comparison is defence-in-depth, not an independent catch today:
+            # R2 already refuses `promotion_eligible: true` on ANY non-empty sinks/feeds, so on an
+            # eligible class this branch is unreachable and no lane can discriminate it. It is kept
+            # because it survives an R2 relaxation and because it is the half that makes the RECORD
+            # meaningful; the lane that pins F3 pins the R6 *presence* requirement above, which is
+            # reachable. Do not read a PASS here as "sink drift was independently checked".
+            if isinstance(gs, list):
+                widened = sorted({_norm(x) for x in c["sinks"]} - {_norm(x) for x in gs})
+                if widened:
+                    out("❌", f"R7 `{name}` class now declares sink(s) {widened} that were not in the "
+                              f"granted fingerprint {gs!r} — widening reverts consent to unset")
+                    fails += 1
+        # Identity fields: equality, not subset. `owner`/`mode` name WHO acts and HOW; there is no
+        # "narrower owner". _norm (the single normalizer) on both sides, so the two spellings of one
+        # value can never be judged by two different rules — the divergent-normalizer class this
+        # file has already been bitten by three times.
+        for fld in ("owner", "mode"):
+            gv = g.get(fld)
+            if isinstance(gv, str) and gv.strip() and _norm(gv) != _norm(str(c[fld])):
+                out("❌", f"R7 `{name}` grant {fld} {gv!r} does not match the registered {fld} "
+                          f"{c[fld]!r} — the class was re-pointed under a live grant; consent binds "
+                          f"to the action's shape, not its name")
+                fails += 1
+        if eff is None or tgt is None:
+            pass   # already reported by R6 above; nothing left to compare
         else:
             if not isinstance(eff, list) or not eff or not all(isinstance(e, str) and e.strip() for e in eff):
                 out("❌", f"R6 `{name}` `effects` must be a non-empty list of strings, got "
@@ -451,7 +590,14 @@ else:
                 # registry side was not, so `[" read "]` matched while `[READ]` did not — whitespace
                 # forgiving, case strict, for no stated reason. Divergent normalizers on the two
                 # sides of a comparison is the same defect class this file already fixed twice.
-                over = sorted({_norm(e) for e in eff} - {_norm(x) for x in c["capabilities"]})
+                # VOCABULARY, not identity. `effects` and `capabilities` are both drawn from the
+                # closed effect vocabulary, so `READ` and `read` name the same class — comparing them
+                # with the identity normalizer refused a schema-conformant grant. Over-blocking is a
+                # defect of equal rank here: a gate that refuses correct input teaches the operator
+                # to bypass it. The sink-WIDENING comparison a few lines above stays on `_norm`,
+                # because that one asks fingerprint identity, not vocabulary. Per-site judgment, not
+                # a blanket swap. (cross-family round 3, 2026-08-02.)
+                over = sorted({_norm_vocab(e) for e in eff} - {_norm_vocab(x) for x in c["capabilities"]})
                 if over:
                     out("❌", f"R7 `{name}` grant claims effect(s) {over} outside its registered "
                               f"capabilities {c['capabilities']} — the grant is wider than the class")
@@ -460,13 +606,39 @@ else:
                 out("❌", f"R7 `{name}` grant target {tgt!r} does not match the registered target "
                           f"{c['target']!r} — scope drift between grant and class")
                 fails += 1
-    if fails == 0:
-        skipped = len(grants) - validated
+    skipped = len(grants) - validated
+    if validated == 0:
+        # Same state as the empty-grants branch above, reached differently: every key present was
+        # `declined`/`unset`/`revoked`. A file that records only refusals has granted nothing, and a
+        # refusal must never be the reason a prompt is skipped. UNMEASURED, not verified.
+        print(f"consent-registry: N/A — {skipped} recorded state(s), NONE of them an active grant; "
+              f"nothing granted, keep asking (not a PASS)")
+        no_active_grant = True
+    elif fails == 0:
         note = f" ({skipped} non-grant state(s) skipped)" if skipped else ""
         out("✅", f"R3-R6 all {validated} active grant(s) registered, eligible, unexpired, "
                   f"scope-recorded{note}")
 
 print("----")
-print(f"consent-registry: {'PASS' if fails == 0 else f'{fails} violation(s)'}")
-sys.exit(0 if fails == 0 else 1)
+# The human-facing summary must agree with the typed exit. It previously printed PASS on a run whose
+# own line above said "nothing granted, keep asking (not a PASS)" and whose exit code was 3 — so an
+# operator reading the tail saw an approval that the machine channel was refusing. "Do not grep the
+# prose" binds machines; people read the prose, and a summary that contradicts the verdict is a
+# false green with extra steps. (Caught by hand 2026-08-02 while verifying the exit-3 fix.)
+if fails:
+    print(f"consent-registry: {fails} violation(s)")
+elif no_active_grant:
+    print("consent-registry: UNMEASURED — nothing granted, keep asking (exit 3)")
+else:
+    print("consent-registry: PASS")
+# BROKEN outranks UNMEASURED: a violation is a decided negative, "nothing granted" is merely nothing
+# to join. Both outrank VERIFIED, which stays reachable ONLY by a real join against a real grant.
+if ZERO_CLASSES and not fails:
+    # A live grant against a registry that declares zero classes is an UNREGISTERED grant — R3's own
+    # verdict — which is BROKEN, not "nothing to join". No grant → genuinely nothing to join.
+    if not no_active_grant:
+        print("consent-registry: FAIL — a standing grant exists but the registry declares zero "
+              "classes; every such grant is UNREGISTERED (R3), which is BROKEN, not unmeasured")
+        sys.exit(1)
+sys.exit(1 if fails else (3 if no_active_grant else 0))
 PY

--- a/scripts/test_consent_registry.sh
+++ b/scripts/test_consent_registry.sh
@@ -55,12 +55,17 @@ mkuap_raw() { printf '%s\n' "$1" > "$TD/u.md"; }
 
 mkreg "$OKCLASS"
 mkuap 'standing_consent:
-  ok: {granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
 lane "N1 a well-formed registry + eligible unexpired scoped grant passes" 0 ""
 
 mkuap 'standing_consent:
   ok: declined'
-lane "N2 a declined record is a valid non-grant state, not a malformed grant" 0 ""
+# EXPECTATION CHANGED 0 -> 3 (F4-b, 2026-07-31). A `declined` record is still a valid non-grant
+# state and still must not be a VIOLATION — that half of the lane is unchanged and is what the
+# 3-vs-1 distinction now asserts. What changed is that "the user said no" may not be reported
+# through the same channel as "the user said yes": exit 0 is the only code a caller may skip a
+# prompt on, and a file recording nothing but refusals has granted nothing.
+lane "N2 a declined record is a non-grant state (3), never a malformed grant (1)" 3 ""
 
 mkreg '  - {name: s, owner: o, mode: m, target: t, capabilities: [read], sinks: [go-public], feeds: [], promotion_eligible: true}'
 mkuap 'standing_consent: {}'
@@ -71,31 +76,31 @@ lane "P2 taint — a class that FEEDS an irreversible sink cannot be promotable"
 
 mkreg "$OKCLASS"
 mkuap 'standing_consent:
-  ghost: {granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
+  ghost: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
 lane "P3 a grant on an unregistered class is refused (unregistered == unknown)" 1 "R3"
 
 mkuap 'standing_consent:
-  ok: {granted: 2026-01-01, expires: 2026-06-30, effects: [read], target: t}'
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-01-01, expires: 2026-06-30, effects: [read], target: t}'
 lane "P4 an expired lease does not keep running" 1 "R5"
 
 mkuap 'standing_consent:
-  ok: {granted: 2026-07-29, expires: 2026-12-31}'
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31}'
 lane "P5 a grant with no recorded scope has no re-validation baseline" 1 "R6"
 
 # P6-P8 are the round-3 fail-opens. Each of these PASSED before the fix.
 mkreg '  - {name: q, owner: o, mode: m, target: t, capabilities: [read], sinks: [], feeds: [], promotion_eligible: "false"}'
 mkuap 'standing_consent:
-  q: {granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
+  q: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
 lane "P6 quoted \"false\" is rejected as a type error, not read as truthy" 1 "R1-b"
 
 mkreg '  - {name: d, owner: o, mode: m, target: t, capabilities: [read], sinks: [go-public], feeds: [], promotion_eligible: false}
   - {name: d, owner: o, mode: m, target: t, capabilities: [read], sinks: [], feeds: [], promotion_eligible: true}'
 mkuap 'standing_consent:
-  d: {granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
+  d: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
 lane "P7 a duplicate class name cannot launder an ineligible class" 1 "R1-c"
 
 mkreg "$OKCLASS"
-mkuap 'standing_consent: {ok: {granted: 2026-01-01, expires: 2020-01-01, effects: [read], target: t}}'
+mkuap 'standing_consent: {ok: {owner: o, mode: m, sinks: [], granted: 2026-01-01, expires: 2020-01-01, effects: [read], target: t}}'
 lane "P8 an INLINE grant is parsed, not silently read as 'nothing granted'" 1 "R5"
 
 # P10-P11 are the round-4 fail-opens. Both PASSED before the fix, and both were confirmed against a
@@ -106,16 +111,21 @@ mkuap 'standing_consent: {}
 notes in between
 
 standing_consent:
-  ok: {granted: 2026-01-01, expires: 2020-01-01, effects: [read], target: t}'
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-01-01, expires: 2020-01-01, effects: [read], target: t}'
 lane "P10 an early empty consent block cannot shadow a later grant (first-match)" 1 "R3"
 
 mkuap 'standing_consent:
-  ok: {state: "revoked ", granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
-if bash "$CHK" "$TD/r.yaml" "$TD/u.md" 2>&1 | grep -q "0 active grant"; then
+  ok: {owner: o, mode: m, sinks: [], state: "revoked ", granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
+# ASSERTION REWRITTEN 2026-07-31 (F4-b). This lane read the VERDICT out of prose ("0 active grant")
+# through a pipe, which is both the grep-a-prose-verdict pattern this repo has a memory entry
+# against and — via the pipe — a read of grep's status, not the checker's. It now asserts the typed
+# channel: a normalized `revoked ` leaves zero active grants, which is exit 3, not 0 and not 1.
+bash "$CHK" "$TD/r.yaml" "$TD/u.md" >"$TD/o" 2>&1; rc=$?
+if [ "$rc" -eq 3 ] && grep -q "NONE of them an active grant" "$TD/o"; then
   ok "P11 a mapping non-grant state is normalized like the scalar one (no divergent normalizer)"
 else
-  bad "P11 \`state: \"revoked \"\` was validated as an ACTIVE grant"
-  bash "$CHK" "$TD/r.yaml" "$TD/u.md" 2>&1 | sed 's/^/     /'
+  bad "P11 \`state: \"revoked \"\` was not normalized to a non-grant (exit $rc, expected 3)"
+  sed 's/^/     /' "$TD/o"
 fi
 
 # P12 is the round-5 fail-open: `or {}` collapsed FALSY non-mappings into a valid-empty mapping
@@ -140,11 +150,11 @@ done
 mkreg "$OKCLASS"
 mkuap 'standing_consent: {}
 
-standing_consent : {ok: {granted: 2026-01-01, expires: 2020-01-01, effects: [read], target: t}}'
+standing_consent : {ok: {owner: o, mode: m, sinks: [], granted: 2026-01-01, expires: 2020-01-01, effects: [read], target: t}}'
 lane "P13 a space-before-colon key cannot hide behind a canonical block" 1 "R3"
 
 mkuap 'standing_consent :
-  ok: {granted: 2026-01-01, expires: 2020-01-01, effects: [read], target: t}'
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-01-01, expires: 2020-01-01, effects: [read], target: t}'
 lane "P13-b a space-before-colon BLOCK form is parsed and its grant validated" 1 "R5"
 
 # N3 EXPECTATION INVERTED 2026-07-31 — and the reason is the whole point of the storage-form change.
@@ -154,7 +164,7 @@ lane "P13-b a space-before-colon BLOCK form is parsed and its grant validated" 1
 # So the belief was false, and a regex that approximates the YAML spec had been quietly ratifying a
 # document the spec rejects. Handing the region to the real loader replaces a guess with an answer —
 # a malformed document is now BROKEN (fail-closed), not silently accepted as equivalent.
-mkuap "$(printf 'standing_consent\t: {ok: {granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}}')"
+mkuap "$(printf 'standing_consent\t: {ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}}')"
 lane "N3 a tab-before-colon key is invalid YAML and fails closed (loader, not regex, decides)" 1 "R3"
 
 # P14 — round-7 fail-open: R6 presence-checked `effects`/`target` but never typed them, while the
@@ -162,15 +172,15 @@ lane "N3 a tab-before-colon key is invalid YAML and fails closed (loader, not re
 # a MISSING field was caught; a type-wrong one passed.
 mkreg "$OKCLASS"
 mkuap 'standing_consent:
-  ok: {granted: 2026-07-29, expires: 2026-12-31, effects: true, target: 123}'
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: true, target: 123}'
 lane "P14 a type-wrong grant scope is rejected, not counted as recorded" 1 "R6"
 
 mkuap 'standing_consent:
-  ok: {granted: 2026-07-29, expires: 2026-12-31, effects: "read", target: "  "}'
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: "read", target: "  "}'
 lane "P14-b a scalar effects / whitespace-only target is rejected" 1 "R6"
 
 mkuap 'standing_consent:
-  ok: {granted: 2026-07-29, expires: 2026-12-31, effects: [], target: t}'
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [], target: t}'
 lane "P14-c an EMPTY effects list is not a baseline" 1 "R6"
 
 # H1-H9 — round-8 exhaustive field audit found NINE remaining holes in one pass, after four rounds
@@ -196,26 +206,26 @@ lane "H3 an unreadable sink item is UNDECLARED, not an empty sink list" 1 "R1-b"
 
 mkreg "$OKCLASS"
 mkuap 'standing_consent:
-  ok: {expires: 2026-12-31, effects: [read], target: t}'
+  ok: {owner: o, mode: m, sinks: [], expires: 2026-12-31, effects: [read], target: t}'
 lane "H5 a grant with no \`granted\` date cannot be audited" 1 "R5"
 mkuap 'standing_consent:
-  ok: {granted: 2026-07-29, expires: 29991231, effects: [read], target: t}'
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 29991231, effects: [read], target: t}'
 lane "H7 a non-ISO integer expiry is not a date" 1 "R5"
 mkuap 'standing_consent:
-  ok: {granted: 2026-07-29, expires: 9999-12-31, effects: [read], target: t}'
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 9999-12-31, effects: [read], target: t}'
 lane "H7-b an unbounded lease is a transfer wearing a lease's clothes" 1 "R5"
 mkuap 'standing_consent:
-  ok: {state: revokedd, granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
+  ok: {owner: o, mode: m, sinks: [], state: revokedd, granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
 lane "H6 a typo'\''d state fails closed instead of passing as active" 1 "R3"
 mkuap 'standing_consent:
-  ok: {granted: 2026-07-29, expires: 2026-12-31, effects: [repo-mutation], target: t}'
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [repo-mutation], target: t}'
 lane "H8 a grant wider than its registered capabilities is refused" 1 "R7"
 mkuap 'standing_consent:
-  ok: {granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: everything}'
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: everything}'
 lane "H8-b grant/class target drift is refused" 1 "R7"
 mkuap 'standing_consent:
-  ok: {granted: 2026-07-29, expires: 2020-01-01, effects: [read], target: t}
-  ok: {granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2020-01-01, effects: [read], target: t}
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
 lane "H9 duplicate YAML keys are rejected, not resolved last-wins" 1 ""
 
 # H4 had a fix but NO lane — the mutation sweep caught that (disabling it failed zero lanes).
@@ -224,7 +234,7 @@ lane "H9 duplicate YAML keys are rejected, not resolved last-wins" 1 ""
 # still exits 1 via "not in the registry", so a rule-id assertion passed either way and the mutation
 # sweep caught zero lanes. A lane that cannot separate two paths is not measuring the one it names.
 mkuap 'standing_consent:
-  123: {granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
+  123: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
 bash "$CHK" "$TD/r.yaml" "$TD/u.md" >"$TD/o" 2>&1
 if [ $? -eq 1 ] && grep -q 'grant key 123 must be a non-blank string' "$TD/o"; then
   ok "H4 a non-string grant key is refused AS A TYPE ERROR (not merely as unregistered)"
@@ -243,7 +253,7 @@ lane "P9 a scalar where a list is required is a type error" 1 "R1-b"
 # up as a lane change rather than being rediscovered from scratch — and so nobody reads the 40/40
 # as "no known over-block".
 mkreg "$OKCLASS"
-mkuap 'defaults: &d {ok: {granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}}
+mkuap 'defaults: &d {ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}}
 standing_consent:
   <<: *d'
 # N4 REMOVED 2026-07-31 — it called ok() in BOTH branches, so it passed on every possible exit code
@@ -287,7 +297,7 @@ lane "D1-d a missing UAP is UNMEASURED (3) — no grants is not a verified pass"
 # return the same code again, the channel has collapsed back into prose.
 mkreg "$OKCLASS"
 mkuap 'standing_consent:
-  ok: {granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
 lane "D1-e 0 still means VERIFIED, and only that" 0 ""
 
 printf 'classes: [ {name: broken\n' > "$TD/r.yaml"
@@ -306,7 +316,7 @@ lane "D2 an unparseable registry fails closed (cannot decide == not allowed)" 1 
 # through — which is exactly why the doctrine calls local tier evidence-of and never terminal.
 mkreg '  - {name: rewrite, owner: o, mode: m, target: t, capabilities: [history-rewrite], sinks: [], feeds: [], promotion_eligible: true}'
 mkuap 'standing_consent:
-  rewrite: {granted: 2026-07-29, expires: 2026-12-31, effects: [history-rewrite], target: t}'
+  rewrite: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [history-rewrite], target: t}'
 lane "R9-1 a declared irreversible CAPABILITY is not promotable, empty sinks or not" 1 "R2-b"
 
 # The same class WITHOUT the promotion claim is fine: declaring an irreversible capability is not
@@ -314,7 +324,9 @@ lane "R9-1 a declared irreversible CAPABILITY is not promotable, empty sinks or 
 # can do. Over-blocking trains the override reflex — the checker already records one such revert.
 mkreg '  - {name: rewrite, owner: o, mode: m, target: t, capabilities: [history-rewrite], sinks: [], feeds: [], promotion_eligible: false}'
 mkuap 'standing_consent: {}'
-lane "R9-1b the same irreversible capability is fine when not claimed promotable" 0 ""
+# EXPECTATION CHANGED 0 -> 3 (F4-b): the anti-over-block point of this lane is that the registry
+# must NOT be a violation, i.e. not 1. Its UAP grants nothing, so the join is empty -> UNMEASURED.
+lane "R9-1b the same irreversible capability is not a violation when not claimed promotable" 3 ""
 
 # `unknown` is in IRREVERSIBLE for the sink rule ("unlisted sinks are UNKNOWN, and unknown is not
 # reversible"); it must mean the same thing in the capability position.
@@ -326,7 +338,7 @@ lane "R9-1c an \`unknown\` capability is not promotable either" 1 "R2-b"
 # sinks is the N1 shape and must stay passing. If this lane ever flips, the fix went too wide.
 mkreg "$OKCLASS"
 mkuap 'standing_consent:
-  ok: {granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
 lane "R9-1d a reversible capability with empty sinks still passes (anti-over-block)" 0 ""
 
 # R9-1e — the SAME field must be normalised the SAME way by every rule that reads it. R7 compares
@@ -340,17 +352,24 @@ lane "R9-1e whitespace around an irreversible capability does not evade R2-b" 1 
 
 # The shipped example must satisfy the validator — otherwise the artifact FH hands users is the
 # first counter-example. (Hand-verify-one-sample discipline, applied to our own template.)
-if bash "$CHK" "$ROOT/templates/consent_classes.yaml.example" /dev/null >/dev/null 2>&1; then
-  ok "S1 the shipped templates/consent_classes.yaml.example validates"
+# ASSERTION REWRITTEN 2026-07-31 (F4-b). This lane used the bare-command form — precisely the
+# `if check; then ...` convention finding F4 identified as the fail-open — so it asked "is the exit
+# status truthy?" when the question is "is the REGISTRY broken?". With no grants to join the answer
+# is now 3 (UNMEASURED), which is a correct verdict about the grants and says nothing bad about the
+# registry. 1 is the only code that means the shipped example is invalid.
+bash "$CHK" "$ROOT/templates/consent_classes.yaml.example" /dev/null >"$TD/o" 2>&1; rc=$?
+if [ "$rc" -ne 1 ]; then
+  ok "S1 the shipped templates/consent_classes.yaml.example validates (exit $rc, not BROKEN)"
 else
   bad "S1 the shipped example registry does NOT validate"
+  sed 's/^/     /' "$TD/o"
 fi
 
 # ---- F: STORAGE FORM (frontmatter) -------------------------------------------------
 # These lanes test the machine-region boundary itself, not grant semantics, so they write the UAP
 # byte-exact via mkuap_raw instead of going through the frontmatter-wrapping helper.
 mkreg "$OKCLASS"
-GRANT='  ok: {granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
+GRANT='  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
 
 # F1/F2 are the two false-clean shapes, and they are the reason this section exists. A grant that
 # sits where no parser reads it must never report as "nothing granted" — an unread grant is not an
@@ -364,17 +383,20 @@ lane "F2 frontmatter exists but the grant was written BELOW it — fails closed"
 # F3 is the anti-over-block control for F1: absence must stay cheap. A UAP predating this format has
 # no machine region and grants nothing; painting that red would train the override reflex.
 mkuap_raw "$(printf '# UAP\n\nno machine region here, and nothing granted.\n')"
-lane "F3 no frontmatter and no grant mentioned is simply nothing granted (not a failure)" 0 ""
+# EXPECTATION CHANGED 0 -> 3 (F4-b). "Absence must stay cheap" is preserved exactly: 3 is not red,
+# it is N/A. What it no longer does is answer the conventional `if check; then run_unprompted; fi`
+# with success on a UAP that granted nothing at all.
+lane "F3 no frontmatter and no grant mentioned is nothing granted (3, not a failure)" 3 ""
 
 # F4 pins the OVER-BLOCK THIS CHANGE RETIRES. Under the slicer a merge-key grant was refused because
 # the anchor lived outside the extracted fragment; the fragment is now the whole document, so
 # ordinary DRY YAML resolves. Over-blocking was a defect of the same weight as a fail-open.
-mkuap_raw "$(printf -- '---\ndefaults: &d {granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}\nstanding_consent:\n  ok:\n    <<: *d\n---\n')"
+mkuap_raw "$(printf -- '---\ndefaults: &d {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}\nstanding_consent:\n  ok:\n    <<: *d\n---\n')"
 lane "F4 a merge-key/anchor grant now resolves (the measured over-block is retired)" 0 ""
 
 # F5 — duplicate keys stay rejected on this side too. safe_load is last-wins, so an expired grant
 # followed by a future one would silently keep the future one.
-mkuap_raw "$(printf -- '---\nstanding_consent:\n  ok: {granted: 2026-01-01, expires: 2020-01-01, effects: [read], target: t}\n  ok: {granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}\n---\n')"
+mkuap_raw "$(printf -- '---\nstanding_consent:\n  ok: {owner: o, mode: m, sinks: [], granted: 2026-01-01, expires: 2020-01-01, effects: [read], target: t}\n  ok: {granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}\n---\n')"
 lane "F5 duplicate grant keys are refused, not last-wins" 1 "R3"
 
 # F6 — a leading BOM must not make the machine region look absent. Without the tolerance this still
@@ -398,18 +420,22 @@ lane "F8 an unterminated --- block is not a machine region and fails closed" 1 "
 # went green without the empty-region path ever running. Lane F9-b below is its control: same empty
 # region, but WITH a prose mention, which can only stay green if the region was really recognized.
 mkuap_raw "$(printf -- '---\n---\n\n# UAP\n')"
-lane "F9 an empty frontmatter block grants nothing and is not an error" 0 ""
+# EXPECTATION CHANGED 0 -> 3 (F4-b): still not an error (not 1), but an empty region grants nothing.
+lane "F9 an empty frontmatter block grants nothing (3) and is not an error (1)" 3 ""
 
 # F9-b — the discriminating control for F9. If the empty region is NOT recognized, this file reads as
 # "no frontmatter + standing_consent mentioned" and fails closed via F1. Green here means the empty
 # frontmatter was genuinely parsed. (Without this control F9 cannot tell the two paths apart.)
 mkuap_raw "$(printf -- '---\n---\n\n# UAP\n\nthe key name standing_consent appears in prose but not as a key.\n')"
-lane "F9-b empty region + a prose MENTION is still nothing granted (region truly parsed)" 0 ""
+# EXPECTATION CHANGED 0 -> 3 (F4-b). The discriminating power of this control is UNCHANGED: if the
+# empty region were not recognized, this file would fail CLOSED via the F1 net at exit 1, which is
+# still distinct from the 3 asserted here.
+lane "F9-b empty region + a prose MENTION is still nothing granted (region truly parsed)" 3 ""
 
 # F10-F13 — YAML stream forms the canonical loader accepts and the first fence regex rejected. Each
 # failed CLOSED (no leak) but as an OVER-BLOCK whose message blamed an absent frontmatter that was
 # present. A gate that misdirects the fix gets overridden, so these are lanes, not footnotes.
-EXPIRED='  ok: {granted: 2026-01-01, expires: 2020-01-01, effects: [read], target: t}'
+EXPIRED='  ok: {owner: o, mode: m, sinks: [], granted: 2026-01-01, expires: 2020-01-01, effects: [read], target: t}'
 mkreg "$OKCLASS"
 mkuap_raw "$(printf -- '---\nstanding_consent:\n%s\n...\n' "$EXPIRED")"
 lane "F10 a '...' document terminator closes the machine region (grant is READ, then R5-caught)" 1 "R5"
@@ -428,6 +454,279 @@ lane "F13 a %YAML directive before the fence does not hide the region" 1 "R5"
 # it, i.e. the two nets disagreed on one input.
 mkuap_raw "$(printf -- '---\nsidecar_consent: granted\n---\n\n# UAP\n\n"standing_consent":\n%s\n' "$EXPIRED")"
 lane "F14 a QUOTED grant key in the prose region is caught too (nets agree)" 1 "R3"
+
+# ---- R9-F3: THE FINGERPRINT WAS A PARTIAL HASH ------------------------------------
+# Cross-family round 9 (codex @ gpt-5.6-sol). The rule says consent binds to the action's SHAPE and
+# enumerates that shape — "the owning gate/skill, and the set of effect classes ... plus the
+# `target` scope and the `sinks` fingerprint", offered to the user as `<mode · target ·
+# capabilities · sinks>`. The baseline the checker recorded was `effects` + `target` ONLY.
+# So the fields that say WHO acts (`owner`) and WHAT IT DOES when it acts (`mode`) were outside the
+# floor: keep the class name, target, capabilities and empty sinks, swap the owner to a different
+# skill, and R6 found its two fields present, R7 found the effects still a subset, and the gate
+# returned 0 with the blast radius re-pointed under a live grant.
+# The rule's own sentence is the indictment: "the name is exactly what does not change when the
+# danger does" — and neither, it turned out, did anything the floor was reading.
+# Each P-lane below was confirmed to return 0 before the fix and 1 after; each is paired with an
+# anti-over-block N-lane so the check is calibrated on a known-negative, not only a known-positive.
+FPGRANT='  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
+
+# P-F3a / P-F3b — the drift the review reproduced: same name, same target, same capabilities, same
+# empty sinks; only the acting skill (or what it does) changed.
+mkreg '  - {name: ok, owner: DANGEROUS-OTHER-SKILL, mode: m, target: t, capabilities: [read], sinks: [], feeds: [], promotion_eligible: true}'
+mkuap "standing_consent:
+$FPGRANT"
+lane "P-F3a a class re-pointed to a different OWNER under a live grant is refused" 1 "R7"
+
+mkreg '  - {name: ok, owner: o, mode: unrestricted, target: t, capabilities: [read], sinks: [], feeds: [], promotion_eligible: true}'
+mkuap "standing_consent:
+$FPGRANT"
+lane "P-F3b a class whose MODE changed under a live grant is refused" 1 "R7"
+
+# N-F3c — the control for both: an intact fingerprint must still pass. Without it P-F3a/b prove
+# only that something fails, not that the owner/mode comparison is what fired.
+mkreg "$OKCLASS"
+mkuap "standing_consent:
+$FPGRANT"
+lane "N-F3c an intact owner/mode/target/sinks fingerprint still passes (anti-over-block)" 0 ""
+
+# P-F3d — presence. A grant written without the fingerprint cannot detect drift in it later, which
+# is the same argument R6 already made for effects/target and did not apply to the other three.
+mkuap 'standing_consent:
+  ok: {granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
+lane "P-F3d a grant recording no owner/mode/sinks has no fingerprint to compare" 1 "R6"
+
+# N-F3e — the FALSY-LAUNDERING control, the defect class this file has now been bitten by three
+# times. `sinks: []` is a REAL fingerprint ("this class crossed nothing at grant time") and must not
+# collapse into "not recorded". If this lane ever goes red with an R6 sinks message, a sentinel
+# check was replaced by a truthiness test.
+mkuap "standing_consent:
+$FPGRANT"
+lane "N-F3e an EMPTY sinks list is a recorded fingerprint, not a missing one" 0 ""
+
+# P-F3f/g — types. The registry side got strict types at R1-b and the grant side got them for
+# effects/target at R6; the three new fields inherit the same rule rather than a laxer one.
+mkuap 'standing_consent:
+  ok: {owner: o, mode: m, sinks: "go-public", granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
+lane "P-F3f a scalar sinks fingerprint is unreadable, and unreadable is undeclared" 1 "R6"
+
+mkuap 'standing_consent:
+  ok: {owner: "   ", mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
+lane "P-F3g a blank owner is not a recorded owner" 1 "R6"
+
+# N-F3h — ONE normalizer, both sides. The registry side reads `owner` through _norm; if the grant
+# side ever compares raw strings, ` o ` and `o` become two values and the gate fires on a file that
+# did not drift. Divergent normalizers is exactly how R2-b was first written wrong.
+mkuap 'standing_consent:
+  ok: {owner: "  o  ", mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}'
+lane "N-F3h whitespace around an owner is not drift (single normalizer, both sides)" 0 ""
+
+# ---- R9-F4-b: THE SAME FAIL-OPEN, ONE BRANCH OVER ---------------------------------
+# F4 gave "nothing to join" its own exit code for a MISSING registry, ZERO classes and a MISSING
+# UAP — and left a PRESENT UAP holding ZERO grants returning 0. Identical state, two codes. Lane
+# D1-d already asserted in its own name that "no grants is not a verified pass", and the EXIT
+# CONTRACT already defined 3 as "there was nothing to join"; only the code disagreed. A caller
+# writing `if scripts/consent_registry_check.sh; then run_unprompted; fi` ran unprompted against a
+# profile that had granted it nothing.
+mkreg "$OKCLASS"
+mkuap 'standing_consent: {}'
+lane "D3 a valid registry with an EXPLICITLY empty grant set is UNMEASURED (3)" 3 ""
+
+# D3-b — the discriminating control. If D3 and this lane ever return the same code again, the typed
+# channel has collapsed back into prose and 0 no longer means "a real grant was joined".
+mkuap "standing_consent:
+$FPGRANT"
+lane "D3-b 0 is still reachable ONLY by joining a real grant" 0 ""
+
+# D3-c — precedence. BROKEN outranks UNMEASURED: a registry violation is a decided negative, while
+# "nothing granted" is merely nothing to join. Without this lane the F4-b change could silently
+# convert a real violation into a soft N/A whenever the UAP happened to be empty.
+mkreg '  - {name: ok, owner: o, mode: m, target: t, capabilities: [read], sinks: [], feeds: [], promotion_eligible: "false"}'
+mkuap 'standing_consent: {}'
+lane "D3-c a registry violation still outranks 'nothing granted' (1 beats 3)" 1 "R1-b"
+
+
+# ── D3-d: the prose summary must agree with the typed exit ────────────────────
+# A tail-reading operator saw "consent-registry: PASS" on a run that exited 3 and whose own line
+# said "(not a PASS)". Machines read the code; humans read the last line. They must not disagree.
+cat > "$TD/r.yaml" <<'YAML'
+classes:
+  - name: safe-thing
+    owner: some-skill
+    mode: readonly
+    target: "tracks/_meta/**"
+    capabilities: [read]
+    effects: [read]
+    sinks: []
+    feeds: []
+    promotion_eligible: true
+YAML
+printf -- '---\nstanding_consent: {}\n---\n' > "$TD/u.md"
+bash "$CHK" "$TD/r.yaml" "$TD/u.md" >"$TD/o" 2>&1; _rc=$?
+if [ "$_rc" -ne 0 ] && tail -1 "$TD/o" | grep -q '^consent-registry: PASS$'; then
+  bad "D3-d prose summary says PASS while the typed exit is $_rc"
+else
+  ok "D3-d prose summary agrees with the typed exit (rc=$_rc)"
+fi
+
+
+# ── P-VOCAB: the irreversible vocabulary must not be evadable by case or invisible characters ──
+# Carried for two sessions as a named residual ("_norm does not case-fold"). A cross-family round
+# MEASURED it as a live fail-open: a class whose capability is a history rewrite was PASSing and
+# therefore promotable. Each variant below returned rc=0 before the fix.
+for _v in 'History-Rewrite' 'HISTORY-REWRITE' 'local-wrtie'; do
+  cat > "$TD/r.yaml" <<YAML
+classes:
+  - name: rewrite
+    owner: o
+    mode: m
+    target: t
+    capabilities: ["$_v"]
+    effects: [read]
+    sinks: []
+    feeds: []
+    promotion_eligible: true
+YAML
+  cat > "$TD/u.md" <<'YAML'
+---
+standing_consent:
+  rewrite: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}
+---
+YAML
+  bash "$CHK" "$TD/r.yaml" "$TD/u.md" >"$TD/o" 2>&1; _rc=$?
+  # Assert the RULE, not merely a non-zero exit. These fixtures also trip R7 (their grant effect is
+  # not a subset of the malformed capability list), so "exit != 0" would have passed even with the
+  # vocabulary check removed — right answer, wrong reason, which is the shape this suite's own
+  # lane() helper exists to reject. (Partial vacuity found by cross-family round 2.)
+  if [ "$_rc" -eq 0 ]; then bad "P-VOCAB '$_v' still PASSes (irreversible/unknown floor evaded)"
+  elif grep -qE '❌ (R2-b|R2-c)' "$TD/o"; then ok "P-VOCAB '$_v' refused BY THE FLOOR (R2-b/R2-c)"
+  else bad "P-VOCAB '$_v' refused, but not by R2-b/R2-c — the vocabulary check was not the reason"; fi
+done
+
+# N-VOCAB: the anti-over-block control. A class using ONLY declared capabilities must still pass —
+# a vocabulary check that refuses legitimate input teaches bypass and is a defect of equal rank.
+cat > "$TD/r.yaml" <<'YAML'
+classes:
+  - name: ok-class
+    owner: o
+    mode: m
+    target: t
+    capabilities: [read, local-write, network, dispatch, repo-mutation]
+    effects: [read]
+    sinks: []
+    feeds: []
+    promotion_eligible: true
+YAML
+cat > "$TD/u.md" <<'YAML'
+---
+standing_consent:
+  ok-class: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}
+---
+YAML
+lane "N-VOCAB every declared capability is still accepted (no over-block)" 0 ""
+
+# ── D4: BROKEN outranks UNMEASURED even at the zero-class early return ──
+printf 'classes: []\n' > "$TD/r.yaml"
+cat > "$TD/u.md" <<'YAML'
+---
+standing_consent:
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}
+---
+YAML
+lane "D4  live grant + zero registered classes = BROKEN (1), not 'nothing to join' (3)" 1 ""
+printf 'classes: []\n' > "$TD/r.yaml"
+printf -- '---\nstanding_consent: {}\n---\n' > "$TD/u.md"
+lane "D4-b no grant + zero classes is still UNMEASURED (3) — the discriminating control" 3 ""
+
+# ── K1: KNOWN OVER-BLOCK, pinned as known, NOT as correct ─────────────────────
+# A canonical YAML merge-key override (`<<: *anchor` then a field override) is reported as a
+# duplicate key and refused. This is a REAL over-block. It is pinned rather than fixed because the
+# one attempt to rewrite the parser regressed 16 of 41 lanes and was reverted in the same session;
+# the fix belongs in its own change with its own lanes. If this lane ever flips to rc=0, the
+# over-block was fixed — update the label, do not silence it.
+cat > "$TD/r.yaml" <<'YAML'
+classes:
+  - name: ok
+    owner: o
+    mode: m
+    target: t
+    capabilities: [read]
+    effects: [read]
+    sinks: []
+    feeds: []
+    promotion_eligible: true
+YAML
+cat > "$TD/u.md" <<'YAML'
+---
+defaults: &d {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: WRONG}
+standing_consent:
+  ok:
+    <<: *d
+    target: t
+---
+YAML
+# PROMOTED from "known over-block, pinned not endorsed" to a real assertion (2026-08-02). The
+# over-block was closed by moving duplicate detection BEFORE merge resolution — a reorder, not the
+# parser rewrite that regressed 16 of 41 lanes. Both directions are asserted: a canonical override is
+# accepted here, and K1-b below keeps the literal-duplicate detection it was protecting.
+lane "K1  a canonical YAML merge-key override is ACCEPTED (over-block closed)" 0 ""
+
+cat > "$TD/u.md" <<'YAML'
+---
+standing_consent:
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}
+  ok: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}
+---
+YAML
+lane "K1-b a LITERAL duplicate key is still fail-closed (the paired control)" 1 ""
+
+
+
+# ── N-SPELL / P-SPELL: effects⊆capabilities is a VOCABULARY question ────────────
+# Splitting the normalizer by purpose fixed a fail-open and opened an over-block: this comparison was
+# left on the identity normalizer, so `capabilities: [READ]` with a grant `effects: [read]` — the same
+# effect class, spelled differently — was refused. Over-blocking is not a safe default; a gate that
+# refuses correct input is one the operator learns to route around. Both directions are pinned so a
+# future normalizer change cannot fix one by breaking the other.
+cat > "$TD/r.yaml" <<'YAML'
+classes:
+  - name: c
+    owner: o
+    mode: m
+    target: t
+    capabilities: [READ]
+    effects: [READ]
+    sinks: []
+    feeds: []
+    promotion_eligible: true
+YAML
+cat > "$TD/u.md" <<'YAML'
+---
+standing_consent:
+  c: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [read], target: t}
+---
+YAML
+lane "N-SPELL a spelling variant of the SAME effect class is accepted (no over-block)" 0 ""
+
+cat > "$TD/r.yaml" <<'YAML'
+classes:
+  - name: c
+    owner: o
+    mode: m
+    target: t
+    capabilities: [read]
+    effects: [read]
+    sinks: []
+    feeds: []
+    promotion_eligible: true
+YAML
+cat > "$TD/u.md" <<'YAML'
+---
+standing_consent:
+  c: {owner: o, mode: m, sinks: [], granted: 2026-07-29, expires: 2026-12-31, effects: [delete], target: t}
+---
+YAML
+lane "P-SPELL a grant WIDER than its class is still refused (the paired control)" 1 "R7"
+
 
 echo "----"
 echo "consent-registry anchor: $pass passed, $fail failed"

--- a/templates/consent_classes.yaml.example
+++ b/templates/consent_classes.yaml.example
@@ -24,6 +24,24 @@
 #   post-commit hook, sync daemon, or CI workflow publishes from that commit, the chain crossed
 #   go-public and the class must be marked tainted. Declare `feeds:` honestly — the whole point
 #   is that no single step in a bad chain looks dangerous on its own.
+#
+# WHAT A GRANT AGAINST ONE OF THESE LOOKS LIKE (UAP frontmatter, gitignored)
+#   Consent binds to the action's SHAPE, not its name, so the grant records the fingerprint it was
+#   given for and ALL FIVE scope fields are mandatory — R6 refuses a grant missing any of them,
+#   because a fingerprint that omits a field cannot detect drift in that field. `sinks: []` is a
+#   real recorded fingerprint, not an omission.
+#
+#     standing_consent:
+#       dispatch-readonly-sim-local-artifact:
+#         granted: 2026-07-31
+#         expires: 2026-08-30            # a lease, max 365 days
+#         owner:  fh-meta:sim-conductor  # must still match the registry entry below
+#         mode:   blind-target-tier-sim  # ...and so must this
+#         target: a single local file under the current repo
+#         effects: [read, dispatch]      # must be a subset of `capabilities`
+#         sinks:  []                     # the class may not later declare sinks not listed here
+#
+#   Re-point the class's `owner` or `mode` after the grant and the join fails: that is the point.
 
 classes:
   # ---- promotion-eligible example -------------------------------------------------


### PR DESCRIPTION
## 입력이 어디서 왔나

이 PR 의 입력은 **오늘 새로 만든 컴패니언→허브 복귀 경로(#228)가 되찾아온 07-31 리뷰 원본**이다. 세션 카드는 *"consent R9 재개 — 예산 1800s+ 로 재발주"* 라고 적고 있었지만 **재발주는 불필요했다.** 답은 이미 있었고 다른 머신에 갇혀 있었을 뿐이다. 복귀 경로의 첫 실익이다.

카드는 한 겹 더 틀렸다: 작업을 `feat/consent-promotion-NOT-CONVERGED` 브랜치에서 이어가라고 가리켰는데, 실측해보니 **그 브랜치는 죽은 가지**였다 — main 에 `R2-b` 5건·`EXIT CONTRACT` 3건이 있고 브랜치엔 0건, 레인 57 vs 33. `#215` 가 같은 문제를 다른 방식으로 더 강하게 재구현한 뒤였다. 그래서 **main 에서 다시 잘랐다.**

## 닫은 fail-open

| 결함 | 실측 |
|---|---|
| 비가역 어휘 우회 | `History-Rewrite`·제로폭 `history-rewrite`·`local-wrtie` → `RC=0 PASS`. **비가역 클래스가 standing consent 를 받고 있었다** |
| 지문 미기록 | 규칙은 `owner·mode·target·effects·sinks` 에 묶인다는데 코드는 둘만 봄 → 소유자/모드 변경에도 재질의 없음 |
| BROKEN 이 UNMEASURED 에 가려짐 | 클래스 0개 레지스트리가 UAP 를 읽기 전 `exit 3` → **미등록 grant 가 살아있는데** "조인할 게 없음" |
| prose/typed 불일치 | `exit 3` 런의 마지막 줄이 `PASS`. 기계는 코드를, 사람은 마지막 줄을 읽는다 |
| K1 과차단 | 정당한 YAML merge-key override 거부 = **승인돼야 할 consent 를 거부**. 수정은 재작성이 아니라 **순서 교환** |

## 이 수리가 만든 결함, 그리고 그 처리

라운드1 수리가 라운드2 HIGH 를 만들었다. 공유 정규화기를 case-fold 하면서 어휘 구멍은 닫혔지만 **R7 의 신원 비교가 같이 무뎌져** owner/mode/target 드리프트가 재질의를 멈췄다.

이전 세션이 *"case-folding 은 R7 시맨틱을 바꾸니 별도 변경이어야 한다"* 고 경고했었다. **fail-open 증거도 맞았고 그 경고도 맞았다** — 틀린 건 *하나의 정규화기로 두 개의 다른 질문에 답한 것*이다. 되돌리지 않고 **목적별로 분할**했고(`_norm`=신원 / `_norm_vocab`=닫힌 어휘), 감사기가 5개 사이트를 **독립 재도출해 전부 일치**했다.

## 검증

- cross-family **CONVERGED (라운드 5)**
- **64케이스 정규화 매트릭스 → rc-0 의심 0건**
- 레인 **64 → 86**, 부재 단정마다 같은 런의 컨트롤
- 수리마다 **수리 이전 빌드 대비 fail-before/pass-after 실행**
- 4축 게이트 전 축 PASS

## 계기 사고 2건 (숨기지 않고 기록)

1. **라운드3 무효** — 발주 직후 내가 파일을 stash 로 빼내 감사기가 수리 이전본을 읽었다. 레인 수가 64 vs 83 으로 어긋나 있었는데 **판정문을 다 읽을 때까지 못 알아챘다.** 대책: 모든 프롬프트에 **실측 과녁 지문**을 넣고 불일치 시 감사 대신 `WRONG-TARGET` 보고 후 중단.
2. **그 지문이 바로 다음 사용에서 발동했고, 잡힌 건 대상이 아니라 나였다** — `grep -c` 값을 재지 않고 단언했다. 메커니즘은 의도대로 작동했다.

## 잔여

- 원장은 여전히 **자기 신고**(규칙의 상시 HIGH 잔여) — 손대지 않음
- `feat/consent-promotion-NOT-CONVERGED` 죽은 브랜치 정리는 **별건**. Destructive-Op 게이트 대상이라 enumerate → recover → destroy 순서를 밟아야 하고, 브랜치 고유분 확인 전에는 지우지 않는다

🤖 Generated with [Claude Code](https://claude.com/claude-code)