### PR TITLE
fix(full-harness): 복사로 끝나던 설치에 가지치기·치환·검증 단계를 붙인다

### DIFF
--- a/knowledge/shared/rules/auto_project_mapping.md
+++ b/knowledge/shared/rules/auto_project_mapping.md
@@ -91,11 +91,74 @@ governance depth to condition 4 (mechanical-anchor / 4-axis gate) — the litmus
 
 | # | Item | Source → target | Effect |
 |---|---|---|---|
-| 1 | Session rules | `templates/.claude/rules/session.md` → `{project}/.claude/rules/session.md` | Session-start auto-read, backup, rule hierarchy |
+| 1 | Session rules | `templates/.claude/rules/session.md` → `{project}/.claude/rules/session.md` **→ then §6-b prune + substitute (the copy is not the install)** | Session-start auto-read, backup, rule hierarchy |
 | 2 | Context filter | `templates/.claudeignore` → `{project}/.claudeignore` | Token footprint control |
 | 3 | Env card | `templates/fh_env_context.jsonc` → `{project}/.claude/rules/fh_env_context.jsonc` | Environment context for sessions |
 | 4 | **MCP tool gating** (conditional — offered only when the project mounts an external MCP server: `.mcp.json`/`mcp.json` present, or the user is adding one) | `templates/.claude/rules/mcp_tool_gating.md` → `{project}/.claude/rules/mcp_tool_gating.md` | Name-keyed ask/allow tiers for external MCP tools — server annotations are unreliable (measured 2026-06-11: a live server shipped all-None hints incl. its irreversible send tool); §3 table filled at mount time |
 | 5 | **Official-plugin scan** (recommend list only — **never auto-install**) | plugin-recommender Tier 0/1 pass on the project's stack | No-reinvention acceleration: matching `*-lsp` for the project's language + workflow plugins (code-review · commit-commands · feature-dev …) from `claude-plugins-official` — see `knowledge/shared/plugin-catalog/recommended_plugins.md` §Category 0.5. Each install user-approved |
