### PR TITLE
chore(log): qasp AX-레디 축 디스패치 6건 — 탈상관이 내 수리의 fail-open 을 잡았다

### DIFF
--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -1516,3 +1516,48 @@
     ★ 폼: codex 는 `nohup + timeout + 파일 출력 + until grep DONE_rc`(Bash 툴 2분 상한 회피).
     agy 는 `--model "<디스플레이명>" --print-timeout`. R4 타임아웃은 프롬프트가 커진 탓 —
     라운드가 깊어질수록 **범위를 좁혀야** 한다(같은 폭으로 더 파면 시간이 먼저 끝난다).
+
+- date: 2026-08-09
+  session: qasp AX-레디 축 (홈, 병렬 세션) — pmh #42 배선 · qasp #88 열화 방향
+  agents:
+    - "Explore — qasp 이슈 123/122/88 정찰"
+    - "codex exec gpt-5.6-sol high ×3 — 방향 게이트 R1·R2·R3"
+    - "agy gemini-3.1-pro-high ×2 — 게이트 대안 설계 · qasp 88 적대"
+  why: >-
+    운영자 지시 — *"초기 영혼 → 중간 탈상관 가속화 → 마무리 적대검증으로 태우기"*.
+    축을 실패모드에 맞춰 갈랐다: codex=레포 접지 실행 감사(내 수리가 새 구멍을 내는가) ·
+    agy=다른 설계 축(이 접근이 애초에 옳은 모양인가) · Explore=파일 교차 0 인 독립 트랙.
+    verdict enum·exit 계약을 바꾸는 load-bearing 변경이라 Field-Harness Load-Bearing
+    Change Gate 적용 대상이었다.
+  dispatch_count: 6
+  outcome: accepted
+  evidence: >-
+    **codex R1** — 11건. 최대 기여 = `rc=4` 가 `gh` 의 "authentication required" 와 충돌한다는
+    실측(내가 새 exit 코드를 신설하려던 참이었다) · 기존 계약 자기모순(헤더는 rc=1 을 NO-OP
+    전용이라 하는데 로컬 파일 부재도 1) · 집계기에 default 가 없어 알 수 없는 rc 가 CLEAN 으로
+    샘 · 로컬 파일 부재가 `return 0`(skip) 이라 cwd 배선 실수가 CLEAN.
+    **codex R2** — ★ 이 세션 최대 소득. 내가 과차단을 닫으려고 넣은 3-way(`(R−B)−(L−B)`,
+    B=merge-base)에 대해 **반례**를 냈다: `HEAD == 원격 tip` 이면 `B == R` → `R−B=∅` →
+    워킹트리가 stale/외부 바이트여도 **항상 CLEAN**. merge-base 는 공통 조상이지 "이 업로드가
+    파생된 버전" 의 증거가 아니다. 내 수리가 측정된 과차단을 **못 재는 fail-open** 과 바꾸고
+    있었고 자력 적발 0. → 3-way 통째 철회, 판정은 `R−L` 전량 차단으로 복귀하고 과차단은
+    **ACK 를 손실 집합 해시에 결박**해서 다뤘다(파킹한 ACK 재사용 불가).
+    또 A21 이 장식 레인이라고 지목 — fake gate 가 cwd·인자를 안 봐서 `cd "$TOP"` 을 지워도
+    초록이었다. 고친 뒤 되돌림 실측으로 적색 확인.
+    **agy(게이트)** — "줄 내용을 정체성으로 쓰는 것 자체" 를 독립 지목. codex 의 Frankenstein
+    PASS 와 **같은 지점에 두 계열이 수렴**. 대안(ETag OCC · 3-way 병합)은 범위 밖으로 기록.
+    **agy(qasp #88)** — 상태 플래그가 `p2_audit` 밖 호출자에서는 소비자가 없어 **장식**이라는
+    지적 수용, 커밋 메시지의 "동치" 주장을 조건부로 좁혔다. 단 *"B arm 이 장식"* 은 **반박** —
+    B 는 컨트롤이고 되돌림 민감은 A 가 맡는다(A 만 적색인 것을 실측).
+    **Explore** — #88 이 AX Lobby 진입의 실제 블로커임을 소스로 특정(호출자 수 포함).
+    ⚠️ 소견 1건은 **틀렸다**: `self_cross_validator.py:312` 가 fail-open 경로라 했으나 그 자리는
+    `.audit()` 을 안 부른다(유틸 사용). 소스로 닫아서 멀쩡한 코드 수리를 막았다.
+  note: >-
+    ★ **탈상관이 없었으면 내 수리가 결함이었다.** 과차단(측정된 것)을 닫으려다 fail-open
+    (측정 불가한 것)을 넣었고, self-test 20/20 · 앵커 25/25 · 실물 arm 5종이 전부 초록인
+    상태였다. 초록은 "내가 던진 질문 공간 안에서만" 초록이다
+    ([[feedback_adversarial_review_not_substitute_for_first_use]] 와 같은 얼굴).
+    ★ 축 배분이 기록과 맞았다 — memory recorded default 대로 codex=repo-grounded 워크호스,
+    agy=breadth. agy 는 짧은 설계 질문에 6분, codex 는 전문 감사에 8~12분.
+    ★ 폼: codex 는 stdin 인라인 + nohup + timeout + DONE 마커(argv 폼 hang 회피),
+    agy 는 `agy models` 출력 문자열 그대로 핀 + `--print-timeout`.


### PR DESCRIPTION
chore(log): qasp AX-레디 축 디스패치 6건 — 탈상관이 내 수리의 fail-open 을 잡았다

원장 append 1건(42줄). 이 세션(qasp AX-레디 축)의 서브에이전트 디스패치 6건 등재.

핵심은 evidence 필드에 적힌 것: **탈상관이 없었으면 내 수리 자체가 결함이었다.**
방향 게이트의 측정된 과차단을 닫으려고 3-way 를 넣었는데, codex 가 `HEAD == 원격 tip` 이면
`B == R` 이라 **어떤 손실도 못 잡는다**는 반례를 냈다. 그 시점에 self-test 20/20 · 앵커 25/25 ·
실물 arm 5종이 전부 초록이었고 자력 적발은 0이었다.

⚠️ 이 브랜치를 만드는 과정에서 사고 1건 — 공유 체크아웃이 병렬 세션 브랜치에 있는 걸 확인 안 하고
커밋해서 그쪽 브랜치에 얹혔다. `git branch -f` 로 그쪽을 원위치(47efdd5)시키고 HEAD 도 되돌렸으며,
그쪽 미커밋 4건은 손대지 않았다. [[feedback_shared_checkout_ops_touch_others_work]] 의 n+1 —
어제 배운 건 "append 하면 먼저 커밋" 이었는데, 오늘 빠진 건 **"커밋 전에 어느 브랜치인지 봐라"** 다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)