### PR TITLE
fix(close): ①-c 여분 히트는 «마감이 덜 끝난 세션» — 노이즈 아님

### DIFF
--- a/scripts/session_close_check.sh
+++ b/scripts/session_close_check.sh
@@ -157,7 +157,16 @@ fi
 if [ "$PEER_UNKNOWN" = "-1" ]; then
   echo "ℹ️  ①-c peer scan UNMEASURED — no session-socket dir at $SOCK_DIR (not 'no peers')"
 elif [ "$PEER_LIVE" -gt 0 ]; then
-  echo "⚠️  ①-c $PEER_LIVE live peer session(s) in THIS harness —$PEER_IDS"
+  echo "⚠️  ①-c $PEER_LIVE peer CANDIDATE(s) in THIS harness —$PEER_IDS"
+  echo "     This counts LIVE PROCESSES, which is deliberately WIDER than the fleet view Working"
+  echo "     list — and the surplus is signal, not noise. Measured 2026-08-09: the extras were"
+  echo "     sessions shown as Completed whose CLOSE NEVER FINISHED, so their process lingered."
+  echo "     Read the two cases differently:"
+  echo "       alive + Working   → active peer. Ask before folding."
+  echo "       alive + Completed → that close did not finish. Nobody else surfaces this."
+  echo "     Do NOT switch to the job state file to narrow it: it marked THIS session done"
+  echo "     (firstTerminalAt set) while it was still running — it under-reports as hard as"
+  echo "     sockets over-report. Cross-read with the fleet view; neither source alone is right."
   echo "     Before folding, ASK them '지금부터 마감이다, 더 있나' — the question is wider than a"
   echo "     PR sweep: a peer's inheritance-channel or landing-check work has no PR to find."
   echo "     Then fold, then re-check \`gh pr list --merged\`. Merging their delta stays MANUAL."


### PR DESCRIPTION
40분 전 출하한 ①-c 의 **첫 실사용**에서 내가 오발신했고, 그 과정에서 판독 규칙이 틀렸다는 게 드러났다.

## 무슨 일

peer 4명으로 보고 → fleet 뷰 Working 은 2명 → 셋에 마감 통지 오발신(운영자 적발).
**처음엔 «과다보고» 로 결론지었다. 그게 틀렸다.** 운영자 정정: 여분은 **Completed 로 보이지만 마감을 끝까지 안 해서 프로세스가 남은** 세션들이다.

## 그래서 약화가 아니라 분기

```
alive + Working    → 활성 peer. 접기 전에 물어라
alive + Completed  → 그 세션 마감이 안 끝났다. 이걸 surface 하는 곳이 달리 없다
```

## 상태파일로 좁히면 반대로 틀린다 (실측)

job `state.json` 이 **이 세션 자신을 running 중에 `state: done` + `firstTerminalAt`** 로 표시한다. 소켓이 넓은 만큼 상태파일은 좁다 → **교차 판독**하라고 출력에 명시.

## Evidence

레인 **18/18 그대로** — 스코프·파싱 동작 무변경, 판독 규칙만 변경. 첫 실사용 자체가 증거다(보고 4 / 실제 Working 2 / 여분 3 중 최소 1건이 확인된 미완 마감).

## 부수 소득

오발신 답장으로 **카드에서 빠져 있던 이월 4건 회수**(심지 forge 루프 · phantom-quench Mode R · 병렬 dispatch 규칙 · ⑤-c 발화 착지 검증). 파일은 살아 있었고 카드에서만 안 잡히던 상태.

→ **새 결함 클래스**: 채널 규약의 «접기 전에 더 있나» 는 *동료 세션* 용이라 **직전 세대 카드 자신의 이월분**은 구조적으로 못 잡는다. 처방 = 카드 재작성 시 이전 카드 이월 블록 grep 대조.