### PR TITLE
fix(package): 출하본 selfcheck 가 첫 실행부터 빨간불이었다 — 앵커 2개를 싣는다

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,8 @@
     "templates/settings.PreToolUse.snippet.json",
     "scripts/halffix_propagation_scan.sh",
     "scripts/test_halffix_lanes.sh",
-    "scripts/test_ollama_panel_lanes.sh"
+    "scripts/test_ollama_panel_lanes.sh",
+    "scripts/test_tag_version_lanes.sh",
+    "templates/subagent-tally-hook.json"
   ]
 }

--- a/scripts/package_coverage_check.sh
+++ b/scripts/package_coverage_check.sh
@@ -77,10 +77,6 @@ ACCEPTED_ABSENT=(
   # regression run must not compare against this harness's probe set). Shipping the reader without
   # its corpus would put a script in the package that can only ever report "instrument error".
   "scripts/probe_scope_check.sh"
-  # Anchors templates/.git-hooks/pre-push, which is itself source-tree-only infra (the hooks dir is
-  # not in files[]). Shipping the lane without its subject would put a test in the package that can
-  # only ever SKIP. selfcheck guards on the subject's presence, so package mode skips honestly.
-  "scripts/test_tag_version_lanes.sh"
 )
 
 out=$(python3 - "${ACCEPTED_ABSENT[@]}" <<'PY'


### PR DESCRIPTION
## Pre-Publish 게이트가 1.4.86 출하를 막아서 나온 PR

`/security-review` 가 blocking finding 을 냈고, **사이드카 말로 받지 않고 실물로 확인**했다:
`npm pack` → 압축 해제 → `bash scripts/selfcheck.sh` → **`SELFCHECK: FAIL`** (FAIL 2줄).
소비자가 설치하면 첫 실행부터 그렇다.

## 무엇이 틀렸나 — 주체는 싣고 앵커는 안 싣는다 (같은 결함 두 벌)

| 출하되는 주체 | 단언되는 앵커 | files[] |
|---|---|---|
| `templates/.git-hooks/pre-push` | `scripts/test_tag_version_lanes.sh` | ❌ 없음 |
| `test_dispatch_log_lanes.sh`(출하됨) | `templates/subagent-tally-hook.json` | ❌ 없음 |

**더 나쁜 건 계기가 스스로를 껐다는 것이다.** `package_coverage_check.sh` 는 정확히 이 클래스를
잡으라고 있는데, ACCEPTED_ABSENT 근거가 이렇게 적혀 있었다:

> `# Anchors templates/.git-hooks/pre-push, which is itself source-tree-only infra (the hooks dir is not in files[]).`

**`files[]` 에 `templates/.git-hooks` 가 있다.** 사실이 아닌 문장 하나가 예외를 정당화하고 있었다.
둘째 결함은 예외 목록에 있지도 않았다 — 체커가 `$SCRIPT_DIR/../` 형태 참조를 못 본다(자기 맹점).

## 수리

- `files[]` 에 두 앵커 추가
- 거짓 근거의 ACCEPTED_ABSENT 항목 삭제

## 검증 (같은 절차, before/after)

```
before:  FAIL  test_tag_version_lanes.sh: pre-push present but its anchor is missing
         FAIL  test_dispatch_log_lanes.sh: the dispatch-log reconciliation would mis-report
         SELFCHECK: FAIL
after:   SELFCHECK: PASS
```

기계 앵커 3종으로 접지: ① `files[]` 에 `templates/.git-hooks` 존재 True / 앵커 False
② 예외 근거 문장이 ①에 의해 반증됨 ③ 실물 tarball 실행(추론 아님).

## 왜 이게 B급이 아닌가

출하본 첫 실행이 빨간불이면 소비자가 배우는 건 **"이 체크는 무시해도 된다"**이고, 그 무시는 같은
훅에 든 **Destructive-Op · Pre-Publish 게이트까지 함께 무장해제**시킨다. 하나는 1.4.85 에도
이미 있던 것이라 **누적 2회차**다.

## 번들하지 않은 것 (Added-Scope Gate)

같은 리뷰의 B급 4건은 별건으로 간다 — `DESTRUCTIVE_OP_OK` 가 태그/버전 검사를 대납하는 경로 ·
버전 추출 sed 의 greedy 매칭 · 새 판별식의 레인 커버리지 0 · 체커의 `$SCRIPT_DIR/../` 맹점.
묶으면 2026-08-02 에 실측된 실수(덧붙인 범위가 다음 3라운드의 결함을 생산)를 반복한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETDksE6XTJrUE2yedEPv5o
