### PR TITLE
docs(log): 원장 헤더에 공개·공유 경고 — 규칙이 행위자가 읽는 곳에 없었다

### DIFF
--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -1,6 +1,26 @@
 # Sub-agent invocation log (operations.md §Sub-agent Operations).
 # Fields: date · agent · model · purpose · prompt_summary · outcome · finding · note
 # outcome ∈ {accepted, partial, rejected, sustained}
+#
+# ⚠️ THIS FILE IS PUBLIC AND SHARED. Generalize before you write, not after.
+#
+#   PUBLIC   — git-tracked in a public repo. Company/corp asset names, internal
+#              hostnames, restricted-env identifiers, and absolute home paths do NOT
+#              belong here. Write "a restricted-env model gateway", not its product name.
+#              (The pre-commit confidentiality scan blocks these — but being blocked is
+#              an upstream failure, not a demonstration that the gate is healthy.)
+#
+#   SHARED   — parallel sessions append to this same file. A blocked entry does not
+#              just block you: it blocks EVERY session whose commit stages this file,
+#              and they cannot fix it, because editing another session's delegation
+#              record is not theirs to do. Your violation is billed to someone else.
+#
+#   Measured 2026-08-08: an entry naming a corp model-gateway asset was blocked HIGH;
+#   a parallel session hit the block, correctly declined to edit another session's
+#   record, and stalled. Two sessions paid for one careless line.
+#
+#   If you are blocked by an entry that is NOT yours: do not edit it. Report it to the
+#   operator with the file:line and the flagged token — the owning session generalizes it.
 
 - date: 2026-06-10
   agent: general-purpose


### PR DESCRIPTION
## 무엇이 일어났나 (2026-08-08 실측)

한 세션이 `subagent_invocations_log.yaml` 에 회사 모델-게이트웨이 자산명을 적었고
pre-commit 기밀 스캔이 **HIGH 로 차단**했다. 게이트는 잡았다. 문제는 **비용이 그 세션에
머물지 않았다**는 것이다:

```
공유 append-only 파일  →  병렬 세션의 커밋도 같이 막힘
                      →  그쪽은 남의 위임 기록이라 고칠 권한 없음
                      →  대기
한 줄로 두 세션이 값을 치렀다.
```

## 왜 헤더인가 — gate-locality

residency 규칙은 `CLAUDE.md` 에 있다. 그런데 **이 파일에 append 하는 순간 읽히는 곳에는
아무 경고도 없었다** — 헤더가 필드 목록만 적고 있었다. 안전 규칙이 행위자가 읽는 곳에
없으면 장식이다. 경고를 쓰기 지점에 둔다.

## 같이 적은 두 가지

1. **"막혔다" 를 게이트 건강 증거로 적지 마라.** 원 세션은 커밋 메시지에 *"게이트가 제 일을
   한 사례"* 라고 적었다 — **자기 앞단 실패를 성과로 기록한 것**이다. 기계층이 결함을 잡으면
   앞단 실패로 분류돼야 한다.
2. **남의 항목에 막혔을 때의 프로토콜** — 고치지 마라. `file:line` + 걸린 토큰을 운영자에게
   보고하고 **소유 세션이 일반화한다.** 병렬 세션은 실제로 이렇게 행동했고 그게 옳았다.
   그 옳은 행동이 대기로 이어지던 구조가 문제였다.

## 범위 — 새 floor 아님

문서 변경만이다. 기계 차단은 여전히 pre-commit 스캔이 한다. 이 헤더는 그 위의 **살리언스
층**이지 floor 가 아니다. 산문이 훅을 대신한다고 읽지 마라.