### PR TITLE
fix(psa): override 부재를 clean PASS 로 읽던 것 — 미측정은 0 이 아니다 (S7)

### DIFF
--- a/knowledge/shared/harness-core/claude_md_gate_details.md
+++ b/knowledge/shared/harness-core/claude_md_gate_details.md
@@ -196,6 +196,13 @@ destroys live state without anyone noticing. This is why the loss class is calle
   plaintext only (encoded tokens out of scope); a line-split backstop catches a token wrapped across
   lines; `PUBLIC_SURFACE_OK=1` overrides and is logged to a gitignored audit trail for the weekly audit.
   Residuals (split-encoding, override-not-populated, override abuse) are documented, not silent.
+  **Verdict labelling (2026-08-06)**: with the override absent, a clean scan reports
+  `⚠️ PARTIAL — company/companion literals UNMEASURED`, **never `✅ PASS`**. The commit still
+  proceeds (reversible surface → advisory degrade), but a run whose operator-literal layer never
+  executed may not present the same verdict as one where it did — a missing measurement is not a
+  zero. Anchored in `universal_guard_check.sh` as a **pair**: absent override must say `PARTIAL`,
+  and the control (override present, no hit) must still say `✅ PASS`, so the label cannot drift
+  back to a bare PASS *or* become an unconditional warning.
 - **(c) `npm publish`** — mechanically gated by `scripts/public_surface_scan_files.sh`, wired into
   `prepublishOnly` (`npm run release` also runs it *outside* the lifecycle). Unlike (b) it scans the
   **full content of the exact npm-published file set** (`npm pack --dry-run`), *not* a commit diff — so a
@@ -203,6 +210,36 @@ destroys live state without anyone noticing. This is why the loss class is calle
   registry boundary. HIGH/MED block; `PUBLIC_SURFACE_OK=1` overrides + logs. **Fail-closed** when patterns
   or the file set are unresolved, when the parse looks partial, **or when the gitignored operator override
   is absent** — defaults-only would otherwise green-PASS a HIGH company literal on a fresh clone or CI runner.
+
+**The git-push surface, and why it was the lenient one (2026-08-06).** (c) blocked on an absent
+override; the `git push` gate in `templates/.git-hooks/pre-push` only warned. Both make content
+public, so two irreversible surfaces were degrading in **opposite directions on the same state** —
+the actual defect, and `git push` (the one nobody publishes through deliberately) was the permissive
+side. The 2026-07-26 reasoning behind that warn was not wrong, it was **unscoped**: an absent
+override in a fresh clone / CI runner / worktree is a legitimate per-operator configuration gap (the
+file is gitignored, so it is absent there *by construction*), and blocking it trains
+`PUBLIC_SURFACE_OK` into a reflex — which disarms the same channel the publish gate depends on.
+
+So the warn is **scoped, not reverted**. `psa_detect_operator_context` (`scripts/psa_scan_lib.sh`)
+splits the state: in an **operator-configured checkout** an absent override is *evidence missing
+where evidence is expected* → BLOCK; everywhere else → WARN, exactly as before. The signal is
+`CLAUDE.local.md`, the operator's own gitignored binding file.
+
+**Calibration matters here more than the rule** — a second candidate signal, "`tracks/_meta` is
+non-empty", reads as the same test and is not: `tracks/_meta/.gitkeep` and one sibling are
+**tracked**, so a fresh clone satisfies it and would have been blocked, re-shipping the 07-26
+over-block under a new name. It was rejected by measuring it against a known pair, not by reasoning
+about it. **Named residual, deliberately in the under-blocking direction**: an operator who never
+created a `CLAUDE.local.md` stays in the WARN arm. **Second residual, and it is the sharper one**:
+deleting `CLAUDE.local.md` drops this checkout back into the WARN arm, and unlike `PUBLIC_SURFACE_OK=1`
+that bypass **writes no log line**. It is a conscious act on the operator's own file, so it is not a
+weak-model fail-open — but it is a quieter exit than the sanctioned one, which is the wrong ordering
+for a bypass. Not closed here: making it loud means the hook must distinguish "never had one" from
+"had one and lost it", and that needs state the hook does not currently keep. Named rather than
+mechanized, per this repo's own threshold — mechanize on the first measured recurrence.
+Anchored as a pair in `prepush_guard_check.sh`
+(6-a absent override → PASS · 6-b absent override + operator checkout → BLOCK); both arms are
+required, since 6-b passing alone would not distinguish a scoped block from a blanket one.
 
 **Named residuals for (c)** — it is a denylist **on the npm CLI path with scripts enabled**, not a
 universal secret-scanner:

