### PR TITLE
chore(release): 1.4.85 — 1.4.84 가 ④-e 바닥 없이 나갔다

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,13 @@
   "plugins": [
     {
       "name": "fh-meta",
-      "version": "1.4.84",
+      "version": "1.4.85",
       "description": "Hub meta-operations toolkit — 35 skills + 7 agents. New in 1.4.53: `fh-codex-doctor` (npm bin) — Codex adapter drift scanner; reads the documented M1/M2/M3 skill tier map + skill/agent source and reports codex-native/adapter-required/claude-native/unclassified per unit, wired into `npm test`/`prepublishOnly` (fail-closed on unclassified Claude-native primitives). New in 1.4.49: steel-quench gains Step 0.6 Verdict-Invariance Probe (groundedness axis — a load-bearing judged gate's verdict must track behavior, not rubric phrasing; measured flip-count over cross-family paraphrases; arXiv:2605.06161 Policy Invariance anchor); multi_model_sidecar_strategy §Vendor-native harness (a model is strongest in its own vendor CLI — Claude/CC, GPT/codex, Gemini/Antigravity; a universal router degrades all of them, so it stays an autocomplete/QA sidecar, never orchestration); predelete_check.sh fail-closed rewrite; memory-hygiene A-TMA anchor. New in 1.4.48: phantom-quench + steel-quench gain external frontier anchors (arXiv:2607.02052 package-hallucination; arXiv:2607.02057 prompt-coverage-adequacy); README model-flat claim reframed from a per-release point-curve to structural invariants (operation flattens across tiers; depth tier-order fixed within a generation). New in 1.4.47: onboarding step ① surfaces the Mode D companion-store session-start load in the auto-read salience anchor (previously only in the local binding + rules, so a greeting could skip the load). New in 1.4.46: context-doctor command-output axis (route to rtk/proxy for verbose CLI stdout, complementing .claudeignore; risk-gated to token-scarce envs). New in 1.4.41: context-doctor 2026 trigger vocab (context engineering/rot/collapse) + phantom-citation hardening; hub measurement-integrity-checklist (cross-model measurement pre-flight: display-name pin/reps≥3/discriminating probe). New in 1.4.40: install-wizard queryable-wiki scaffold (INDEX + session-start read + R/W/C ingest). New in 1.4.39: auto-decorrelation (cross-family verifier sidecar recruitment) + video-ingest (capability-routed video ingestion). New in 1.4.x: verify-axis check-class taxonomy (mandatory-pass/measured/judged), no-reinvention Tier-0 inventory, 7-class failure taxonomy, Destructive-Op Gate, Wave-T (Temper), tier-floor governance, Mode D Model Notice, FC consent lane, default-Sonnet guidance. New in 1.3.0: public-surface-audit, field-harvest Mode B auto-trigger, 4-axis gate scope ext. Validated cross-CLI: Claude Code, Codex, Gemini.",
       "source": "./plugins/fh-meta"
     },
     {
       "name": "fh-commons",
-      "version": "1.4.84",
+      "version": "1.4.85",
       "description": "Project-agnostic utility skills — 4 skills (convergence-loop · deliberation · mcp-circuit-breaker · token-budget-gate) + 1 agent (quench-challenger). Domain-independent utilities transplantable into any project.",
       "source": "./plugins/fh-commons"
     }

--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -812,3 +812,19 @@
     whether an agent can locate it. Both arms independently cited the same residual (the paths: trigger is a READ,
     so a from-scratch Write never loads the detail rule), which is exactly the path the probe encodes. Method costs
     ~2 min/section and replaces the coverage number that was cut for being wrong four times.'
+
+- date: '2026-08-02'
+  agent: general-purpose x6 pinned to sonnet (ablation known pairs — 3 sections x 2 arms)
+  task: Ablation sweep — 3 sections x 2 arms (6 dispatches; the day's SubagentStop tally read 7, the extra being one earlier probe). Two largest MEASURABLE sections of CLAUDE.md — §Autonomous Initiative (12,224 chars,
+    8 probes) and §Session Wrap-up (8,398 chars, 2 probes) — plus the earlier §New Skill Creation Pre-Commit Gate
+  mode: paired arms per section (asset WITH vs WITHOUT the section), floor tier, all file access denied except the
+    one arm file
+  outcome: accepted
+  evidence: '3 sections ablated, 3 KEEP. §Autonomous Initiative: 5 routing behaviours GROUNDED in arm A and NOT
+    IN MY CONTEXT in arm B (context-doctor, harvest-loop, goal-quench, deep-clarify, the already-running Guard).
+    §Session Wrap-up: 4 of 6 close-chain answers fully absent without it (the ordered sequence, the absolute-last
+    rule and its reason, the late-finding re-run rule, the open-PR sweep). §New Skill gate: 3 of 3 absent.'
+  note: 'By-product worth more than the verdicts: the Pre-Publish row IN the initiative table is redundant — arm
+    B answered the full chain and the order invariant correctly from the gate''s own section (719 chars, ablatable).
+    And the headline: three measurements, three KEEPs. The ''CLAUDE.md is bloated'' premise is not surviving contact
+    — the earlier 46%-unmeasured framing measured probe coverage, which is not necessity.'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrono-meta/fh-gate",
-  "version": "1.4.84",
+  "version": "1.4.85",
   "description": "FH runtime adapters — run FH governance, skills, and agents via Claude or Codex with machine-parseable gates.",
   "license": "MIT",
   "keywords": [

--- a/plugins/fh-commons/.claude-plugin/plugin.json
+++ b/plugins/fh-commons/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-commons",
-  "version": "1.4.84",
+  "version": "1.4.85",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/.claude-plugin/plugin.json
+++ b/plugins/fh-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-meta",
-  "version": "1.4.84",
+  "version": "1.4.85",
   "engines": {
     "claudeCode": ">=1.0.0"
   },


### PR DESCRIPTION
마감 ④-b 에서 **재지 않고** "v1.4.84 이후 변경은 로그 1건뿐 → 재퍼블리시 보류"라고 썼는데, diff 는 CLAUDE.md·session_close_check.sh·selfcheck.sh·신규 레인·신규 템플릿을 담고 있었다.

순서 실측: **v1.4.84 = `a180021`, PR #237(호출로그 바닥)은 태그 뒤 머지.** 파일 수준 확인:

```
git show v1.4.84:scripts/session_close_check.sh | grep -c ④-e  →  0
현재 main                                                      →  5
```

**오늘 만든 floor 가 출하본에 없다.** 재퍼블리시한다.

같은 문단의 "Codex 진입점 언급 0건"도 산술 실패한 grep 근거였다. 재측정: `SubagentStop` 0/0 · invocation log 0/0 은 맞고 `dispatch` 는 **4/3**. drift:none 은 앞 둘로 서지 뭉뚱그린 0건으로 서지 않는다.

lockstep 4곳 · 구버전 참조 0 · count PASS · public-surface PASS · 출하 .sh 51 + .js 4 파싱 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrXpp4EurL1QjqmZ7wE8Zb