### PR TITLE
chore(release): v1.4.87 — v1.4.86 이후 출하자산 19개 반영

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,13 @@
   "plugins": [
     {
       "name": "fh-meta",
-      "version": "1.4.86",
+      "version": "1.4.87",
       "description": "Hub meta-operations toolkit — 35 skills + 7 agents. New in 1.4.53: `fh-codex-doctor` (npm bin) — Codex adapter drift scanner; reads the documented M1/M2/M3 skill tier map + skill/agent source and reports codex-native/adapter-required/claude-native/unclassified per unit, wired into `npm test`/`prepublishOnly` (fail-closed on unclassified Claude-native primitives). New in 1.4.49: steel-quench gains Step 0.6 Verdict-Invariance Probe (groundedness axis — a load-bearing judged gate's verdict must track behavior, not rubric phrasing; measured flip-count over cross-family paraphrases; arXiv:2605.06161 Policy Invariance anchor); multi_model_sidecar_strategy §Vendor-native harness (a model is strongest in its own vendor CLI — Claude/CC, GPT/codex, Gemini/Antigravity; a universal router degrades all of them, so it stays an autocomplete/QA sidecar, never orchestration); predelete_check.sh fail-closed rewrite; memory-hygiene A-TMA anchor. New in 1.4.48: phantom-quench + steel-quench gain external frontier anchors (arXiv:2607.02052 package-hallucination; arXiv:2607.02057 prompt-coverage-adequacy); README model-flat claim reframed from a per-release point-curve to structural invariants (operation flattens across tiers; depth tier-order fixed within a generation). New in 1.4.47: onboarding step ① surfaces the Mode D companion-store session-start load in the auto-read salience anchor (previously only in the local binding + rules, so a greeting could skip the load). New in 1.4.46: context-doctor command-output axis (route to rtk/proxy for verbose CLI stdout, complementing .claudeignore; risk-gated to token-scarce envs). New in 1.4.41: context-doctor 2026 trigger vocab (context engineering/rot/collapse) + phantom-citation hardening; hub measurement-integrity-checklist (cross-model measurement pre-flight: display-name pin/reps≥3/discriminating probe). New in 1.4.40: install-wizard queryable-wiki scaffold (INDEX + session-start read + R/W/C ingest). New in 1.4.39: auto-decorrelation (cross-family verifier sidecar recruitment) + video-ingest (capability-routed video ingestion). New in 1.4.x: verify-axis check-class taxonomy (mandatory-pass/measured/judged), no-reinvention Tier-0 inventory, 7-class failure taxonomy, Destructive-Op Gate, Wave-T (Temper), tier-floor governance, Mode D Model Notice, FC consent lane, default-Sonnet guidance. New in 1.3.0: public-surface-audit, field-harvest Mode B auto-trigger, 4-axis gate scope ext. Validated cross-CLI: Claude Code, Codex, Gemini.",
       "source": "./plugins/fh-meta"
     },
     {
       "name": "fh-commons",
-      "version": "1.4.86",
+      "version": "1.4.87",
       "description": "Project-agnostic utility skills — 4 skills (convergence-loop · deliberation · mcp-circuit-breaker · token-budget-gate) + 1 agent (quench-challenger). Domain-independent utilities transplantable into any project.",
       "source": "./plugins/fh-commons"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrono-meta/fh-gate",
-  "version": "1.4.86",
+  "version": "1.4.87",
   "description": "FH runtime adapters — run FH governance, skills, and agents via Claude or Codex with machine-parseable gates.",
   "license": "MIT",
   "keywords": [

--- a/plugins/fh-commons/.claude-plugin/plugin.json
+++ b/plugins/fh-commons/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-commons",
-  "version": "1.4.86",
+  "version": "1.4.87",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/.claude-plugin/plugin.json
+++ b/plugins/fh-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-meta",
-  "version": "1.4.86",
+  "version": "1.4.87",
   "engines": {
     "claudeCode": ">=1.0.0"
   },


### PR DESCRIPTION
카드 1순위였던 npm 재퍼블리시. 버전은 4개 선언 전부 락스텝
(package.json · marketplace.json 2엔트리 · plugin.json 2개) — Codex 가 plugin.json
version 으로 캐시하므로 하나라도 어긋나면 stale 진입점이 나간다.

실측: v1.4.86..HEAD 변경 27개 중 **출하 대상 19개**(카드에 적힌 18은 한 개 적었다).
신규 4 = capability_composition_contract.md · 레인 3종.

Pre-Publish 게이트 (비가역 표면 → fail-closed):
- public-surface scan 전 출하파일 본문 PASS. known-pair 컨트롤로 계기 구분력 확인
  (알려진-양성 심으면 exit 1 + HIGH/MED 둘 다 검출).
- marketplace-gate Check 5 SAFE — 내부 호스트명 0/218파일(유일 히트는 스캐너 자기
  패턴 문자열), 시크릿 0, LICENSE(MIT) 존재.
- security-review: 내장 게이트의 diff 가 브랜치-vs-main(버전범프뿐)이라 비어 공허
  PASS 였다. 출하 실행물 델타 1,147줄로 재스코핑해 실측 — HIGH/MED 0. 위험 히트 3건은
  전부 `mktemp -d` 직후 정리 trap(따옴표+set -u 하 안전).

selfcheck 178 PASS / 0 FAIL, **macOS·Linux 양쪽 동일**(verdict 라인 diff 0).
이번에 리눅스 환경이 생겨 처음으로 출하 전 검증을 두 OS 에서 돌렸다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>