### PR TITLE
fix(template): 이 레포를 겨냥한 적 없는 절을 심는 원인을 소스에서 고친다

### DIFF
--- a/templates/.claude/rules/session.md
+++ b/templates/.claude/rules/session.md
@@ -79,7 +79,10 @@ EOF
 
 ### Automatic Response to Issues
 
-<!-- [CUSTOMIZE] Adjust report tool/path to match your project -->
+<!-- [CUSTOMIZE] DOMAIN-SCOPED — delete this whole section if the project has no test-report
+     artifact to analyse. The old wording here said "adjust report tool/path", which assumes the
+     tool exists and reads as a config note rather than a delete instruction; the same measurement
+     that found the two sections below inert found this one inert for the same reason. -->
 
 #### Automatic Check Trigger
 
@@ -98,9 +101,27 @@ When the user mentions a problem, **automatically** locate and analyze the lates
 
 ### Code Writing Principles
 
-<!-- [CUSTOMIZE] Adjust to match your project's coding conventions. The 5 principles below are universal and valid for any project. -->
+<!-- [CUSTOMIZE] Adjust to match your project's coding conventions.
+     THREE of the five below are universal (#1 #2 #5). TWO are DOMAIN-SCOPED and belong only to
+     UI/mobile-QA projects (#3 locator stability, #4 flakiness) — DELETE them outright if this
+     project has no UI automation. Do not keep them "just in case": measured 2026-08-03 across
+     THREE repos that inherited this file. One (a bash/python wiki engine) carried both for its
+     entire 11-day life before being pruned; the other two are byte-identical to this template
+     right now and still carry them.
+     If you delete a section, also fix any sentence that counts them — the wiki engine shipped
+     "all 5 principles" over three for an hour before an outside reviewer caught it.
+     What the fix here does and does NOT do, measured as a before/after pair (Sonnet, reps=3).
+     The gain depends on how explicitly the asker names what the project lacks:
+       * question naming no-UI/no-mobile only  -> before: #3 3/3, #4 **1/3**;  after: both 3/3
+       * question also naming no-test-reports  -> before: 8 of 9 cells;        after: 9 of 9
+     So the honest claim is narrow: the old wording is mostly adequate for someone who spells out
+     every absence, and loses a section for someone who does not. Both numbers are recorded because
+     citing only the first would overstate this edit.
+     THE FIELD CAUSE IS STILL OPEN, and it is a different moment: the wiki engine did not prune
+     either section, which means nobody was asked. `light-harness init` copies this file whole,
+     with no pruning step. A marker only works on a reader who has stopped to read it. -->
 
-Be conscious of all 5 principles **before** writing code — directly reduces back-and-forth where Claude rushes to create something and the user has to correct it.
+Be conscious of every principle below **before** writing code — directly reduces back-and-forth where Claude rushes to create something and the user has to correct it.
 
 #### 1. Reference Existing Code (Consistency First)
 
@@ -116,7 +137,7 @@ Be conscious of all 5 principles **before** writing code — directly reduces ba
 
 #### 3. Locator and Identifier Stability (UI code only)
 
-<!-- [CUSTOMIZE] Can be removed for non-mobile QA / non-web QA projects -->
+<!-- [CUSTOMIZE] DOMAIN-SCOPED — delete this whole section for non-UI projects (see the note above #1) -->
 
 - Do not depend on dynamically generated attributes (auto-generated id, timestamps in content-desc)
 - Avoid absolute XPath — fragile to structural changes
@@ -124,6 +145,8 @@ Be conscious of all 5 principles **before** writing code — directly reduces ba
 - If the project has `.claude/rules/LOCATOR_*` guides, those take precedence
 
 #### 4. Flakiness Risk Management
+
+<!-- [CUSTOMIZE] DOMAIN-SCOPED — delete this whole section for projects without UI automation -->
 
 - **No `time.sleep`** — use explicit waits (implicit/explicit wait) + condition-based polling
 - No unbounded waits without a timeout


### PR DESCRIPTION
2026-08-03 실측이 이 템플릿을 상속한 **세 레포**를 셌다. bash/python 위키 엔진 하나가 모바일 로케이터·Appium flakiness·테스트 리포트 절을 **11일 수명 내내** 들고 있었고, 나머지 둘은 **지금도 바이트 동일**이다. 필드 사본은 따로 걷어냈고(forge-wiki #9), 이건 소스다.

## 고친 것
- 코드원칙 머리의 **"아래 5원칙은 universal 하고 어떤 프로젝트에나 유효하다"** 는 거짓 — #3(로케이터)·#4(flakiness)는 UI/모바일 전용. 정정.
- 도메인 전용 절 **셋**을 `DOMAIN-SCOPED — 통째로 삭제하라`로 표시. 테스트 리포트 절의 옛 마커는 *"report tool/path 를 조정하라"* 였는데 그건 그 도구가 **있다는 전제**라 없는 프로젝트한텐 삭제 지시가 아니었다.
- 개수 의존 문장(`all 5 principles`) → 개수 비의존.

## 측정 — 유리한 쪽만 인용하지 않는다
before/after known pair, Sonnet reps=3. **이득 폭이 질문의 명시성에 달려 있다**:
- 질문이 no-UI/no-mobile 만 말할 때 → before #3 3/3, **#4 1/3** / after 둘 다 3/3
- 질문이 no-test-report 까지 말할 때 → before **9칸 중 8** / after 9/9

정직한 주장은 좁다: 옛 문구는 *모든 부재를 스스로 나열하는 사람*에겐 대체로 충분하고, 그러지 않는 사람에겐 절을 하나 놓친다. 둘 다 파일에 적었다.

## 이 PR 이 닫지 *못하는* 것
**필드 원인은 그대로다.** 위키 엔진은 셋 다 안 지웠는데, 그건 **아무도 안 물었다**는 뜻이다. `auto_project_mapping.md §6` 은 이 파일을 한 줄로 복사하고 가지치기도 `{FH_ROOT}` 치환도 없다 — 상속 세 레포 전부 플레이스홀더가 날것. 측정된 이득은 *물어본 경우*고 필드 실패는 *물어보는 순간이 없는 것*. 인스톨 경로의 prune+substitute 단계가 진짜 수리이고 **별건**이다.

템플릿 SPLIT(core+domain 모듈)은 **하지 않는다** — 측정이 지목한 건 파일 모양이 아니라 설치 단계.

## 근거 정정
근거 문장이 **N=1** 이라 적혀 있었으나 실측은 N=3(둘은 현재 미조치). 카드의 기계화 게이트("N≥2 확인되면")는 명령 한 줄로 확인 가능했는데 안 했다.

4축: Axis 1 PASS · Axis 2 1R 0S/3A **NOT CONVERGED**(3A 전부 인브랜치 종결) · Axis 3 PASS(기계) · Axis 4 기록. cross-family = 의도적 same-family-only, 사유 마커에 기재.

> #243 위에 쌓여 있던 원 브랜치를 부모 머지 후 main 에서 cherry-pick 으로 재생성한 것(비가역 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMYiB6HuSnTgnzvmsXLoPC
