### PR TITLE
fix(chamber): 러너 계약이 소스에만 살던 것 — 에러가 형식을 가르치게

### DIFF
--- a/scripts/chamber_run.sh
+++ b/scripts/chamber_run.sh
@@ -85,7 +85,15 @@ fi
 # gate (a) is "artifact exists WITH real content", not just "placeholder removed" (Axis-2 LOW-6): require
 # at least one non-empty numbered success condition so a gutted INTENT.md doesn't pass.
 if ! awk '/^## Success conditions/{f=1;next} /^## /{f=0} f && /^[0-9]+\.[[:space:]]*[^[:space:]]/{print; exit}' "$WS/INTENT.md" | grep -q .; then
-  echo "  ⛔ step 2 BLOCKED: $WS/INTENT.md has no filled success condition (need a numbered line with content), re-run."; exit 1
+  # 계약을 **에러 메시지가 가르친다.** 이 형식은 CHAMBER_RUN_SKELETON.md 에 한 글자도 없어서,
+  # 스켈레톤만 읽고 쓴 INTENT 가 반려됐다 — gate-locality(계약이 게이트 구현에만 산다).
+  # 같은 런에서 step 6 도 같은 이유로 막혔다(N=2). 문서는 드리프트하지만 에러는 코드와 같이 산다.
+  echo "  ⛔ step 2 BLOCKED: $WS/INTENT.md has no filled success condition."
+  echo "     Expected — an English heading, then NUMBERED lines with content:"
+  echo "       ## Success conditions"
+  echo "       1. <condition> · [measured|mandatory-pass|judged]"
+  echo "       2. ..."
+  echo "     A table alone does NOT satisfy this check. Re-run after adding it."; exit 1
 fi
 _stamp "step-2-done"; echo "  ✓ step 2: INTENT.md present"
 
@@ -152,7 +160,11 @@ _stamp "step-5-done"; echo "  ✓ step 5: Emission Gate verdict = $VERDICT"
 
 # STEP 6 — actual cost / carry-forward record.
 if grep -qE '^ACTUAL:[[:space:]]*<' "$WS/BUDGET.md" || ! grep -qE '^ACTUAL:[[:space:]]*\S' "$WS/BUDGET.md"; then
-  echo "  ⛔ step 6 BLOCKED: record ACTUAL cost in $WS/BUDGET.md (actual-vs-estimate calibration), re-run."; exit 1
+  echo "  ⛔ step 6 BLOCKED: record ACTUAL cost in $WS/BUDGET.md (actual-vs-estimate calibration)."
+  echo "     Expected — a LINE PREFIX, not a heading:"
+  echo "       ACTUAL: <number/summary>        ← this form is checked"
+  echo "       ## ACTUAL                       ← a heading does NOT satisfy it"
+  echo "     Re-run after adding the line."; exit 1
 fi
 _stamp "step-6-done"; echo "  ✓ step 6: actual cost recorded"
 


### PR DESCRIPTION
## 무엇을

챔버 런 #10 이 **실전에서** 낸 결함(F1). `chamber_run.sh` 의 계약이 러너 소스에만 있어서,
스켈레톤만 읽고 쓴 `INTENT.md` 가 반려됐다.

```
러너가 실제로 요구  ## Success conditions   (영문 헤딩)
                    1. …                     (번호줄)
스켈레톤이 말한 것   "success conditions (each with a check class)"   ← 형식 언급 0건
```

**같은 런에서 step 6 도 같은 이유로 막혔다** — `ACTUAL:` 은 줄 접두사인데 `## ACTUAL` 헤딩으로 썼다.
한 런 안에서 동일 클래스 2표면 = `[[feedback_mechanize_at_repetition_prose_before]]` 의
"동일클래스 타표면 재발 → 기계화 의무" 충족.

## 어떻게

두 층 다 채웠다. 우선순위는 ⓐ 다 — **문서는 드리프트하지만 에러 메시지는 코드와 같이 산다.**

- **ⓐ 에러가 기대 형식을 인쇄한다** (step 2 · step 6). 표만 있으면 *"A table alone does NOT
  satisfy this check"* 까지 말한다
- **ⓑ 스켈레톤 표에 형식을 박았다** — 저자가 처음 보는 곳이라서

**검사 조건 자체는 불변이다.** 반려 시 인쇄만 추가됐다 — 통과/차단 경계는 안 움직인다.

## 증거

출하 `scripts/chamber_run.sh` 로 known-pair 직접 실행 (손으로 복사한 스니펫이 아니라 출하본):

```
known-positive  한글 헤딩 + 표만        → 반려 + 기대 형식 인쇄
known-negative  ## Success conditions
                + 번호줄 추가          → step 2 통과, step 3 로 진행
```

- Axis 1 `regression_guard --staged` = **PASS** (M-tier 0 · S-tier 0)
- `crossfamily: declined` — 판정 로직·게이트 열거형·비가역 경로 모두 안 건드린다(load-bearing 아님)

## 남은 형제 결함

챔버 런 #10 이 낸 나머지 둘은 별도다 — **F5**(추출 실패한 조회에 `✅ 1차 직독` 등급을 준 것) ·
**F7**(외부조회의 recency 편향 — 최신 논문에서 멈추고 정본 개념·서베이를 놓친다).
둘 다 `novelty_claim_check` 의 자연 확장이라 그 계기가 재개될 때 같이 간다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNfoCWTHsoWcXDU3WCVJwQ