### PR TITLE
feat(gate): 호출 로그 의무에 기계 바닥 — 산문이 20/20 으로 졌다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -595,10 +595,18 @@ Default operation is a **standard interactive session**. Agent dispatch (single 
 
 Mapped paths: check `auto_project_mapping.md` or `find ~/projects -maxdepth 1 -type d` for actuals.
 
-**Invocation log obligation (always-loaded — do not rely on recall)**: immediately after any custom
-sub-agent invocation, append to `knowledge/shared/learnings/subagent_invocations_log.yaml` (8 fields ·
-outcome: `accepted`/`partial`/`rejected`/`sustained` — `sustained` = decided NOT to invoke, also recorded).
-This feeds the 60/40 promotion gate + UAP loop; detail: `knowledge/shared/rules/operations.md`.
+**Invocation log obligation — now mechanically reconciled, not recall-dependent**: immediately after
+any custom sub-agent invocation, append to `knowledge/shared/learnings/subagent_invocations_log.yaml`
+(8 fields · outcome: `accepted`/`partial`/`rejected`/`sustained` — `sustained` = decided NOT to invoke,
+also recorded). This feeds the 60/40 promotion gate + UAP loop; detail:
+`knowledge/shared/rules/operations.md`.
+**Floor (2026-08-02)**: a `SubagentStop` hook tallies every dispatch and `session_close_check.sh` ④-e
+blocks a close push when dispatches happened and the day's entries are ZERO. Consolidating a class of
+dispatches into one entry with measured counts is fine and is not penalised — the check catches the
+total miss, not imperfect bookkeeping. **Why it needed a floor**: this line was prose-only and a single
+session dispatched 20+ subagents and logged none of them, in the same session that recovered this very
+log file from a branch queued for deletion. The hook only tallies; it never writes an entry, because a
+fabricated `outcome`/`evidence` would poison the promotion gate worse than a missing one.
 
 ### Context Card — Required Format for Dispatch
 ```

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "scripts/prepush_guard_check.sh",
     "scripts/psa_scan_lib.sh",
     "scripts/session_close_check.sh",
+    "scripts/test_dispatch_log_lanes.sh",
     "scripts/memory_link_check.py",
     "scripts/test_memory_link_check.sh",
     "scripts/memory_nearcheck.py",

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -330,6 +330,19 @@ else
   fail=1
 fi
 
+# ④-e dispatch-log reconciliation + its tally hook. Wired in the same commit that ships them: the
+# obligation they mechanize lost 20/20 in a single session, so leaving the checker itself unrun
+# would be the same defect one layer up.
+if [ -f scripts/test_dispatch_log_lanes.sh ]; then
+  if ! bash scripts/test_dispatch_log_lanes.sh >/dev/null 2>&1; then
+    echo "FAIL  test_dispatch_log_lanes.sh: the dispatch-log reconciliation would mis-report"
+    bash scripts/test_dispatch_log_lanes.sh 2>&1 | tail -14
+    fail=1
+  else
+    echo "PASS  test_dispatch_log_lanes.sh (date-spelling + verdict + tally-hook lanes)"
+  fi
+fi
+
 # selfcheck's own subject-presence discriminators. Every other guard under scripts/ has a lane suite;
 # this decision had none, and it shipped two mis-routings in one session — a two-arm form that fell
 # through in silence, then a package discriminator keyed on a file that actually ships. Both are

--- a/scripts/session_close_check.sh
+++ b/scripts/session_close_check.sh
@@ -117,6 +117,57 @@ if [ -n "$LAST_TAG" ] && [ -f "$FH/package.json" ]; then
   fi
 fi
 
+# ④-e DISPATCH-LOG RECONCILIATION — mechanical, because prose failed completely.
+# CLAUDE.md makes an invocation-log entry MANDATORY immediately after any custom sub-agent
+# invocation (it feeds the 60/40 promotion gate and the UAP loop). Measured 2026-08-02: a single
+# session dispatched 20+ subagents and logged ZERO — not a marginal lapse, a total one, in the same
+# session that RECOVERED that very log file from a branch about to be deleted. An obligation that
+# loses 20 times out of 20 is not under-emphasised; it is unmechanized. Per this repo's own rule
+# (1-2 occurrences -> prose; N>=3 or a repeat on another surface -> mechanize), this is well past it.
+#
+# The check is a RECONCILIATION, not an auto-writer. A hook cannot fill `outcome` or `evidence`
+# without fabricating judgment, and a fabricated log entry is worse than a missing one — it would
+# poison the promotion gate with invented outcomes. So the hook only TALLIES (SubagentStop appends a
+# date line) and this step compares the tally against today's entries.
+#
+# It deliberately does NOT demand 1:1. Consolidating twenty challenger rounds into one entry with
+# measured counts is better bookkeeping than twenty stubs, and punishing it would train stub-spam.
+# What it catches is the failure that actually happened: dispatches occurred and NOTHING was written.
+# ABSENCE IS NOT ZERO. The tally comes from a SubagentStop hook configured in `.claude/settings.json`,
+# which is GITIGNORED by design (it also carries local permissions). So a fresh clone, another
+# machine, or a wiped settings file has no hook — and without this branch the check would read an
+# empty tally as "no dispatches today" and pass in silence. That is the exact fail-open this whole
+# step exists to close, re-created inside it; caught before commit by asking where the tally comes
+# from. Installable snippet: templates/subagent-tally-hook.json.
+TALLY="$FH/tracks/_meta/.subagent_dispatch_tally"
+LOG="$FH/knowledge/shared/learnings/subagent_invocations_log.yaml"
+HOOK_OK=0
+if [ -f "$FH/.claude/settings.json" ]; then
+  grep -q '"SubagentStop"' "$FH/.claude/settings.json" 2>/dev/null && HOOK_OK=1
+fi
+if [ "$HOOK_OK" -eq 0 ]; then
+  echo "⚠️  ④-e dispatch log NOT MEASURED — no SubagentStop tally hook in .claude/settings.json"
+  echo "     (that file is gitignored, so a fresh clone has none). An unmeasured dispatch count is"
+  echo "     NOT a count of zero. Install: templates/subagent-tally-hook.json → .claude/settings.json"
+fi
+DISPATCHED=$(grep -c "^$TODAY$" "$TALLY" 2>/dev/null | tr -d ' ' || echo 0)
+# Both quotings, because the file carries both: hand-written entries use `- date: 2026-08-02`
+# while anything appended via yaml.dump renders `- date: '"'"'2026-08-02'"'"'`. Matching one form counted
+# half the entries as absent — a divergent-normalizer miss inside the check that exists to catch
+# missing records. Known-pair calibrated below in test_dispatch_log_lanes.sh.
+LOGGED=$(grep -cE "^- date: *'?$TODAY'?" "$LOG" 2>/dev/null | tr -d ' ' || echo 0)
+if [ "${DISPATCHED:-0}" -gt 0 ] && [ "${LOGGED:-0}" -eq 0 ]; then
+  echo "❌ ④-e $DISPATCHED sub-agent dispatch(es) today and ZERO invocation-log entries — the 60/40"
+  echo "     promotion gate and the UAP loop both read that file; an unlogged session is invisible to"
+  echo "     them. Append to knowledge/shared/learnings/subagent_invocations_log.yaml (consolidated"
+  echo "     per class is fine — record counts and outcomes, not one stub per dispatch)."
+  FAIL=1
+elif [ "${DISPATCHED:-0}" -gt 0 ]; then
+  echo "✅ ④-e dispatch log: $DISPATCHED dispatch(es) today, $LOGGED log entr(ies) recorded"
+elif [ "$HOOK_OK" -eq 1 ]; then
+  echo "✅ ④-e dispatch log: no sub-agent dispatches tallied today"
+fi
+
 # ⑤ CARD-LAST invariant — the card must be the NEWEST close artifact. A card older than
 # fh_completed / signal files written this session = ⑤ ran before ①–④ finished (the bug class).
 if [ -f "$CARD" ]; then

--- a/scripts/test_dispatch_log_lanes.sh
+++ b/scripts/test_dispatch_log_lanes.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# test_dispatch_log_lanes.sh — known-pair anchor for session_close_check.sh ④-e (dispatch-log
+# reconciliation) and for the SubagentStop tally hook that feeds it.
+#
+# WHY (2026-08-02): CLAUDE.md makes an invocation-log entry mandatory immediately after any custom
+# sub-agent invocation — it feeds the 60/40 promotion gate and the UAP loop. Measured: one session
+# dispatched 20+ subagents and logged ZERO, in the same session that recovered that very log file
+# from a branch queued for deletion. An obligation that loses 20/20 is not under-emphasised, it is
+# unmechanized, so ④-e now reconciles a hook-written tally against the day's entries.
+#
+# The reconciliation itself then shipped a defect this suite exists to prevent from returning: the
+# log carries TWO date spellings — `- date: 2026-08-02` for hand-written entries and
+# `- date: '2026-08-02'` for anything appended through yaml.dump — and the first matcher saw only
+# one, counting half the entries as absent. A missing-records check that itself miscounts records is
+# the worst possible shape, so both spellings are lanes below.
+#
+# Exit 0 = the reconciliation discriminates · 1 = it would mis-report.
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK="$SCRIPT_DIR/session_close_check.sh"
+SETTINGS="$SCRIPT_DIR/../.claude/settings.json"
+FAILED=0; PASS=0
+chk() { if [ "$1" -eq 0 ]; then PASS=$((PASS+1)); echo "  ✅ $2"; else FAILED=1; echo "  ❌ $2"; fi; }
+
+[ -f "$CHECK" ] || { echo "FAIL  dispatch-log lanes: subject $CHECK missing"; exit 1; }
+
+# The matcher under test, lifted from the subject rather than re-spelled (a hand-copied predicate is
+# a divergent normalizer — which is exactly the bug being anchored). If it is gone, fail loudly.
+MATCHER=$(grep -oE "grep -cE \"\^- date: \*'\?\\\$TODAY'\?\"" "$CHECK" | head -1)
+if [ -z "$MATCHER" ]; then
+  echo "FAIL  the ④-e date matcher is no longer in session_close_check.sh in the expected form —"
+  echo "      this lane cannot verify what it claims to. Update the lane WITH the subject."
+  exit 1
+fi
+echo "── matcher located in the subject"
+
+T=$(mktemp -d); trap 'rm -rf "$T"' EXIT
+D=2026-08-02
+
+echo "── date-spelling lanes (the shipped miscount) ──"
+printf -- "- date: %s\n" "$D" > "$T/plain.yaml"
+printf -- "- date: '%s'\n" "$D" > "$T/quoted.yaml"
+printf -- "- date: %s\n- date: '%s'\n- date: 2020-01-01\n" "$D" "$D" > "$T/both.yaml"
+count() { grep -cE "^- date: *'?$D'?" "$1" 2>/dev/null | tr -d ' '; }
+[ "$(count "$T/plain.yaml")"  = 1 ] ; chk $? "unquoted date counted"
+[ "$(count "$T/quoted.yaml")" = 1 ] ; chk $? "yaml.dump-quoted date counted (the half the first matcher missed)"
+[ "$(count "$T/both.yaml")"   = 2 ] ; chk $? "mixed file counts both, and ignores another date"
+# known-POSITIVE for the bug itself: the reverted single-form matcher DOES undercount
+[ "$(grep -c "^- date: *$D" "$T/both.yaml")" = 1 ] ; chk $? "known-POSITIVE: the reverted matcher undercounts (1 of 2) — the defect is real"
+
+echo "── reconciliation verdict lanes ──"
+verdict() { # $1=dispatched $2=logged -> BLOCK | OK | NONE
+  if [ "$1" -gt 0 ] && [ "$2" -eq 0 ]; then echo BLOCK
+  elif [ "$1" -gt 0 ]; then echo OK
+  else echo NONE; fi
+}
+[ "$(verdict 20 0)" = BLOCK ] ; chk $? "dispatches with ZERO entries → BLOCK (this is the 2026-08-02 failure)"
+[ "$(verdict 20 4)" = OK ]    ; chk $? "consolidated logging (20 dispatches, 4 entries) → OK, not punished"
+[ "$(verdict 1 1)"  = OK ]    ; chk $? "1:1 logging → OK"
+[ "$(verdict 0 0)"  = NONE ]  ; chk $? "no dispatches → silent, not a failure"
+
+echo "── the tally hook that feeds it ──"
+if [ -f "$SETTINGS" ]; then
+  python3 - "$SETTINGS" <<'PY' >"$T/hookcmd" 2>/dev/null || true
+import json,sys
+d=json.load(open(sys.argv[1]))
+g=d.get("hooks",{}).get("SubagentStop",[])
+print(g[0]["hooks"][0]["command"] if g and g[0].get("hooks") else "")
+PY
+  cmd=$(cat "$T/hookcmd")
+  [ -n "$cmd" ] ; chk $? "SubagentStop hook is configured (an untallied dispatch is invisible to ④-e)"
+  if [ -n "$cmd" ]; then
+    case "$cmd" in *"exit 0"*) ok=0 ;; *) ok=1 ;; esac
+    [ "$ok" -eq 0 ] ; chk $? "hook ends in exit 0 — a non-zero hook exit discards its stdout SILENTLY"
+    # run it against a scratch HUB and confirm it appends today's date
+    CLAUDE_PROJECT_DIR="$T/hub" bash -c "$cmd" >/dev/null 2>&1
+    [ "$(grep -c "$(date +%Y-%m-%d)" "$T/hub/tracks/_meta/.subagent_dispatch_tally" 2>/dev/null || echo 0)" -ge 1 ]
+    chk $? "hook actually appends a dated line when run (not merely present)"
+  fi
+else
+  echo "  ⏭️  .claude/settings.json absent — hook lanes unchecked (not a pass)"
+fi
+
+echo "── absence-is-not-zero (the fail-open this fix nearly shipped) ──"
+# .claude/settings.json is GITIGNORED, so a fresh clone has no hook and an empty tally. Without an
+# explicit branch the reconciliation would read that as "no dispatches" and pass in silence.
+hookless_verdict() { # $1=hook_configured -> MEASURED | NOT-MEASURED
+  [ "$1" -eq 1 ] && echo MEASURED || echo NOT-MEASURED
+}
+[ "$(hookless_verdict 0)" = NOT-MEASURED ] ; chk $? "no hook → NOT MEASURED (an unmeasured count is not zero)"
+[ "$(hookless_verdict 1)" = MEASURED ]     ; chk $? "hook present → measured"
+grep -q "NOT MEASURED" "$CHECK" ; chk $? "the subject actually carries that branch (not just this lane)"
+[ -f "$SCRIPT_DIR/../templates/subagent-tally-hook.json" ] ; chk $? "installable snippet exists for a clone that has no settings.json"
+
+echo ""
+if [ "$FAILED" -ne 0 ]; then echo "DISPATCH-LOG LANES: FAIL"; exit 1; fi
+echo "DISPATCH-LOG LANES: PASS ($PASS/$PASS)"
+exit 0

--- a/templates/subagent-tally-hook.json
+++ b/templates/subagent-tally-hook.json
@@ -1,0 +1,17 @@
+{
+  "_readme": "FH dispatch-tally hook. Merge the `hooks.SubagentStop` block below into your .claude/settings.json (that file is gitignored, which is why this template exists). It feeds session_close_check.sh ④-e, which blocks a close push when sub-agents were dispatched and the day's invocation-log entries are zero. The hook TALLIES ONLY — it never writes a log entry, because a fabricated outcome/evidence field would poison the 60/40 promotion gate worse than a missing one.",
+  "hooks": {
+    "SubagentStop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'HUB=\"${CLAUDE_PROJECT_DIR:-$HOME/projects/forge-harness}\"; T=\"$HUB/tracks/_meta/.subagent_dispatch_tally\"; mkdir -p \"$(dirname \"$T\")\" 2>/dev/null; printf \"%s\\n\" \"$(date +%Y-%m-%d)\" >> \"$T\" 2>/dev/null; exit 0'",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
CLAUDE.md 는 서브에이전트 호출 직후 로그 기록을 의무로 둔다(60/40 승격 게이트 + UAP 루프의 입력). 실측: **한 세션이 20회 넘게 디스패치하고 0건 기록** — 하필 그 로그 파일을 삭제 예정 브랜치에서 회수한 그 세션에. 20/20 으로 지는 의무는 살리언스 부족이 아니라 **기계가 없는 것**이다.

## 설계에서 제일 중요한 결정

**훅은 세기만 하고 절대 항목을 쓰지 않는다.** `outcome`·`evidence` 는 판단이라 훅이 채우면 지어내는 것이고, **지어낸 항목은 빠진 항목보다 나쁘다**(승격 게이트를 가짜 결과로 오염시킴). `SubagentStop` 은 날짜 한 줄만 tally, `session_close_check.sh` **④-e** 가 그날 로그 항목과 대조.

**1:1 요구 안 함** — 20라운드를 실측 수치와 함께 1건으로 묶는 게 스텁 20개보다 나은 기록이고, 벌하면 스텁 스팸을 훈련시킨다. 잡는 건 **디스패치 있었는데 항목 0건**.

## 만들면서 잡은 자기 결함 2건

1. **날짜 매처가 절반을 못 셌다** — 로그에 표기 두 벌(수기 `- date: X`, yaml.dump `- date: 'X'`). **기록 누락을 잡는 검사가 스스로 기록을 오계수**했다.
2. **`.claude/settings.json` 은 gitignore** — 훅이 리포와 안 다닌다. 신선한 클론엔 훅 없음 → tally 빔 → "오늘 디스패치 없음"으로 **조용히 통과**. **부재는 0이 아니다.** NOT MEASURED 분기 + `templates/subagent-tally-hook.json` 으로 봉합.

**한 세션에 세 번째** — fail-open 픽스가 자기 fail-open 을 싣는 것. 공통 형태: **픽스의 입력이 출력만큼 검사받지 않는다.**

레인 **15/15**, fail-before 4종 전부 빨감(단일표기 매처 되돌림 · 훅 제거 · NOT-MEASURED 분기 제거 · 훅을 **실제로 실행해** append 확인 — 존재만으로 통과 안 시킴).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrXpp4EurL1QjqmZ7wE8Zb