### PR TITLE
fix(claude-md): 게이트 범위를 잘못 말하던 포인터 — 그리고 그걸 고치다 세 번 더 틀렸다

### DIFF
--- a/.claude/regression/ablation_verdicts.md
+++ b/.claude/regression/ablation_verdicts.md
@@ -14,7 +14,7 @@ arms, its rep count and its date belong here; the narrative belongs in the sessi
 | Section (CLAUDE.md §) | Verdict | Instrument | Reps | Date | Basis |
 |---|---|---|---|---|---|
 | Pre-Publish Surface Gate | **KEEP** | headless · `claude -p --model sonnet --tools ''` · cwd outside repo · per-arm dirs · known pair passed before the arms ran (that pair carries two named residuals — see `scripts/ablation_calibrate.sh`) | 3 | 2026-08-03 | arm B recovered the trigger + both audit skills from the Autonomous-Initiative row and the Degrade Invariant, but lost `/security-review` in 3/3 — the third check that actually blocked the 1.4.86 publish |
-| FH Improvement 4-Axis Auto-Gate | **KEEP** (tighten, do not cut) | headless · `claude -p --model sonnet --tools ''` · cwd outside repo · per-arm dirs · known pair passed before the arms ran (that pair carries two named residuals — see `scripts/ablation_calibrate.sh`) | 3 | 2026-08-03 | the `G-GATE-02` slice is genuinely redundant (both arms 3/3), but on the surface no probe covered, arm B was **confidently wrong** 3/3: it concluded the gate does not apply to `AGENTS.md`/`templates/` edits and could not name the mandatory-read rule file. Withdraws the provisional CUT candidate |
+| FH Improvement 4-Axis Auto-Gate | **UNCALIBRATED** — owes a re-run | headless · `claude -p --model sonnet --tools ''` · cwd outside repo · per-arm dirs · known pair passed before the arms ran (that pair carries two named residuals — see `scripts/ablation_calibrate.sh`) | 3 | 2026-08-03 | see §Basis narrowed below — leg 1 REDUCED (not eliminated), leg 2 falsified by grep |
 | Permission-Denial Guidance | **KEEP** | headless · `claude -p --model sonnet --tools ''` · cwd outside repo · per-arm dirs · known pair passed before the arms ran (that pair carries two named residuals — see `scripts/ablation_calibrate.sh`) | 3 | 2026-08-03 | arm A 2/3, arm B 0/3. The single arm-A miss is the runner's nondeterminism, not a finding |
 | New Skill Creation Pre-Commit Gate | **UNCALIBRATED** | subagent method (leak channel 1 open) | — | 2026-08-02 | recorded KEEP by an instrument that had the uncut original in its system prompt. Not disproved — unqualified. Owes a re-run |
 
@@ -25,6 +25,79 @@ then cut — `scripts/ablation_calibrate.sh` header, NAMED RESIDUAL), and would 
 verdicts to a calibrator version would demote them on every edit to the calibrator. What a re-run
 owes is a configuration change, not a calibrator change. If the configuration column ever stops
 matching what `ablation_calibrate.sh` certifies, the row is UNCALIBRATED, not merely dated.
