### PR TITLE
fix(gate): 자산목록 드리프트 앵커 재시도 — 잘렸던 두 이유를 둘 다 닫는다

### DIFF
--- a/scripts/gate_pathspec_check.sh
+++ b/scripts/gate_pathspec_check.sh
@@ -155,6 +155,77 @@ else
   fail=$((fail + 1))
 fi
 
+# ── 5. CLAUDE.md asset-list parity — the FIXED per-class needle table ─────────
+# WHY A TABLE, AND WHY FIXED. A parity check was attempted for this on 2026-08-03 and CUT the same
+# day: it guessed its needles per run, produced four findings in one adversarial round, and — the
+# decisive part — never fired on `CLAUDE.md` at all, because `CLAUDE\.md` was not in the hook's
+# GATE_IMPL trigger. Both defects are addressed here and neither is optional: the needles below are
+# FIXED (a literal table, reviewed as data), and the hook gained a SEPARATE trigger
+# (`ASSETLIST_IMPL`) so this anchor actually runs when the list it guards is edited. The trigger is
+# deliberately NOT `GATE_IMPL`: that variable also feeds `$LOADBEARING`, and enrolling every
+# CLAUDE.md prose edit into cross-family review is a different job. Retrying without both the
+# fixed table AND a trigger repeats the cut.
+#
+# WHAT IT GUARDS. `CLAUDE.md` §FH Improvement 4-Axis Auto-Gate carries a canonical asset list, and
+# `.claude/rules/fh_4axis_gate.md` carries another. When a class is added to the hook but not to a
+# prose list (or dropped from one list only), the divergence is silent — the gate still blocks, so
+# nothing goes red, while the resident text tells readers a class is not covered. That is the exact
+# shape measured on 2026-08-03, when two classes were added to both lists with no anchor behind them.
+#
+# SCOPE, deliberately narrow: this asserts the asset-list SENTENCE names each class. It does not
+# assert the hook and the sentence are equal sets — that stronger claim needs a parse of the regex
+# into classes, which is the guessing this table replaces. Narrow and mechanical beats broad and
+# self-generating; the enumeration sweep in §4 is where breadth lives.
+CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
+# Read the STAGED blob as well as the worktree, and require BOTH to declare the class.
+# Cross-family review (2026-08-04, codex/gpt-5.5) reproduced the fail-open: reading only the worktree
+# lets a commit stage a broken asset line, repair the worktree WITHOUT staging, and pass — the hook
+# sees CLAUDE.md in $STAGED, runs this anchor, and validates content that is not what is being
+# committed. Measured before the fix: index 0 occurrences / worktree 1 / anchor exit 0.
+# Checking only the index would invert the same hole (a broken UNSTAGED edit would pass a manual
+# run), so both are required. `git show :CLAUDE.md` fails outside a repo or with nothing in the
+# index; that is a skip of the staged leg, never a pass of it.
+_asset_line_of() {  # $1 = file-or-'-' content source label; reads stdin
+  grep -m1 '^\*\*FH 자산을 수정하면\*\*' || true
+}
+ASSET_LINE=$(_asset_line_of < "$CLAUDE_MD" 2>/dev/null || true)
+ASSET_LINE_STAGED=$(git -C "$REPO_ROOT" show :CLAUDE.md 2>/dev/null | _asset_line_of || true)
+if [ -z "$ASSET_LINE" ]; then
+  echo "  ❌ CLAUDE.md asset-list declaration line not found — instrument error, NOT a pass"
+  echo "     (looked for a line starting '**FH 자산을 수정하면**' in $CLAUDE_MD)"
+  fail=$((fail + 1))
+else
+  # label|needle (ERE, matched against the declaration line only)
+  for entry in \
+    'SKILL.md|SKILL\.md' \
+    'SKILL_detail.md|SKILL_detail\.md' \
+    '.claude/rules|\.claude/rules/' \
+    'knowledge/shared/rules|knowledge/shared/rules/' \
+    'templates/|templates/' \
+    'CLAUDE.md|CLAUDE\.md' \
+    'AGENTS.md|AGENTS\.md' \
+    'scripts/**/*.sh|scripts/\*\*/\*\.sh' \
+    'agent definitions (plugins/*/agents)|plugins/\*/agents/' \
+    'agent definitions (.claude/agents)|\.claude/agents/'
+  do
+    lbl="${entry%%|*}"; needle="${entry#*|}"
+    _hit=1
+    printf '%s' "$ASSET_LINE" | grep -qE "$needle" || _hit=0
+    # The staged leg only votes when it exists — an empty index blob is "not measured", not "absent".
+    if [ -n "$ASSET_LINE_STAGED" ]; then
+      printf '%s' "$ASSET_LINE_STAGED" | grep -qE "$needle" || _hit=0
+    fi
+    if [ "$_hit" -eq 1 ]; then
+      echo "  ✅ CLAUDE.md asset list declares: $lbl"; pass=$((pass + 1))
+    else
+      echo "  ❌ CLAUDE.md asset list no longer declares: $lbl"
+      echo "     The hook still gates it, so nothing goes red — the resident text now tells readers"
+      echo "     a gated class is not covered. Re-add it, or retire the class from the hook too."
+      fail=$((fail + 1))
+    fi
+  done
+fi
+
 echo
 if [ "$fail" -eq 0 ]; then
   echo "gate_pathspec_check: PASS ($pass pairs)"

