### PR TITLE
fix(close-check): ④-e 가드가 자기 목적 케이스에서만 죽어 있었다

### DIFF
--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -914,3 +914,33 @@
     instances, four different causes (a lane carrying no input that exposes the defect; a revert that
     silently did not apply; a needle matching unrelated prose; a stub short-circuiting the layer the
     guard lives in). None was self-caught. Harvested to [[feedback_anchor_can_be_decorative]].'
+
+- date: 2026-08-04
+  agent: codex (gpt-5.5) — cross-family adversarial sidecar
+  invoked_by: FH self-dev session (card carry-over autopilot)
+  task: >-
+    Two separate adversarial audits. (1) A pre-commit hook trigger split plus a new known-pair
+    section in scripts/gate_pathspec_check.sh. (2) The §ⓐ restriction-union merge spec in
+    knowledge/shared/harness-core/capability_composition_contract.md.
+  outcome: accepted
+  evidence: >-
+    Audit (1): 3 defects, same-family inline pass found 0. The load-bearing one was a worktree-vs-
+    staged FAIL-OPEN — the checker read the worktree copy of CLAUDE.md, so staging a broken asset
+    line and then repairing the worktree WITHOUT staging passed the gate; reproduced before fixing
+    (index 0 occurrences / worktree 1 / anchor exit 0) and re-measured closed after (exit 1 both
+    directions). The other two: an `agents/` needle that passed on a partial class drop, and a stale
+    comment instructing the next maintainer to restore the exact coupling the change removed.
+    Codex explicitly CLEARED the LOADBEARING separation and the bash-3.2 quoting — a negative result
+    recorded because "found nothing here" is also evidence.
+    Audit (2): 5 defects, inline pass found 4 of them independently. The one net-new finding was the
+    worst of the set — §ⓐ.3 check 2 was written `merged ⊒ l` while §ⓐ.1 defined `a ⊑ b` as "a is at
+    least as strict as b", i.e. the spec's only mechanical direction check asserted the INVERSE of
+    its own invariant. Fixed by removing the glyph and writing every strictness claim as a
+    `permits(...) ⊆` relation.
+  note: >-
+    Second consecutive session where the cross-family leg produced net-new findings that same-family
+    rounds walked past, and where the net-new finding was the most severe one. Counted 5 dispatches
+    in the SubagentStop tally (2 codex audits plus 3 harness-side spawns); consolidated into this one
+    entry per the "counts and outcomes, not one stub per dispatch" rule.
+    Instrument note: the invocation form matters — `| codex exec -` (stdin) as recorded in
+    [[feedback_sidecar_liveness_not_passive_wait]]; the argv form hangs nondeterministically.

--- a/scripts/session_close_check.sh
+++ b/scripts/session_close_check.sh
@@ -156,12 +156,20 @@ if [ "$HOOK_OK" -eq 0 ]; then
   echo "     (that file is gitignored, so a fresh clone has none). An unmeasured dispatch count is"
   echo "     NOT a count of zero. Install: templates/subagent-tally-hook.json → .claude/settings.json"
 fi
-DISPATCHED=$(grep -c "^$TODAY$" "$TALLY" 2>/dev/null | tr -d ' ' || echo 0)
+# `grep -c` PRINTS 0 and EXITS 1 when the count is zero. Under `set -o pipefail` (line 16) that
+# makes the pipeline fail, `|| echo 0` appends a SECOND line, and the value becomes "0\n0" — which
+# `[ -eq ]` rejects as a bash error, so the branch it guards is skipped. The guard was therefore
+# disarmed in EXACTLY the case it exists for (zero log entries). Measured 2026-08-04 during a close:
+# the check printed ✅ while `[: 0\n0: integer expression expected` went to stderr.
+# Fix = no `|| echo`, plus integer sanitation. This is the documented prescription for this class
+# ([[feedback_pipefail_fallback_disarms_guard]]) applied to the checker that cited it.
+_int() { case "${1:-}" in (''|*[!0-9]*) echo 0 ;; (*) echo "$1" ;; esac; }
+DISPATCHED=$(_int "$(grep -c "^$TODAY$" "$TALLY" 2>/dev/null | tr -d ' ' || true)")
 # Both quotings, because the file carries both: hand-written entries use `- date: 2026-08-02`
 # while anything appended via yaml.dump renders `- date: '"'"'2026-08-02'"'"'`. Matching one form counted
 # half the entries as absent — a divergent-normalizer miss inside the check that exists to catch
 # missing records. Known-pair calibrated below in test_dispatch_log_lanes.sh.