+
+### Basis narrowed — §FH 4-Axis Auto-Gate, same day, after a resident-layer fix
+
+The 2026-08-03 KEEP stood on **two** legs, both measured on the surface no probe covered:
+(1) arm B answered **confidently wrong** 3/3 — it concluded the gate does not apply to `AGENTS.md`
+or `templates/` edits; (2) arm B named the mandatory-read rule file in only 1 of 3 reps (arm A: 3/3).
+
+Leg (1) was a symptom of a *separate* defect the ablation surfaced rather than of the section being
+load-bearing: `CLAUDE.md` told the reader the rule file was "`paths:`-scoped to
+`plugins/**/SKILL.md`" while its frontmatter lists six globs, and it conflated *when the rule file
+loads* with *whether the gate applies*. Fixing that sentence (this commit) and re-measuring with the
+same calibrated runner at reps=3:
+
+| | before the fix | after |
+|---|---|---|
+| arm A — does the gate apply to `AGENTS.md`/`templates/`? | 3/3 correct | 3/3 correct |
+| arm B (§4-Axis cut) — same question | **3/3 WRONG** | **1 wrong in 16** (see the correction below) |
+| arm A — does it apply to an agent definition + `scripts/**/*.sh`? | not asked | 3/3 correct, citing the **asset list** |
+
+The corrected sentence names neither `AGENTS.md` nor `templates/`, so the re-run doubles as the
+discriminating probe: arm B answers WRONG far less often without the pattern-match crutch, which
+attributes the improvement to the principle rather than to keyword adjacency. **Far less often is
+not never — see the correction below before citing this row.**
+
+> **Target freshness.** The rows above were re-measured against the FINAL text of this commit, after
+> an intermediate draft — which had explained the gap in prose ("the hook's path set is wider than
+> the asset list") — was replaced by widening the asset lists themselves. An earlier version of this
+> table cited that deleted clause as arm A's evidence, i.e. the record described an artifact that no
+> longer shipped. Corrected here; the lesson is [[feedback_audit_target_must_be_frozen]] applied to
+> the record rather than to the runner.
+
+> 🔴 **The "after" number was wrong when first written, and the correction is the point.** This row
+> originally read `0/3 wrong`, then `0 wrong in 6`. An independent re-run at n=6 by the adversarial
+> round reproduced a **confidently wrong** arm-B answer against the FINAL text, quoting the pointer's
+> own backstop clause: *"the gate applies to any `SKILL.md` path … but neither `AGENTS.md` nor a
+> generic file under `templates/` is a `SKILL.md`, so … the 4-axis gate does not apply."* A further
+> n=10 by the author returned 10/10 correct. **Pooled: 1 confidently wrong + 1 wrong-reasoned hedge
+> in 16 reps** — a real rate, not zero. The zero was a small-sample artifact of n≤6 on a ~6% event,
+> which is exactly what `reps>=3` is too small to see. The clause that produced it has since been
+> rewritten to say the hook blocks on every listed asset class, not only `SKILL.md`; that rewrite is
+> **not** re-measured at a sample large enough to resolve a 6% rate, and is recorded as such.
+>
+> **Artifact residual**: the re-measure batches were not persisted to disk; the counts above are
+> transcript-attested. The 2026-08-03 first batch (`out/*.txt`, 24 files) was persisted and is the
+> only measurement here with a durable artifact.
+
+**So leg (1) is REDUCED, not withdrawn** — from 3/3 wrong to roughly 1 in 16. And a second adversarial round then falsified leg (2) by grep, before
+any re-run: `.claude/rules/fh_4axis_gate.md` is named at **CLAUDE.md:264**, which is OUTSIDE the cut
+(the arm removes 268–279). **Arm B held the answer string the whole time.** So "arm B named the rule file
+in only 1 of 3" measures the runner failing to use text it was handed — the nondeterminism the
+procedure already documents — not the cut section being load-bearing. It also fails CUT-reachability
+condition (b): arm A's answer is not grep-verifiable as coming *from the cut text*, because line 264
+alone supports it.
+
+The contamination was visible in the record before this commit — `ablation_method_correction_2026-08-03.md`
+noted arm B assembling its answer from "§New Skill Creation 포인터 + Autonomous Initiative 표 행 +
+§Surface-Class Degrade Invariant" — and was not carried forward into the verdict. That is the failure
+this ledger exists to prevent, committed by the ledger's own author.
+
+**Verdict: `UNCALIBRATED`, not KEEP and not CUT.** CUT is not reachable (the read-obligation surface
+still has no clean probe), and KEEP now rests on nothing that survives a grep. What is owed, in order:
+grep-verify that the obligation text exists **only** inside the cut range, build an arm whose retained
+text does not contain the answer, then re-measure. Until then this row is a re-run target, not a
+finding — the same status the subagent-method verdict below carries, and for the same reason.
+
+**Named residual — the two asset classes added on 2026-08-03 have no regression anchor.**
+`scripts/**/*.sh` and `plugins/*/agents/**/*.md` were added to both canonical asset lists in the same
+commit. `scripts/gate_pathspec_check.sh` anchors only the `SKILL_detail.md` mention and sweeps only
+`plugins/*/skills/`, so deleting either new class from either list leaves it exit 0. A parity check
+was built for exactly this and **cut in the same session**: it produced four findings in one
+adversarial round and never fired on `CLAUDE.md`, the file it was written to guard. Re-attempting it
+owes, first, a fixed per-class needle table and `CLAUDE\.md` in the hook's `GATE_IMPL` trigger —
+without those two it repeats.
 
 ## Reading a verdict
 
@@ -44,6 +117,7 @@ unfalsifiable.
 | 2026-08-03 | Pre-Publish Surface Gate | 1 (`G-TRIG-05`'s own question) | probes.md | 1 | 0 |
 | 2026-08-03 | FH 4-Axis Auto-Gate | 2 — `G-GATE-02`'s question, plus one aimed at the asset-type list + mandatory-read obligation | probes.md, plus the verbatim prior-session registration quoted below | 2 | 1 |
 | 2026-08-03 | Permission-Denial Guidance | 1 (`G-DENY-01`'s own question) | probes.md | 1 | 0 |
+| 2026-08-03 | FH 4-Axis Auto-Gate (re-measure after the CLAUDE.md pointer fix) | 2 — the same asset-type question, plus one aimed at a gated path the corrected sentence does NOT name (agent definition + `scripts/*.sh`) | pre-registered by the adversarial round that demanded a probe the fix could not satisfy by keyword adjacency | 2 | 2 (leg 1 REDUCED to ~1-in-16 by re-measure, NOT eliminated; leg 2 falsified by grep → row is now UNCALIBRATED) |
 
 ### Verbatim registration — FH 4-Axis, question 2 (2026-08-03)
 
@@ -59,3 +133,14 @@ same phantom citation this file exists to remove:
 **Named residual — this log is self-attested.** `k tried` is reported by the session that did the
 trying; a third question tried and discarded would not appear. Quoting the registration makes the
 *claim* auditable, not the *count*. Mechanize on the first recurrence of a disputed k, not before.
+
+---
+
+## Why this file needs an outside reader
+
+Four same-family adversarial rounds passed over the paragraph above without noticing that it said
+**"REDUCED, not withdrawn"** in one place and **"withdrawn"** in three others, 40 lines apart. A
+cross-family auditor found it in one pass and named the mechanism: *this file performs visible
+self-correction in a persuasive narrative voice, which makes an internal contradiction easy to wave
+through.* The voice that makes a correction legible is the same voice that makes the next
+overstatement legible. **Grep this file for its own verdict words before citing it.**

--- a/.claude/rules/fh_4axis_gate.md
+++ b/.claude/rules/fh_4axis_gate.md
@@ -45,7 +45,7 @@ paths:
 
 ## FH Improvement 4-Axis Auto-Gate (Self-Verification Orchestrator)
 
-**Whenever the AI modifies FH assets** (SKILL.md · **`SKILL_detail.md`** · `.claude/rules/*.md` · `knowledge/shared/rules/*.md` (relocated protocol rules — always full-gate, NOT under the knowledge carve-out) · `templates/` · `CLAUDE.md` · substantive `knowledge/` docs · substantive `docs/*.md` · `AGENTS.md` — see Substantive carve-out below),
+**Whenever the AI modifies FH assets** (SKILL.md · **`SKILL_detail.md`** · `.claude/rules/*.md` · `knowledge/shared/rules/*.md` (relocated protocol rules — always full-gate, NOT under the knowledge carve-out) · `templates/` · `CLAUDE.md` · substantive `knowledge/` docs · substantive `docs/*.md` · `AGENTS.md` · `scripts/**/*.sh` · agent definitions (`plugins/*/agents/**/*.md` · `.claude/agents/**/*.md`) — see Substantive carve-out below),
 the 4-axis verification chain runs **automatically before the first commit** of that session.
 No user request is needed — this is a mandatory autonomous step, not a proposal.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,17 +261,17 @@ Every new `SKILL.md` must clear a **6-item bar** (role-duplication via `/asset-p
 
 **Consequence (kept resident on purpose)**: a skill shipped **without a `Done When` definition automatically qualifies as harness-doctor L2 M-tier** — the bar has teeth, and those teeth stay in the always-loaded layer even though the bar's detail does not. Each `Done When` condition must also declare its check class (mandatory-pass / measured / judged); a **judged** condition names its adversarial pairing — no judge-only path.
 
-> **정본**: `.claude/rules/fh_4axis_gate.md §New Skill Creation Pre-Commit Gate` — the full 6-item table, the judged→measured upgrade path, and the routing/gate test. It is `paths:`-scoped to `plugins/**/SKILL.md`, so it **auto-loads when you read a SKILL.md**. **Creating a skill from scratch reads no SKILL.md — go read it explicitly.** Mechanical floor either way: `templates/.git-hooks/pre-commit` runs the full 4-axis gate on any `SKILL.md` path plus a new-skill count-consistency slice.
+> **정본**: `.claude/rules/fh_4axis_gate.md §New Skill Creation Pre-Commit Gate` — the full 6-item table, the judged→measured upgrade path, and the routing/gate test. **`paths:` governs only when that rule file AUTO-LOADS, and it covers just *some* gated assets — never read it as the gate's scope; applicability is the asset list in §FH Improvement 4-Axis Auto-Gate below.** **Creating a skill from scratch reads no SKILL.md, and several gated assets are outside the globs — go read it explicitly.** Mechanical backstop: `templates/.git-hooks/pre-commit` fires on **every asset class listed below — not only `SKILL.md`** — plus a count-consistency slice whenever a skill is added, removed or renamed. It blocks on a **missing or vacuous marker**, never on proof the axes ran; provenance is yours.
 
 ---
 
 ## FH Improvement 4-Axis Auto-Gate (Self-Verification Orchestrator)
 
-**FH 자산을 수정하면**(SKILL.md · **SKILL_detail.md** · `.claude/rules/*.md` · `knowledge/shared/rules/*.md` · `templates/` · `CLAUDE.md` · substantive `knowledge/`·`docs/*.md` · `AGENTS.md`) **4축 검증 체인이 그 세션 첫 커밋 전에 자동 실행된다.** 사용자 요청 불요 — 제안이 아니라 의무 단계다.
+**FH 자산을 수정하면**(SKILL.md · **SKILL_detail.md** · `.claude/rules/*.md` · `knowledge/shared/rules/*.md` · `templates/` · `CLAUDE.md` · substantive `knowledge/`·`docs/*.md` · `AGENTS.md` · **`scripts/**/*.sh`** · **에이전트 정의**(`plugins/*/agents/**/*.md` · `.claude/agents/**/*.md`)) **4축 검증 체인이 그 세션 첫 커밋 전에 자동 실행된다.** 사용자 요청 불요 — 제안이 아니라 의무 단계다.
 
 **기계 floor**: `git commit` 은 `templates/.git-hooks/pre-commit` 이 **하드 차단**한다. 축이 전부 PASS 할 때까지 커밋 자체가 안 된다. 아래 상세가 로드되지 않아도 **훅이 막는다** — 이 산문은 훅 위의 살리언스 층이지 유일 floor 가 아니다.
 
-> **상세 정본**: `.claude/rules/fh_4axis_gate.md` — 4축 정의·마커 필수 필드·경량 예외·substantive carve-out·target-tier sim 게이트·Mode D 모델 공지·cross-family 보완. **`paths:` 로 FH 자산 경로에 스코핑돼 있어 그 파일들을 *읽을 때* 자동 로드된다** (공식 트리거는 read — `code.claude.com/docs/en/memory.md` §Path-specific rules).
+> **상세 정본**: `.claude/rules/fh_4axis_gate.md` — 4축 정의·마커 필수 필드·경량 예외·substantive carve-out·target-tier sim 게이트·Mode D 모델 공지·cross-family 보완. **`paths:` 로 *일부* FH 자산 경로에 스코핑돼 있어 그 파일들을 *읽을 때* 자동 로드된다 — 로드 조건이지 게이트 적용 범위가 아니다** (공식 트리거는 read — `code.claude.com/docs/en/memory.md` §Path-specific rules).
 > (2026-07-20 분리. **파일 char 실측**: 이 절 자체가 76,706자 중 **10,331자(13.5%)**로 단일 최대였다. 그 분리 + 같은 세션의 중복 3건 제거 + New-Skill 게이트 편입까지 **합산**해 파일은 **76,706 → 67,611 (순감 9,095자, 11.9%)** — 합산치이지 이 절 하나의 성과가 아니다 — 이건 파일 크기지 `/context` 상주 실측이 아니다(계기≠대상, [[feedback_resident_memory_measured_fresh_toplevel]]: 상주는 톱레벨 새 세션 `/context` 로만 잰다 — 미측정). 트리거가 *파일*이고 *기계 백스톱*이 있어 1순위 후보였다. 같은 이유로 **비가역 게이트 3종은 이동 불가** — 의도 트리거라 경로 스코핑하면 fail-open 이 된다.)
 > **의무**: 이 요약에는 **축 이름·마커 필수 필드·경량 예외 기준이 없다.** 4축을 실제로 실행하거나 마커를 쓰기 전에 위 파일을 **반드시 직접 읽어라** — 안 읽고 마커를 쓰면 필드를 지어내게 된다(2026-07-20 Sonnet sim 이 스스로 지목한 실패 모드).
 > **잔여(살리언스 층에 한함, 훅은 무관)**: ⓐ 트리거가 read 라서 **신규 SKILL.md 를 Write 로 새로 만드는** 경로는 규칙이 안 실린다 ⓑ `CLAUDE.md` 는 glob 에서 의도적 제외라 CLAUDE.md-only 세션은 이 요약 + 훅만 본다. **두 경로에선 위 "반드시 읽어라"가 유일한 살리언스 층이다** — 단, 둘 다 pre-commit 훅이 여전히 커밋을 하드 차단한다.


### PR DESCRIPTION
`CLAUDE.md` 가 4축 규칙파일의 로드 범위를 "`paths:`-scoped to `plugins/**/SKILL.md`" 라고 적었는데 frontmatter 엔 glob 이 6개고, **규칙파일이 언제 로드되는지**와 **게이트가 어디에 적용되는지**를 뭉갰다. 캘리브레이션된 어블레이션 실측: 이 절을 지우면 독자가 3/3 으로 "`AGENTS.md`·`templates/` 편집엔 게이트 미적용"이라고 결론냈다.

## 고친 것
- 포인터 문장 + 8줄 아래 한국어 쌍둥이 정정
- 산문 서술 대신 **목록을 고침** — `scripts/**/*.sh` 와 에이전트 정의를 **양쪽 정본 목록에** 추가(훅은 몇 달째 게이트해왔는데 산문 목록엔 없었다)
- `.claude/agents/**/*.md` 복원 — 디렉터리 부재는 phantom 이 아니라 forward coverage
- "hard-blocks" 과대서술 정정(훅은 provenance 를 안 본다, `pre-commit:538`)

## 수리가 세 번 더 틀렸다 (same-family 4R + cross-family 1R)
`0S3A → 1S5A → 1S6A → 1S2A` → cross-family 4건. **네 라운드 중 셋이 직전 라운드의 수리에서** 결함을 찾았다.
- R1 — 사실오류 수리 문장에 새 사실오류. 판정 귀속 불가라 나열 제거.
- R2 — fail-open 방향 과확장 + "above" 가 실제로는 아래 + `:202` 와 독트린 충돌. §FH 4-Axis 를 **UNCALIBRATED** 로 강등(KEEP 근거 두 다리가 grep 으로 반증됨).
- R3 — 패리티 앵커가 한 라운드에 findings 4건 + **정작 `CLAUDE.md` 편집엔 미발동**. 통째로 잘랐다 → `gate_pathspec_check.sh` 는 main 과 바이트 동일.
- R4 — 감축이 버텼다.
- cross-family(codex) — same-family 4R 이 지나간 **기록의 자기모순**(한 곳 "REDUCED" / 세 곳 "withdrawn")을 1패스에 잡음. 진단을 §Why this file needs an outside reader 로 파일에 박음.

## 내 숫자 정정
"arm B 오답 0" 을 n=3, n=6 에서 두 번 적었으나 독립 n=6 이 자신 있게 틀린 답을 재현. **풀링 16회 중 확정오답 1 + 유보 1** — 0 이 아니다. ~6% 사건은 `reps>=3` 으로 구조적으로 안 보인다.

## 남긴 잔여
추가 자산 클래스에 **회귀 앵커 없음**(재시도 선행 = per-class needle 테이블 + `CLAUDE.md` 를 `GATE_IMPL` 에 추가) · 재작성된 backstop 문장 6% 미재측정 · `scripts/**/*.sh` 깊이 미검증.
**별건(선재)**: `:272` "기계 floor" vs `:202` "deliberately not the floor" 독트린 충돌.

4축: Axis 1 SKIP · Axis 2 **NOT CONVERGED** + cross-family 1R · Axis 3 PASS(기계) · Axis 4 기록. 타깃티어 심 PASS, **0 을 주장하지 않는다**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMYiB6HuSnTgnzvmsXLoPC
