### PR TITLE
fix(hooks): /clear 를 진짜 시작과 구분한다 + ①-c live peer 탐지

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,8 @@
     "scripts/relay_channel.sh",
     "scripts/test_relay_channel_lanes.sh",
     "scripts/fh_session_load.sh",
+    "scripts/hook_source_lib.sh",
+    "scripts/test_hook_source_gate_lanes.sh",
     "templates/.claude/rules/mcp_tool_gating.md",
     ".claude/rules/fh_4axis_gate.md",
     "templates/degrade_direction_scan.sh",

--- a/scripts/fh_env_delta_scan.sh
+++ b/scripts/fh_env_delta_scan.sh
@@ -28,6 +28,14 @@
 #  - Non-Mode-D public users: harmless — it only ever PROPOSES /install-wizard --dry-run, which is
 #    itself read-only. Still, gate on the hub being present so a bare plugin install stays silent.
 
+
+# ── SessionStart source (단일 소스 lib) ─────────────────────────────────────────
+_FH_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/hook_source_lib.sh"
+# shellcheck source=scripts/hook_source_lib.sh
+if [ -f "$_FH_LIB" ]; then . "$_FH_LIB"; else
+  fh_hook_source() { printf 'unknown\n'; }; fh_cadence_due() { return 0; }
+fi
+_FH_HOOK_SRC="$(fh_hook_source)"
 set -u
 
 # FH = the HUB, derived from THIS script's location ($FH/scripts/fh_env_delta_scan.sh → ../ = hub) —
@@ -83,6 +91,13 @@ done
 CWD_UNMAPPED="$(_candidate "${CLAUDE_PROJECT_DIR:-$PWD}")" || CWD_UNMAPPED=""
 
 # Nothing new → silent no-op (majority path).
+# ── /clear·compact 억제는 **표시 판단보다 먼저** 접는다 ─────────────────────────
+# sibling 줄은 «사람이 이미 보고 결정한 나그» 라 같은 세션에서 다시 안 띄운다. 반면 cwd-미매핑
+# 줄은 «지금 그 안에서 일하고 있다» 는 상태라 /clear 직후에 오히려 필요하다 — 둘을 같이 묶지
+# 않는다. ★출력 지점이 아니라 여기서 접는 이유: 뒤에서 접으면 sibling 만 있는 경우에
+#   «변화 감지» 헤더가 찍히고 그 아래가 비는 알림이 나간다(=내용 없는 경보).
+fh_cadence_due "$_FH_HOOK_SRC" || COUNT=0
+
 [ "$COUNT" -eq 0 ] && [ -z "$CWD_UNMAPPED" ] && exit 0
 
 # Emit the delta proposal (one block, imperative). Trim trailing ", ".

--- a/scripts/fh_session_load.sh
+++ b/scripts/fh_session_load.sh
@@ -24,6 +24,16 @@
 # hard-codes no private path). HUB_DIR overrides the hub path. Never commit the registration to
 # the public settings.json — the hook is Mode-D-only.
 
+
+# ── SessionStart source (단일 소스 lib) ─────────────────────────────────────────
+# stdin 페이로드는 **한 번만** 읽을 수 있으므로 맨 앞에서 소비하고 변수로 들고 간다.
+_FH_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/hook_source_lib.sh"
+# shellcheck source=scripts/hook_source_lib.sh
+if [ -f "$_FH_LIB" ]; then . "$_FH_LIB"; else
+  # lib 부재 = 파싱 불가. 무음으로 억제하지 말고 unknown(=띄운다) 으로 degrade 한다.
+  fh_hook_source() { printf 'unknown\n'; }; fh_cadence_due() { return 0; }
+fi
+_FH_HOOK_SRC="$(fh_hook_source)"
 set -uo pipefail
 
 FH="${HUB_DIR:-${CLAUDE_PROJECT_DIR:-$HOME/projects/forge-harness}}"
@@ -161,7 +171,10 @@ fi
 # so it surfaces and never blocks. Silent when current, and silent when the dir does not exist
 # (a fresh clone has no audit history and must not be nagged about one).
 _AUDIT_DIR="$FH/tracks/_audit"
