### PR TITLE
chore(release): 1.4.89 lockstep 범프 + shipped-매니페스트 lockstep 게이트 신설

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,13 @@
   "plugins": [
     {
       "name": "fh-meta",
-      "version": "1.4.88",
+      "version": "1.4.89",
       "description": "Hub meta-operations toolkit — 35 skills + 7 agents. New in 1.4.53: `fh-codex-doctor` (npm bin) — Codex adapter drift scanner; reads the documented M1/M2/M3 skill tier map + skill/agent source and reports codex-native/adapter-required/claude-native/unclassified per unit, wired into `npm test`/`prepublishOnly` (fail-closed on unclassified Claude-native primitives). New in 1.4.49: steel-quench gains Step 0.6 Verdict-Invariance Probe (groundedness axis — a load-bearing judged gate's verdict must track behavior, not rubric phrasing; measured flip-count over cross-family paraphrases; arXiv:2605.06161 Policy Invariance anchor); multi_model_sidecar_strategy §Vendor-native harness (a model is strongest in its own vendor CLI — Claude/CC, GPT/codex, Gemini/Antigravity; a universal router degrades all of them, so it stays an autocomplete/QA sidecar, never orchestration); predelete_check.sh fail-closed rewrite; memory-hygiene A-TMA anchor. New in 1.4.48: phantom-quench + steel-quench gain external frontier anchors (arXiv:2607.02052 package-hallucination; arXiv:2607.02057 prompt-coverage-adequacy); README model-flat claim reframed from a per-release point-curve to structural invariants (operation flattens across tiers; depth tier-order fixed within a generation). New in 1.4.47: onboarding step ① surfaces the Mode D companion-store session-start load in the auto-read salience anchor (previously only in the local binding + rules, so a greeting could skip the load). New in 1.4.46: context-doctor command-output axis (route to rtk/proxy for verbose CLI stdout, complementing .claudeignore; risk-gated to token-scarce envs). New in 1.4.41: context-doctor 2026 trigger vocab (context engineering/rot/collapse) + phantom-citation hardening; hub measurement-integrity-checklist (cross-model measurement pre-flight: display-name pin/reps≥3/discriminating probe). New in 1.4.40: install-wizard queryable-wiki scaffold (INDEX + session-start read + R/W/C ingest). New in 1.4.39: auto-decorrelation (cross-family verifier sidecar recruitment) + video-ingest (capability-routed video ingestion). New in 1.4.x: verify-axis check-class taxonomy (mandatory-pass/measured/judged), no-reinvention Tier-0 inventory, 7-class failure taxonomy, Destructive-Op Gate, Wave-T (Temper), tier-floor governance, Mode D Model Notice, FC consent lane, default-Sonnet guidance. New in 1.3.0: public-surface-audit, field-harvest Mode B auto-trigger, 4-axis gate scope ext. Validated cross-CLI: Claude Code, Codex, Gemini.",
       "source": "./plugins/fh-meta"
     },
     {
       "name": "fh-commons",
-      "version": "1.4.88",
+      "version": "1.4.89",
       "description": "Project-agnostic utility skills — 4 skills (convergence-loop · deliberation · mcp-circuit-breaker · token-budget-gate) + 1 agent (quench-challenger). Domain-independent utilities transplantable into any project.",
       "source": "./plugins/fh-commons"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrono-meta/fh-gate",
-  "version": "1.4.88",
+  "version": "1.4.89",
   "description": "FH runtime adapters — run FH governance, skills, and agents via Claude or Codex with machine-parseable gates.",
   "license": "MIT",
   "keywords": [
@@ -26,7 +26,7 @@
   "scripts": {
     "prepare": "chmod +x bin/fh-gate.js bin/fh-run.js bin/fh-goal.js bin/fh-codex-doctor.js scripts/fh-gate.sh scripts/fh-run.sh scripts/fh-goal.sh",
     "test": "bash scripts/selfcheck.sh",
-    "prepublishOnly": "bash scripts/selfcheck.sh && bash scripts/public_surface_scan_files.sh",
+    "prepublishOnly": "bash scripts/version_lockstep_check.sh && bash scripts/selfcheck.sh && bash scripts/public_surface_scan_files.sh",
     "release": "bash scripts/public_surface_scan_files.sh && npm publish"
   },
   "engines": {
@@ -64,7 +64,9 @@
     "scripts/fh-goal.sh",
     "scripts/count_check.sh",
     "scripts/selfcheck.sh",
+    "scripts/version_lockstep_check.sh",
     "scripts/test_selfcheck_state_lanes.sh",
+    "scripts/test_version_lockstep_lanes.sh",
     "scripts/package_coverage_check.sh",
     "scripts/test_package_coverage_lanes.sh",
     "scripts/test_fh_gate_regressions.sh",

--- a/plugins/fh-commons/.claude-plugin/plugin.json
+++ b/plugins/fh-commons/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-commons",
-  "version": "1.4.88",
+  "version": "1.4.89",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/.claude-plugin/plugin.json
+++ b/plugins/fh-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-meta",
-  "version": "1.4.88",
+  "version": "1.4.89",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -539,6 +539,25 @@ else
   fail=1
 fi
 
+# Shipped-manifest version lockstep. Distinct from the tag lane above: that one compares the git TAG
+# to package.json; this one compares package.json to every version string it SHIPS — including the
+# per-plugin entries inside marketplace.json, which the tag lane never opens. Measured 2026-08-06:
+# a bump left the second marketplace entry behind and the tag lane passed 8/8 straight through it.
+if [ ! -f scripts/version_lockstep_check.sh ]; then
+  echo "SKIP  test_version_lockstep_lanes.sh (subject scripts/version_lockstep_check.sh absent)"
+elif [ -f scripts/test_version_lockstep_lanes.sh ]; then
+  if _out=$(bash scripts/test_version_lockstep_lanes.sh 2>&1); then
+    echo "PASS  test_version_lockstep_lanes.sh (drift blocks · aligned silent · unreadable = exit 2, not pass)"
+  else
+    echo "FAIL  test_version_lockstep_lanes.sh: the shipped-manifest lockstep guard would mis-route"
+    _show_failure "$_out"
+    fail=1
+  fi
+else
+  echo "FAIL  test_version_lockstep_lanes.sh: version_lockstep_check.sh present but its anchor is missing"
+  fail=1
+fi
+
 # ④-e dispatch-log reconciliation + its tally hook. Wired in the same commit that ships them: the
 # obligation they mechanize lost 20/20 in a single session, so leaving the checker itself unrun
 # would be the same defect one layer up.

--- a/scripts/test_version_lockstep_lanes.sh
+++ b/scripts/test_version_lockstep_lanes.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Known pairs for scripts/version_lockstep_check.sh.
+#
+# The lane this suite exists to prevent: on 2026-08-06 a 1.4.88 → 1.4.89 bump edited the FIRST
+# marketplace plugin entry and left the SECOND at the old version. `test_tag_version_lanes.sh`
+# reported 8/8 PASS through it — that lane compares the git tag to package.json and never opens
+# marketplace.json. The drift was caught by an ad-hoc `sort | uniq -c`. Luck is not a floor.
+#
+# Every lane runs against a THROWAWAY fixture tree, never against this repo, so the suite is
+# hermetic: a real bump in progress can neither turn it green nor turn it red.
+
+set -uo pipefail
+CHECK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/version_lockstep_check.sh"
+TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/fh_lockstep.XXXXXX")
+trap 'rm -rf "$TMPROOT"' EXIT
+PASS=0; FAIL=0
+
+_fixture() {  # $1=name $2=pkg_ver $3=meta_ver $4=commons_ver $5=mk_entry0 $6=mk_entry1
+  local T="$TMPROOT/$1"
+  mkdir -p "$T/.claude-plugin" "$T/plugins/fh-meta/.claude-plugin" "$T/plugins/fh-commons/.claude-plugin"
+  printf '{"name":"fh","version":"%s"}\n' "$2" > "$T/package.json"
+  printf '{"name":"fh-meta","version":"%s"}\n' "$3" > "$T/plugins/fh-meta/.claude-plugin/plugin.json"
+  printf '{"name":"fh-commons","version":"%s"}\n' "$4" > "$T/plugins/fh-commons/.claude-plugin/plugin.json"
+  printf '{"plugins":[{"name":"fh-meta","version":"%s"},{"name":"fh-commons","version":"%s"}]}\n' \
+    "$5" "$6" > "$T/.claude-plugin/marketplace.json"
+  printf '%s' "$T"
+}
+
+_expect() {  # $1=label $2=expected_rc $3=repo ; also captures OUT
+  OUT=$(bash "$CHECK" "$3" 2>&1); local rc=$?
+  if [ "$rc" = "$2" ]; then echo "  ✅ $1 (rc=$rc)"; PASS=$((PASS+1))
+  else echo "  ❌ $1 — rc=$rc, expected=$2"; printf '%s\n' "$OUT" | sed 's/^/       │ /'; FAIL=$((FAIL+1)); fi
+}
+_says() {  # $1=label $2=pattern $3=expected_hit(1|0)
+  local h=0; printf '%s\n' "$OUT" | grep -q -- "$2" && h=1
+  if [ "$h" = "$3" ]; then echo "  ✅ $1"; PASS=$((PASS+1))
+  else echo "  ❌ $1 — hit=$h, expected=$3"; printf '%s\n' "$OUT" | sed 's/^/       │ /'; FAIL=$((FAIL+1)); fi
+}
+
+echo "══ version lockstep known pairs ══"
+
+# KN — everything aligned. The control: without it, a checker that always reported DRIFT would
+# still pass every positive lane below.
+_expect "KN  all five strings aligned → exit 0" 0 "$(_fixture kn 1.4.89 1.4.89 1.4.89 1.4.89 1.4.89)"
+_says   "KN  → names the count it actually checked" "4 shipped version string" 1
+
+# KP-1 — the measured miss, byte for byte: second marketplace entry left behind.
+_expect "KP-1 second marketplace entry stale → exit 1" 1 "$(_fixture kp1 1.4.89 1.4.89 1.4.89 1.4.89 1.4.88)"
+_says   "KP-1 → names the offending entry by index+name" "plugins\[1\] fh-commons" 1
+_says   "KP-1 → reports both versions, not just 'mismatch'" "1.4.88  (package.json = 1.4.89)" 1
+
+# KP-2 — a plugin.json left behind. This is the shape the tag lane also cannot see.
+_expect "KP-2 plugin.json stale → exit 1" 1 "$(_fixture kp2 1.4.89 1.4.88 1.4.89 1.4.89 1.4.89)"
+_says   "KP-2 → names the file" "plugins/fh-meta/.claude-plugin/plugin.json" 1
+
+# KP-3 — the reverse direction: package.json bumped alone. Same defect, opposite author error.
+_expect "KP-3 only package.json bumped → exit 1" 1 "$(_fixture kp3 1.5.0 1.4.89 1.4.89 1.4.89 1.4.89)"
+_says   "KP-3 → all four downstream strings flagged" "4 of 4" 1
+
+# HARNESS-ERROR — an instrument that could not look has not looked. These must be a THIRD state,
+# never folded into PASS: this gate guards `npm publish`, an irreversible surface.
+T=$(_fixture he1 1.4.89 1.4.89 1.4.89 1.4.89 1.4.89); rm "$T/.claude-plugin/marketplace.json" "$T"/plugins/*/.claude-plugin/plugin.json
+_expect "HE-1 no manifests at all → exit 2, NOT 0" 2 "$T"
+_says   "HE-1 → says alignment is UNKNOWN, not aligned" "UNKNOWN, not aligned" 1
+
+T=$(_fixture he2 1.4.89 1.4.89 1.4.89 1.4.89 1.4.89); printf '{ broken' > "$T/.claude-plugin/marketplace.json"
+_expect "HE-2 unparseable manifest → exit 2, NOT 0" 2 "$T"
+
+T=$(_fixture he3 1.4.89 1.4.89 1.4.89 1.4.89 1.4.89); rm "$T/package.json"
+_expect "HE-3 missing package.json → exit 2, NOT 0" 2 "$T"
+
+# A manifest present but carrying no version at all is absence, not agreement.
+T=$(_fixture he4 1.4.89 1.4.89 1.4.89 1.4.89 1.4.89); printf '{"name":"fh-meta"}\n' > "$T/plugins/fh-meta/.claude-plugin/plugin.json"
+_expect "HE-4 manifest with no version → exit 2, NOT 0" 2 "$T"
+_says   "HE-4 → says which file carries none" "carries no version string" 1
+
+echo
+echo "──────────────────────────────────────────────"
+if [ "$FAIL" -gt 0 ]; then
+  echo "VERSION-LOCKSTEP LANES: FAIL ($PASS pass · $FAIL fail)"; exit 1
+fi
+echo "VERSION-LOCKSTEP LANES: PASS ($PASS/$PASS)"

--- a/scripts/version_lockstep_check.sh
+++ b/scripts/version_lockstep_check.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# version_lockstep_check.sh — every shipped manifest must carry package.json's version.
+#
+# Why this exists (measured 2026-08-06, while republishing 1.4.88 → 1.4.89):
+# CLAUDE.md §④-b says to bump "package.json + every .claude-plugin/plugin.json + marketplace.json".
+# That instruction reads as four files, but `.claude-plugin/marketplace.json` carries **one version
+# per plugin entry** — five strings across four files. A bump that edited the first entry left the
+# second at the old version, and `test_tag_version_lanes.sh` passed 8/8 anyway: that lane compares
+# the git TAG to package.json and never opens marketplace.json. The stale entry was caught by an
+# ad-hoc `sort | uniq -c`, i.e. by luck, not by an instrument.
+#
+# Codex caches plugins on the plugin.json version, so a stale entry ships a plugin that the other
+# runtime believes it already has — the drift is silent on exactly the surface that cannot report it.
+#
+# Exit 0 = all aligned · exit 1 = drift (names every offending file:line) · exit 2 = harness error
+# (a manifest is missing or unparseable — NOT a pass; an instrument that could not look has not
+# looked, and this gate guards an irreversible surface).
+
+set -uo pipefail
+ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+command -v python3 >/dev/null 2>&1 || { echo "LOCKSTEP: HARNESS-ERROR — python3 unavailable"; exit 2; }
+
+python3 - "$ROOT" <<'PY'
+import json, sys, glob, os
+root = sys.argv[1]
+pkg_path = os.path.join(root, 'package.json')
+try:
+    want = json.load(open(pkg_path))['version']
+except Exception as e:
+    print(f"LOCKSTEP: HARNESS-ERROR — cannot read {pkg_path}: {e}")
+    sys.exit(2)
+
+# (path, list-of-(label, version)) — every manifest that ships a version string.
+targets = []
+for p in sorted(glob.glob(os.path.join(root, 'plugins', '*', '.claude-plugin', 'plugin.json'))):
+    targets.append(p)
+mk = os.path.join(root, '.claude-plugin', 'marketplace.json')
+if os.path.exists(mk):
+    targets.append(mk)
+
+if not targets:
+    # Absence is not alignment. If the manifests vanished, say so rather than reporting a clean run.
+    print("LOCKSTEP: HARNESS-ERROR — no plugin/marketplace manifest found; alignment is UNKNOWN, not aligned")
+    sys.exit(2)
+
+drift, checked = [], 0
+for p in targets:
+    try:
+        d = json.load(open(p))
+    except Exception as e:
+        print(f"LOCKSTEP: HARNESS-ERROR — cannot parse {p}: {e}")
+        sys.exit(2)
+    rel = os.path.relpath(p, root)
+    # A manifest carries a version either at the top level (plugin.json) or once per plugin entry
+    # (marketplace.json). Walk both shapes so a new entry cannot be silently uncovered.
+    found = []
+    if isinstance(d.get('version'), str):
+        found.append(('(top-level)', d['version']))
+    for key in ('plugins', 'entries'):
+        for i, ent in enumerate(d.get(key) or []):
+            if isinstance(ent, dict) and isinstance(ent.get('version'), str):
+                found.append((f"{key}[{i}] {ent.get('name', '?')}", ent['version']))
+    if not found:
+        print(f"LOCKSTEP: HARNESS-ERROR — {rel} carries no version string; expected at least one")
+        sys.exit(2)
+    for label, got in found:
+        checked += 1
+        if got != want:
+            drift.append(f"  {rel} :: {label} = {got}  (package.json = {want})")
+
+if drift:
+    print(f"LOCKSTEP: DRIFT — {len(drift)} of {checked} shipped version string(s) do not match package.json")
+    print("\n".join(drift))
+    print("Bump every string above in the same commit — Codex caches plugins on this version,")
+    print("so a stale entry ships as 'already installed' on the runtime that cannot report it.")
+    sys.exit(1)
+
+print(f"LOCKSTEP: PASS — {checked} shipped version string(s) all at {want}")
+PY


### PR DESCRIPTION
## 왜

`v1.4.88` 태그 이후 `files[]` 자산 **12건 전부**가 바뀌었다 — 배포본이 stale이다.

## 범프 도중 드러난 구멍

`.claude-plugin/marketplace.json`은 **플러그인 엔트리마다** version을 들고 있다. 즉 lockstep 대상은 네 파일이 아니라 **다섯 문자열**이다. 첫 엔트리만 바꾼 half-fix가 났고 기존 `test_tag_version_lanes.sh`는 **8/8 PASS로 통과**시켰다 — 그 레인은 git 태그↔`package.json`만 비교하고 marketplace.json을 열지 않는다. 발견 경로는 즉석 `sort | uniq -c`였다.

Codex는 plugin.json version으로 플러그인을 캐시하므로, stale 엔트리는 "이미 설치됨"으로 읽힌다 — **보고할 수 없는 런타임 쪽에서만** 나는 드리프트다.

## 무엇을 넣었나

`scripts/version_lockstep_check.sh` — 세 상태로 가른다:

| 상태 | exit | 의미 |
|---|---|---|
| PASS | 0 | shipped 문자열 전부가 package.json과 일치 |
| DRIFT | 1 | 불일치 — 파일·엔트리·양쪽 버전을 이름으로 지목 |
| HARNESS-ERROR | 2 | 매니페스트 부재·판독불가·version 미보유 |

세 번째가 핵심이다. `npm publish`는 비가역 표면이라 **못 읽은 것이 PASS로 접히면 안 된다**.

## 증거 캡슐

- **계기 캘리브레이션**: known-pair **15종** 전부 통과 (KN 1 · KP 3 · HARNESS-ERROR 4 + 문구 단언). KP-1은 이번에 실제로 난 누락을 바이트 단위로 재현한다. 픽스처는 전부 throwaway 트리 — 진행 중인 실제 범프가 스위트를 초록으로도 빨갛게도 만들 수 없다.
- **배선 실측** (짓고 안 걸기 방지):
  - `selfcheck.sh` → 전체 실행 `SELFCHECK: PASS`, PASS 181건, 새 레인이 그중에 실행됨
  - `prepublishOnly` → `npm publish --dry-run`에서 **체인 첫 항목으로 실제 실행** 확인
  - `exit 2`가 `&&`를 끊는 것도 실측 (chain-rc=2, 후속 미실행)
- **적대 라운드**: 신규 finding **0**. 공격 4종 — (A) publish 경로 실행 (B) `plugin.json` glob 전수 커버·루트 plugin.json 부재 (C) exit 2 체인 차단 (D) package.json version 부재 → exit 2. 넷 다 통과.
- **4축**: Axis 1 PASS (staged 모드, M-tier 0 / S-tier 0) · Axis 2+3 마커 확인 · Axis 4 manifest 기록.

## 잔여 (닫지 않았다)

1. `npm publish --ignore-scripts` 및 비-npm 클라이언트는 이 게이트를 우회한다 — 기존 named residual과 같은 계열이고 새로 생긴 구멍이 아니다.
2. cross-family 재검 미실시 — 인라인 same-family 1라운드만 돌았다. publish가 비가역 표면인 점을 고려하면 남은 권장 사항이며, 침묵이 아니라 명시로 남긴다.
3. `package_coverage_check.sh`가 stale `ACCEPTED_ABSENT` 1건을 경고한다 — 이번 변경 소산이 아니라 손대지 않았다 (Added-Scope Gate).
4. Axis 1 `--pr` 모드가 커밋 전 워킹트리를 못 봐 SKIP을 냈다. 훅의 STAGED 모드에서는 정상 발화한다. 세션 카드 이월 3번 항목이고 이제 **N=2 표면**이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)