+
+### 6-b. Prune + substitute — the step that was missing, and the measurement that says so
+
+**A copy is not an install.** Item 1 above used to end at the copy, and the field result was measured
+on 2026-08-04 across every repo that inherited this template:
+
+| Repo | `{FH_ROOT}` raw | `[CUSTOMIZE]` raw |
+|---|---|---|
+| A (bash/python wiki engine) | 1 | 3 |
+| B | 2 | 6 |
+| C (a *template* repo — identical is correct here) | 2 | 6 |
+| D | **0** | **0** — the one that was customized by hand |
+
+Three of four shipped with the hub-path placeholder unresolved. The earlier repair went to the
+*template* (marking domain-scoped sections for deletion, 2026-08-04) and measured a real gain — but
+only *when someone asked*. The field failure is that **there was no moment of asking**. This is that
+moment; it is a step, not a better sentence.
+
+Run immediately after each `templates/` copy, in the target repo:
+
+```bash
+TGT={project}/.claude/rules/session.md
+# 1. SUBSTITUTE — the hub path this project should point at
+FH_ROOT_ABS=${FH_ROOT_ABS:-$HOME/projects/forge-harness}   # adjust if the hub lives elsewhere on this machine
+sed -i.bak "s|{FH_ROOT}|$FH_ROOT_ABS|g" "$TGT" && rm -f "$TGT.bak"   # -i.bak = the form BSD requires and GNU accepts
+
+# 2. PRUNE — one ask per SECTION-HEADING marker, then delete the whole section (not just the marker)
+grep -n '<!-- \[CUSTOMIZE\] DOMAIN-SCOPED' "$TGT"
+
+# 3. VERIFY — Done-When. BOTH must print 0.
+grep -c '{FH_ROOT}' "$TGT"
+grep -c '<!-- \[CUSTOMIZE\] DOMAIN-SCOPED' "$TGT"
+```
+
+**Step 3 is the Done-When** *[mandatory-pass]* — and the two counts are deliberately narrow.
+
+- **Why `{FH_ROOT}`**: an unresolved substitution token. It is the exact thing three of four inherited
+  repos shipped raw.
+- **Why only the `<!-- ... -->` form of `DOMAIN-SCOPED`**: those three markers head a deletable
+  section. The template also *mentions* the phrase in prose ("TWO are DOMAIN-SCOPED and belong only
+  to…"), which is documentation and must survive — counting every occurrence would make the target
+  unreachable.
+- **Why `[CUSTOMIZE]` is NOT counted**: the template's own instruction line reads "Change sections
+  marked with [CUSTOMIZE] comments to match your project". A zero target for that string can never be
+  met while the file explains itself, and an unreachable Done-When trains exactly one behaviour —
+  **deleting the marker instead of doing the work** — which is the defect this step exists to prevent.
+  `[CUSTOMIZE]` stays an editing hint, judged by the installer, not a counted gate.
+
+> That distinction is not theory. The first draft of this step counted all three strings and demanded
+> zero; running it on a fresh copy of the template returned **2 after a full prune** — both from lines
+> that must stay. The instrument was checked against a known pair before this step shipped, which is
+> the only reason the unreachable target did not become the rule (`§Instrument-Calibration`).
+
+Do **not** silence a count by deleting the marker alone: the markers are attached to sections, and a
+marker removed from a section that stayed is the same defect with its evidence erased.
+
+**Do not split the template into core+domain modules.** The 2026-08-04 measurement pointed at the
+*install step*, not at the file's shape, and this repo's own history says a new mechanism introduced
+speculatively generates its own defects. The markers plus this step are the fix.
+
+**Residency**: run this inside the target repo only. One of the counted repos is company-adjacent —
+it was counted and left untouched, and its contents are not reproduced here or anywhere outside its
+own environment.
 
 **Field-asset scaffold (on-demand — NOT a `templates/` install)**: harness-ification surfaces field-specific skills/agents *as needed* — the field's domain work produces them. FH accelerates their *creation*: not the domain content (the field team authors that), but the **gate-compliant structure**. When a skill-worthy recurring pattern appears (3+ reps → `#skill-candidate` tag · `field-harvest` signal · a repeated manual workflow), offer to scaffold a skeleton:
 


### PR DESCRIPTION
카드 이월 #5. §6 설치 표의 1번은 템플릿을 **복사하는 데서 끝났다.**

## 실측 — 상속 레포 전수

| | `{FH_ROOT}` 날것 | `[CUSTOMIZE]` 날것 |
|---|---|---|
| A (bash/python 위키 엔진) | 1 | 3 |
| B | 2 | 6 |
| C (**템플릿 레포** — 동일이 정상) | 2 | 6 |
| D | **0** | **0** — 손으로 커스터마이즈된 유일한 곳 |

4개 중 3개가 허브 경로 플레이스홀더를 미해결로 출하했다. 오전 수리는 **템플릿 쪽**이었고(도메인 전용 절에 삭제 마커) *물어봤을 때*의 이득을 실측했다. **필드 실패는 물어보는 순간이 없는 것**이었다 — 이 PR 이 그 순간이다.

## §6-b — 치환 → 가지치기 → 검증

Done-When 은 두 카운트가 **둘 다 0**: `{FH_ROOT}`, 그리고 `<!-- [CUSTOMIZE] DOMAIN-SCOPED` (섹션 머리 형태만).

## 내 첫 초안이 도달 불가능한 Done-When 이었다 (계기 검증이 잡음)

세 문자열을 다 세고 0을 요구했는데, **신선한 템플릿 사본에 절차를 실제로 돌려보니 완전 가지치기 후에도 2가 남았다.** 둘 다 남아야 하는 줄이다 — 템플릿 자신의 설명줄("Change sections marked with [CUSTOMIZE] comments…")과 산문 속 DOMAIN-SCOPED 언급.

**도달 불가능한 Done-When 은 정확히 한 가지 행동만 훈련시킨다: 일을 하는 대신 마커를 지우기** — 내가 같은 문단에서 하지 말라고 쓴 그것이다. 카운트를 좁히고 각 제외 사유를 본문에 적었다. 재검증: 신선한 사본 `2/3 → 0/0`.

이건 산문 수리가 아니라 **known pair 를 먼저 돌렸기 때문에** 도달 불가능한 목표가 규칙이 되지 않은 사례다.

## 안 한 것

**템플릿 SPLIT(core+domain 모듈) 은 하지 않는다.** 측정이 지목한 건 파일 모양이 아니라 설치 단계이고, 이 레포 자기 증거가 투기적 새 메커니즘은 자기 결함을 낳는다고 말한다.

## 증거 캡슐 · 잔여

- **Axis 1** `REGRESSION_GUARD_RESULT=pass`, `M-tier 0 / S-tier 0` (+63줄)
- **Axis 2** inline 1R, **1M 자기 초안에서 적발**, 인브랜치 종결 → 잔여 0
- **Axis 3** 센서스와 절차 명령 **모두 실행으로** 접지(기술이 아니라)
- **Axis 4** manifest 기록 · 게이트 `✅ ALL AXES PASSED`
- **잔여**: `sed -i.bak` 는 macOS 에서만 실측(리눅스 없음) — BSD 요구/GNU 수용은 문서화된 동작이지 이 레포의 측정은 아니다. 허브 경로는 `FH_ROOT_ABS` 로 덮어쓸 수 있게 했다.
- **잔존성**: 센 레포 중 하나는 **사내 인접** — 세기만 하고 건드리지 않았으며 내용은 어디에도 재현하지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMYiB6HuSnTgnzvmsXLoPC