-if [ -d "$_AUDIT_DIR" ]; then
+# ── /clear 게이팅: 이 나그는 «사람이 이미 보고 결정한» 것이라 같은 세션에서 다시 띄우지 않는다.
+#    위의 companion freshness 는 반대로 게이팅하지 않는다 — 그건 «세션이 잃어버린 상태» 라
+#    /clear 직후에 오히려 필요하다. 기준은 그 둘의 구분이지 "시작이냐" 가 아니다.
+if [ -d "$_AUDIT_DIR" ] && fh_cadence_due "$_FH_HOOK_SRC"; then
   _LATEST_AUDIT="$(find "$_AUDIT_DIR" -maxdepth 1 -name 'weekly_audit_*.md' -print 2>/dev/null \
                    | sort | tail -1)"
   if [ -n "$_LATEST_AUDIT" ]; then

--- a/scripts/hook_source_lib.sh
+++ b/scripts/hook_source_lib.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# hook_source_lib.sh — SessionStart 의 `source` 를 읽는 **단일 소스**.
+#
+# WHY: `/clear` 는 SessionStart 를 재발동시키고 `source: "clear"` 를 준다(startup·resume·compact·
+# fork 와 구분되는 별개 값, 공식 hooks 문서). 그런데 FH 훅들은 stdin 페이로드를 안 읽어서 진짜
+# 시작과 구분하지 못했고, 결과적으로 **캐던스 나그가 /clear 마다 재발화**했다(2026-08-09 운영자 지적).
+#
+# WHY A LIB: 파서를 두 스크립트에 복붙하면 한쪽만 고쳐지는 순간 같은 입력이 서로 다르게 분류된다
+# — 이 레포가 이미 이름 붙인 «관대함 갈린 중복 정규화» 다. 여섯 줄이라도 단일 소스로 둔다.
+#
+# 판별 기준(호출부가 지켜야 하는 것): 「세션이 잃어버린 상태」는 다시 보여주고,
+# 「사람이 이미 보고 결정한 나그」는 안 보여준다. freshness/state = 항상, cadence = startup 계열만.
+#
+# DEGRADE: source 를 못 읽으면 `unknown` 이고, unknown 은 **보여주는 쪽**이다.
+# 중복 알림은 눈에 보이는 소음이지만 놓친 캐던스는 무음 누락이고, 이 레포는 무음 누락을 더 나쁘게
+# 친다. `unknown` 을 조용히 `clear` 로 접는 것이 정확히 그 결함이다(not-found ≠ zero).
+#
+# 이식성: `timeout` 을 쓰지 않는다 — GNU coreutils 이고 stock macOS 에 없다(같은 날 selfcheck.sh
+# 에서 실측으로 물린 defect). `head`/`sed` 만 쓴다.
+
+# fh_hook_source — stdout 에 source 를 한 단어로 출력한다.
+fh_hook_source() {
+  # TTY = 사람이 손으로 돌린 것. 페이로드가 없으니 읽으려 하면 매달린다.
+  if [ -t 0 ]; then printf 'unknown\n'; return 0; fi
+  local _p _s
+  _p="$(head -c 65536 2>/dev/null || true)"
+  _s="$(printf '%s' "$_p" \
+        | sed -n 's/.*"source"[[:space:]]*:[[:space:]]*"\([A-Za-z_]*\)".*/\1/p' \
+        | head -1)"
+  [ -n "$_s" ] || _s="unknown"
+  printf '%s\n' "$_s"
+}
+
+# fh_cadence_due — 캐던스 나그를 띄워도 되는 source 인가. 0=띄운다 / 1=억제.
+# 억제 대상은 «같은 세션의 연속»인 두 값뿐이다. resume 은 며칠 뒤일 수 있으므로 띄운다.
+fh_cadence_due() {
+  case "${1:-unknown}" in
+    clear|compact) return 1 ;;
+    *)             return 0 ;;
+  esac
+}

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -478,6 +478,18 @@ else
   fail=1
 fi
 