--- a/scripts/prepush_guard_check.sh
+++ b/scripts/prepush_guard_check.sh
@@ -166,6 +166,21 @@ check "operator override absent (per-operator) → PASS " "$R" pass \
       "refs/heads/f $(cd "$R" && git rev-parse HEAD) refs/heads/f $B"
 rm -rf "$R"
 
+# ── Pair 6-b (2026-08-06): the OTHER arm of the same state, which the 07-26 flag could not see.
+# Identical to 6-a except the checkout carries CLAUDE.local.md — the operator's gitignored binding
+# file, absent in every clone/CI/worktree by construction. There the missing override is not an
+# unset per-operator config, it is evidence missing where evidence is expected, on a surface that
+# publishes. This is what `npm publish` already blocked while `git push` waved through; the two
+# irreversible surfaces now degrade in the same direction.
+# The PAIR is what makes it a measurement: 6-a (no CLAUDE.local.md → PASS) is the known-negative and
+# must keep passing, or this is not a scoped block, it is the 07-26 over-block re-shipped. ──
+R=$(newrepo); B=$(cd "$R" && git rev-parse HEAD)
+( cd "$R" && echo ok > g2.md && git add g2.md && git commit -qm g2 >/dev/null \
+  && rm -f .claude/rules/.public-surface-patterns && printf '# operator binding\n' > CLAUDE.local.md )
+check "override absent + operator checkout    → BLOCK" "$R" block \
+      "refs/heads/f $(cd "$R" && git rev-parse HEAD) refs/heads/f $B"
+rm -rf "$R"
+
 R=$(newrepo); B=$(cd "$R" && git rev-parse HEAD)
 ( cd "$R" && echo ok > g.md && git add g.md && git commit -qm g >/dev/null \
   && : > .claude/rules/.public-surface-patterns.defaults )   # present but EMPTY = broken, not unconfigured

--- a/scripts/psa_scan_lib.sh
+++ b/scripts/psa_scan_lib.sh
@@ -38,6 +38,9 @@
 #   PSA_DEFAULTS_OK       1 = committed defaults present, readable, non-empty
 #   PSA_OVERRIDE_PRESENT  1 = operator override present, readable, non-empty
 #   PSA_BAD_ROWS          count of rows dropped as unusable (uncompilable regex, or no TAB)
+# State set by psa_detect_operator_context (separate call — see that function):
+#   PSA_OPERATOR_CONTEXT  1 = an operator-configured checkout, where an absent override is missing
+#                             evidence rather than a legitimate fresh-clone absence
 # A caller that treats PSA_BAD_ROWS>0 or PSA_DEFAULTS_OK=0 as "clean" has a hole: those states mean
 # the instrument is incomplete, and an incomplete instrument cannot certify anything.
 
@@ -113,6 +116,39 @@ $line"
 $PSA_STREAM
 PSA_ROWS
   PSA_STREAM="$valid"
+}
+
+# psa_detect_operator_context <repo_root>   → sets PSA_OPERATOR_CONTEXT (0/1)
+#
+# Answers ONE question: is an absent operator override a *legitimate absence* (fresh clone, CI
+# runner, worktree — the file is gitignored, so it is absent there by construction) or *evidence
+# missing where evidence is expected* (a checkout the operator has configured, whose literals should
+# be there and are not)?
+#
+# 2026-07-26 changed pre-push from BLOCK to WARN on an absent override, and that change was right for
+# the first case: this repo's own selfcheck flagged the block as over-firing, and over-blocking trains
+# PUBLIC_SURFACE_OK into a reflex, which disarms the same channel the publish gate depends on. It was
+# wrong for the second case, which the flag could not distinguish. This function is that distinction —
+# it does not reopen the reverted block, it scopes it.
+#
+# Signal: CLAUDE.local.md — the operator's own gitignored binding file. Chosen because it is
+# gitignored (verified: `.gitignore:17`), so no clone, CI checkout or worktree carries it.
+#
+# CALIBRATED, and one candidate was REJECTED by that calibration: "tracks/_meta is non-empty" looks
+# like the same signal and is not — `tracks/_meta/.gitkeep` and one more file are TRACKED, so a fresh
+# clone satisfies it and would have been blocked. The discriminator was measured against a known
+# pair before it was trusted, not reasoned about.
+#
+# NAMED RESIDUAL (deliberate, and in the safe direction): an operator who never created a
+# CLAUDE.local.md stays in the WARN arm. This under-blocks rather than over-blocks — the failure mode
+# this scoping exists to avoid is the reflex, not the miss, and the push gate's content scan still
+# runs on the committed defaults in that arm.
+psa_detect_operator_context() {
+  local root="$1"
+  PSA_OPERATOR_CONTEXT=0
+  [ -n "$root" ] || return 0
+  [ -f "$root/CLAUDE.local.md" ] && PSA_OPERATOR_CONTEXT=1
+  return 0
 }
 
 # psa_scan_tagged  — reads "path<TAB>content" lines on stdin, prints one line per reportable hit.

