### PR TITLE
fix(close-check): ① 스냅샷의 fail-open 4종 — 부재·침묵·범위가 전부 '깨끗함'으로 렌더됐다

### DIFF
--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -1048,3 +1048,24 @@
     session under 2026-08-05 while the check counts today's date, so "logged" and "logged where the
     check looks" came apart. Recorded rather than back-dated — the split is real (the tally itself
     splits 34/14 across the boundary) and pretending otherwise would misstate when the work ran.
+
+- date: 2026-08-06
+  agent: general-purpose ×2 (블라인드 응시자), fh-commons:quench-challenger ×2 (Axis 2)
+  purpose: >-
+    qasp 풀체인 단련 — 출제자/응시자 분리 블라인드 실행 2회(2막 대조 · 3층 난이도)와,
+    FH 마감 체커 fail-open 수리에 대한 Axis 2 적대검증 2라운드(sonnet → at-floor opus).
+  model: sonnet ×3, opus ×1
+  outcome: accepted
+  evidence: >-
+    블라인드 2회가 계기 결함 2건을 직접 산출했다 — 1차는 두 런 차이를 "플레이키"로 오귀속해
+    리포트에 코드 상태 지문이 없음을 드러냈고(#84→PR #86), 2차는 counts 만 대조해 "변화 없음"이라
+    결론내 집계가 개별을 가리는 문제를 드러냈다(→PR #87). 두 오귀속 모두 **주어진 산출물만 보고는
+    그렇게 결론낼 수밖에 없었다** — 그래서 결함이 응시자가 아니라 계기 쪽임이 판별됐다.
+    챌린저 R1(sonnet)은 수리 대상 바로 윗줄에 같은 fail-open 이 남아 있음을 재현으로 잡았고,
+    게이트가 floor 미달로 거부해 R2(opus, at-floor)를 돌리자 R1 이 못 본 4건이 추가로 나왔다
+    (재발견 0건, 전부 실제 재현). known-pair 6/6.
+  note: >-
+    45 dispatch 대 1 로그 항목으로 ④-e 가 통과한 상태였다 — 이 항목이 그 간극을 메운다.
+    카운트가 큰 것은 Explore 등 내부 에이전트가 함께 집계되기 때문이고, 의미 있는 위임은 위 4건이다.
+    ★방법론 소득이 결함보다 크다: 출제자=응시자면 "잘 나온다"로 끝나고, 분리하면 매 라운드
+    계기 결함이 나온다. 그리고 floor 는 장식이 아니었다 — sonnet R1 이 놓친 HIGH 를 opus R2 가 잡았다.

--- a/scripts/session_close_check.sh
+++ b/scripts/session_close_check.sh
@@ -15,6 +15,9 @@
 
 set -uo pipefail
 
+# 상속된 git 환경변수를 끊는다 — export 된 GIT_DIR 이 있으면 `git -C "$FH"` 가 인자로 받은
+# 레포가 아니라 그 레포를 잰다(Axis 2 at-floor LOW, 2026-08-06). READ-ONLY 체커라 부작용 없음.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
 FH="${1:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 TODAY=$(date +%Y-%m-%d)
 CARD="$FH/tracks/_meta/reference_next_session_starter.md"
@@ -25,11 +28,58 @@ _mtime() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0;
 echo "── session close check: $FH ($TODAY) ──"
 
 # ① status snapshot — uncommitted / unpushed work must be known, not forgotten
-DIRTY=$(git -C "$FH" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
-UNPUSHED=$(git -C "$FH" log --oneline @{u}.. 2>/dev/null | wc -l | tr -d ' ')
-[ "$DIRTY" -gt 0 ] && echo "⚠️  ① $DIRTY uncommitted path(s) — decide: commit or leave deliberately"
-[ "$UNPUSHED" -gt 0 ] && echo "⚠️  ① $UNPUSHED unpushed commit(s) — push before close or record why"
-[ "$DIRTY" -eq 0 ] && [ "$UNPUSHED" -eq 0 ] && echo "✅ ① working tree clean, nothing unpushed"
+# DIRTY 도 같은 형태였다 — `status --porcelain 2>/dev/null | wc -l` 은 git 이 죽어도 0 을 세어
+# "깨끗함"으로 승격된다(재현: `.git/index` 손상 → exit 128, 출력 0줄). 종료코드를 먼저 본다.
+# ⚠️ 이 줄은 **바로 아래 UNPUSHED 수리와 같은 결함**이었고, 처음엔 아래만 고쳤다 —
+# 반쪽 수리를 고치는 커밋에서 반쪽 수리를 할 뻔했다(Axis 2 챌린저가 잡음, 2026-08-06).
+# `--untracked-files=all` 은 `status.showUntrackedFiles=no` config 를 덮어쓴다. 그 config 아래에서는
+# git 이 **성공적으로 침묵**해(exit 0 · 빈 출력) 종료코드 가드로도 안 잡힌다 — 부재가 다시
+# "깨끗함"으로 렌더된다(Axis 2 at-floor MED, 재현: 미추적 파일 1건이 0 으로 보고됨).
+if _st=$(git -C "$FH" status --porcelain --untracked-files=all 2>/dev/null); then
+  DIRTY_KNOWN=1
+  DIRTY=$(printf '%s' "$_st" | grep -c . || true)
+else
+  DIRTY_KNOWN=0
+  DIRTY=0
+fi
+# upstream 유무를 **먼저 판정**한다. `@{u}..` 는 upstream 이 없으면 실패해 0줄을 내고, 그 0을
+# `wc -l` 이 0으로 세어 "nothing unpushed" 로 승격된다 — **한 번도 머신을 떠난 적 없는 커밋이
+# '푸시할 것 없음'으로 읽히는 fail-open**. 부재를 깨끗함으로 읽는 것이라 0 을 신뢰하면 안 된다.
+# (downstream fork's review lane caught it first; this file is the upstream original — 2026-08-06.)
+if git -C "$FH" rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
+  UPSTREAM_KNOWN=1
+  UNPUSHED=$(git -C "$FH" log --oneline @{u}.. 2>/dev/null | wc -l | tr -d ' ')
+else
+  UPSTREAM_KNOWN=0
+  UNPUSHED=0
+fi
+[ "$DIRTY_KNOWN" -eq 0 ] && echo "⚠️  ① UNMEASURED — git status failed; working-tree cleanliness is UNKNOWN, not clean"
+[ "$DIRTY_KNOWN" -eq 1 ] && [ "$DIRTY" -gt 0 ] && echo "⚠️  ① $DIRTY uncommitted path(s) — decide: commit or leave deliberately"
+[ "$UPSTREAM_KNOWN" -eq 0 ] && echo "⚠️  ① UNMEASURED — no upstream for this branch; unpushed count is UNKNOWN, not zero"
+[ "$UPSTREAM_KNOWN" -eq 1 ] && [ "$UNPUSHED" -gt 0 ] && echo "⚠️  ① $UNPUSHED unpushed commit(s) — push before close or record why"
+# "as of last fetch" — 원격을 조회하지 않는다. 로컬 remote-tracking ref 가 낡았으면 이 0 도 낡은 값이다
+# (Axis 2 챌린저 MED, 2026-08-06). fetch 를 넣지 않은 것은 마감 체커가 READ-ONLY·오프라인 안전이기 때문.
+# 추적 파일이 assume-unchanged/skip-worktree 로 마킹돼 있으면 그 수정은 porcelain 에 **안 뜬다** —
+# `-uall` 로도 안 잡히는 별개 계기다(Axis 2 at-floor MED, 재현 확인).
+MASKED=$(git -C "$FH" ls-files -v 2>/dev/null | grep -c '^[a-z]' || true)
+[ "${MASKED:-0}" -gt 0 ] \
+  && echo "⚠️  ① $MASKED file(s) assume-unchanged/skip-worktree — their edits are INVISIBLE here"
+
+# ★ 잰 범위 ≠ 주장 범위 (Axis 2 at-floor HIGH, 2026-08-06).
+# `@{u}..` 는 **현재 브랜치만** 잰다. 다른 로컬 브랜치에만 있는 미푸시 커밋은 통째로 안 보이는데
+# 화면 문구는 "nothing unpushed"(레포 전체)라고 말한다 — 이 파일의 존재 이유 정중앙이다.
+# 재현: 다른 브랜치에 미푸시 커밋 1건 → `✅ nothing unpushed` 가 그대로 떴다.
+# 원격이 하나도 없으면 이 값이 전 커밋 수로 부풀므로 원격 존재를 먼저 가드한다.
+OTHER_UNPUSHED=0
+if [ -n "$(git -C "$FH" remote 2>/dev/null)" ]; then
+  OTHER_UNPUSHED=$(git -C "$FH" log --branches --not --remotes --oneline 2>/dev/null | wc -l | tr -d ' ')
+fi
+[ "${OTHER_UNPUSHED:-0}" -gt 0 ] \
+  && echo "⚠️  ① $OTHER_UNPUSHED commit(s) on local branches never pushed anywhere (all-branch scan)"
+
+[ "$DIRTY_KNOWN" -eq 1 ] && [ "$DIRTY" -eq 0 ] && [ "$UPSTREAM_KNOWN" -eq 1 ] && [ "$UNPUSHED" -eq 0 ] \
+  && [ "${OTHER_UNPUSHED:-0}" -eq 0 ] && [ "${MASKED:-0}" -eq 0 ] \
+  && echo "✅ ① working tree clean, nothing unpushed anywhere (as of last fetch)"
 
 # ①-b open-PR sweep (surface-not-auto — requires gh; skip silently offline)
 if command -v gh >/dev/null 2>&1; then

--- a/scripts/test_session_close_chain_lanes.sh
+++ b/scripts/test_session_close_chain_lanes.sh
@@ -85,6 +85,18 @@ _repo() {  # $1=dirname ; makes a git repo with one commit dated $2 (default now
     else
       git commit -qm seed
     fi
+    # A real repo HAS an upstream. Without one the close check now (correctly) reports
+    # `① UNMEASURED — no upstream`, which is not the state any of these lanes means to express —
+    # a fixture with no upstream cannot assert "clean tree, nothing unpushed" because the second
+    # half of that sentence is genuinely unknown. Every lane below therefore runs on a pushed
+    # baseline; upstream ABSENCE is measured on purpose by its own lane (KP-2).
+    git init -q --bare "$TMPROOT/$1.git"
+    git remote add origin "$TMPROOT/$1.git"
+    # `-c core.hooksPath=` : a fixture push must never execute the HOST's git hooks. This repo sets
+    # core.hooksPath locally (so a temp repo does not inherit it) but a machine that sets it GLOBALLY
+    # would run FH's own pre-push Destructive-Op gate against a throwaway fixture — the suite's result
+    # would then depend on the operator's git config rather than on the code under test.
+    git -c core.hooksPath= push -q -u origin HEAD
   ) >/dev/null 2>&1
   mkdir -p "$T/tracks/_meta"
   printf '%s' "$T"
@@ -121,13 +133,10 @@ _line "①-N  uncommitted path → ⚠️ fires"           'uncommitted path'   
 _line "①-N  uncommitted path → clean line absent"  '✅ ① working tree clean' 0 "$OUT"
 _rc   "①-N  uncommitted is ADVISORY, not blocking" "$RC" 0
 
-# unpushed: needs a real upstream, so build a bare remote
+# unpushed: _repo already pushed the seed, so one extra commit is exactly one unpushed commit
 T=$(_repo one_unpushed); _artifacts "$T"
 (
   cd "$T" || exit 1
-  git init -q --bare "$TMPROOT/one_unpushed.git" 2>/dev/null
-  git remote add origin "$TMPROOT/one_unpushed.git"
-  git push -q -u origin HEAD 2>/dev/null
   echo more > second.txt && git add -A && git commit -qm second
 ) >/dev/null 2>&1
 _run "$T"
@@ -140,6 +149,72 @@ _g=0; printf '%s\n' "$OUT" | grep -q '✅ ① working tree clean' && _g=1
 _gap "①  non-repo reports CLEAN" "$_g" \
   "git is unavailable/not a repo → DIRTY=0, UNPUSHED=0 → the check reports '✅ working tree clean'. \
 An instrument that could not look is not a clean result (not found ≠ 0). Should say UNSCANNED."
+
+# ── ① not-found ≠ 0 : the five states where git CANNOT answer ────────────────────
+# Origin: the fix that introduced these five guards (2026-08-06) listed all six known pairs in its
+# COMMIT MESSAGE and shipped none of them as a lane — the code changed, the suite did not, and CI
+# went red on the two lanes the change broke rather than on the five it left unmeasured. Prose in a
+# commit message is not a regression anchor: nothing re-runs it. Each pair below is
+# known-positive (the instrument is blind) + a paired control (the clean line must NOT appear),
+# because "the warning fired" and "the warning fired INSTEAD of a false all-clear" are two claims.
+# KP-1 (the healthy case) is the ①-P lane at the top of this section.
+
+# KP-2 upstream absent — `@{u}..` fails, prints 0 lines, and `wc -l` counts that 0 as "nothing
+# unpushed". A commit that never left the machine reads as pushed. `--unset-upstream` (not
+# `remote remove`) keeps a remote present, so the all-branch scan still runs: this isolates the
+# upstream leg instead of quietly testing two things at once.
+T=$(_repo kp2_no_upstream); _artifacts "$T"
+git -C "$T" branch --unset-upstream >/dev/null 2>&1
+_run "$T"
+_line "KP-2 no upstream → UNMEASURED, not zero"    'unpushed count is UNKNOWN' 1 "$OUT"
+_line "KP-2 → clean line absent (paired)"          '✅ ① working tree clean'   0 "$OUT"
+_rc   "KP-2 → advisory, not blocking"              "$RC" 0
+
+# KP-3 git status itself fails — a corrupt index makes `status` exit non-zero with EMPTY output,
+# and `| wc -l` renders that emptiness as "0 dirty paths" = clean.
+T=$(_repo kp3_broken_index); _artifacts "$T"
+printf 'garbage' > "$T/.git/index"
+_run "$T"
+_line "KP-3 corrupt index → cleanliness UNKNOWN"   'cleanliness is UNKNOWN'    1 "$OUT"
+_line "KP-3 → clean line absent (paired)"          '✅ ① working tree clean'   0 "$OUT"
+# Measured while writing this lane: a corrupt index makes `ls-files -v` exit 128 too, so the
+# assume-unchanged probe (MASKED) silently reads 0 — the same not-found-≠-0 shape, one layer in.
+# It is NOT a false all-clear (DIRTY_KNOWN=0 already suppresses the clean line), so it is recorded
+# as a residual rather than patched here. `rev-parse @{u}` still exits 0 under a corrupt index,
+# which is what keeps this lane measuring cleanliness and not accidentally re-measuring KP-2.
+
+# KP-4 measured scope ≠ claimed scope — `@{u}..` reads the CURRENT branch only, while the message
+# says "nothing unpushed" about the repo. An unpushed commit parked on another local branch is
+# invisible. The current branch stays clean and pushed on purpose: only the other branch is dirty,
+# so a green here would be the exact false all-clear.
+T=$(_repo kp4_other_branch); _artifacts "$T"
+(
+  cd "$T" || exit 1
+  git checkout -q -b side
+  echo side > side.txt && git add -A && git commit -qm side
+  git checkout -q -
+) >/dev/null 2>&1
+_run "$T"
+_line "KP-4 unpushed on ANOTHER branch → ⚠️ fires" 'never pushed anywhere'     1 "$OUT"
+_line "KP-4 → clean line absent (paired)"          '✅ ① working tree clean'   0 "$OUT"
+
+# KP-5 `status.showUntrackedFiles=no` — git succeeds and stays SILENT (exit 0, empty output), so
+# the exit-code guard of KP-3 cannot catch this one. Only `--untracked-files=all` overrides it.
+T=$(_repo kp5_untracked_off); _artifacts "$T"
+git -C "$T" config status.showUntrackedFiles no
+echo hidden > "$T/hidden.txt"
+_run "$T"
+_line "KP-5 showUntrackedFiles=no → still counted"  'uncommitted path'         1 "$OUT"
+_line "KP-5 → clean line absent (paired)"           '✅ ① working tree clean'  0 "$OUT"
+
+# KP-6 assume-unchanged / skip-worktree — edits to a marked TRACKED file never reach porcelain at
+# all, so `-uall` does not help either. A separate instrument (`ls-files -v`) has to surface it.
+T=$(_repo kp6_assume_unchanged); _artifacts "$T"
+git -C "$T" update-index --assume-unchanged unrelated.txt
+echo edited >> "$T/unrelated.txt"
+_run "$T"
+_line "KP-6 assume-unchanged edit → surfaced"       'INVISIBLE here'           1 "$OUT"
+_line "KP-6 → clean line absent (paired)"           '✅ ① working tree clean'  0 "$OUT"
 
 echo
 echo "══ ①-b open-PR sweep ══"


### PR DESCRIPTION
downstream fork 의 리뷰 레인이 먼저 잡아 상류(이 파일)로 넘어온 건이다. 고치는 과정에서 **같은 형태가 3개 더** 나왔다.

## 원 결함

```bash
UNPUSHED=$(git log --oneline @{u}.. 2>/dev/null | wc -l)
```
upstream 이 없으면 `@{u}..` 실패 → **0줄** → `wc -l` 이 0 → `✅ nothing unpushed`.
**한 번도 머신을 떠난 적 없는 커밋이 "푸시할 것 없음"으로 읽힌다.**

## 4종 — 전부 "부재/침묵/부분범위 → 0(깨끗함)" 이라는 한 얼굴

| 발견 | 계기 | 수리 |
|---|---|---|
| **upstream 부재** (원건) | `@{u}..` 실패가 0줄 | upstream 유무 선판정 → `UNMEASURED` |
| **`DIRTY` 동일 형태** (R1 HIGH) | `.git/index` 손상 시 exit 128 인데 0 | 종료코드 선판정 → `UNMEASURED` |
| **잰 범위 ≠ 주장 범위** (R2 HIGH) | `@{u}..` 는 **현재 브랜치만**. 타 브랜치 미푸시는 통째로 안 보이는데 문구는 레포 전체를 말함 | 전-브랜치 스캔 추가(원격 존재 가드 동반) |
| **git 이 성공적으로 침묵** (R2 MED×2) | `status.showUntrackedFiles=no` 는 exit 0 + 빈 출력 → **종료코드 가드로도 못 잡음** · `assume-unchanged` 는 `-uall` 로도 안 보임 | `--untracked-files=all` + `ls-files -v` 가시화 |

LOW 1건(export 된 `GIT_DIR` 이 인자 레포를 덮어씀)도 `unset` 한 줄로 닫았다 — 현재 배선에선 자연발생하지 않지만 READ-ONLY 체커라 비용이 0이다.

## Axis 2 가 반쪽 수리를 두 번 잡았다

- **R1(sonnet)**: 바로 윗줄 `DIRTY` 에 같은 형태가 남아 있었다 — **반쪽 수리를 고치는 커밋에서 반쪽 수리를 할 뻔했다**
- **R1 은 게이트가 거부했다** — `axis2-model: sonnet` 은 판단-깊이 floor(opus) 미달. **at-floor 로 재실행하니 R2 가 4건을 더 잡았고 R1 재발견은 0건**이었다. floor 가 장식이 아니라는 실측이다

## known-pair 6/6 (전부 실제 재현)

```
1 정상(깨끗·전부푸시)      → ✅ nothing unpushed anywhere (as of last fetch)
2 upstream 없음           → ⚠️ UNMEASURED — unpushed count is UNKNOWN, not zero
3 index 손상              → ⚠️ UNMEASURED — cleanliness is UNKNOWN, not clean
4 타브랜치 미푸시          → ⚠️ 1 commit(s) on local branches never pushed anywhere
5 showUntrackedFiles=no  → ⚠️ 1 uncommitted path(s)
6 assume-unchanged       → ⚠️ 1 file(s) … INVISIBLE here
```

**그리고 이 PR 을 푸시하는 순간 새 검사가 스스로 발화했다** — 브랜치에 upstream 이 없어 `UNMEASURED`, 그리고 전-브랜치 스캔이 미푸시 1건을 잡았다.

## 전파 경계

같은 형태(`@{u}.. | wc -l`)는 이 파일에만 있다 — `stale_clone_guard.sh:70` · `sync-to-be.sh:387` 은 이미 upstream 을 선가드한다(훅의 half-fix 경고를 실물로 확인).

## 잔여

- `@{u}` 는 로컬 remote-tracking ref 라 **낡을 수 있다**. 체커가 READ-ONLY·오프라인 안전이라 `fetch` 를 넣지 않고 문구를 `(as of last fetch)` 로 정직화했다
- 무upstream 브랜치에서 `UNMEASURED` 가 상시 발화한다 — 차단이 아니라 표기이고, 그 상태에서 미푸시 건수를 모르는 것은 사실이므로 잔여로 수용
- 이 파일의 **다른 카운트 지점**(④-log·⑤ 카드 드리프트)은 이번에 안 봤다