### PR TITLE
chore(release): v1.4.90 — dispatch 조건절 독트린 + install-wizard Step 3-D 출하

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,13 @@
   "plugins": [
     {
       "name": "fh-meta",
-      "version": "1.4.89",
+      "version": "1.4.90",
       "description": "Hub meta-operations toolkit — 35 skills + 7 agents. New in 1.4.53: `fh-codex-doctor` (npm bin) — Codex adapter drift scanner; reads the documented M1/M2/M3 skill tier map + skill/agent source and reports codex-native/adapter-required/claude-native/unclassified per unit, wired into `npm test`/`prepublishOnly` (fail-closed on unclassified Claude-native primitives). New in 1.4.49: steel-quench gains Step 0.6 Verdict-Invariance Probe (groundedness axis — a load-bearing judged gate's verdict must track behavior, not rubric phrasing; measured flip-count over cross-family paraphrases; arXiv:2605.06161 Policy Invariance anchor); multi_model_sidecar_strategy §Vendor-native harness (a model is strongest in its own vendor CLI — Claude/CC, GPT/codex, Gemini/Antigravity; a universal router degrades all of them, so it stays an autocomplete/QA sidecar, never orchestration); predelete_check.sh fail-closed rewrite; memory-hygiene A-TMA anchor. New in 1.4.48: phantom-quench + steel-quench gain external frontier anchors (arXiv:2607.02052 package-hallucination; arXiv:2607.02057 prompt-coverage-adequacy); README model-flat claim reframed from a per-release point-curve to structural invariants (operation flattens across tiers; depth tier-order fixed within a generation). New in 1.4.47: onboarding step ① surfaces the Mode D companion-store session-start load in the auto-read salience anchor (previously only in the local binding + rules, so a greeting could skip the load). New in 1.4.46: context-doctor command-output axis (route to rtk/proxy for verbose CLI stdout, complementing .claudeignore; risk-gated to token-scarce envs). New in 1.4.41: context-doctor 2026 trigger vocab (context engineering/rot/collapse) + phantom-citation hardening; hub measurement-integrity-checklist (cross-model measurement pre-flight: display-name pin/reps≥3/discriminating probe). New in 1.4.40: install-wizard queryable-wiki scaffold (INDEX + session-start read + R/W/C ingest). New in 1.4.39: auto-decorrelation (cross-family verifier sidecar recruitment) + video-ingest (capability-routed video ingestion). New in 1.4.x: verify-axis check-class taxonomy (mandatory-pass/measured/judged), no-reinvention Tier-0 inventory, 7-class failure taxonomy, Destructive-Op Gate, Wave-T (Temper), tier-floor governance, Mode D Model Notice, FC consent lane, default-Sonnet guidance. New in 1.3.0: public-surface-audit, field-harvest Mode B auto-trigger, 4-axis gate scope ext. Validated cross-CLI: Claude Code, Codex, Gemini.",
       "source": "./plugins/fh-meta"
     },
     {
       "name": "fh-commons",
-      "version": "1.4.89",
+      "version": "1.4.90",
       "description": "Project-agnostic utility skills — 4 skills (convergence-loop · deliberation · mcp-circuit-breaker · token-budget-gate) + 1 agent (quench-challenger). Domain-independent utilities transplantable into any project.",
       "source": "./plugins/fh-commons"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrono-meta/fh-gate",
-  "version": "1.4.89",
+  "version": "1.4.90",
   "description": "FH runtime adapters — run FH governance, skills, and agents via Claude or Codex with machine-parseable gates.",
   "license": "MIT",
   "keywords": [

--- a/plugins/fh-commons/.claude-plugin/plugin.json
+++ b/plugins/fh-commons/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-commons",
-  "version": "1.4.89",
+  "version": "1.4.90",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/.claude-plugin/plugin.json
+++ b/plugins/fh-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-meta",
-  "version": "1.4.89",
+  "version": "1.4.90",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -229,7 +229,13 @@ for _subj in compaction_probe judgment_circuit_lint novelty_claim_check; do
     # 존재검사가 진위를 못 본다는 그 클래스의 재발이다. **실행이 일어났다는 증거**를 요구한다.
     # `< /dev/null` 필수: 인식 못 한 모드로 떨어지면 스크립트가 stdin 을 기다려 **무한 대기**한다
     # (실측 — 디스패처 제거 known-negative 가 2분 타임아웃). CI 를 멈추는 건 조용한 통과보다 나쁘다.
-    _st_out="$(timeout 120 bash "scripts/$_subj.sh" --self-test < /dev/null 2>&1)"; _st_rc=$?
+    # `timeout` 은 GNU coreutils 이고 **stock macOS 에 없다**. 가용성 확인 없이 부르면 rc=127 +
+    # 빈 출력 → 아래 `*)` 가 발동해 "dispatcher missing?" 이라는 **틀린 원인**으로 거짓 FAIL 이
+    # 난다(실측: homebrew 없는 PATH 에서 3개 subject 전부). 소비자 머신에서 `npm test` 와
+    # `prepublishOnly` 를 깨뜨리는 경로다. 정답 폼은 이미 레포에 있다(sync-from-be.sh:134).
+    # 없으면 무한대기 방지를 잃는 대신 도는 쪽을 택한다 — `< /dev/null` 이 그 방어의 본체다.
+    local _to=""; command -v timeout >/dev/null 2>&1 && _to="timeout 120"
+    _st_out="$($_to bash "scripts/$_subj.sh" --self-test < /dev/null 2>&1)"; _st_rc=$?
     case "$_st_out" in
       *캘리브레이션*) : ;;
       *) echo "FAIL  $_subj: --self-test produced no calibration verdict (dispatcher missing?)"


### PR DESCRIPTION
## 무엇이 나가나

v1.4.89 이후 **35파일 / 27커밋**. 소비자 행동이 실제로 바뀌는 건 둘이다:
- `CLAUDE.md §Agent Dispatch Operation` — 디스패치 금지문이 **조건절**임을 실측하고 RECORDED(인용발화·lease·scope) / NOT RECORDED(absent≠granted → 건별로 묻는다) 로 갈랐다
- `install-wizard` **Step 3-D 신설** — 설치 계약에서 상시요청을 받아 적고, 기계적 설정 변경도 같은 동의 아래. **lease 기간은 사용자가 정한다**

버전은 4곳 lockstep(`package.json` · 양 `plugin.json` · `marketplace.json`) — Codex 가 plugin.json 버전으로 캐시해서 하나만 빠져도 진입점이 stale 로 남는다. `LOCKSTEP: PASS`.

## Pre-Publish Surface Gate

| 단계 | 결과 |
|---|---|
| ① operator-private token scan (출하 236파일) | ✅ PASS |
| ② marketplace-gate Check 5 | ✅ PASS — LICENSE MIT · 내부도메인 0 · 절대홈경로 0 |
| ③ code-security (출하 실행파일 74건 = **적용 대상**, N/A 아님) | ✅ **SAFE-WITH-NOTES** |

**②의 "API키 5건"은 손검증했다** — 전부 `AKIAIOSFODNN7EXAMPLE`(AWS 공식 문서 예시 키)이고, 면제가 동작하는지 보려고 **일부러 리터럴로 둔 픽스처**다(주석 명시). 진짜 시크릿 0.

**③의 범위는 이번 배포 델타**(변경된 스크립트)지 출하 74건 전수가 아니다 — "전수 감사"가 아니라 "델타 감사"가 정확한 표현이라 그렇게 적는다. 리뷰어가 범위도 정정했다: 지목한 17개 중 **2개는 files[] 부재로 애초에 출하 안 됨** → 실제 15개.

요지: 도달 가능한 주입 없음 · 모든 `rm -rf` 가 `mktemp` 결과 대상 · **네트워크 호출 1건뿐이고 로컬 내용은 전송 0** · 운영자 식별자 0 · `npm install` 자동 실행 코드 0(preinstall/postinstall 부재).

## 게이트가 잡아서 배포 전에 고친 것

`selfcheck.sh` 가 `timeout` 을 가용성 확인 없이 불렀다. **stock macOS 엔 없다** → rc=127 → "dispatcher missing?" 이라는 **틀린 원인**으로 거짓 FAIL. coreutils 없는 소비자에겐 `npm test`·`prepublishOnly` 가 깨진 채 나간다. 공격면은 아니지만 소비자가 받는 물건이 안 도는 문제라 닫았다 — 정답 폼은 이미 레포에 있었다(`sync-from-be.sh:134`). known-pair 양쪽 확인.

## 1.4.91 로 넘기는 것 (명시)

- `relay_channel.sh` — `mkdir -p` 실패를 삼켜서 **안 돈 노드의 rc=1 이 verdict 로 해독**된다. capfile 이 `1=PASS` 면 미실행이 PASS 로 렌더. 파일 자신의 D4("빈/부재 verdict = HARNESS_ERROR")와 모순
- `directional_diff_gate.sh:255` — sed 가 경로 속 `&` 를 먹어서 서로 다른 두 경로가 같은 ACK 재료로 해시될 수 있다. `printf` 로 교체
- 둘 다 명시적 호출 경로, 공격면 아님

## 배포 순서

머지 → `npm publish`(prepublishOnly 가 출하 파일셋을 다시 스캔) → `git tag v1.4.90`.