### PR TITLE
fix(selfcheck): 게이트의 앵커에 앵커가 없었다 — 훅 건 머신에서만 돌던 것을 배선한다

### DIFF
--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -224,6 +224,38 @@ else
   fail=1
 fi
 
+# gate-pathspec anchor — wired here 2026-08-04. It was reachable ONLY from templates/.git-hooks/
+# pre-commit, i.e. only in a clone where the operator had run `git config core.hooksPath`. Every
+# other clone, every CI run, and the npm package carried the anchor file and never executed it —
+# the built-but-not-wired shape, one layer up: the anchor for the gate had no anchor of its own.
+# That mattered the same day: PR #254 added five known-pairs to it, all of which would have been
+# unexecuted outside the author's machine.
+# Subject = the two implementations it reads (the hook's HEAVY term and the guard's GUARD_PATHSPEC).
+# Absent subject → package/partial surface → legitimate SKIP; present subject with the anchor gone
+# → FAIL, same shape as every block above.
+# NAMED RESIDUAL (cross-family, gpt-5.5, 2026-08-04): if a distribution that SHOULD be complete
+# accidentally drops one subject, this reports SKIP, not FAIL — silent non-coverage. Measured the
+# same day: removing `templates/.git-hooks` from package.json `files[]` and running
+# scripts/package_coverage_check.sh still PASSED, so no existing anchor catches that omission
+# either. Deliberately NOT patched with a stricter branch: the only discriminator available
+# ("templates/ exists but the hook does not") would be built on an UNMEASURED assumption about how
+# a narrower package is shaped, and this repo's rule is not to build before the constraint is
+# measured. What is cheap and honest is naming WHICH subject is missing, so a SKIP is diagnosable
+# instead of opaque. Revisit when a real partial distribution is observed.
+_gps_missing=""
+[ -f templates/.git-hooks/pre-commit ] || _gps_missing="templates/.git-hooks/pre-commit"
+[ -f templates/regression_guard.sh ] || _gps_missing="${_gps_missing:+$_gps_missing, }templates/regression_guard.sh"
+if [ -n "$_gps_missing" ]; then
+  echo "SKIP  gate_pathspec_check.sh (subject absent: $_gps_missing) — not-checked, NOT a pass"
+elif [ -f scripts/gate_pathspec_check.sh ]; then
+  if ! bash scripts/gate_pathspec_check.sh; then
+    fail=1
+  fi
+else
+  echo "FAIL  gate_pathspec_check.sh: the gate implementations are present but their coverage anchor is missing"
+  fail=1
+fi
+
 if [ ! -f scripts/ablation_calibrate.sh ]; then
   echo "SKIP  test_ablation_calibrate_lanes.sh (subject scripts/ablation_calibrate.sh absent)"
 elif [ -f scripts/test_ablation_calibrate_lanes.sh ]; then


### PR DESCRIPTION
`gate_pathspec_check.sh` 는 `templates/.git-hooks/pre-commit` 에서만 불렸다. 즉 운영자가
`git config core.hooksPath` 를 실행한 클론에서만 돌고, **CI·`npm test`·새 클론·npm 패키지**에서는
파일만 실려 가고 한 번도 실행되지 않았다. 어제 PR #254 가 거기에 known-pair 5쌍을 더했는데,
그 다섯은 **이 머신 한 대에서만** 돌 뻔했다. built-but-not-wired 를, 게이트의 앵커에 적용한 꼴.

`selfcheck.sh` 에 주변 블록과 같은 형태로 배선했다(subject 없으면 SKIP · subject 있는데 앵커
없으면 FAIL · 있으면 실행). selfcheck 는 `npm test` · `prepublishOnly` · CI 가 전부 돌린다.

**장식이 아님을 되돌림으로 증명**: `GUARD_PATHSPEC` 에서 `'scripts/*.sh'` 를 빼면(=#254 가 닫은
갭 재현) `gate_pathspec_check: FAIL (2 broken, 22 ok)` + `SELFCHECK: FAIL` exit 1, 복원하면 0.
**실제 출하 표면에서도 확인**: `npm pack` 산출물을 풀어 패키지 루트에서 실행 → `PASS (24 pairs)`.

**잔여(고치지 않고 이름을 붙였다)**: 완전해야 할 배포판이 subject 하나를 실수로 빠뜨리면 FAIL 이
아니라 SKIP 이다. cross-family(gpt-5.5)가 지적했고, 실측으로 확인까지 했다 — `files[]` 에서
`templates/.git-hooks` 를 빼도 `package_coverage_check.sh` 는 그대로 PASS 라 **다른 앵커도 못 잡는다**.
그런데도 더 엄격한 분기를 안 지은 이유: 쓸 수 있는 판별자("templates/ 는 있는데 훅이 없다")가
**좁은 패키지의 모양에 대한 미측정 가정** 위에 서기 때문이다. 대신 SKIP 이 **어느 subject 가 없는지
이름을 찍고** "not-checked, NOT a pass" 라고 말하게 했다. 진짜 부분 배포판을 관측하면 재검토.

양 OS selfcheck 0 / package-coverage PASS / Axis 1 `RESULT=pass`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
**Evidence capsule (sanitized)**
- **Not decorative — proven by applying the break**: drop `'scripts/*.sh'` from GUARD_PATHSPEC (re-opening what #254 closed) → `gate_pathspec_check: FAIL (2 broken, 22 ok)` + `SELFCHECK: FAIL`, exit 1. Restored → exit 0.
- **Runs on the real shipped surface**: `npm pack` tarball extracted, anchor run from the package root → `PASS (24 pairs)`.
- **Both branches exercised**: normal → anchor executes; subject removed → `SKIP … (subject absent: templates/regression_guard.sh) — not-checked, NOT a pass`.
- **crossfamily** (codex/gpt-5.5): no blocker; confirmed `fail=1` propagation matches neighbours and no loop/masking. Its one residual was then **tested and confirmed uncovered** — removing `templates/.git-hooks` from `files[]` still PASSes `package_coverage_check.sh`.
- **Residual named, not patched**: SKIP-not-FAIL on an accidentally incomplete distribution. The stricter branch would rest on an unmeasured assumption about narrow-package shape, so what shipped is a diagnosable SKIP instead of a speculative gate.
- **Suites**: selfcheck 0 on macOS and Linux · package-coverage PASS · Axis 1 `RESULT=pass`.