### PR TITLE
fix(degrade-scan): S5 가 앵커를 파이프 유무에 걸어, 어제 출하된 결함을 못 봤다

### DIFF
--- a/scripts/degrade_direction_scan.sh
+++ b/scripts/degrade_direction_scan.sh
@@ -164,9 +164,41 @@ for f in "${FILES[@]}"; do
     # yields "9\n0" and the `-gt` guard goes silent. Verified as a known pair (both directions) in
     # scripts/test_degrade_scan_shell_probes.sh; narrowing without that anchor would just trade a
     # noisy probe for a blind one.
+    #
+    # WIDENED 2026-08-04 — the narrowing had gone one step too far, and the proof is that this
+    # probe was BLIND to the live instance that bit us the day before. PR #251 fixed
+    # `grep -c … | tr -d ' ' || echo 0` in session_close_check.sh ④-e; running this scanner over
+    # the pre-#251 file produced ZERO hits (re-measured: fixed rule = 2, old rule = 0).
+    #
+    # THE ANCHOR WAS ON THE WRONG PROPERTY. The old regex asked "is there an upstream pipe" and
+    # required the counter to be the LAST stage. Neither is the discriminator. The discriminator
+    # is: **does the failing side still EMIT?** `grep -c` prints "0" and exits 1 on no-match, so it
+    # disarms with no upstream pipe at all, and any trailing stage that passes that "0" through
+    # keeps the "0\n0" intact.
+    #
+    # A first fix widened to a NAMED filter list (tr|head|sed|…). Cross-family review (gpt-5.5,
+    # 2026-08-04) refuted it with reproduced counter-examples, and the refutation held on
+    # measurement in BOTH directions:
+    #   · still missed, all verified to yield "0\n0": `grep -Ec …`, `grep --count …`, `grep -Fcx …`
+    #     (combined/long flag forms the `-c` literal never matched) and `| cat`.
+    #   · newly over-matched: `| tail -n +2` after the counter yields ONE line — not a disarm.
+    # Name-based approximation produced under-match and over-match simultaneously. So the trailing
+    # chain is no longer enumerated: the rule keys on the COUNTER (grep with a `c` in any flag
+    # cluster or `--count`; or `wc` behind a real pipe) plus the `|| echo 0` fallback, and accepts
+    # any chain between them.
+    #
+    # PRESERVED from the 2026-07-28 narrowing, still pinned as known-negatives: (a) `a || b ||
+    # echo 0` has no pipeline, and (b) a stage that emits NOTHING on failure (`| jq -r … ||
+    # echo 0`) — there the fallback supplies the only line, as intended.
+    # KNOWN RESIDUAL, stated not hidden: a trailing stage that can swallow the counter's output
+    # (`| tail -n +2`, `| sed -n '/[1-9]/p'`) is now flagged though it is not a disarm. That is a
+    # deliberate recall-over-precision trade on an ADVISORY probe, taken because the measured cost
+    # of the other direction was a real defect shipping. Revisit if non-fixture FPs appear.
+    # Known pair: scripts/test_degrade_scan_shell_probes.sh (9 positives / negatives silent).
+    # Reverting this line turns the positive lane red — checked by applying the revert.
     while IFS= read -r m; do