+# hook_source_gate 는 subject 가 session_close_check.sh 가 아니라 별도로 돌린다 — 위 루프의
+# SKIP 조건(subject 부재)에 얹으면 엉뚱한 이유로 건너뛴다.
+if [ -f scripts/test_hook_source_gate_lanes.sh ]; then
+  if bash scripts/test_hook_source_gate_lanes.sh >/dev/null 2>&1; then
+    echo "PASS  test_hook_source_gate_lanes.sh"
+  else
+    echo "FAIL  test_hook_source_gate_lanes.sh (SessionStart source 게이트 쌍 붕괴)"
+    bash scripts/test_hook_source_gate_lanes.sh 2>&1 | grep "❌" | head -5 | sed "s/^/      /"
+    fail=1
+  fi
+fi
+
 for _anchor in scripts/test_session_close_lanes.sh scripts/test_card_drift_probe.sh scripts/test_session_close_chain_lanes.sh; do
   if [ ! -f scripts/session_close_check.sh ]; then
     echo "SKIP  ${_anchor##*/} (subject scripts/session_close_check.sh absent)"

--- a/scripts/session_close_check.sh
+++ b/scripts/session_close_check.sh
@@ -94,6 +94,83 @@ if command -v gh >/dev/null 2>&1; then
   [ "${PRS:-0}" -gt 0 ] && echo "⚠️  ①-b $PRS open PR(s) by you — classify: self-mergeable vs awaiting-external"
 fi
 
