### PR TITLE
feat(gate): 태그가 자기 버전을 가리키는지 검사 — 오늘 나를 막은 건 npm 이었다

### DIFF
--- a/scripts/package_coverage_check.sh
+++ b/scripts/package_coverage_check.sh
@@ -77,6 +77,10 @@ ACCEPTED_ABSENT=(
   # regression run must not compare against this harness's probe set). Shipping the reader without
   # its corpus would put a script in the package that can only ever report "instrument error".
   "scripts/probe_scope_check.sh"
+  # Anchors templates/.git-hooks/pre-push, which is itself source-tree-only infra (the hooks dir is
+  # not in files[]). Shipping the lane without its subject would put a test in the package that can
+  # only ever SKIP. selfcheck guards on the subject's presence, so package mode skips honestly.
+  "scripts/test_tag_version_lanes.sh"
 )
 
 out=$(python3 - "${ACCEPTED_ABSENT[@]}" <<'PY'

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -330,6 +330,24 @@ else
   fail=1
 fi
 
+# tag/version consistency guard. Wired with the guard it anchors: the guard exists because a wrong
+# tag reached the remote and a publish from the wrong tree was stopped only by npm's own collision
+# check, so an unrun anchor here would be the same luck-as-floor arrangement one layer up.
+if [ ! -f templates/.git-hooks/pre-push ]; then
+  echo "SKIP  test_tag_version_lanes.sh (subject templates/.git-hooks/pre-push absent)"
+elif [ -f scripts/test_tag_version_lanes.sh ]; then
+  if ! bash scripts/test_tag_version_lanes.sh >/dev/null 2>&1; then
+    echo "FAIL  test_tag_version_lanes.sh: the tag/version guard would mis-route"
+    bash scripts/test_tag_version_lanes.sh 2>&1 | tail -12
+    fail=1
+  else
+    echo "PASS  test_tag_version_lanes.sh (mismatch blocks · match silent · scope · override)"
+  fi
+else
+  echo "FAIL  test_tag_version_lanes.sh: pre-push present but its anchor is missing"
+  fail=1
+fi
+
 # ④-e dispatch-log reconciliation + its tally hook. Wired in the same commit that ships them: the
 # obligation they mechanize lost 20/20 in a single session, so leaving the checker itself unrun
 # would be the same defect one layer up.

--- a/scripts/test_tag_version_lanes.sh
+++ b/scripts/test_tag_version_lanes.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# test_tag_version_lanes.sh — known-pair anchor for the pre-push tag/version consistency guard.
+#
+# WHY (measured 2026-08-02): a release tag was pushed onto the WRONG commit. `git pull --ff-only`
+# had failed with a diverging-branches error that went unread, so `main` was still the pre-release
+# tree; the tag landed there and `npm publish` was then attempted from that same tree. The ONLY
+# thing that stopped the publish was npm's own "cannot publish over 1.4.84" collision check.
+# Publishing does not un-happen — being saved by the registry's bookkeeping is luck, not a floor.
+#
+# Built at N=1 on purpose. This repo's escalation rule ("1-2 occurrences -> prose, N>=3 -> mechanize")
+# is scoped to REVERSIBLE surfaces; a wrong tag on a public repo plus a publish from the wrong tree
+# is the irreversible class, where the Surface-Class Degrade Invariant says fail-CLOSED immediately.
+#
+# The lanes drive the REAL hook through its real stdin contract (`<local_ref> <local_sha>
+# <remote_ref> <remote_sha>`), not a re-spelling of its predicate — a hand-copied condition is a
+# divergent normalizer and drifts lenient.
+#
+# Exit 0 = the guard discriminates · 1 = it would let a mismatched tag through, or block a good one.
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$REPO/templates/.git-hooks/pre-push"
+FAILED=0; PASS=0
+chk() { if [ "$1" -eq 0 ]; then PASS=$((PASS+1)); echo "  ✅ $2"; else FAILED=1; echo "  ❌ $2"; fi; }
+
+[ -f "$HOOK" ] || { echo "FAIL  tag-version lanes: subject $HOOK missing"; exit 1; }
+ZERO=0000000000000000000000000000000000000000
+
+# A throwaway repo so the lanes never depend on this repo's live history.
+T=$(mktemp -d); trap 'rm -rf "$T"' EXIT
+( cd "$T" && git init -q . && git config user.email a@b && git config user.name a
+  printf '{\n  "name": "x",\n  "version": "1.0.0"\n}\n' > package.json
+  git add -A && git commit -qm v100
+  printf '{\n  "name": "x",\n  "version": "1.1.0"\n}\n' > package.json
+  git add -A && git commit -qm v110
+  printf 'no manifest here\n' > README.md && rm -f package.json
+  git add -A && git commit -qm nomanifest ) >/dev/null 2>&1
+
+C_100=$(cd "$T" && git rev-parse HEAD~2)
+C_110=$(cd "$T" && git rev-parse HEAD~1)
+C_NONE=$(cd "$T" && git rev-parse HEAD)
+
+# Drive the hook exactly as git does. Run it INSIDE the scratch repo so its rev-parse/cat-file
+# resolve against that history. Only the tag verdict is under test here, so a non-zero exit from an
+# unrelated guard would be a false red — assert on the MESSAGE, and on rc only for the clean lane.
+run() { # $1=tag  $2=sha   -> prints hook output
+  printf '%s %s %s %s\n' "refs/tags/$1" "$2" "refs/tags/$1" "$ZERO" \
+    | ( cd "$T" && bash "$HOOK" origin 2>&1 )
+}
+says_mismatch() { printf '%s' "$1" | grep -q "TAG/VERSION MISMATCH"; }
+blocks()        { printf '%s' "$1" | grep -q "FH Tag/Version Consistency"; }
+
+echo "── the measured failure, reproduced ──"
+out=$(run v1.1.0 "$C_100")
+says_mismatch "$out" ; chk $? "known-POSITIVE: v1.1.0 on a commit whose package.json says 1.0.0 → MISMATCH"
+blocks "$out"        ; chk $? "…and it BLOCKS (detection wired to a blocker, not just printed)"
+
+echo "── the good case must not be blocked (over-blocking trains the override) ──"
+out=$(run v1.1.0 "$C_110")
+if says_mismatch "$out"; then chk 1 "known-NEGATIVE: matching tag/version is silent"; else chk 0 "known-NEGATIVE: matching tag/version is silent"; fi
+if blocks "$out"; then chk 1 "…and does not block"; else chk 0 "…and does not block"; fi
+
+echo "── scope: not every tag is a release tag ──"
+out=$(run v1.0.0 "$C_NONE")
+if says_mismatch "$out"; then chk 1 "no package.json at that commit → not applicable, not a block"; else chk 0 "no package.json at that commit → not applicable, not a block"; fi
+out=$(run sprint-42 "$C_100")
+if says_mismatch "$out"; then chk 1 "non-version tag name (sprint-42) is out of scope"; else chk 0 "non-version tag name (sprint-42) is out of scope"; fi
+
+echo "── the override channel exists and is explicit ──"
+grep -q 'TAG_VERSION_OK' "$HOOK" ; chk $? "TAG_VERSION_OK override present (mirrors MAIN_PUSH_OK / DESTRUCTIVE_OP_OK)"
+out=$(printf '%s %s %s %s\n' "refs/tags/v1.1.0" "$C_100" "refs/tags/v1.1.0" "$ZERO" \
+      | ( cd "$T" && TAG_VERSION_OK=1 bash "$HOOK" origin 2>&1 ))
+if blocks "$out"; then chk 1 "override actually lets the push through"; else chk 0 "override actually lets the push through"; fi
+
+echo ""
+if [ "$FAILED" -ne 0 ]; then echo "TAG-VERSION LANES: FAIL"; exit 1; fi
+echo "TAG-VERSION LANES: PASS ($PASS/$PASS)"
+exit 0

--- a/templates/.git-hooks/pre-push
+++ b/templates/.git-hooks/pre-push
@@ -54,6 +54,7 @@ DEL_OTHER=""      # refs/tags/* refs/notes/* etc. being deleted
 FORCED_REFS=""
 UNCLASSIFIED=""   # force-check impossible (remote tip not fetched)
 DIRECT_MAIN=""    # non-delete update pushed straight at the integration branch (PR-only policy)
+TAG_MISMATCH=""   # vX.Y.Z tag whose commit's package.json disagrees (irreversible-adjacent)
 SEP=$'\n'   # ranges are newline-separated and evaluated ONE REF AT A TIME: concatenating
             # them into one arg string let `--not` from ref A flip polarity for ref B, so a
             # multi-ref push could return an empty or wrong commit set (R6 audit 2026-07-26).
@@ -184,6 +185,40 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         fi ;;
     esac
   fi
+  # TAG/VERSION CONSISTENCY — a `vX.Y.Z` tag must point at a commit whose package.json says X.Y.Z.
+  # WHY (measured 2026-08-02): a release tag was pushed onto the WRONG commit because `git pull`
+  # had failed with a diverging-branches error that went unread, so `main` was still the pre-release
+  # tree. `npm publish` was then attempted from that same tree — and the ONLY thing that stopped it
+  # was npm's own "cannot publish over 1.4.84" collision check. Publishing is irreversible; being
+  # saved by the registry's bookkeeping is luck, not a floor.
+  # This is N=1 and it is built anyway: the repetition rule ("1-2 occurrences -> prose") is scoped to
+  # REVERSIBLE surfaces. A wrong tag on a public repo plus a publish from the wrong tree is the
+  # irreversible class, where this repo's own Surface-Class Degrade Invariant says fail-CLOSED now.
+  # Scope is deliberately narrow: only a NEW `refs/tags/v<digits>` push, only when package.json
+  # exists at that commit. Absent package.json -> not applicable (a tag in a non-npm repo is fine);
+  # unreadable package.json at a commit that HAS one -> BLOCK (cannot decide != allowed).
+  if [ "$local_sha" != "$ZERO" ] && [ "${remote_sha:-$ZERO}" = "$ZERO" ]; then
+    case "$remote_ref" in
+      refs/tags/v[0-9]*)
+        _tv="${remote_ref#refs/tags/v}"
+        _commit=$(git rev-parse "${local_sha}^{commit}" 2>/dev/null)
+        if [ -z "$_commit" ]; then
+          echo "  ⛔ TAG/VERSION: $remote_ref does not resolve to a commit — cannot verify, refusing"
+          TAG_MISMATCH="$TAG_MISMATCH $remote_ref"
+        elif git cat-file -e "${_commit}:package.json" 2>/dev/null; then
+          _pv=$(git show "${_commit}:package.json" 2>/dev/null \
+                | sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+          if [ -z "$_pv" ]; then
+            echo "  ⛔ TAG/VERSION: package.json exists at ${_commit} but its version is unreadable — refusing"
+            TAG_MISMATCH="$TAG_MISMATCH $remote_ref"
+          elif [ "$_pv" != "$_tv" ]; then
+            echo "  ⛔ TAG/VERSION MISMATCH: $remote_ref points at ${_commit}, whose package.json says $_pv"
+            TAG_MISMATCH="$TAG_MISMATCH $remote_ref"
+          fi
+        fi ;;
+    esac
+  fi
+
   # PR-only policy: a non-delete update aimed straight at the integration branch.
   # Detected INSIDE this loop because this is the only place git's ref list is readable.
   if [ "$local_sha" != "$ZERO" ]; then
@@ -403,6 +438,27 @@ fi
 # instead of a bare server rejection, and it keeps working if the server setting is ever relaxed.
 # It is deliberately NOT the hard floor — a client-side hook is bypassable by `--no-verify`.
 # Scope: blocks the PUSH, not the merge — `gh pr merge` operates server-side and is unaffected.
+if [ -n "$TAG_MISMATCH" ] && [ "${TAG_VERSION_OK:-0}" != "1" ]; then
+  echo ""
+  echo "══════════════════════════════════════════════"
+  echo " ⛔ FH Tag/Version Consistency (pre-push)"
+  echo "══════════════════════════════════════════════"
+  echo "  Tag(s) whose commit disagrees with package.json:$TAG_MISMATCH"
+  echo ""
+  echo "  A release tag is the thing a human and a script both trust to answer \"what shipped\"."
+  echo "  Measured 2026-08-02: a tag went onto the pre-release commit because a failed \`git pull\`"
+  echo "  went unread, and \`npm publish\` was then attempted from that same tree. Only npm's own"
+  echo "  version-collision check stopped it. Publishing does not un-happen; that was luck."
+  echo ""
+  echo "  Fix:  git fetch origin && git switch main && git pull --ff-only"
+  echo "        git tag -d <tag> && git push origin :refs/tags/<tag>   # if already pushed"
+  echo "        # then re-tag on the commit whose package.json really carries that version"
+  echo ""
+  echo "  Deliberate exception (explicit, logged — mirrors MAIN_PUSH_OK / DESTRUCTIVE_OP_OK):"
+  echo "      TAG_VERSION_OK=1 git push …"
+  exit 1
+fi
+
 if [ -n "$DIRECT_MAIN" ] && [ "${MAIN_PUSH_OK:-0}" != "1" ]; then
   echo ""
   echo "══════════════════════════════════════════════"


### PR DESCRIPTION
2026-08-02 실측: 릴리스 태그가 **잘못된 커밋**에 붙었다. `git pull --ff-only` 가 diverging 으로 실패한 걸 못 읽어 `main` 이 릴리스 이전 트리였고, 태그가 거기 박혔고, **그 트리에서 `npm publish` 까지 시도**했다. 멈춘 건 npm 의 버전 충돌 검사. **출하는 안 되돌아간다 — 레지스트리 장부가 막아준 건 floor 가 아니라 운이다.**

## 가드
`refs/tags/vX.Y.Z` 신규 push → 그 커밋 `package.json` 이 X.Y.Z 인가. 불일치 차단, `TAG_VERSION_OK=1` 명시적 예외.

## N=1 인데 지은 이유
"1~2회는 산문, N≥3 이면 기계화"는 **가역 표면** 스코프다. 공개 리포의 잘못된 태그 + 잘못된 트리 publish 는 비가역 부류이고 Surface-Class Degrade Invariant 가 **즉시 fail-closed** 를 요구한다.

## 범위와 과차단 방지 (둘 다 레인)
신규 `v<숫자>` 태그 + 그 커밋에 package.json 있을 때만. 비-npm 리포 태그·`sprint-42` 는 무관. **정상 태그를 안 막는 것도 레인** — 건강한 push 에 뜨는 가드는 override 를 습관화시키고, 그 override 는 같은 훅의 Destructive-Op 게이트를 같이 무장해제한다.

## 검증
레인 **8/8**, 훅을 **git stdin 계약으로 실제 구동**(술어 재작성 금지 — 손으로 옮긴 조건은 갈린 정규화기). fail-before 2종: **차단부만 떼도 rc=1**(검출만 있고 배선 없으면 레인이 거부) · 검출 범위 무력화 rc=1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrXpp4EurL1QjqmZ7wE8Zb