### PR TITLE
chore(log): 서브에이전트 10건+ 를 돌리고 원장에 한 줄도 안 썼다 — 마감 체커가 잡았다

### DIFF
--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -996,3 +996,55 @@
     invented: a fabricated outcome would poison the 60/40 promotion gate worse than a missing one,
     which is the stated reason the hook only tallies and never writes an entry. Open question for
     the next session that touches the tally: which tool events actually fire SubagentStop here.
+
+- date: '2026-08-05'
+  agent: persona-innovator ×2 · quench-challenger ×3 · beginner ×5 (Agent tool) + codex gpt-5.5 ×2 (CLI)
+  context: >-
+    Innovator autopilot session. Two sister-asset absorption scans (innovator); steel-quench Wave 1
+    and Wave 3 on the selfcheck run-twice repair, plus one opus Axis-2 pass on the AGENTS.md change
+    (quench-challenger); five Sonnet-pinned cold-read sims on one AGENTS.md checklist item
+    (beginner); two cross-family audits (codex CLI, tool-use disabled — not counted by the tally
+    hook, which only fires on Agent-tool SubagentStop).
+  dispatches: '10 via Agent tool + 2 CLI sidecars (tally recorded 14 — the delta is unattributed,
+    see the 2026-08-05 entry above about unknown tally sources; not invented here either)'
+  outcome: accepted
+  evidence: >-
+    Every class changed the outcome, which is why this is `accepted` rather than `partial`.
+    quench-challenger: Wave 1 produced 2S/3A/4B and Wave 3 produced 2S/1A/3B on the REPAIR — one of
+    those overturned a judgment already reported to the operator (a "refuted" verdict measured on a
+    non-canonical absolute core.hooksPath; the documented relative-path install reproduces the
+    bypass). The opus Axis-2 pass produced 2S that caused a full revert of the AGENTS.md change.
+    beginner: 5 rounds, each blocking at a DIFFERENT point, each block introduced by the previous
+    round's repair; author self-catch across rounds 1-4 was ZERO. innovator: 4 external repos
+    verified by gh api with known-pair controls, 3 net-new items confirmed by in-repo greps with
+    live controls. codex: round 1 was fed a STALE diff (my error — the target was not frozen) so 2
+    of its findings were already closed and 1 was a misread; round 2 on a fingerprinted target found
+    the BSD `tr -d '[:space:]'` defect that both same-family rounds missed.
+  note: >-
+    Logged at close, after the session_close_check ④-e block caught the omission — the obligation
+    is prose in CLAUDE.md and I did not discharge it during the session despite dispatching 10+
+    agents. That is the same shape the ④-e check was built for. Consolidated per class with counts
+    rather than one stub per dispatch, which the check explicitly permits.
+
+- date: '2026-08-06'
+  agent: beginner ×5 (Sonnet-pinned cold read) · quench-challenger ×1 (opus Axis-2) — same session as 2026-08-05
+  context: >-
+    The innovator autopilot session crossed midnight; the tally records 14 dispatches under
+    2026-08-06 while the substantive description lives in the 2026-08-05 entry above. These are not
+    additional work — they are the same session's later half: the five cold-read rounds on the
+    AGENTS.md worktree item and the opus adversarial pass that ended it.
+  dispatches: '6 attributable here (tally: 14 under this date; the remainder shares the
+    unattributed-source question already recorded on 2026-08-05)'
+  outcome: accepted
+  evidence: >-
+    The opus Axis-2 pass returned 2S — a recipe that commits to the WRONG BRANCH (git forbids two
+    worktrees sharing a branch, so the main checkout and a worktree are always on different
+    branches, and the recipe never aligned them), and a hook that hands out a marker-fabrication
+    one-liner at the exact moment it blocks. Both were reproduced against the live repo, and the
+    change was REVERTED in full rather than patched. The five beginner rounds each blocked at a
+    different point with author self-catch of zero across rounds 1-4.
+  note: >-
+    Written after the close check refused the push a SECOND time: the first correction logged the
+    session under 2026-08-05 while the check counts today's date, so "logged" and "logged where the
+    check looks" came apart. Recorded rather than back-dated — the split is real (the tally itself
+    splits 34/14 across the boundary) and pretending otherwise would misstate when the work ran.


### PR DESCRIPTION
## 무엇을 등재하나

이노베이터 자율주행 세션의 서브에이전트 dispatch — `innovator ×2 · quench-challenger ×3 ·
beginner(Sonnet cold-read sim) ×5` + `codex CLI ×2`. 세션이 자정을 넘겨 두 날짜로 나뉜다
(tally 실측: 08-05 = 34 · 08-06 = 14).

## 왜 전부 `outcome: accepted` 인가

각 클래스가 결과를 바꿨기 때문이다. 등재는 형식이 아니라 60/40 승격 게이트와 UAP 루프의 입력이다.

| 클래스 | 무엇이 바뀌었나 |
|---|---|
| quench-challenger (Wave 1 · Wave 3) | S4건. 그중 하나가 **이미 보고된 판정을 뒤집었다** — worktree 우회를 "반증"이라 판정한 측정이 비정본 절대 `core.hooksPath` 위에서 이뤄졌고, 문서화된 상대경로 설치에서는 우회가 재현된다 |
| quench-challenger (opus, Axis 2) | S2건 → 대상 변경 **전량 되돌림**. 레시피가 틀린 브랜치에 커밋했고, 훅이 차단하는 그 순간 마커 조작 원라이너를 출력하고 있었다 |
| beginner (Sonnet, 5R) | 매 라운드 **다른 지점**에서 막힘, 매번 직전 수리가 만든 구멍. 저자 자력 적발 **R1~R4 전부 0** |
| codex CLI (cross-family) | R1 은 내가 **stale diff** 를 줘서 판정 일부 무효(과녁을 안 얼린 내 실수). R2 가 same-family 두 라운드가 놓친 BSD `tr -d '[:space:]'` 결함을 잡음 |

## 정직하게 적은 것

- **세션 중에 안 썼다.** `session_close_check` ④-e 가 마감에서 잡았고 그때 기록했다 — 그 체크가
  정확히 이 실패를 위해 만들어졌다는 게 실증됐다.
- **체커가 push 를 두 번 거부했다.** 1회차는 원장이 비어서, 2회차는 **썼는데도** — 체커는 오늘
  날짜를 세는데 엔트리가 어제 날짜였다. 백데이트하지 않고 날짜별로 나눠 적었다. 분할이 실재하고
  (tally 가 34/14 로 갈린다), 아닌 척하면 작업 시점을 잘못 진술하게 된다.
- **tally 잔여**: 오늘 14건 중 6건만 귀속 가능하다. 나머지의 출처는 여전히 미상이고, 지어내지
  않고 미상으로 남겼다 — 날조된 `outcome` 은 빠진 것보다 승격 게이트를 더 오염시킨다.

## 형식

클래스별 consolidated(카운트 + outcome + 증거)이지, dispatch 당 스텁 나열이 아니다.
체커가 명시적으로 허용하는 형식이다.