--- a/scripts/universal_guard_check.sh
+++ b/scripts/universal_guard_check.sh
@@ -196,8 +196,12 @@ run_case "placeholder BEFORE real, one line → BLOCK" \
 # Each of these previously passed at commit time while BLOCKING at publish time — the two copies
 # of this logic had diverged in leniency. run_state_case swaps the pattern source rather than the
 # staged content, so it needs its own runner.
-run_state_case() {  # <name> <override-content|__NONE__> <defaults:keep|drop> <expect-exit: block|pass>
-  local name="$1" ovc="$2" defmode="$3" expect="$4" out rc got
+run_state_case() {  # <name> <override-content|__NONE__> <defaults:keep|drop> <expect-exit: block|pass> [expect-verdict-substring]
+  # The 5th arg exists because exit code alone cannot see this defect class: a scan whose
+  # operator-literal layer never ran exits 0 and used to print the same `✅ PASS` as a scan where
+  # every layer ran. Identical verdicts for different amounts of measurement is the fail-open —
+  # so the anchor has to read the verdict LINE, not just the status.
+  local name="$1" ovc="$2" defmode="$3" expect="$4" want="${5:-}" out rc got
   printf 'operator literal zzsynthoperator\n' > "$SANDBOX/README.md"
   git -C "$SANDBOX" add -- README.md >/dev/null 2>&1
   local ov="$SANDBOX/.psa_state_override"
@@ -208,17 +212,26 @@ run_state_case() {  # <name> <override-content|__NONE__> <defaults:keep|drop> <e
   if [ "$defmode" = drop ]; then mv "$defbak" "$SANDBOX/.claude/rules/.public-surface-patterns.defaults" 2>/dev/null; fi
   git -C "$SANDBOX" rm -q --cached -- README.md >/dev/null 2>&1; rm -f "$SANDBOX/README.md" "$ov"
   if [ "$rc" -ne 0 ]; then got=block; else got=pass; fi
-  if [ "$got" = "$expect" ]; then
-    echo "  ✅ $name (expected $expect)"
-  else
+  if [ "$got" != "$expect" ]; then
     echo "  ❌ $name — expected $expect, got $got (exit $rc)"
     printf '%s\n' "$out" | sed 's/^/       | /' | head -10
     FAILED=1
+  elif [ -n "$want" ] && ! printf '%s' "$out" | grep -qF "$want"; then
+    echo "  ❌ $name — exit was $got but the verdict line did not say: $want"
+    printf '%s\n' "$out" | grep -E 'PASS|PARTIAL|Confidentiality' | sed 's/^/       | /' | head -5
+    FAILED=1
+  else
+    echo "  ✅ $name (expected $expect${want:+, verdict names \"$want\"})"
   fi
 }
 run_state_case "no patterns at all (instrument down) → BLOCK" "__NONE__" drop  block
 run_state_case "malformed regex in override          → BLOCK" "HIGH	zzsynth[" keep block
-run_state_case "empty override + defaults present    → PASS " ""              keep pass
+# 2026-08-06 — this state still PASSES (a commit is reversible; blocking every fresh clone's first
+# commit is what trains the override into a reflex), but it may no longer CLAIM a clean scan. Pinned
+# as a pair so the label cannot drift back to a bare PASS, and so an unconditional PARTIAL — which
+# would be just as wrong — is caught by the control below it.
+run_state_case "empty override + defaults present    → PASS " ""              keep pass "PARTIAL"
+run_state_case "control: override PRESENT, no hit    → PASS " "HIGH	zzunrelatedliteral" keep pass "✅ PASS"
 
 # ── Pair 7: pattern-ROW malformations that are not invalid regex. Each of these used to be skipped
 # in silence, i.e. a detector the author believed in that never existed, and a scan that certified

--- a/templates/.git-hooks/pre-commit
+++ b/templates/.git-hooks/pre-commit
@@ -303,6 +303,14 @@ else
         echo "  → '~' or '{project}'), or PUBLIC_SURFACE_OK=1 git commit … for a reviewed mention."
         FAILED=1
       fi
+    elif [ "$PSA_OVERRIDE_PRESENT" -eq 0 ]; then
+      # NOT `✅ PASS`. The scan found nothing, but one whole layer of it — the operator/company
+      # literals — never ran. A missing measurement is not a zero (CLAUDE.md §Instrument
+      # Calibration), and a verdict that reads identically whether a layer ran or not is the
+      # fail-open this repo names. The commit is still allowed: a commit is reversible, so the
+      # degrade here is advisory by the Surface-Class Degrade Invariant. Push and publish, which
+      # are the acts that make content public, block this same state.
+      echo "  ⚠️  PARTIAL — no hit in the committed defaults; company/companion literals UNMEASURED."
     else
       echo "  ✅ PASS"
     fi

--- a/templates/.git-hooks/pre-push
+++ b/templates/.git-hooks/pre-push
@@ -298,9 +298,21 @@ else
   _pp_why=""
   [ "$_PP_APPLICABLE" -eq 1 ] && [ "$PSA_DEFAULTS_OK" -eq 0 ] && _pp_why="committed pattern defaults unreadable/empty"
   [ "$_PP_APPLICABLE" -eq 1 ] && [ "$PSA_BAD_ROWS" -gt 0 ]    && _pp_why="${_pp_why:+$_pp_why; }$PSA_BAD_ROWS unusable pattern row(s)"
+  # 2026-08-06 — the 07-26 warn stays for the case it was right about, and is SCOPED, not reverted.
+  # An absent override is a legitimate configuration gap in a fresh clone / CI runner / worktree (the
+  # file is gitignored, so it is absent there by construction) → WARN, exactly as 07-26 concluded.
+  # In an operator-configured checkout the same state is missing evidence, not a missing config, and
+  # this is an irreversible surface → BLOCK, matching what `public_surface_scan_files.sh` already does
+  # at `npm publish`. Two irreversible surfaces degrading in opposite directions on the same state was
+  # the actual defect; git push was the lenient one.
+  psa_detect_operator_context "$REPO_ROOT"
   if [ "$_PP_APPLICABLE" -eq 1 ] && [ "$PSA_OVERRIDE_PRESENT" -eq 0 ]; then
-    echo "  ⚠️  operator-literal override absent — only the committed defaults (home paths + credential"
-    echo "     shapes) are active. Populate .claude/rules/.public-surface-patterns for company literals."
+    if [ "$PSA_OPERATOR_CONTEXT" -eq 1 ]; then
+      _pp_why="${_pp_why:+$_pp_why; }operator-literal override absent in an operator-configured checkout (company/companion literals NOT scanned)"
+    else
+      echo "  ⚠️  operator-literal override absent — only the committed defaults (home paths + credential"
+      echo "     shapes) are active. Populate .claude/rules/.public-surface-patterns for company literals."
+    fi
   fi
   if [ -n "$_pp_why" ]; then
     if [ "${PUBLIC_SURFACE_OK:-0}" = "1" ]; then


### PR DESCRIPTION
세션 카드의 **S7 기밀 스캔 fail-open**. 운영자 지시 = *"증거 부재면 차단"*.

## 먼저: 처방 후보 3개 중 2개는 답이 이미 나와 있었다

| 후보 | 실측 |
|---|---|
| ② 패턴을 committed defaults 로 승격 | **07-28 에 이미 완료** — `.public-surface-patterns.defaults`, 3,109B, tracked |
| ① 경고 → 차단 | **07-26 에 했다가 되돌린 것.** 이 레포 selfcheck 가 과차단으로 지목했고(T7 *"guard over-fires; that trains the override"*), 논거도 성립한다 — override 는 **이 운영자의** 리터럴을 담는다. 다른 환경이 그걸 안 가진다고 자기 유출에 무방비인 게 아니다. 그대로 다시 하면 **되돌린 변경의 재출하** |
| ③ 부재를 UNMEASURED 로 | **안 한 것.** 남은 하나 |

그래서 ①을 그대로 재시도하지 않았다.

## 실제 결함 — 두 비가역 표면의 degrade 방향이 반대였다

- `npm publish` (`public_surface_scan_files.sh`) → override 부재에 **차단**
- `git push` (pre-push) → **경고만**

둘 다 내용을 공개하는데 방향이 반대였고, **관대한 쪽이 하필 아무도 의도적으로 publish 하지 않는 표면**이었다.

## 처방 — 되돌리지 않고 **범위를 좁힌다**

07-26 의 논거는 틀린 게 아니라 **범위가 없었다.**

| 상태 | 뜻 | 방향 |
|---|---|---|
| fresh clone · CI · worktree 에서 override 부재 | 정당한 미설정(gitignored 라 구조적으로 없다) | **WARN** — 종전 그대로 |
| **운영자가 설정한 체크아웃**에서 override 부재 | 미설정이 아니라 **있어야 할 증거의 부재** | **BLOCK** (push) |

`psa_detect_operator_context` 가 그 둘을 가른다. 판별 신호 = `CLAUDE.local.md`(운영자 고유 gitignored 바인딩).

표면별 방향은 Surface-Class Degrade Invariant 를 그대로 따른다:

- **커밋(가역)** → 차단하지 않는다. 다만 `✅ PASS` 를 못 쓴다 → `⚠️ PARTIAL — company/companion literals UNMEASURED`. **한 층이 안 돌았는데 verdict 가 돈 것과 똑같이 보이는 게 fail-open 의 본체다**
- **푸시(비가역)** → operator-configured 체크아웃에서만 차단

## 판별자는 추론이 아니라 캘리브레이션으로 골랐다 — 후보 하나가 **반증**됐다

첫 후보는 `tracks/_meta 가 비어있지 않음` 이었다. 같은 신호처럼 읽히는데 **아니다** — `tracks/_meta/.gitkeep` 등이 **tracked** 라 **fresh clone 이 그 조건을 만족한다.** 그대로 갔으면 07-26 과차단을 새 이름으로 재출하했다.

known-pair 로 재보고 `CLAUDE.local.md`(`git check-ignore` → `.gitignore:17` 확인)로 교체했다. *추론으로 고르고 나중에 검증했으면 이 PR 이 고치려는 것을 다시 만들었다.*

## 앵커 — 양 arm 이 필수다

- **`prepush_guard_check.sh` 6-b 신설**: override 부재 + operator 체크아웃 → BLOCK
  6-a(부재 + 일반 체크아웃 → PASS)는 **그대로 통과해야 한다** — 아니면 이건 범위 좁힌 차단이 아니라 그냥 과차단이다
- **`universal_guard_check.sh`**: `run_state_case` 에 verdict-문자열 인자 추가. **종료코드만으로는 이 결함이 안 보인다** — 한 층이 안 돌아도 exit 0 이고 같은 `✅ PASS` 를 찍었다. 부재 arm 은 `PARTIAL` 을, **컨트롤(override 있고 무히트)은 `✅ PASS`** 를 말해야 한다. 컨트롤이 없으면 *무조건 PARTIAL* 도 통과한다

**fail-before 실행 증명**: 훅을 HEAD 판으로 되돌리면 6-b 는 `pass` 로, PARTIAL 쌍은 `verdict line did not say PARTIAL` 로 각각 실패하고, **컨트롤은 양쪽에서 초록을 유지**한다(단언이 항진명제가 아님을 보인다). 되돌림 해제하면 전부 초록.

## 잔여 — 닫은 척하지 않는다

- **`CLAUDE.local.md` 를 지우면 경고 arm 으로 떨어지고, `PUBLIC_SURFACE_OK=1` 과 달리 로그가 안 남는다.** 승인된 우회보다 조용한 탈출구이고 순서가 거꾸로다. *"가진 적 없음"* 과 *"가졌다가 잃음"* 을 가르려면 훅이 상태를 들어야 해서 이번엔 명명만 했다 — 실측 재발 시 기계화
- 운영자가 `CLAUDE.local.md` 를 만든 적 없으면 계속 경고 arm(**under-block 방향** — 의도)
- **cross-family 재검 미실시.** 인라인 same-family 1라운드만 돌았다. 게이트가 이 침묵을 실제로 잡아 마커에 `crossfamily:` 를 명시하게 만들었다 — **게이트가 행동을 바꿨다**

## 증거 캡슐 (sanitize)

- `selfcheck.sh` **PASS**
- `universal_guard_check.sh` **24쌍 전량 성립** (신규 2 포함: PARTIAL 라벨 + 컨트롤)
- `prepush_guard_check.sh` **20쌍 전량 성립** (신규 1: 6-b operator-context BLOCK)
- `degrade_direction_scan.sh` — 스테이징된 load-bearing 파일의 플래그 2줄은 **내 hunk 밖 기존 코드**로 확인, 신규 smell 0건
- 4축 전량 PASS · Axis 3 phantom 0(신규 참조 5경로 + `.gitignore:17` 실측)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6iiFzRc28prnPH2xvbiG7