### PR TITLE
docs(dispatch): 서브에이전트 디폴트 적극 사용 — 단, 없는 floor 를 있다고 쓰지 않는다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -604,13 +604,53 @@ Self-healing is not only FH-self-dev (Mode D 4-axis) and reactive (`verify-bidir
 
 > **Runtime authority (canonical):** one explicit governor per context + capability-routed sidecars; sidecar findings are evidence candidates, not terminal verdicts, until source-closed by the governor *via a mechanical anchor* — never governor agreement alone. CC=action/governor · Codex=repo-grounded audit sidecar · Gemini/agy=breadth/multimodal sidecar · other runtimes=portable `AGENTS.md` entrypoint only. Full doctrine + Maintenance-Cost Rule: `knowledge/shared/harness-core/multi_model_sidecar_strategy.md §Runtime Authority`.
 
-Default operation is a **standard interactive session**. Agent dispatch (single or parallel) is used when the task warrants it — not as a default mode. Three execution paths:
+**Isolated delegation is a component of the identity, not an optional extra** (operator decision,
+2026-08-08). FH/PMH are defined as governor + orchestrator; a harness that cannot dispatch is a
+contradiction in its own terms. So **agent dispatch is default-active**: reach for it whenever a unit
+of work is genuinely separable — independent tasks, a blind evaluation that must not see the author's
+reasoning, a search that would otherwise flood this context — **without waiting to be asked**. The
+earlier wording here ("used when the task warrants it — not as a default mode") is superseded.
+
+**The one thing that overrides it** is the user saying not to, *in this environment*.
+
+⚠️ **Neither direction has a confirmed hook-level floor. Say that plainly rather than implying one.**
+```
+opening    salience only — CONFIRMED. If a runtime's SYSTEM PROMPT carries a prohibition
+           ("do not use subagents unless the user asked"), neither this file nor a hook
+           overrides it; a system prompt outranks both, by construction.
+blocking   ALSO not hook-enforced. `SubagentStart` fires on spawn but is **context-only** —
+           it cannot block, exit 2 only surfaces stderr, and it has no decision field
+           (official hooks reference, read 2026-08-08). It can INJECT context at the moment
+           of dispatch, which is better-placed salience than this file, but still salience.
+UNVERIFIED whether a `permissions` deny entry or a `PreToolUse` matcher can target subagent
+           spawning at all — the reference does not name a tool for it, and this repo has no
+           precedent. **Do not cite a blocking mechanism until someone runs the known pair**
+           (configure the deny, attempt a dispatch, observe). Until then: unverified, not absent.
+```
+An earlier draft of this very block asserted "a `SubagentStart` hook can deny, and a denial there is a
+real floor." That was false, taken on trust from an adjacent session and written here before the
+reference was read. A blind target-tier sim then read it back correctly — which shows a sim measures
+whether text is *followable*, never whether it is *true*. Both checks are needed; neither substitutes.
+
+So "default-active" is a **posture, not a guarantee**. Measured 2026-08-08: a session running under
+exactly that system-prompt instruction worked alone for a full session and dispatched only at the two
+points where the operator named it — while this file said dispatch was available. A session that
+*cannot* dispatch must **say so** rather than quietly doing everything inline; the silent version is
+what made that case invisible until the operator asked. Writing "default is active" into a remote
+canon without this paragraph produces the next session that reads it and still cannot comply.
+
+**Onboarding**: at first setup, ask whether this environment wants dispatch and record the answer then —
+that is the one moment where the choice is cheap to make. Wiring it to a *mechanism* waits on the
+UNVERIFIED line above; until that known pair is run, the answer is recorded and honoured by salience,
+and the honest install note says so.
+
+Three execution paths:
 
 | Path | Situation | Method |
 |---|---|---|
 | **Direct edit** | Simple modification of mapped project files | Read/Edit with absolute path (no cwd switch needed) |
 | **Agent dispatch** | Field project work · single independent task | Inject Context Card then dispatch Agent |
-| **Parallel dispatch** | 2+ genuinely independent tasks, explicitly requested | Dispatch parallel Agents |
+| **Parallel dispatch** | 2+ genuinely independent tasks (no explicit request needed — see the default above) | Dispatch parallel Agents |
 
 **Why not Agent View by default**: Agent View introduces worktree isolation (blocks settings.json writes, Stop hook timing differs), session context gaps (session card stale content bug), and path friction — with no benefit unless the user is actively managing multiple agent sessions. Parallel agents via `Agent` tool work identically in a standard session.
 
@@ -650,7 +690,10 @@ true statement about one thing (provenance) was standing in for an untested clai
 recurrence is 1, below this repo's own N≥3 mechanization threshold. If it recurs, the check is a
 two-line hook addition, not a research problem.
 
-**Forbidden responses**: *"I can't do that — I'm not in that project's cwd"* — self-check Agent dispatch first.
+**Forbidden responses**: *"I can't do that — I'm not in that project's cwd"* — self-check Agent dispatch
+first. And **silently working alone while dispatch is unavailable**: if this environment blocks
+subagents, name it once rather than absorbing the whole job inline — an unstated constraint reads as a
+capability the harness simply chose not to use.
 
 Mapped paths: check `auto_project_mapping.md` or `find ~/projects -maxdepth 1 -type d` for actuals.
 


### PR DESCRIPTION
## 무엇을

`CLAUDE.md` §Agent Dispatch Operation 한 절. 서브에이전트 디스패치를 **디폴트 적극 사용**으로 바꾼다.

**정체성 모순의 해소** (운영자 결정): FH/PMH 를 거버너·오케스트레이터로 정의해놓고 오케스트레이션
수단을 비디폴트로 두는 건 앞뒤가 안 맞는다.

```
before  "Agent dispatch is used when the task warrants it — not as a default mode"
        표: "2+ genuinely independent tasks, explicitly requested"
after   "agent dispatch is default-active ... without waiting to be asked"
        표: "2+ genuinely independent tasks (no explicit request needed)"
```

## 이 PR 의 절반은 정정이다

인수받은 델타에 *"쓰지 말라 하면 `SubagentStart` 훅으로 막는다"* 가 있었고, 나도 "훅 슬롯 실재
확인됨"이라며 보강해서 초안에 썼다. **공식 훅 레퍼런스 직독 결과 거짓이다:**

| | 실측 |
|---|---|
| `SubagentStart` | **차단 불가.** exit 2 는 stderr 만 표시 · 결정 필드 없음 · 문서 표현 그대로 *"No blocking or decision control"* = context-only |
| `PreToolUse` | deny 는 지원. 다만 **서브에이전트 생성이 툴로 노출되는지 문서에 없음**, 이 레포 매처 선례 0건 |

즉 비대칭이 초안보다 **나쁘다** — 여는 것도 막는 것도 살리언스고, 실효 우선순위를 갖는 건
**시스템 프롬프트뿐**이다. 이 세션이 그 실증이다: 금지가 시스템 프롬프트에 실려 있어서, 이 파일이
디스패치 가능하다고 말하는 동안 운영자가 명시한 두 지점에서만 디스패치했다.

**다른 확신 문장으로 갈아끼우지 않았다.** `UNVERIFIED` 로 라벨하고 known-pair 절차를 적었다
(deny 설정 → 디스패치 시도 → 관찰). 헤지를 달아놓고 ✅ 를 주는 건 오늘 챔버 런이 잡은 결함이라
같은 자리를 두 번 밟지 않는다.

## 계기에 대한 발견 (파일에 박았다)

1차 블라인드 sim 이 그 **거짓 문장을 5/5 로 정확히 되읽었다.**
→ **sim 은 텍스트가 *따라갈 수 있는지*를 재지 *참인지*를 재지 않는다.** 둘 다 필요하고 대체 불가.

정정 후 2차 sim **6/6**, 최종 판정이 *"오늘 작동하는 차단 기전은 없다"* 로 정확히 나왔다 —
정직한 판본이 정직하게 읽힌다는 확인.

## 증거 캡슐

- Axis 1 `regression_guard --staged` = **PASS** (M-tier 0 · S-tier 0)
- Axis 2+3 마커 확인 + floor 필드 유효 · `crossfamily: DEGRADED_PANEL_UNUSED` (근거: 산문 1개 절 ·
  가역 표면 · **핵심 사실주장은 cross-family 가 아니라 1차 출처 직독으로 검증**)
- target-tier 블라인드 sim(Sonnet, 격리) **2회** — 1차 5/5(구 판본) · 2차 6/6(정정본)
- 자기검증 grep: 거짓 문장 잔존 0 · `UNVERIFIED` 라벨 1 · 옛 문구는 supersession **인용** 1건뿐

## 남는 것

`UNVERIFIED` 한 줄 — `permissions` deny 나 `PreToolUse` 매처가 서브에이전트 생성을 겨냥할 수
있는지. 누가 known-pair 를 돌리기 전까지 **차단 기전을 인용하지 않는다.** 미검증이지 부재가 아니다.

⚠️ **PMH 원격 정본에도 같은 정정이 필요하다** — 델타 원본이 그 거짓 주장을 담고 있었다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNfoCWTHsoWcXDU3WCVJwQ
