### PR TITLE
chore(log): 서브에이전트 원장 통합 엔트리 — 탤리와 원장은 다른 축을 센다

### DIFF
--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -1291,3 +1291,11 @@
     ④-e 에서 실제로 막혀 내 미커밋 항목 5건이 드러났다 — 훅이 산문이 아니라 작동한다.
     ★ 이번 라운드 위임 3건은 전부 **accepted**(반환을 손으로 재현해 닫음: engine.py
     접촉 diff·스위트 직접 실행·되돌림 9 failed 독립 재현). 상세는 08-07 항목.
+
+- date: 2026-08-08
+  agent: "consolidated — workflow code-review ×3 (34+38+39 agents) · fh-meta personas ×3 (beginner·main-player·challenger) · Sonnet target-tier sim ×2 · codex cross-family sidecar ×1"
+  context: "엔진 4요소 RC 세션 — 3라운드 high 리뷰 + 챔버 런 #10 페르소나 시뮬 + 서브에이전트 정책 살리언스 sim"
+  ask: "리뷰=수리가 결함을 옮겼는지 · 페르소나=EMIT 가치/실패비용/안 보이는 것 · sim=텍스트가 따라와지는지"
+  outcome: accepted
+  evidence: "리뷰 3라운드 10·10·10(벡터 평평, 2·3차 다수가 직전 수리 산물) → 축소 착지 판단의 근거. 페르소나 3인이 핵심 결함에 독립 수렴 → 챔버 KILL. sim 2회: 1차가 **거짓 기계-주장을 5/5 로 되읽음**(sim 은 followable 을 재지 true 를 안 잰다), 정정 후 2차 6/6"
+  note: "★계기 관찰 — `④-e` 탤리는 **148**, 이 원장 엔트리는 **3**이다. 탤리 훅은 워크플로 내부 에이전트를 전부 세고(리뷰 1회 = 34~39), 원장은 **내가 낸 디스패치 단위**를 센다. 둘은 다른 축이라 격차 자체는 결함이 아니지만, 그 사실이 어디에도 안 적혀 있어서 **148 vs 3 을 보면 기록 누락처럼 읽힌다**. 다음에 `session_close_check` ④-e 문구에 축 차이를 한 줄 붙일 것."


### PR DESCRIPTION
## 무엇을

세션 마감 `④-e` 가 `148 dispatch / 3 log entries` 를 보고했다. 체크는 **통과**했지만(0건일 때만 차단)
격차가 기록 누락처럼 읽힌다. 원인을 확인하고 통합 엔트리 + 관찰을 남긴다.

## 격차는 누락이 아니라 축 차이다

```
탤리 훅   워크플로 **내부** 에이전트를 전부 센다 (code-review 1회 = 34~39 에이전트)
원장      **내가 낸 디스패치 단위**를 센다 (워크플로 1회 = 1건)
```

그래서 리뷰 3라운드만으로 111 이 쌓인다. 둘은 다른 걸 재는 계기라 격차 자체는 결함이 아니다 —
**다만 그 사실이 어디에도 안 적혀 있어서 `148 vs 3` 이 누락처럼 보인다.**

→ 다음에 `session_close_check` `④-e` 문구에 축 차이를 한 줄 붙인다(이 PR 범위 밖, 카드에 이월).

## 이번 세션 실적 (통합 엔트리)

```
workflow code-review ×3     34+38+39 — 10·10·10, 벡터 평평, 2·3차 다수가 직전 수리 산물
                            → 축소 착지 판단의 근거가 된 측정
fh-meta 페르소나 ×3          beginner·main-player·challenger — 핵심 결함에 **독립 수렴** → 챔버 KILL
Sonnet target-tier sim ×2   1차가 **거짓 기계-주장을 5/5 로 되읽음** → 정정 후 2차 6/6
codex cross-family ×1        7건 지적, 소스로 7/7 확인
```

## 부수 — 이 커밋이 게이트에 걸렸던 것

처음에 `main` 에 직접 커밋했고 **pre-push 훅이 막았다**(`MAIN_PUSH_OK=1` 요구).
integration branch 는 PR-only 라는 규칙이 실제로 집행된 사례라 그대로 기록한다.
`main` 은 `origin/main` 으로 되돌렸고 이 브랜치로 옮겨 왔다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNfoCWTHsoWcXDU3WCVJwQ