### PR TITLE
fix(probe-scope): 이월 4건 중 진짜는 하나였고, 그 하나도 절반이었다

### DIFF
--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -893,3 +893,24 @@
     15/15 green. Two different causes: two lanes did not carry an input that exposes the defect (they
     went red for an unrelated reason and read as coverage), and one revert silently did not apply. A
     revert is an instrument too; measure that it took effect before believing the anchor.'
+
+- date: 2026-08-03
+  agent: fh-meta:challenger (isolated Agent) ×6 across three branches + codex gpt-5.5 (cross-family)
+    ×1 + headless Sonnet target-tier sims ×6 (claude -p, tools stripped, repo-external cwd)
+  task: session 2 — Axis 2 for the CLAUDE.md gate-scope pointer fix (4R), the templates/ domain-scoped
+    sections fix (1R), the probe_scope_check carryovers (1R), plus the cross-family leg on the
+    load-bearing pointer change and the before/after known-pair sims for each salience change
+  mode: consolidated entry with measured counts, per the log's own allowance
+  outcome: accepted
+  evidence: 'Pointer branch 0S3A → 1S5A → 1S6A → 1S2A; template branch 0S/3A; probe-scope branch
+    0S/3A/5B. The cross-family leg found in ONE pass what four same-family rounds had walked past —
+    the record asserted "REDUCED, not withdrawn" in one place and "withdrawn" in three others, 40
+    lines apart — and named the mechanism: the file performs visible self-correction in a persuasive
+    narrative voice, which makes an internal contradiction easy to wave through. Three separate
+    rounds independently pushed toward REDUCTION rather than tightening, and all three reductions
+    held: a second tool control, a prose/mechanism parity check, and a `[ -r ]` guard were each
+    measured inert or finding-generating and removed.'
+  note: 'The dominant new-defect class this session was MY OWN ANCHORS BEING DECORATIVE — four
+    instances, four different causes (a lane carrying no input that exposes the defect; a revert that
+    silently did not apply; a needle matching unrelated prose; a stub short-circuiting the layer the
+    guard lives in). None was self-caught. Harvested to [[feedback_anchor_can_be_decorative]].'