--- a/scripts/gate_pathspec_check.sh
+++ b/scripts/gate_pathspec_check.sh
@@ -189,7 +189,21 @@ _asset_line_of() {  # $1 = file-or-'-' content source label; reads stdin
   grep -m1 '^\*\*FH 자산을 수정하면\*\*' || true
 }
 ASSET_LINE=$(_asset_line_of < "$CLAUDE_MD" 2>/dev/null || true)
-ASSET_LINE_STAGED=$(git -C "$REPO_ROOT" show :CLAUDE.md 2>/dev/null | _asset_line_of || true)
+# Distinguish "not in the index" (a real skip) from "git failed" (an instrument error). The advisory
+# degrade lint flagged the first draft here, and correctly: a bare `|| true` let the staged leg
+# silently abstain on ANY git failure, which half-reopens the fail-open this section was just fixed
+# for. Tracked files always have an index entry, so for this repo the abstain branch is unreachable
+# in normal operation — it exists for a clone where CLAUDE.md is untracked.
+if git -C "$REPO_ROOT" ls-files --error-unmatch CLAUDE.md >/dev/null 2>&1; then
+  ASSET_LINE_STAGED=$(git -C "$REPO_ROOT" show :CLAUDE.md 2>/dev/null | _asset_line_of)
+  if [ -z "$ASSET_LINE_STAGED" ]; then
+    echo "  ❌ CLAUDE.md is tracked but its staged blob yielded no declaration line —"
+    echo "     instrument error (or the staged content dropped the line entirely), NOT a pass."
+    fail=$((fail + 1))
+  fi
+else
+  ASSET_LINE_STAGED=""   # untracked clone — worktree leg is the only measurable one
+fi
 if [ -z "$ASSET_LINE" ]; then
   echo "  ❌ CLAUDE.md asset-list declaration line not found — instrument error, NOT a pass"
   echo "     (looked for a line starting '**FH 자산을 수정하면**' in $CLAUDE_MD)"

--- a/templates/.git-hooks/pre-commit
+++ b/templates/.git-hooks/pre-commit
@@ -706,8 +706,15 @@ run_universal_guards
 # not a reversible-surface concern — it disables the commit gate itself.
 GATE_IMPL=$(echo "$STAGED" \
   | grep -E '(templates/\.git-hooks/pre-commit|templates/regression_guard\.sh|\.claude/rules/fh_4axis_gate\.md|scripts/gate_pathspec_check\.sh)' || true)
-if [ -n "$GATE_IMPL" ]; then
-  echo "[Gate] gate implementation staged — path-coverage known-pair anchor..."
+# CLAUDE.md carries a canonical asset list that gate_pathspec_check §5 verifies, so editing it must
+# RUN the anchor. It is deliberately NOT added to GATE_IMPL: that variable also feeds $LOADBEARING,
+# which demands a cross-family acknowledgment line in the marker. Enrolling every CLAUDE.md prose
+# edit into cross-family review is a different job from path coverage, and over-blocking is how an
+# override becomes muscle memory (CLAUDE.md §Destructive-Op — the same reasoning that keeps the
+# session-close check advisory on ordinary pushes). Separate trigger, same anchor.
+ASSETLIST_IMPL=$(echo "$STAGED" | grep -E '^CLAUDE\.md$' || true)
+if [ -n "$GATE_IMPL" ] || [ -n "$ASSETLIST_IMPL" ]; then
+  echo "[Gate] gate implementation or asset list staged — path-coverage known-pair anchor..."
   PSCHECK="$REPO_ROOT/scripts/gate_pathspec_check.sh"
   if [ ! -f "$PSCHECK" ]; then
     echo "  ❌ FAIL — scripts/gate_pathspec_check.sh missing while a gate file is being changed."


### PR DESCRIPTION
카드 이월 #4. 2026-08-03 에 지었다가 **같은 날 잘린** 패리티 체크의 재시도다.

## 왜 두 선행조건을 같이 싣나 (측정)