-      emit "$f" "${m%%:*}" "S5:pipefail-fallback(sh)" "\`|| echo 0\` fallback on a pipeline ending in a counter (grep -c/wc) — that stage emits even when an upstream stage fails, so under \`set -o pipefail\` the value gains a SECOND line, the integer comparison errors out, and the guard passes silently; split the pipeline and sanitize to an integer"
-    done < <(grep -nE '[^|]\|[[:space:]]*([a-z]+[[:space:]]+)*(grep[^|]*-c|wc)[^|]*\|\|[[:space:]]*echo[[:space:]]+[\"'"'"']?0' "$f" 2>/dev/null \
+      emit "$f" "${m%%:*}" "S5:pipefail-fallback(sh)" "\`|| echo 0\` fallback after a COUNTER (grep with -c / --count, or wc) — the counter PRINTS \"0\" and exits non-zero on no-match, so the fallback appends a SECOND line, the value becomes \"0\\n0\", the integer test dies with 'integer expression expected' (stderr only) and the guard goes silent; split it and sanitize: n=\$(...); n=\${n:-0}; case \$n in *[!0-9]*) n=0;; esac. VERIFY the trailing stage can actually emit — if it swallows the count (| tail -n +2), this is a known false positive"
+    done < <(grep -nE '(([^|]\|[[:space:]]*([a-z]+[[:space:]]+)*wc[^|]*)|(grep([[:space:]]+-[A-Za-z]*c[A-Za-z]*|[[:space:]]+--count)[^|]*))([^|]*\|[^|]*)*\|\|[[:space:]]*echo[[:space:]]+[\"'"'"']?0' "$f" 2>/dev/null \
              | grep -vE '^[0-9]+:[[:space:]]*#' \
              | grep -vE '#[[:space:]]*noqa[:[:space:]]*degrade')
   fi

--- a/scripts/test_degrade_scan_shell_probes.sh
+++ b/scripts/test_degrade_scan_shell_probes.sh
@@ -163,6 +163,15 @@ cat > "$TMP/s5_positive.sh" <<'EOF'
 set -uo pipefail
 N=$(find /nope . -maxdepth 1 2>/dev/null | grep -c . || echo 0)
 M=$(git log --oneline 2>/dev/null | wc -l || echo 0)
+# WIDENED 2026-08-04. Every line below was INVISIBLE to the narrowed rule, and each was verified to
+# actually produce "0\n0" before being pinned here (line count measured, not assumed):
+P=$(cat /etc/hosts | grep -c . | tr -d ' ' || echo 0)   # transparent filter after the counter
+Q=$(grep -c "^nosuchline$" /etc/hosts 2>/dev/null | tr -d ' ' || echo 0)  # the PR #251 shape
+R=$(grep -Ec "^nosuchline$" /etc/hosts || echo 0)       # combined flag cluster -Ec
+S=$(grep --count "^nosuchline$" /etc/hosts || echo 0)   # long option
+T=$(grep -Fcx "nosuchline" /etc/hosts || echo 0)        # -Fcx
+U=$(false | grep -c . | cat || echo 0)                  # trailing stage that always emits
+V=$(false | grep -c . | grep -v nosuch || echo 0)       # trailing grep whose pattern misses the "0"
 EOF
 cat > "$TMP/s5_negative.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -174,8 +183,8 @@ J=$(printf '%s' "$x" | jq -r '.a // 0' 2>/dev/null || echo 0)
 # A comment describing the defect must not be scored as the defect: cmd | grep -c . || echo 0
 EOF
 n=$(s_hits "$TMP/s5_positive.sh")
-[ "$n" -eq 2 ] && ok "S5 known-positive: counter-stage fallbacks (grep -c, wc) detected 2/2" \
-                || bad "S5 known-positive: expected 2 S-hits, got $n — the pipefail disarm is invisible"
+[ "$n" -eq 9 ] && ok "S5 known-positive: 9/9 — incl. -Ec/--count/-Fcx flag clusters, trailing \`| cat\`/\`| grep -v\`, and the no-upstream-pipe form" \
+                 || bad "S5 known-positive: expected 9 S-hits, got $n — 2 = the pre-2026-08-04 rule (pipe-presence anchor); 4 = the first widening, which still missed every combined flag cluster (\`-Ec\`, \`--count\`, \`-Fcx\`) and any trailing stage outside a hardcoded name list"
 
 n=$(s_hits "$TMP/s5_negative.sh")
 [ "$n" -eq 0 ] && ok "S5 known-negative: \`||\` chains, empty-on-failure pipelines and comments stay silent" \

--- a/scripts/test_dispatch_log_lanes.sh
+++ b/scripts/test_dispatch_log_lanes.sh
@@ -75,7 +75,14 @@ PY
     [ "$ok" -eq 0 ] ; chk $? "hook ends in exit 0 — a non-zero hook exit discards its stdout SILENTLY"
     # run it against a scratch HUB and confirm it appends today's date
     CLAUDE_PROJECT_DIR="$T/hub" bash -c "$cmd" >/dev/null 2>&1
-    [ "$(grep -c "$(date +%Y-%m-%d)" "$T/hub/tracks/_meta/.subagent_dispatch_tally" 2>/dev/null || echo 0)" -ge 1 ]
+    # Split + sanitize, not `grep -c … || echo 0`: on no-match `grep -c` PRINTS "0" and exits 1, so
+    # the fallback appends a SECOND line and `[ -ge ]` dies with "integer expression expected".
+    # Here that error happens to land on the FAIL branch — honest scope: this was never a live
+    # fail-open, it was a verdict reached by a bash error instead of a comparison, one refactor
+    # away from flipping. Found by the S5 sweep after the rule was widened (2026-08-04).
+    _tally_n=$(grep -c "$(date +%Y-%m-%d)" "$T/hub/tracks/_meta/.subagent_dispatch_tally" 2>/dev/null); _tally_n=${_tally_n:-0}
+    case "$_tally_n" in (*[!0-9]*|'') _tally_n=0 ;; esac
+    [ "$_tally_n" -ge 1 ]
     chk $? "hook actually appends a dated line when run (not merely present)"
   fi
 else

--- a/templates/degrade_direction_scan.sh
+++ b/templates/degrade_direction_scan.sh
@@ -164,9 +164,41 @@ for f in "${FILES[@]}"; do
     # yields "9\n0" and the `-gt` guard goes silent. Verified as a known pair (both directions) in
     # scripts/test_degrade_scan_shell_probes.sh; narrowing without that anchor would just trade a
     # noisy probe for a blind one.
+    #
+    # WIDENED 2026-08-04 — the narrowing had gone one step too far, and the proof is that this
+    # probe was BLIND to the live instance that bit us the day before. PR #251 fixed
+    # `grep -c … | tr -d ' ' || echo 0` in session_close_check.sh ④-e; running this scanner over
+    # the pre-#251 file produced ZERO hits (re-measured: fixed rule = 2, old rule = 0).
+    #
+    # THE ANCHOR WAS ON THE WRONG PROPERTY. The old regex asked "is there an upstream pipe" and
+    # required the counter to be the LAST stage. Neither is the discriminator. The discriminator
+    # is: **does the failing side still EMIT?** `grep -c` prints "0" and exits 1 on no-match, so it
+    # disarms with no upstream pipe at all, and any trailing stage that passes that "0" through
+    # keeps the "0\n0" intact.
+    #
+    # A first fix widened to a NAMED filter list (tr|head|sed|…). Cross-family review (gpt-5.5,
+    # 2026-08-04) refuted it with reproduced counter-examples, and the refutation held on
+    # measurement in BOTH directions:
+    #   · still missed, all verified to yield "0\n0": `grep -Ec …`, `grep --count …`, `grep -Fcx …`
+    #     (combined/long flag forms the `-c` literal never matched) and `| cat`.
+    #   · newly over-matched: `| tail -n +2` after the counter yields ONE line — not a disarm.
+    # Name-based approximation produced under-match and over-match simultaneously. So the trailing
+    # chain is no longer enumerated: the rule keys on the COUNTER (grep with a `c` in any flag
+    # cluster or `--count`; or `wc` behind a real pipe) plus the `|| echo 0` fallback, and accepts
+    # any chain between them.
+    #
+    # PRESERVED from the 2026-07-28 narrowing, still pinned as known-negatives: (a) `a || b ||
+    # echo 0` has no pipeline, and (b) a stage that emits NOTHING on failure (`| jq -r … ||
+    # echo 0`) — there the fallback supplies the only line, as intended.
+    # KNOWN RESIDUAL, stated not hidden: a trailing stage that can swallow the counter's output
+    # (`| tail -n +2`, `| sed -n '/[1-9]/p'`) is now flagged though it is not a disarm. That is a
+    # deliberate recall-over-precision trade on an ADVISORY probe, taken because the measured cost
+    # of the other direction was a real defect shipping. Revisit if non-fixture FPs appear.
+    # Known pair: scripts/test_degrade_scan_shell_probes.sh (9 positives / negatives silent).
+    # Reverting this line turns the positive lane red — checked by applying the revert.
     while IFS= read -r m; do
-      emit "$f" "${m%%:*}" "S5:pipefail-fallback(sh)" "\`|| echo 0\` fallback on a pipeline ending in a counter (grep -c/wc) — that stage emits even when an upstream stage fails, so under \`set -o pipefail\` the value gains a SECOND line, the integer comparison errors out, and the guard passes silently; split the pipeline and sanitize to an integer"
-    done < <(grep -nE '[^|]\|[[:space:]]*([a-z]+[[:space:]]+)*(grep[^|]*-c|wc)[^|]*\|\|[[:space:]]*echo[[:space:]]+[\"'"'"']?0' "$f" 2>/dev/null \
+      emit "$f" "${m%%:*}" "S5:pipefail-fallback(sh)" "\`|| echo 0\` fallback after a COUNTER (grep with -c / --count, or wc) — the counter PRINTS \"0\" and exits non-zero on no-match, so the fallback appends a SECOND line, the value becomes \"0\\n0\", the integer test dies with 'integer expression expected' (stderr only) and the guard goes silent; split it and sanitize: n=\$(...); n=\${n:-0}; case \$n in *[!0-9]*) n=0;; esac. VERIFY the trailing stage can actually emit — if it swallows the count (| tail -n +2), this is a known false positive"
+    done < <(grep -nE '(([^|]\|[[:space:]]*([a-z]+[[:space:]]+)*wc[^|]*)|(grep([[:space:]]+-[A-Za-z]*c[A-Za-z]*|[[:space:]]+--count)[^|]*))([^|]*\|[^|]*)*\|\|[[:space:]]*echo[[:space:]]+[\"'"'"']?0' "$f" 2>/dev/null \
              | grep -vE '^[0-9]+:[[:space:]]*#' \
              | grep -vE '#[[:space:]]*noqa[:[:space:]]*degrade')
   fi


### PR DESCRIPTION
카드 #9(`grep -c … || echo 0` 클래스 스윕)를 돌리려다 **스윕 계기 자체가 눈이 먼 것**을 봤다.

**앵커가 틀린 속성에 걸려 있었다.** 옛 룰은 "위에 파이프가 있나" + "카운터가 마지막 스테이지인가"를
물었다. 진짜 판별자는 **실패한 쪽이 그래도 출력을 내는가**다. `grep -c` 는 매치 0에서 `0` 을 찍고
exit 1 하므로 파이프가 없어도 disarm 이고, 뒤에 무슨 스테이지가 붙든 그 `0` 이 통과되면
`"0\n0"` 은 그대로 만들어진다.

**역사적 known-pair**: 수리 전(PR #251 이전) `session_close_check.sh` 에 대해 고친 스캐너 =
S5 2히트, 옛 스캐너 = 0히트. 합성 픽스처가 아니라 실제로 출하됐던 결함으로 계기를 쟀다.

**내 첫 수리안은 cross-family 가 반증했다** (codex/gpt-5.5, 1라운드 4건). 이름 붙인 필터 목록
(tr|head|sed|…) 방식이 **양방향으로 틀렸다**:
- 여전히 놓침 — `grep -Ec` · `grep --count` · `grep -Fcx` · `| cat` (전부 여기서 재측정해 `"0\n0"` 확인)
- 새로 과매치 — `| tail -n +2` 는 라인수 1이라 disarm 이 아닌데 잡혔다
- 내가 known-NEGATIVE 로 넣은 `| grep -v` 는 사실 **양성**이었다(픽스처의 upstream 이 성공해서
  주장하던 실패 경로를 한 번도 안 밟았다 — 지적당하고 실측으로 확인)

그래서 이름 목록을 접고, **카운터**(`grep` 의 플래그 클러스터/`--count` 어디든 `c`, 또는 파이프 뒤
`wc`) + `|| echo 0` 로만 키를 잡고 중간 체인은 열어뒀다.

**남긴 잔여(숨기지 않음)**: 카운터 출력을 삼킬 수 있는 트레일링 스테이지(`| tail -n +2`,
`| sed -n`)는 disarm 이 아닌데도 잡힌다. **자문 프로브**에서 recall 을 precision 보다 택한
의도적 트레이드다 — 반대 방향의 실측 비용이 "진짜 결함 출하"였기 때문. 픽스처 밖 FP 가
나오면 재검토.

스윕 결과: 라이브 인스턴스 1건(`test_dispatch_log_lanes.sh:78`)뿐이고, 정직하게 적으면
**fail-open 이 아니었다** — bash 에러가 FAIL 분기로 떨어져 방향은 맞았다. 비교가 아니라 에러로
판정이 나던 것이라 고쳤고, 견고성으로 주장한다.

회귀 앵커 known-positive 2 → 9(플래그 클러스터 3종 + `| cat` + `| grep -v` 포함).
**되돌림을 실제 적용해 fail-before 확인**(첫 넓힘본으로 되돌리면 `got 4`).
`templates/` 전파본 `cmp -s` 동일. 양 OS 14 passed / 0 failed · selfcheck 178/0.

Axis 1 은 `SKIP (not-checked, NOT a pass)` — `GUARD_PATHSPEC` 에 `scripts/*.sh` 가 없다(카드 #5,
오늘 세 번째 관측). 통과로 세지 않았고, Added-Scope 게이트 2번에 따라 묶지 않았다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
**Evidence capsule (sanitized)**
- **Axis 1**: `SKIP (not-checked, NOT a pass)` — `GUARD_PATHSPEC` lacks `scripts/*.sh` (card #5, third observation today). Not counted as a pass; deliberately not bundled (Added-Scope Gate Q2).
- **Axis 2** (inline, opus-5, at-floor): same-family round closed 3/3 — and the cross-family round **refuted one of those closures**. Recorded as-is rather than rewritten.
- **crossfamily**: codex/gpt-5.5, 1 round, 4 findings, 3 confirmed-by-reproduction + fixed. Net-new: the named-filter-list fix was wrong in **both** directions (missed `grep -Ec`/`--count`/`-Fcx`/`| cat`; newly false-positived `| tail -n +2`), and a fixture labelled known-NEGATIVE was actually a positive whose upstream succeeded so it never exercised the failure path. Every finding re-run locally before acceptance — not accepted on the auditor's say-so.
- **Axis 3** (inline back-trace): 0 phantom refs; PR #251's removed line read out of commit `1aa682c`.
- **Historical known pair**: fixed scanner over pre-#251 `session_close_check.sh` = **2 S5 hits**; old scanner = **0**.
- **Regression anchor revert-checked**: stash the scanner change → `❌ expected 9 S-hits, got 4`, suite exits 1.
- **Suites**: degrade-scan probes **14/0** and selfcheck **178 PASS / 0 FAIL** — macOS **and** Linux (new OrbStack lane).
- **Named residual, not hidden**: a trailing stage that can swallow the count (`| tail -n +2`) is now flagged though not a disarm — a deliberate recall-over-precision trade on an ADVISORY probe.