### PR TITLE
fix(gitignore): .residency-patterns 등록 누락 — 공개 레포에 조직 리터럴이 무방비였다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,11 @@ context/
 # public-surface-audit pattern source — operator-private token patterns (real username, employer, store).
 # The skill reads this file; it must never be public (it literally lists the private tokens to hunt for).
 .claude/rules/.public-surface-patterns
+# 자매 파일 — 같은 «리터럴은 gitignored 소스에만» 패턴. 2026-08-09 마감 스윕에서
+# 이 줄이 빠져 있는 걸 발견했다: 파일은 untracked 였지 ignored 가 아니었고,
+# 내용은 회사 식별 리터럴이라 누가 `git add -A` 하면 공개 레포로 그대로 올라간다.
+# 이력 확인 결과 커밋된 적은 없다(유출 미발생). 자매 줄이 있는데 이 줄이 없던 게 원인.
+.claude/rules/.residency-patterns
 
 # Paper — PDF regenerated from HTML; canonical version on Zenodo/arXiv
 paper/*.pdf


### PR DESCRIPTION
## 무엇

`.claude/rules/.residency-patterns` 를 `.gitignore` 에 등록한다 (1줄).

## 왜

자매 파일 `.claude/rules/.public-surface-patterns` 는 이미 `.gitignore` 에 있다. **같은 «리터럴은 gitignored 소스에만» 2층 패턴인데 이 줄만 누락**돼서, 조직 식별 리터럴(kakao·payqa·kpap 계열)을 담은 파일이 **untracked-but-not-ignored** 상태였다. 누가 `git add -A` 하면 그대로 공개 레포에 올라간다.

## 유출 여부

✅ **없다.** `git log --all -- <path>` 이력 **0건** — 커밋된 적 없다.

## 🟥 이 건이 드러낸 것 — 공개면 스캔의 사각

공개면 스캔은 **staged tracked content** 를 본다. **untracked-but-not-ignored 파일은 스캔 대상에 아예 안 들어온다.** 그러니 「스캔 통과」가 「이 레포에 사설 리터럴이 없다」를 뜻하지 않는다.

잡은 건 게이트가 아니라 **마감 스윕의 `git status` 한 줄**이었다.

## 순서 제약

🟥 **이 PR 이 먼저 머지돼야 한다.** 후속 `fix/residency-closure-scan` 은 중복 제거 과정에서 같은 줄을 **뺐으므로**, 이것 없이 그쪽만 머지하면 파일이 다시 무방비가 된다.

## 검증

known-pair — 추가 후 `git check-ignore` 가 대상 파일을 잡고, **추적 대상인 `.defaults` 는 안 걸린다**(과차단 아님).

---
작성: if(kakao) 병렬 세션 · 제출: qasp 축 세션 (운영자 지시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)