### PR TITLE
fix(gate): Axis 1 이 자기 자산목록의 네 클래스를 못 보고 있었다 — 그중 둘은 자기 바닥

### DIFF
--- a/scripts/gate_pathspec_check.sh
+++ b/scripts/gate_pathspec_check.sh
@@ -107,7 +107,12 @@ spec_matches() {  # $1 = path
 for pair in \
   "plugins/fh-meta/skills/frontier-digest/SKILL_detail.md|tracks/_meta/x.md|PATHSPEC covers SKILL_detail.md" \
   "plugins/fh-meta/skills/frontier-digest/SKILL.md|README.md|PATHSPEC still covers SKILL.md" \
-  "CLAUDE.md|CLAUDE.local.md|PATHSPEC covers CLAUDE.md but not the local override"
+  "CLAUDE.md|CLAUDE.local.md|PATHSPEC covers CLAUDE.md but not the local override" \
+  "scripts/selfcheck.sh|README.md|PATHSPEC covers scripts/*.sh (seam #1 — the HEAVY term already gated it, this array did not)" \
+  "scripts/sub/nested.sh|package.json|PATHSPEC covers scripts/ recursively (git/bash globs cross '/')" \
+  "templates/regression_guard.sh|package-lock.json|PATHSPEC covers templates/*.sh — i.e. the guard can guard ITSELF" \
+  "templates/.git-hooks/pre-commit|.gitignore|PATHSPEC covers the git-hook floor (the hook that hard-blocks commits)" \
+  "plugins/fh-meta/agents/challenger.md|tracks/_meta/y.md|PATHSPEC covers agent definitions (seam #3)"
 do
   IFS='|' read -r pos neg label <<< "$pair"
   ok=1

--- a/templates/regression_guard.sh
+++ b/templates/regression_guard.sh
@@ -117,6 +117,31 @@ GUARD_PATHSPEC=(
   'AGENTS.md'
   'docs/*.md'
   'templates/*.md'
+  # ── Added 2026-08-04 — the pathspec had drifted from the 4-axis ASSET LIST it exists to gate.
+  # Measured that day by mechanically walking every asset class in CLAUDE.md §FH Improvement
+  # 4-Axis against this array: four classes had NO covering pattern, and two of them are this
+  # repo's own mechanical floor — `templates/.git-hooks/*` (the hook that hard-blocks commits)
+  # and `templates/*.sh` (THIS FILE — the guard could not guard itself). The pre-commit HEAVY
+  # classifier already listed `^scripts/.*\.sh$`, so a scripts-only change entered the heavy
+  # path and then met Axis 1 returning `SKIP (not-checked, NOT a pass)`. Observed three times
+  # on 2026-08-04 alone, the third being the S5 fix (PR #253) — a change to a verdict-surface
+  # scanner that shipped with zero Axis-1 coverage.
+  #
+  # Calibrated before shipping, both directions (a widened copy, run against real history):
+  #   · 12 consecutive historical commits touching scripts/*.sh → M=0 S=0 (no FP storm), and a
+  #     control confirmed the files were actually SELECTED (4 files checked) rather than the
+  #     zero coming from an inert pathspec — the unwired-instrument reading of a clean 0.
+  #   · known-positive: truncating a shipped .sh by 60% → M-TIER BLOCK (`BLOCK` token dropped
+  #     100%, 60% line reduction). The md-shaped checks (F1 frontmatter, F2 sections, F3 fences)
+  #     are inert on shell files; F4 keyword / F5 xref / F6 line-loss / F7 syntax are the ones
+  #     that carry, and they are exactly the regressions that matter in a gate script.
+  # NOTE on globbing: git pathspec `*` crosses `/` (verified here — `templates/*.md` matches
+  # `templates/.claude/rules/session.md`), so these single-star forms are recursive.
+  'scripts/*.sh'
+  'templates/*.sh'
+  'templates/.git-hooks/*'
+  'plugins/*/agents/*.md'
+  '.claude/agents/*.md'
 )
 
 # 계기 무결: base ref 가 안 풀리면 diff 실패가 2>/dev/null 로 삼켜져 CHANGED 공백 →


### PR DESCRIPTION
`GUARD_PATHSPEC` 가 4축 자산목록에서 **갈라져 있었다**. pre-commit 분류기는 `^scripts/.*\.sh$` 를
HEAVY 로 라우팅하는데, 정작 가드 배열엔 그 패턴이 없어서 스크립트-온리 변경은 무거운 경로로 들어와
Axis 1 이 `SKIP (not-checked, NOT a pass)` 를 찍고 exit 0 했다. **오늘만 세 번 관측**했고, 세 번째가
PR #253 — 판정 표면 스캐너가 Axis 1 커버리지 0으로 나갔다.

자산목록을 기계로 걸어보니 갭이 하나가 아니라 **넷**이었고, 그중 둘이 이 레포 자신의 바닥이다:
`templates/.git-hooks/*`(커밋을 하드 차단하는 훅) · `templates/*.sh`(**이 가드 자신**).
나머지 둘 = `scripts/*.sh` · `plugins/*/agents/*.md`.

**넓히기 전에 쟀다(양방향)**:
- 과거 `scripts/*.sh` 변경 커밋 **12건 연속 M=0 S=0** — FP 폭풍 없음.
- 그 0이 "죽은 pathspec"이 아님을 컨트롤로 확인: 넓힌 사본은 1845e54 에서 **4파일을 실제 선택**해
  검사했고, 안 넓힌 원본은 같은 커밋을 **통째 SKIP** 했다.
- known-positive: 출하 셸을 60% 절단 → **M-TIER BLOCK**(`BLOCK` 토큰 100% 소실 + 60% 라인 급감).
- md 전용 검사가 셸에서 오발화하는지도 실측: F1 은 코드상 SKILL.md 한정 · F2 는 **명명된 섹션만**
  보며 출하 셸 전체에서 0히트(같은 계기가 SKILL.md 35개는 매치 = 컨트롤) · F3 은 펜스 3→2 로
  줄여도 M=0 S=0(파일이 선택된 것 확인).

앵커: `gate_pathspec_check.sh` 에 known-pair **5쌍** 추가(재발명 아님 — 이 목적의 앵커가 이미 있다).
**되돌림 적용해 fail-before 확인** — `FAIL (5 broken, 19 ok)` exit 1, 복원 시 `PASS (24 pairs)`.
dogfood: 이 변경 자신에 대해 Axis 1 이 이제 `SKIP` 이 아니라 `REGRESSION_GUARD_RESULT=pass` 를 낸다.

잔여(묶지 않음): `gate_pathspec_check.sh` 는 여전히 pre-commit 에서만 불린다 — `core.hooksPath`
안 건 클론엔 이 앵커가 아예 없다(카드 #3). Added-Scope 게이트 2번에 따라 별건으로 남긴다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
**Evidence capsule (sanitized)**
- **Axis 1 (dogfood)**: on this very change it now returns `REGRESSION_GUARD_RESULT=pass` with both files listed — previously `SKIP (not-checked, NOT a pass)`.
- **Calibration, both directions**: 12 consecutive historical scripts/*.sh commits → M=0 S=0; control proved the files were SELECTED (4 checked on `1845e54`) while the unwidened guard SKIPped the same commit; known-positive (60% truncation) → **M-TIER BLOCK**.
- **md-shaped-check FP risk closed by measurement**: F1 conditioned on SKILL.md in code · F2 keys on NAMED sections, 0 hits across shipped .sh while matching 35 SKILL.md files (control) · F3 fence 3→2 → M=0 S=0 with the file confirmed selected.
- **Anchor revert-checked**: `gate_pathspec_check: FAIL (5 broken, 19 ok)` exit 1 on revert → `PASS (24 pairs)` restored.
- **crossfamily** (codex/gpt-5.5): no real defect, and it retracted its own candidate. Recorded as a **weak** signal — it could not see F1-F3 (not in the diff it was given); that residual was closed locally by measurement, not by the auditor.
- **Suites**: selfcheck 178/0 + gate_pathspec_check PASS on macOS **and** Linux.
- **Not bundled** (Added-Scope Gate Q2): wiring `gate_pathspec_check.sh` into selfcheck/CI — card #3.