+# ── ①-c LIVE PEER SESSIONS in this same harness ─────────────────────────────────
+# WHY: FH's close chain has an agreed two-axis order (peer appends → ping → **ask "더 있나" before
+# folding** → fold → re-check merged PRs), and it lived only in the session card as prose. Measured
+# 2026-08-09, the first two-axis close: the ping surfaced four deltas the closing session did not
+# know about, and **two of them were structurally invisible to `gh pr list`** (an inheritance
+# channel and a landing check — no PR exists for either). So a PR sweep is not a substitute; the
+# question is. This block does the DETECTION half mechanically. It never merges anything and never
+# blocks — the merge is where the loss risk is (two sessions writing one card is the shared-checkout
+# hazard this repo already named), and one occurrence is below this repo's own mechanization bar.
+#
+# HOW: a live session owns /tmp/cc-socks/<pid>.sock. pid → cwd resolves the ONE thing that actually
+# matters, "is this peer in MY harness" — which the agent-facing session list cannot answer, because
+# it reports names, not directories. Stale sockets are detectable (pid gone), so absence here is a
+# measurement rather than silence.
+# SCOPE (operator, 2026-08-09): this is a **claude-agents / Agent-View** feature — the surface where
+# sessions are deliberately run in parallel. A plain solo terminal must not be nagged because some
+# other window happens to be open. Discriminator is env, set by the parent that spawns the session.
+#   ⚠️ NEGATIVE ARM UNVERIFIED: a child session cannot observe a top-level session's environment, so
+#   "a real top-level session lacks these vars" is asserted, not measured. The lane simulates absence
+#   by unsetting them, which tests THIS SCRIPT'S logic — not that claim. Verify from a plain terminal.
+if [ -z "${CLAUDE_CODE_CHILD_SESSION:-}${CLAUDE_CODE_AGENT:-}" ] && [ "${FH_PEER_SCAN_FORCE:-0}" != "1" ]; then
+  : # solo/top-level surface — ①-c is out of scope here, and silence is the correct output
+else
+PEER_LIVE=0; PEER_UNKNOWN=0; PEER_STALE=0; PEER_IDS=""
+SOCK_DIR="${FH_PEER_SOCK_DIR:-/tmp/cc-socks}"
+# Self-exclusion must walk the ANCESTOR chain, not compare `$$`. This script is a grandchild of the
+# session process that owns the socket, so `$$` never matches it — measured: the first run counted
+# the calling session as its own peer, i.e. it would tell you to go ask yourself.
+SELF_CHAIN=" $$ "
+_p=$$
+while :; do
+  _p=$(ps -o ppid= -p "$_p" 2>/dev/null | tr -d ' ')
+  case "$_p" in ''|0|1) break ;; esac
+  SELF_CHAIN="$SELF_CHAIN$_p "
+done
+_peer_cwd() { # $1=pid → cwd on stdout, empty if unresolvable
+  if [ -r "/proc/$1/cwd" ]; then readlink "/proc/$1/cwd" 2>/dev/null; return; fi
+  command -v lsof >/dev/null 2>&1 || return 0
+  lsof -a -p "$1" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1
+}
+if [ -d "$SOCK_DIR" ]; then
+  for _s in "$SOCK_DIR"/*.sock; do
+    [ -e "$_s" ] || continue
+    _pid="${_s##*/}"; _pid="${_pid%.sock}"
+    case "$_pid" in ''|*[!0-9]*) continue ;; esac
+    case "$SELF_CHAIN" in *" $_pid "*) continue ;; esac   # 나 자신(조상 체인)
+    if ! ps -p "$_pid" >/dev/null 2>&1; then PEER_STALE=$((PEER_STALE+1)); continue; fi
+    _pcwd="$(_peer_cwd "$_pid")"
+    if [ -z "$_pcwd" ]; then
+      # Alive but undirected. NOT zero — a peer we cannot place is exactly the case that must not
+      # render as "no peers" (not-found != zero).
+      PEER_UNKNOWN=$((PEER_UNKNOWN+1)); continue
+    fi
+    case "$_pcwd" in
+      "$FH"|"$FH"/*) PEER_LIVE=$((PEER_LIVE+1)); PEER_IDS="$PEER_IDS $_pid" ;;
+    esac
+  done
+else
+  PEER_UNKNOWN=-1
+fi
+if [ "$PEER_UNKNOWN" = "-1" ]; then
+  echo "ℹ️  ①-c peer scan UNMEASURED — no session-socket dir at $SOCK_DIR (not 'no peers')"
+elif [ "$PEER_LIVE" -gt 0 ]; then
+  echo "⚠️  ①-c $PEER_LIVE live peer session(s) in THIS harness —$PEER_IDS"
+  echo "     Before folding, ASK them '지금부터 마감이다, 더 있나' — the question is wider than a"
+  echo "     PR sweep: a peer's inheritance-channel or landing-check work has no PR to find."
+  echo "     Then fold, then re-check \`gh pr list --merged\`. Merging their delta stays MANUAL."
+  [ "$PEER_UNKNOWN" -gt 0 ] && echo "     + $PEER_UNKNOWN live session(s) whose directory is UNKNOWN (counted, not dismissed)"
+elif [ "$PEER_UNKNOWN" -gt 0 ]; then
+  echo "⚠️  ①-c 0 peers placed in this harness, but $PEER_UNKNOWN live session(s) are UNPLACEABLE"
+  echo "     — treat as possible peers and ask; do not read this as 'closing alone'."
+else
+  echo "✅ ①-c no live peer session in this harness (${PEER_STALE} stale socket(s) ignored)"
+fi
+
+fi
+
 # ② FH assets changed today → harvest-loop owed
 # NOTE: no `grep -q` here — under `set -o pipefail`, -q's early exit SIGPIPEs git log (141),
 # masking a real match as pipeline failure so the warning NEVER fired on true positives

--- a/scripts/test_hook_source_gate_lanes.sh
+++ b/scripts/test_hook_source_gate_lanes.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# test_hook_source_gate_lanes.sh — SessionStart `source` 게이팅 known-pair.
+#
+# 무엇을 재는가: 캐던스 나그가 `clear`/`compact` 에서 **억제**되고 나머지에서 **뜨는가**.
+# 왜 known-pair 인가: 억제만 확인하면 «아무것도 안 뜨는 스크립트» 도 만점이다 — 양성 arm 이
+# 없으면 기능이 죽은 것과 구분이 안 된다(이 레포의 «부재측정엔 컨트롤 동반»).
+# Exit: 0 전 쌍 성립 / 1 쌍 붕괴 / 10 하네스 오류
+set -uo pipefail
+D=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+LIB="$D/hook_source_lib.sh"
+[ -f "$LIB" ] || { echo "❌ harness-error: $LIB 없음"; exit 10; }
+# shellcheck source=scripts/hook_source_lib.sh
+. "$LIB"
+F=0; ok(){ echo "  ✅ $1"; }; ng(){ echo "  ❌ $1"; F=1; }
+
+echo "[hook-source] known-pair 앵커"
+echo
+echo "  ── 파서: 페이로드에서 source 를 뽑는가 ──"
+for pair in 'startup:startup' 'clear:clear' 'compact:compact' 'resume:resume'; do
+  want="${pair##*:}"
+  got=$(printf '{"session_id":"x","source":"%s","cwd":"/tmp"}' "${pair%%:*}" | fh_hook_source)
+  [ "$got" = "$want" ] && ok "source=$want 추출" || ng "source=$want 인데 '$got'"
+done
+got=$(printf '{"session_id":"x","cwd":"/tmp"}' | fh_hook_source)
+[ "$got" = "unknown" ] && ok "source 키 부재 → unknown (조용히 clear 로 접지 않는다)" \
+                       || ng "키 부재인데 '$got'"
+got=$(printf '' | fh_hook_source)
+[ "$got" = "unknown" ] && ok "빈 stdin → unknown" || ng "빈 stdin 인데 '$got'"
+got=$(printf 'not json at all' | fh_hook_source)
+[ "$got" = "unknown" ] && ok "비-JSON → unknown" || ng "비-JSON 인데 '$got'"
+
+echo
+echo "  ── 게이트: 억제(양성) ──"
+for s in clear compact; do
+  fh_cadence_due "$s" && ng "source=$s 인데 캐던스가 뜬다" || ok "source=$s → 억제"
+done
+echo "  ── 게이트: 통과해야 함 (음성 — 과억제가 더 위험하다) ──"
+for s in startup resume fork unknown ''; do
+  fh_cadence_due "$s" && ok "source='${s:-<빈값>}' → 뜬다" || ng "source='${s:-<빈값>}' 인데 억제됐다"
+done
+
+echo
+echo "  ── 실물: fh_env_delta_scan 이 헤더만 남기지 않는가 ──"
+# 억제 시 sibling-only 케이스에서 «헤더 있고 내용 없음» 이 나오면 안 된다.
+T=$(mktemp -d) || { echo "❌ harness-error: mktemp"; exit 10; }
+trap 'rm -rf "$T"' EXIT
+out_clear=$(printf '{"source":"clear"}' | bash "$D/fh_env_delta_scan.sh" 2>/dev/null || true)
+if printf '%s' "$out_clear" | grep -q 'capability-surface change detected'; then
+  printf '%s' "$out_clear" | grep -q '  • ' \
+    && ok "clear 에서 헤더가 떴다면 항목도 있다 (cwd-미매핑은 억제 대상 아님)" \
+    || ng "clear 에서 **헤더만 있고 항목이 없다** — 내용 없는 경보"
+else
+  ok "clear: 헤더 자체가 안 뜬다 (sibling-only 였다는 뜻)"
+fi
+out_start=$(printf '{"source":"startup"}' | bash "$D/fh_env_delta_scan.sh" 2>/dev/null || true)
+if [ -n "$out_start" ] && [ -z "$out_clear" ]; then
+  ok "CONTROL: startup 에서는 뜨고 clear 에서는 안 뜬다 (게이트가 실제로 동작)"
+elif [ -z "$out_start" ] && [ -z "$out_clear" ]; then
+  ok "CONTROL: 이 머신엔 델타가 없어 양쪽 무출력 — 게이트 판정 불가(미측정, 통과 아님)"
+else
+  ok "CONTROL: startup 출력 유무=$([ -n "$out_start" ] && echo Y || echo N)"
+fi
+
+echo
+echo "  ── ①-c peer 스캔: claude-agents 스코프 ──"
+CC="$D/session_close_check.sh"
+if [ -f "$CC" ]; then
+  a=$(CLAUDE_CODE_CHILD_SESSION=1 bash "$CC" 2>/dev/null | grep -c '①-c' || true)
+  b=$(env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDE_CODE_AGENT bash "$CC" 2>/dev/null | grep -c '①-c' || true)
+  c=$(env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDE_CODE_AGENT FH_PEER_SCAN_FORCE=1 bash "$CC" 2>/dev/null | grep -c '①-c' || true)
+  [ "$a" -gt 0 ] && ok "자식 세션 → ①-c 뜬다" || ng "자식 세션인데 ①-c 없음"
+  [ "$b" -eq 0 ] && ok "톱레벨(env 부재 시뮬) → 침묵 (솔로 세션 나그 금지)" || ng "env 부재인데 ①-c 떴다"
+  [ "$c" -gt 0 ] && ok "CONTROL: override 로 강제하면 뜬다 (b 의 침묵이 기능 사망이 아님을 증명)" \
+                 || ng "override 인데 안 뜬다 — b 의 0 은 기능 사망일 수 있다"
+else
+  ok "session_close_check.sh 부재 — ①-c 레인 미측정(통과 아님)"
+fi
+
+echo
+if [ "$F" -eq 0 ]; then echo "[hook-source] ✅ all known pairs hold"; exit 0
+else echo "[hook-source] ❌ 쌍 붕괴"; exit 1; fi


### PR DESCRIPTION
## 왜

`/clear` 는 SessionStart 를 재발동시키고 `source: "clear"` 를 준다(startup·resume·compact·fork 와 구분되는 별개 값). FH 훅 3종은 stdin 페이로드를 안 읽어서 **진짜 시작과 구분하지 못했고**, 주간 감사·env-delta 나그가 `/clear` 마다 재발화했다.

## 판별 기준

«시작이냐» 가 아니라 **«세션이 잃어버린 상태냐, 사람이 이미 결정한 나그냐»**:

| 유지 | 억제 |
|---|---|
| companion freshness · 카드 vs 커밋 델타 | 🗓️ weekly-audit "7일 전이다" |
| frontier-digest 오늘 상태 | ⚙️ env-delta sibling repo N개 |
| ⚙️ cwd-미매핑 (지금 그 안에서 일하는 중) | |

파서는 `hook_source_lib.sh` **단일 소스**. 복붙하면 «관대함 갈린 중복 정규화» 를 내가 만든다. `timeout` 미사용(같은 날 stock macOS 부재로 물린 defect).

## 작업 중 나온 구조 결함 2건도 닫음

- 출력 지점 게이팅 → sibling-only 케이스에서 **«변화 감지» 헤더만 찍히고 아래가 빈** 알림. 표시 판단 **전에** 접도록 재구조화
- 자기 제외를 `$$` 로 비교 → **호출 세션을 자기 peer 로 셌다**(가서 자신에게 물어보라는 출력). 조상 체인 순회로 수정

## ①-c live peer 탐지 (신규)

마감 전에 같은 하네스의 **살아있는** peer 를 기계로 찾아 «접기 전에 물어라» 를 표면화. 오늘 2축 마감에서 그 질문이 델타 4건을 꺼냈고 **둘은 PR 이 없어 `gh pr list` 로 구조적으로 안 잡혔다** — PR 스윕은 대체재가 아니다.

- 탐지: `/tmp/cc-socks/<pid>.sock` → pid → cwd. 세션 목록이 못 주는 «내 하네스인가» 를 준다
- scope: **claude-agents / Agent-View 세션 한정**(운영자 결정). 솔로 터미널은 나그 대상 아님
- 🚫 **머지는 자동화 안 함** — 두 세션이 한 카드를 쓰는 건 이 레포가 이미 겪은 손실이고, 2축 마감은 오늘이 n=1 이라 자기 임계 미달

## Evidence

`test_hook_source_gate_lanes.sh` **18 arms 전부 성립**. 파서(4 source + 3 degrade) · 게이트 양성 2 · **음성 5**(과억제가 더 위험하므로 음성을 두껍게) · 실물 env-delta 헤더 검사 · ①-c 스코프 3-arm(자식=뜸 / env부재=침묵 / override=뜸 ← 침묵이 기능 사망이 아님을 증명).

**되돌림 실측 2회**: 게이트 무력화 → 정확히 그 두 레인만 적색, 복원 → 초록. 별도로 selfcheck 가 `FAIL test_hook_source_gate_lanes.sh` 를 내므로 **배선이 실제 호출자**다(장식 아님).

## 계기 note

peer 수를 두 계기가 다르게 셌다 — 소켓 4 / ListAgents 5. 평균 내지 않고 갈랐다: 소켓은 «돌고 있는 프로세스», ListAgents 는 «재개 포함 주소 지정 가능». 마감 질문은 전자다.

## 미검증으로 남긴 것

**음성 arm 의 전제** — 자식 세션은 톱레벼 세션의 env 를 관측할 수 없어, "진짜 톱레벨엔 `CLAUDE_CODE_CHILD_SESSION`/`CLAUDE_CODE_AGENT` 가 없다" 는 **주장이지 실측이 아니다**. 레인은 env 를 지워 스크립트 로직을 검증할 뿐이다. 평범한 터미널에서 한 번 확인 필요.