--- a/scripts/package_coverage_check.sh
+++ b/scripts/package_coverage_check.sh
@@ -88,6 +88,10 @@ ACCEPTED_ABSENT=(
   # selfcheck in front of every 1.4.85/1.4.86 consumer. selfcheck's block SKIPs when the subject is
   # missing, so the package stays green without pretending the lanes ran.
   "scripts/test_ablation_calibrate_lanes.sh"
+  # Anchor for probe_scope_check.sh, which is ACCEPTED_ABSENT above for want of its corpus. Same
+  # pairing rule: an anchor whose subject does not ship must not ship either, or the consumer's
+  # selfcheck goes red on a subject they do not have.
+  "scripts/test_probe_scope_lanes.sh"
 )
 
 out=$(python3 - "${ACCEPTED_ABSENT[@]}" <<'PY'

--- a/scripts/probe_scope_check.sh
+++ b/scripts/probe_scope_check.sh
@@ -257,7 +257,22 @@ _control() {
           echo "  ⚠️  UNCHECKABLE $a §$n — not a markdown asset; this extractor cannot resolve section anchors in it"
           nonmd=$((nonmd+1)); continue ;;
     esac
-    if ! _anchors "$path" | awk -v n="$n" 'substr($0,1,length(n))==n{f=1} END{exit !f}'; then
+    _anchors_out="$(_anchors "$path")"; _anchors_rc=$?
+    # DIAGNOSTIC-ONLY, MEASURED: the verdict is unchanged with and without this branch — `pipefail`
+    # already propagated awk's nonzero, so both forms exit 3. What changes is that the operator is
+    # told "instrument error" instead of "STALE", which sends them to the file instead of to a probe
+    # that was fine. Recorded as a message improvement, NOT as a closed fail-open.
+    # ANY nonzero from the extractor is an instrument error, not a finding. Routing on `-ne 0`
+    # rather than a sentinel: an explicit `[ -r ]` guard was added here first and measured to be
+    # observably INERT — awk already exits 2 on an unreadable file, so the guard changed nothing and
+    # only looked like coverage. Reverting it left behaviour identical, which is the test that
+    # caught it. The direction that matters is that an unreadable asset must not be scored STALE:
+    # that would send the next reader to edit a probe that was fine.
+    if [ "$_anchors_rc" -ne 0 ]; then
+      echo "  ⚠️  UNREADABLE $a §$n — the asset exists but cannot be read; this is an instrument error, NOT a stale probe"
+      nofile=$((nofile+1)); continue
+    fi
+    if ! printf '%s\n' "$_anchors_out" | awk -v n="$n" 'substr($0,1,length(n))==n{f=1} END{exit !f}'; then
       echo "  ❌ STALE   $a §$n — no section by that name in the asset (renamed, or relocated by a split)"
       stale=$((stale+1))
     fi
@@ -296,13 +311,13 @@ _ambig_gate_arm() {
   cp "$d/clean.md" "$d/ambig.md"
   printf '| `X-AMBIG-01` | t | e | plugin.json §Anything | mandatory-pass |\n' >> "$d/ambig.md"
 
-  bash "$0" --fixture-corpus "$d/clean.md" >/dev/null 2>&1; rc_neg=$?
+  bash "${BASH_SOURCE[0]}" --fixture-corpus "$d/clean.md" >/dev/null 2>&1; rc_neg=$?
   # Keep the positive arm's OUTPUT, not just its exit code. Exit 3 is the generic "a Scope does not
   # resolve" code, so `rc_pos == 3` alone proves only that the child failed *somehow* — a fixture that
   # went stale or unresolvable for an unrelated reason would satisfy it and the arm would certify a
   # gate that never fired. Cross-family review named this: an untyped child exit accepted as proof.
   # So the arm asserts the typed reason too: the child must report ambiguous-basename >= 1.
-  out_pos=$(bash "$0" --fixture-corpus "$d/ambig.md" 2>&1); rc_pos=$?
+  out_pos=$(bash "${BASH_SOURCE[0]}" --fixture-corpus "$d/ambig.md" 2>&1); rc_pos=$?
   amb_pos=$(printf '%s\n' "$out_pos" | sed -n 's/.*ambiguous-basename: \([0-9][0-9]*\).*/\1/p' | head -1)
   amb_pos=${amb_pos:-0}
   echo "  control C (ambig gate): clean fixture exit=$rc_neg (need 0) · duplicated-basename fixture exit=$rc_pos (need 3) · its ambiguous-basename count=$amb_pos (need >0 — the typed reason, not just the code)"
@@ -336,5 +351,20 @@ if ! _control; then
   exit 3
 fi
 
-echo "✅ every probe Scope resolves to a real section"
+# Recomputed here, NOT read from control B's `local skipped` — that variable is function-scoped and
+# reads as unset at this point, so `${skipped:-0}` silently took the "nothing unvalidated" branch and
+# printed the unqualified success line while four cells were unchecked. An instrument that cannot see
+# its own number is the failure this file exists to report, committed by this file.
+unparsed_n=$(_all_scopes 2>&1 >/dev/null | grep -c '^UNPARSED' || true)
+# BOTH classes are unvalidated, and the first version of this line counted only the first — so it
+# said "4 UNVALIDATED" when 5 cells were unchecked, and a corpus of only non-markdown scopes printed
+# ⚠️ UNCHECKABLE and then the UNQUALIFIED success line on the very next row. That is the defect this
+# conditional exists to remove, reproduced one axis over inside the fix for it.
+nonmd_n=$(_all_scopes 2>/dev/null | awk -F'\t' '{print $1}' | grep -vc '\.md$' || true)
+unvalidated=$((unparsed_n + nonmd_n))
+if [ "${unvalidated:-0}" -gt 0 ]; then
+  echo "✅ every probe Scope this parser could decompose resolves to a real section — ${unvalidated} cell(s) UNVALIDATED (${unparsed_n} in a notation this parser cannot split + ${nonmd_n} non-markdown; neither proven sectionless nor proven fine)"
+else
+  echo "✅ every probe Scope resolves to a real section"
+fi
 exit 0

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -209,6 +209,21 @@ fi
 # machine and nowhere else, which is the case this file exists to prevent. Stub runners, no API
 # spend, so running them here costs nothing. Not hermetic w.r.t. the filesystem: two isolation lanes
 # create and remove an empty, per-PID, git-invisible directory in the worktree.
+# probe-scope lanes — the subject had 15 sibling checkers with an anchor and none of its own, so
+# three repairs shipped on 2026-08-03 that could each be reverted with nothing turning red. Same
+# SKIP/FAIL shape as the blocks above: a missing SUBJECT is a legitimate skip, a present subject with
+# a missing anchor is a real failure.
+if [ ! -f scripts/probe_scope_check.sh ]; then
+  echo "SKIP  test_probe_scope_lanes.sh (subject scripts/probe_scope_check.sh absent)"
+elif [ -f scripts/test_probe_scope_lanes.sh ]; then
+  if ! bash scripts/test_probe_scope_lanes.sh; then
+    fail=1
+  fi
+else
+  echo "FAIL  test_probe_scope_lanes.sh: probe_scope_check.sh present but its anchor is missing"
+  fail=1
+fi
+
 if [ ! -f scripts/ablation_calibrate.sh ]; then
   echo "SKIP  test_ablation_calibrate_lanes.sh (subject scripts/ablation_calibrate.sh absent)"
 elif [ -f scripts/test_ablation_calibrate_lanes.sh ]; then

--- a/scripts/test_probe_scope_lanes.sh
+++ b/scripts/test_probe_scope_lanes.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# test_probe_scope_lanes.sh — regression lanes for scripts/probe_scope_check.sh.
+#
+# WHY (2026-08-03): the script had 15 sibling checkers with a `test_*_lanes.sh` and none of its own,
+# so three repairs shipped that day could each be reverted with nothing turning red — which the
+# script's own header forbids in the same words ("a repair with no arm that goes red when you revert
+# it is not anchored"). An adversarial round found that gap, not the author.
+#
+# SCOPE, MEASURED — read this before treating a green run as coverage:
+#   * the SUCCESS-LINE honesty lane below is the only one of the three repairs that is verdict-
+#     bearing; it is anchored here.
+#   * the `${BASH_SOURCE[0]}` change is INERT on every invocation form this repo uses ($0 and
+#     BASH_SOURCE produced byte-identical output for bash-relative, bash-absolute, direct-exec and
+#     symlink calls). It is kept as hygiene, not as a fix, and is deliberately NOT laned — a lane
+#     that cannot fail is the decorative-anchor defect this file exists to prevent.
+#   * the unreadable-asset routing is DIAGNOSTIC-ONLY (both forms exit 3 because pipefail already
+#     propagates awk's status). Its MESSAGE is laned below; its verdict never changed.
+#
+# Usage: bash scripts/test_probe_scope_lanes.sh
+# Exit 0 = all lanes pass · 1 = a lane failed
+
+set -uo pipefail
+FH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+SUBJ="$FH/scripts/probe_scope_check.sh"
+[ -r "$SUBJ" ] || { echo "❌ lanes: $SUBJ not readable" >&2; exit 1; }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/pscl.XXXXXX")" || exit 1
+trap 'rm -rf -- "$TMP"' EXIT
+pass=0; fail=0
+
+hdr() { printf '| Probe ID | Input Pattern | Expected Behavior | Scope | Class |\n|---|---|---|---|---|\n'; }
+chk() { # $1 label, $2 = 0 ok
+  if [ "$2" -eq 0 ]; then printf "  ✅ %s\n" "$1"; pass=$((pass+1))
+  else printf "  ❌ %s\n" "$1"; fail=$((fail+1)); fi
+}
+
+echo "── probe_scope_check lanes ──"
+
+# base fixture, built first — every lane below derives from it (see the note at L2)
+awk -F'|' 'NR<=2 || ($5 ~ /§/ && $5 ~ /\.md[[:space:]]*§/)' "$FH/.claude/regression/probes.md" > "$TMP/clean.md"
+
+# ── L1 — the success line must not speak for cells it could not check. A corpus whose only scope is
+# a NON-MARKDOWN asset produced `⚠️ UNCHECKABLE` and then, on the very next line, the unqualified
+# "every probe Scope resolves to a real section". The counter behind that line originally tallied
+# only the UNPARSED class and ignored the non-markdown one.
+{ cat "$TMP/clean.md"; printf '| `X-NONMD-01` | t | e | package.json §Anything | mandatory-pass |\n'; } > "$TMP/nonmd.md"
+out="$(bash "$SUBJ" --fixture-corpus "$TMP/nonmd.md" 2>&1)"
+printf '%s' "$out" | grep -q 'UNVALIDATED'; chk "non-markdown scope → success line says UNVALIDATED" $?
+printf '%s' "$out" | grep -qE '✅ every probe Scope resolves to a real section$'; \
+  [ $? -ne 0 ]; chk "non-markdown scope → the UNQUALIFIED success line is NOT printed" $?
+
+# ── L2 — a corpus this parser can fully decompose must still get the plain line, or the guard is
+# just over-blocking. Without this lane, "always print UNVALIDATED" would pass L1.
+# The fixture is DERIVED from the real corpus, not hand-written: `--fixture-corpus` still runs
+# control A, which looks for specific rows, so a minimal hand-made corpus fails control A and the
+# lane would go red for a reason that has nothing to do with what it claims to test. Filter the real
+# rows down to the fully-decomposable ones (markdown asset + `§` notation).
+awk -F'|' 'NR<=2 || ($5 ~ /§/ && $5 ~ /\.md[[:space:]]*§/)' "$FH/.claude/regression/probes.md" > "$TMP/clean.md"
+out="$(bash "$SUBJ" --fixture-corpus "$TMP/clean.md" 2>&1)"
+printf '%s' "$out" | grep -qE '✅ every probe Scope resolves to a real section$'; \
+  chk "fully-decomposable corpus → plain success line (guard does not over-block)" $?
+
+# ── L3 — the UNVALIDATED count must be the SUM of both classes. One UNPARSED + one non-markdown is
+# two, and the first version of the counter said one.
+{ cat "$TMP/clean.md"
+  printf '| `X-NONMD-02` | t | e | package.json §Anything | mandatory-pass |\n'
+  printf '| `X-UNPARSED-01` | t | e | scripts/selfcheck.sh · package.json | mandatory-pass |\n'; } > "$TMP/both.md"
+out="$(bash "$SUBJ" --fixture-corpus "$TMP/both.md" 2>&1)"
+printf '%s' "$out" | grep -qE '2 cell\(s\) UNVALIDATED'; chk "both unvalidated classes are summed, not just one" $?
+
+# ── L4 — an asset that EXISTS but cannot be read is an instrument error, not a stale probe. The
+# verdict is exit 3 either way (pipefail already propagates awk); what this lane pins is that the
+# operator is not sent to edit a probe that was fine.
+LOCK="$FH/knowledge/shared/.psc_lane_locked.$$.md"
+printf '## Ghost\n' > "$LOCK"; chmod 000 "$LOCK"
+{ cat "$TMP/clean.md"; printf '| `X-LOCK-01` | t | e | .psc_lane_locked.%s.md §Ghost | mandatory-pass |\n' "$$"; } > "$TMP/lock.md"
+out="$(bash "$SUBJ" --fixture-corpus "$TMP/lock.md" 2>&1)"; rc=$?
+chmod 644 "$LOCK"; rm -f "$LOCK"
+printf '%s' "$out" | grep -q 'UNREADABLE'; chk "unreadable asset reports UNREADABLE, not STALE" $?
+printf '%s' "$out" | grep -q '❌ STALE'; [ $? -ne 0 ]; chk "unreadable asset is NOT scored STALE" $?
+[ "$rc" -eq 3 ]; chk "unreadable asset still fails the gate (exit 3, fail-closed)" $?
+
+# ── L5 — a genuinely stale scope must still be caught. Without it, "call everything an instrument
+# error" would pass L4.
+{ cat "$TMP/clean.md"; printf '| `X-STALE-01` | t | e | CLAUDE.md §No Such Section Anywhere | mandatory-pass |\n'; } > "$TMP/stale.md"
+out="$(bash "$SUBJ" --fixture-corpus "$TMP/stale.md" 2>&1)"; rc=$?
+printf '%s' "$out" | grep -q '❌ STALE'; chk "a real stale scope is still reported STALE" $?
+[ "$rc" -eq 3 ]; chk "a real stale scope still fails the gate" $?
+
+echo "── lanes: $pass passed · $fail failed ──"
+[ "$fail" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
카드가 Added-Scope 로 이월한 4건 처리. 처리하면서 **셋 중 둘이 무동작**이라는 게 실측으로 나왔고, 감추지 않고 적는다.

## 진짜 결함 하나 — 성공 문구가 못 검사한 칸까지 대변했다
`✅ every probe Scope resolves to a real section` 이 바로 윗줄의 "파서가 분해 못한 칸" 보고와 모순됐다. 이 레포가 하루 종일 걷어낸 과장 클래스가 그걸 보고하는 계기 안에 있었다.

수리 첫 판도 절반이었다 — 카운터가 UNPARSED 만 세고 **non-markdown 칸을 빼먹어** 5를 4로 보고했고, non-md scope 만 있는 코퍼스에선 `⚠️ UNCHECKABLE` 다음 줄에 **무조건부 성공 문구**를 찍었다. 적대검증이 잡음. 이제 두 클래스를 합산하고 따로 이름 붙인다. (첫 시도의 `local skipped` 함수 밖 참조 → unset→0 틀린 가지도 사용 지점 재계산으로 교체.)

## 무동작 둘 — 지우지 않고 위생으로 남기되, 무동작이라고 적는다
- `$0` → `${BASH_SOURCE[0]}`: bash-상대/절대/직접실행/**심링크** 전부 출력 바이트 동일. 카드의 근거 두 개 **실측상 거짓**.
- 읽기불가 자산 라우팅: 판정 불변(`pipefail` 이 awk nonzero 를 이미 전파, 양쪽 exit 3). 바뀌는 건 **메시지**뿐 — 진단 개선이지 닫힌 구멍이 아니다.
- 같은 자리 `[ -r ]` 가드는 **관측상 무동작**이라 **제거**. 오늘 세 번째 "조이지 말고 줄여라".

## 선언 하나 철회
이월 (a) gate-locality 를 "이미 닫혔다"고 적었으나 독립 grep 이 반증. 닫힌 건 판정 **원장**이고 **절차 정본**은 여전히 bash 헤더에만 있다 — `CLAUDE.md`·`AGENTS.md`·`.claude/rules/` 전부 `ablation` **0 히트**. 열린 채로 이월.

## 앵커 — 형제 15종엔 있고 이것만 없었다
`scripts/test_probe_scope_lanes.sh` 신설(9 레인) + `selfcheck.sh` 배선. 판정 3종 각각 **되돌리면 2레인씩 빨감**, 되돌림 적용은 diff 로 확인. 픽스처는 실코퍼스 파생(손으로 쓴 최소 코퍼스는 control A 에서 죽어 레인이 무관한 이유로 빨개졌다).

## 남긴 잔여
절차 정본 gate-locality **열림** · invalid UTF-8 1바이트 파일을 UNREADABLE 로 오분류(도달불가·과차단 방향) · `-ne 0` 라우팅 gawk/mawk 미측정(리눅스 없음, BSD-first 전례 있음).

4축: Axis 1 PASS · Axis 2 1R 0S/3A **NOT CONVERGED** · Axis 3 PASS(기계) · Axis 4 기록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMYiB6HuSnTgnzvmsXLoPC