- 잘린 판이 죽은 이유 ① — 니들을 **매 실행 추측**해서 한 라운드에 findings 4건.
- 죽은 이유 ② — `CLAUDE.md` 가 훅 트리거에 없어 **정작 CLAUDE.md 편집엔 발동조차 안 함**.
- 오늘 실측: **선행조건 ②만 넣으면 무동작**이다 — `gate_pathspec_check` 는 `CLAUDE.md` 자산목록에 대해 아무것도 단언하지 않으므로 트리거만 붙는 껍데기가 된다. 그래서 §5(고정 니들 테이블)와 트리거가 한 커밋에 간다(구성물 + 도달 배선 = 한 변경).

## 트리거는 `GATE_IMPL` 이 아니라 별도다

`GATE_IMPL` 은 `$LOADBEARING` 에도 먹여지고 그건 마커에 `crossfamily:` 를 요구한다. `CLAUDE.md` 를 거기 넣으면 **모든 산문 편집이 cross-family 리뷰 대상**이 된다 — 경로 커버리지와 다른 일이고, 과차단은 override 를 습관으로 만든다. `ASSETLIST_IMPL` 신설. 라이브 확인: 자산목록 파손 → 앵커 발동+차단, cross-family 요구 없음.

## cross-family 가 3건 잡았다 — same-family 는 0건이었다

codex/gpt-5.5 적대 감사. 전부 소스 확인 후 인브랜치 수정.

1. **fail-open — 고치기 전에 재현했다.** §5 가 **워크트리**를 읽어서, 깨진 자산 라인을 스테이징한 뒤 워크트리만 복구하면 통과한다. 실측 **인덱스 0회 / 워크트리 1회 / exit 0**. 수리 = 스테이징 blob 과 워크트리 **둘 다** 요구(인덱스만 보면 같은 구멍이 반대로 뚫린다).
2. **`agents/` 니들이 부분 드롭을 통과** — `.claude/agents/` 를 남기고 `plugins/*/agents/` 를 지워도 매칭. 두 항목으로 분할.
3. **낡은 주석**이 다음 정비자에게 "`CLAUDE.md` 를 `GATE_IMPL` 에 넣으라"고 지시 — 이 변경이 피하려는 바로 그 결합. 재작성.

codex 는 `LOADBEARING` 분리와 bash 3.2 인용 처리를 **결함 없음**으로 명시 통과.

## 두 번째 커밋 — 자문 lint 가 내 새 줄을 지목했고 맞았다

첫 커밋의 게이트 출력에서 degrade lint 가 `:189` 을 자문 경고했다. 밀지 않고 보니 실재였다: `git show :CLAUDE.md … || true` 가 **git 실패 시 스테이징 레그를 무음 기권**시켜, 방금 닫은 fail-open 이 반쯤 되살아나는 경로였다. `ls-files --error-unmatch` 로 **미추적(기권)** 과 **계기오류(FAIL)** 를 가르도록 수리. *자문층은 차단하지 않으므로, 이 커밋은 게이트 강제가 아니라 자문을 읽었기 때문에 존재한다.*

## 증거 캡슐

- **known pair** — R1 스테이징-파손 `exit 1` · R2 워크트리-파손 `exit 1` · R3 agents 부분드롭 `exit 1` · R4 정상 `exit 0` · **19 pairs pass**
- **Axis 1** `REGRESSION_GUARD: SKIP (not-checked, NOT a pass)` — `scripts/*.sh` 는 `GUARD_PATHSPEC` 밖이다(아래 잔여)
- **Axis 2** inline **0건** → cross-family **3건**, 전부 인브랜치 종결 → 잔여 0
- **Axis 3** fail-open 을 **실행으로 재현**한 뒤 수리 후 재측정; 인용한 줄 번호 전부 grep 확인
- **Axis 4** manifest 2026-08-04 기록 · 게이트 출력 `✅ ALL AXES PASSED`

## 명명된 잔여 (안 고침, 번들 안 함)

- **테이블 드리프트 비대칭** — 이 앵커는 CLAUDE.md 에서의 **제거**를 막지, 훅에만 클래스를 **추가**하고 테이블에 안 넣는 경우는 못 본다.
- **앵커 자체가 pre-commit 훅에서만 불린다** — `selfcheck`·CI 어디서도 안 부른다. 즉 `core.hooksPath` 미설정 클론에선 존재하지 않는다. floor 문제라 Added-Scope 게이트에 따라 분리.
- **Axis 1 이 `scripts/*.sh` 를 안 본다** — 분류기(`pre-commit:148`)엔 있고 `GUARD_PATHSPEC` 엔 없다. 방향은 정직(스스로 skip 이라 말함)하고 다른 축이 막으므로 fail-open 아님. PR #246 원장에도 기록됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMYiB6HuSnTgnzvmsXLoPC