### PR TITLE
feat(field-canon): 필드 하네스 정본을 세션에 싣는다 — 종일 파고도 안 읽는 걸 막는다

### DIFF
--- a/scripts/field_canon_preload.sh
+++ b/scripts/field_canon_preload.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# field_canon_preload.sh — 매핑된 필드 하네스가 언급되면 **그 하네스의 정본 경로**를 띄운다.
+#
+# WHY (2026-08-09 실측, 하루 4회 정정 · 자력 적발 0):
+#   FH 세션 시작 자동 적재는 **FH 자기 정본만** 싣는다(`fh_session_load.sh` = 동반자 저장소).
+#   그런데 한 세션이 종일 qasp 를 파면서 qasp `README.md`(604줄) · `docs/governance/`(32개)를
+#   **하나도 안 읽고** 코드에서 역추론했다. 네 번 정정당했고 네 번 다 **정본에 답이 있었다**:
+#     · MTM 을 "조건부 화이트박스 모드" 로 요약   → 정본은 블박+화박 **동시**(이중시야)
+#     · "매트릭스 = 축이 여럿"                  → 영화 매트릭스에서 **네오가 보는 시야**
+#     · 3막 본체가 act2 에 있는 걸 배치 결함 판정 → README 가 **의도**라고 명시(L1 공유·중복 0)
+#     · 전수조사 모수를 src/act2 로 한정         → b레인·mate 는 모수 밖
+#   README 는 그중 하나를 *"이 축이 안 보이면 3막을 mate 판정 전용으로 오해한다"* 로
+#   **경고까지 하고 있었다.** 산문 규율로는 안 읽힌다 — `fh_session_load.sh` 헤더가 이미 같은
+#   결론을 적었다("prose is salience-dependent"). 같은 처방을 필드 하네스에 적용한다.
+#
+# WHAT: 프롬프트에 매핑된 프로젝트 이름이 나오면, **실재하는 정본 파일 경로만** 골라 한 번 띄운다.
+#   ★ 일반 훈계("정본을 읽어라")가 아니라 **이 레포의 이 파일들**이어야 한다 — 오늘의 실패는
+#     규율을 몰라서가 아니라 **그 파일들이 거기 있는 줄 몰라서**였다.
+#
+# 프로젝트당 세션당 1회. 센티넬로 재나그 방지 — 반복 알림은 무시를 학습시킨다.
+#
+# 종료: 항상 0 · 보고는 stdout. (비영 종료는 stdout 이 폐기되고 stderr 도 안 전달된다 —
+#       `[[feedback_hook_nonzero_exit_is_silent]]`.)
+set -uo pipefail
+
+HUB="${CLAUDE_PROJECT_DIR:-$HOME/projects/forge-harness}"
+PROJ_ROOT="${FIELD_CANON_PROJECT_ROOT:-$HOME/projects}"
+SENT_DIR="${FIELD_CANON_SENTINEL_DIR:-${TMPDIR:-/tmp}/fh_field_canon_$$}"
+[ -n "${FIELD_CANON_SENTINEL_DIR:-}" ] || SENT_DIR="${TMPDIR:-/tmp}/fh_field_canon_${CLAUDE_SESSION_ID:-shared}"
+mkdir -p "$SENT_DIR" 2>/dev/null || true
+
+# stdin 은 훅 페이로드(JSON). prompt 를 못 뽑아도 **조용히 죽지 않는다** — 원문 전체로 폴백한다.
+RAW=$(cat 2>/dev/null || true)
+PROMPT=$(printf '%s' "$RAW" | python3 -c "
+import json,sys
+try: print(json.load(sys.stdin).get('prompt',''))
+except Exception: print('')
+" 2>/dev/null)
+[ -n "$PROMPT" ] || PROMPT="$RAW"
+[ -n "$PROMPT" ] || exit 0
+
+# 매핑된 프로젝트 = tracks/ 하위 디렉토리(언더스코어 접두는 메타라 제외)
+mapped=$(ls -d "$HUB"/tracks/*/ 2>/dev/null | while read -r d; do
+  b=$(basename "$d")
+  [ "${b#_}" = "$b" ] || continue          # 언더스코어 접두 = 메타 디렉토리, 제외
+  printf '%s\n' "$b"
+done)
+[ -n "$mapped" ] || exit 0
+
+emitted=0
+for name in $mapped; do
+  # 프롬프트에 이름이 나오는가 (대소문자 무시). 짧은 이름의 오탐은 감수 — 과소보다 낫다.
+  printf '%s' "$PROMPT" | grep -qi -- "$name" || continue
+  [ -e "$SENT_DIR/$name" ] && continue          # 이 세션에서 이미 띄웠다
+
+  # 레포 해석: tracks 이름 그대로 → 없으면 `-dev` 접미 (qasp → qasp-dev 실측 사례)
+  repo=""
+  for cand in "$PROJ_ROOT/$name" "$PROJ_ROOT/${name}-dev"; do
+    [ -d "$cand/.git" ] && { repo="$cand"; break; }
+  done
+  [ -n "$repo" ] || continue
+
+  # **실재하는 것만** 싣는다. 없는 파일을 가리키면 다음 사람이 그 지시를 못 믿게 된다.
+  lines=""
+  [ -f "$repo/README.md" ] && lines="$lines\n     README.md ($(wc -l < "$repo/README.md" | tr -d ' ')줄) — §구조·§지도 절 먼저"
+  [ -f "$repo/CLAUDE.md" ] && lines="$lines\n     CLAUDE.md ($(wc -l < "$repo/CLAUDE.md" | tr -d ' ')줄)"
+  gov=$(ls "$repo/docs/governance" 2>/dev/null | wc -l | tr -d ' ')
+  [ "${gov:-0}" -gt 0 ] && lines="$lines\n     docs/governance/ — 정본 ${gov}개 (용어·모드·계약의 출처)"
+  [ -n "$lines" ] || continue
+
+  if [ "$emitted" -eq 0 ]; then
+    echo ""
+    echo "📚 [field-canon] 매핑된 필드 하네스가 언급됐다 — **코드 역추론 전에 그쪽 정본을 읽어라.**"
+    emitted=1
+  fi
+  echo "  ▸ $name  →  $repo"
+  printf '%b\n' "$lines"
+  : > "$SENT_DIR/$name" 2>/dev/null || true
+done
+
+if [ "$emitted" -eq 1 ]; then
+  cat <<'EOF'
+  ⚠️ 이 안내는 프로젝트당 세션당 1회다. 2026-08-09 실측: 정본 미독으로 하루 4회 정정,
+     자력 적발 0 — 네 번 다 답이 정본에 있었고 그중 하나는 README 가 그 오해를 경고까지 했다.
+     ★ 필드 하네스 용어를 일반 개념으로 정규화하지 마라(「MTM=화이트박스 모드」가 그 실패다).
+EOF
+fi
+exit 0

--- a/scripts/test_field_canon_lanes.sh
+++ b/scripts/test_field_canon_lanes.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# field_canon_preload.sh 레인 — known-pair 교정.
+#
+# 이 파일이 있는 이유: 2026-08-09 에 한 세션이 종일 qasp 를 파면서 그 레포 정본(README 604줄 ·
+# docs/governance 32개)을 **하나도 안 읽고** 코드 역추론했고 **네 번 정정당했다(자력 적발 0)**.
+# ①은 그날의 **첫 메시지를 그대로** 넣는다 — 훅이 있었다면 그 자리에서 걸렸어야 한다.
+set -uo pipefail
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+H="$HERE/field_canon_preload.sh"
+TMP=$(mktemp -d) || exit 10
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  ✅ %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  ❌ %s — %s\n' "$1" "$2"; }
+# ★`${3:+VAR=v}` 는 파라미터 확장이라 bash 가 **환경 할당으로 안 읽는다** — env 로 넘긴다.
+#   (이 파일 초판이 그렇게 써서 「레포 부재」 레인이 거짓 적색을 냈다. 계기 결함이었다.)
+run(){ local extra=""; [ -n "${3:-}" ] && extra="FIELD_CANON_PROJECT_ROOT=$3"
+  printf '%s' "$1" | env FIELD_CANON_SENTINEL_DIR="$2" $extra bash "$H" 2>&1; }
+
+echo "== field-canon preload 레인 =="
+
+out=$(run '{"prompt":"세션 시작하자 qasp 병렬세션"}' "$TMP/1")
+case "$out" in *qasp*README.md*) ok "① 그날의 첫 메시지 → 정본 경로 제시" ;;
+  *) no "① 그날의 첫 메시지" "정본 경로 미출력" ;; esac
+case "$out" in *docs/governance*) ok "①-b governance 정본 수를 함께 낸다" ;;
+  *) no "①-b governance" "미출력" ;; esac
+
+run '{"prompt":"qasp 시작"}' "$TMP/2" >/dev/null
+out=$(run '{"prompt":"qasp 또"}' "$TMP/2")
+[ -z "$out" ] && ok "② 세션당 1회 — 재나그 없음" || no "②" "2회차에 또 출력(무시를 학습시킨다)"
+
+out=$(run '{"prompt":"오늘 날씨 어때"}' "$TMP/3")
+[ -z "$out" ] && ok "★컨트롤: 매핑 밖 프롬프트는 조용" || no "컨트롤" "오탐 출력"
+
+out=$(run '{"prompt":"qasp"}' "$TMP/4" /nonexistent)
+[ -z "$out" ] && ok "★컨트롤: 레포 부재 → 조용(허위 지시 금지)" || no "레포 부재" "없는 경로를 가리켰다"
+
+printf 'not-json' | FIELD_CANON_SENTINEL_DIR="$TMP/5" bash "$H" >/dev/null 2>&1
+[ $? = 0 ] && ok "깨진 입력도 rc=0 (비영종료는 stdout 폐기 = 무음)" || no "깨진 입력" "rc≠0"
+printf '' | FIELD_CANON_SENTINEL_DIR="$TMP/6" bash "$H" >/dev/null 2>&1
+[ $? = 0 ] && ok "빈 입력 rc=0" || no "빈 입력" "rc≠0"
+
+echo "── PASS $PASS · FAIL $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## 무엇

`scripts/field_canon_preload.sh` — `UserPromptSubmit` 훅. 프롬프트에 매핑된 프로젝트(`tracks/*`) 이름이 나오면 **그 레포의 실재하는 정본 파일 경로만** 골라 한 번 띄운다.
앵커: `scripts/test_field_canon_lanes.sh` (7레인).

## 왜 (2026-08-09 실측 — 하루 4회 정정 · 자력 적발 0)

한 세션이 종일 qasp 를 팠는데 그 레포의 `README.md`(604줄)·`CLAUDE.md`(281줄)·`docs/governance/`(**32개**)를 **하나도 안 읽고** 코드에서 역추론했다. 네 번 정정당했고 **네 번 다 정본에 답이 있었다**:

- MTM 을 "조건부 화이트박스 모드" 로 요약 → 정본은 블박+화박 **동시**(이중시야)
- "매트릭스 = 축이 여럿" → 영화 매트릭스에서 **네오가 보는 시야**
- 3막 본체가 act2 에 있는 걸 배치 결함 판정 → README 가 **의도**라고 명시(L1 공유·중복 0)
- 전수조사 모수를 `src/act2` 로 한정 → b레인·mate 는 모수 밖

README 는 그중 하나를 *"이 축이 안 보이면 3막을 mate 판정 전용으로 오해한다"* 로 **경고까지 하고 있었다.** 산문 규율로는 안 읽힌다.

## 재발명 아님

`fh_session_load.sh` 가 같은 진단(*"prose is salience-dependent"*)으로 이미 SessionStart 훅을 세웠다. 그건 **FH 자기 정본**(동반자 저장소)만 싣는다. 이건 **필드 하네스 정본**이고 **트리거가 다르다** — 어느 하네스인지는 세션 시작엔 모르므로 프롬프트 언급이 트리거다.

## 설계

- **일반 훈계가 아니라 이 레포의 이 파일들.** 오늘의 실패는 규율을 몰라서가 아니라 **그 파일들이 거기 있는 줄 몰라서**였다 — 그래서 실재하는 것만, 줄 수·개수까지 붙인다
- **레포 부재 시 조용하다**(컨트롤 검증). 없는 경로를 가리키면 다음 사람이 그 지시를 못 믿게 된다
- 프로젝트당 세션당 1회 (반복 알림은 무시를 학습시킨다)
- 항상 `exit 0` + stdout 보고 (비영 종료는 stdout 폐기 = 무음)
- 레포 해석 `name` → `name-dev` 폴백 (qasp → qasp-dev 실측 사례)

## 레인 7종 — ①은 **그날의 첫 메시지를 그대로** 넣는다

정본 경로 제시 · governance 수 동반 · 세션당 1회 · **컨트롤 3종**(매핑 밖 · 레포 부재 · 깨진/빈 입력 → 전부 조용·rc=0).
**되돌림 실측**: README 목록 생성 무력화 시 **정확히 ① 하나만** 적색.

⚠️ 자력 적발 1건: 테스트 하네스가 `${3:+VAR=v}` 로 환경을 넘기려 해서(파라미터 확장이라 bash 가 할당으로 안 읽는다) 「레포 부재」 레인이 **거짓 적색**을 냈다. `env` 로 교체 — 계기 결함이었다.

## 배선

`.claude/settings.json`(로컬·gitignored) `UserPromptSubmit` 에 등록 완료. **파일 존재 가드** 포함 — 체크아웃이 이 브랜치가 아닐 때 조용히 넘어간다(배선 중 실제로 그 결함이 났고 실행 증명으로 잡았다).

🤖 Generated with [Claude Code](https://claude.com/claude-code)