### PR TITLE
fix(close-check): 오픈 PR 개수를 줄이 아니라 출현으로 센다

### DIFF
--- a/scripts/session_close_check.sh
+++ b/scripts/session_close_check.sh
@@ -33,7 +33,13 @@ UNPUSHED=$(git -C "$FH" log --oneline @{u}.. 2>/dev/null | wc -l | tr -d ' ')
 
 # ①-b open-PR sweep (surface-not-auto — requires gh; skip silently offline)
 if command -v gh >/dev/null 2>&1; then
-  PRS=$(gh pr list --author "@me" --state open --json number 2>/dev/null | grep -c '"number"' || true)
+  # `gh --json` emits COMPACT single-line JSON when piped, so counting LINES returned 1 for ANY
+  # non-zero number of open PRs — the sweep hid every PR after the first, in the exact step CLAUDE.md
+  # pairs with count consistency. Count OCCURRENCES instead. Measured 2026-08-02 with a known pair:
+  # `[{"number":227},{"number":226},{"number":225}]` → old 1, new 3; `[]` → 0 both ways — which is
+  # why an environment with zero open PRs can never surface this, and why the 0-case alone is not a
+  # calibration. Observed live the same day: 2 open PRs reported as 1.
+  PRS=$(gh pr list --author "@me" --state open --json number 2>/dev/null | grep -o '"number"' | wc -l | tr -d ' ' || true)
   [ "${PRS:-0}" -gt 0 ] && echo "⚠️  ①-b $PRS open PR(s) by you — classify: self-mergeable vs awaiting-external"
 fi
 


### PR DESCRIPTION
## 결함

`gh pr list --json` 은 **파이프될 때 한 줄 compact JSON** 을 낸다. 스윕은 `grep -c` 로 **줄을 세고 있었다** → 열린 PR 이 몇 개든 항상 **"1"**. 첫 PR 이후는 전부 숨었고, 하필 CLAUDE.md 가 count-consistency 와 짝지어둔 그 스텝이다.

## 실측

```
[{"number":227},{"number":226},{"number":225}]   →  옛 grep -c: 1   ❌   새 grep -o|wc -l: 3   ✅
[]                                                →  양쪽 0
```

**0 케이스만 보면 영영 안 잡힌다** — 옛 술어도 0 은 맞다. 그래서 0-케이스 단독은 캘리브레이션이 아니다. 같은 날 라이브로도 확인: **PR 2건을 1건으로** 보고.

## 출처

발견은 저자가 아니라 **이 스텝의 레인을 쓰던 독립 에이전트**가 했다. 저자가 자기 코드를 읽어서는 안 나온 종류다.

## 단독 추출한 이유

이 한 줄은 무관한 이유로 막힌 changeset(콕핏 계약, S/M 미해결)의 **stash 에 갇혀 있었다.** 검증 끝난 수리가 재설계를 기다릴 이유가 없다 — 오늘 세션의 교훈 자체가 **"만들고 배선 안 함"** 이었고, stash 에만 사는 수리가 정확히 그 형태다.

## 게이트

4축 전 축 PASS. cross-family 는 **NOT RUN** 으로 기록했다(한 줄 술어 변경 + known-pair + 라이브 검증) — 돌린 척하지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)