-LOGGED=$(grep -cE "^- date: *'?$TODAY'?" "$LOG" 2>/dev/null | tr -d ' ' || echo 0)
+LOGGED=$(_int "$(grep -cE "^- date: *'?$TODAY'?" "$LOG" 2>/dev/null | tr -d ' ' || true)")
 if [ "${DISPATCHED:-0}" -gt 0 ] && [ "${LOGGED:-0}" -eq 0 ]; then
   echo "❌ ④-e $DISPATCHED sub-agent dispatch(es) today and ZERO invocation-log entries — the 60/40"
   echo "     promotion gate and the UAP loop both read that file; an unlogged session is invisible to"

--- a/scripts/test_dispatch_log_lanes.sh
+++ b/scripts/test_dispatch_log_lanes.sh
@@ -93,6 +93,39 @@ hookless_verdict() { # $1=hook_configured -> MEASURED | NOT-MEASURED
 grep -q "NOT MEASURED" "$CHECK" ; chk $? "the subject actually carries that branch (not just this lane)"
 [ -f "$SCRIPT_DIR/../templates/subagent-tally-hook.json" ] ; chk $? "installable snippet exists for a clone that has no settings.json"
 
+echo "── pipefail disarm (the guard was dead in EXACTLY its target case) ──"
+# `grep -c` PRINTS 0 and EXITS 1 on a zero count. Under `set -o pipefail` the old
+# `grep -c … | tr -d ' ' || echo 0` therefore produced "0\n0", `[ -eq ]` threw, and the ❌ branch
+# was skipped — so ④-e reported ✅ whenever the log had ZERO entries, which is the one situation it
+# exists to block. Measured live 2026-08-04 during a session close.
+# Lane 1: reproduce the OLD form and assert it is broken (a control — if this ever passes, the
+# premise changed and the fix below is measuring nothing).
+old_form=$(bash -c 'set -uo pipefail; grep -c "^NOSUCHDATE$" '"$CHECK"' 2>/dev/null | tr -d " " || echo 0')
+[ "$(printf %s "$old_form" | grep -c "")" -eq 2 ] ; chk $? "control: the old \`|| echo 0\` form really does yield TWO lines under pipefail"
+# Lane 2: the shipped form yields a single sanitised integer.
+new_form=$(bash -c 'set -uo pipefail; _int() { case "${1:-}" in (""|*[!0-9]*) echo 0 ;; (*) echo "$1" ;; esac; }; _int "$(grep -c "^NOSUCHDATE$" '"$CHECK"' 2>/dev/null | tr -d " " || true)"')
+[ "$new_form" = "0" ] ; chk $? "shipped form yields a single sanitised 0"
+( set -uo pipefail; [ "$new_form" -eq 0 ] ) 2>/dev/null ; chk $? "and \`[ -eq ]\` accepts it (the old form threw here)"
+# Lane 3-5: BEHAVIOUR, not spelling. The first draft of these lanes string-matched the old form and
+# went GREEN on a revert — the needle did not match `tr -d ' '` (quotes), so the anchor was
+# decorative in the way this repo already named ([[feedback_anchor_can_be_decorative]], cause:
+# "needle matching unrelated text"). Extract the subject's OWN assignment lines and evaluate them.
+_eval_subject_assign() {  # $1 = variable name; echoes what the SUBJECT computes for a zero match
+  local var="$1" line
+  line=$(grep -E "^${var}=" "$CHECK" | head -1)
+  [ -n "$line" ] || { echo "NOLINE"; return; }
+  bash -c "set -uo pipefail
+    _int() { case \"\${1:-}\" in (''|*[!0-9]*) echo 0 ;; (*) echo \"\$1\" ;; esac; }
+    TODAY=NOSUCHDATE; TALLY='$CHECK'; LOG='$CHECK'
+    $line
+    printf %s \"\$$var\"" 2>/dev/null
+}
+for _v in DISPATCHED LOGGED; do
+  _got=$(_eval_subject_assign "$_v")
+  [ "$(printf %s "$_got" | grep -c '')" -le 1 ] ; chk $? "subject's \$$_v is ONE line on a zero match (was two: the disarm)"
+  ( set -uo pipefail; [ "${_got:-x}" -eq 0 ] ) 2>/dev/null ; chk $? "subject's \$$_v survives \`[ -eq 0 ]\` (the disarm threw here)"
+done
+
 echo ""
 if [ "$FAILED" -ne 0 ]; then echo "DISPATCH-LOG LANES: FAIL"; exit 1; fi
 echo "DISPATCH-LOG LANES: PASS ($PASS/$PASS)"


### PR DESCRIPTION
**마감 체인을 돌리다 발견했다.** ④-e 가 ✅ 를 찍는데 그 옆 stderr 로 `[: 0\n0: integer expression expected` 가 나가고 있었다.

## 메커니즘

`grep -c` 는 **0을 출력하고 exit 1** 한다. `set -uo pipefail` 아래에서 `grep -c … | tr -d ' ' || echo 0` 은 파이프라인 실패로 판정돼 `|| echo 0` 이 **둘째 줄**을 붙이고, 값이 `"0\n0"` 이 된다. `[ "0\n0" -eq 0 ]` 은 bash 에러(=거짓)라 **❌ 분기가 통째로 스킵**된다.

즉 이 가드는 **로그 항목이 0건일 때만** 죽는다 — 그게 이 가드가 존재하는 유일한 이유다. 이 레포가 이미 `[[feedback_pipefail_fallback_disarms_guard]]` 로 기록한 클래스가, **그 교훈을 주석으로 인용하고 있는 체커 안에서** 재발했다.

## 수리와 즉시 나온 참 판정

`|| echo` 제거 + `_int()` 정수 소독. 고치자마자 가드가 **참인 차단**을 냈다 — `5 dispatch / 0 log entries`. 실제로 오늘 codex 사이드카 감사 2회 포함 5건이 tally 됐는데 호출 로그가 비어 있었다. 그 항목도 이 PR 에 함께 기록(클래스별 통합 1건, 규약대로).

## 앵커가 또 장식이었다 — 이번엔 앵커 자체가 결함

회귀 레인 첫 판은 **옛 형태를 문자열로 매칭**했고, 되돌려보니 **초록이었다** — needle 이 `tr -d ' '` 의 따옴표를 못 잡았다. 이틀 새 **같은 클래스 네 번째**이고, 하필 이 클래스를 막으려고 쓴 앵커 안에서 났다.

철자 매칭을 버리고 **동작 기반**으로 교체: 대상에서 `DISPATCHED=`/`LOGGED=` **할당문을 뽑아 pipefail 셸에서 실제로 평가**하고 결과가 한 줄 정수인지 · `[ -eq 0 ]` 을 통과하는지 본다.

**되돌림 재검증** — 두 줄 **전부** 되돌리고(되돌림 적용을 **diff 로 먼저 확인**) → **exit 1**, 복원 → **exit 0**. **22/22 레인**.

## 증거 캡슐 · 잔여

- **Axis 1** `REGRESSION_GUARD: SKIP (not-checked, NOT a pass)` — `scripts/*.sh` 는 `GUARD_PATHSPEC` 밖(기지 잔여)
- **Axis 2** inline 1R, **1M — 픽스가 아니라 내 앵커에서 적발**, 인브랜치 종결
- **Axis 3** disarm 을 **라이브 stderr 에서 재현**한 뒤 수리·재측정(추론 아님)
- **Axis 4** manifest 기록 · 게이트 `✅ ALL AXES PASSED`
- **잔여**: 이건 스캔이 아니라 **stderr 한 줄을 읽어서** 찾았다. 마감 체인 다른 곳에 같은 `grep -c … || echo 0` 이 더 있는지는 **쓸어보지 않았다** — `verify_next` 에 등재.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMYiB6HuSnTgnzvmsXLoPC