### PR TITLE
feat(gate): 공유 체크아웃에서 «내가 믿는 브랜치 ≠ HEAD» 커밋을 막는다 + 원장 분할 전환 배선

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,8 @@
     "scripts/relay_channel.sh",
     "scripts/test_relay_channel_lanes.sh",
     "scripts/fh_session_load.sh",
+    "scripts/branch_claim.sh",
+    "scripts/test_branch_claim_lanes.sh",
     "scripts/hook_source_lib.sh",
     "scripts/test_hook_source_gate_lanes.sh",
     "templates/.claude/rules/mcp_tool_gating.md",

--- a/scripts/activity_log.sh
+++ b/scripts/activity_log.sh
@@ -100,8 +100,12 @@ for f in tracks/_audit/*.md; do
 done
 
 # 6. subagent_invocations_log.yaml — dispatch events (date: field per entry)
-if [[ -f knowledge/shared/learnings/subagent_invocations_log.yaml ]]; then
-  grep -E '^[[:space:]]*-?[[:space:]]*date:' knowledge/shared/learnings/subagent_invocations_log.yaml \
+# 전환 설계: 레거시 단일 파일 ∪ 세션별 디렉터리를 둘 다 읽는다 (session_close_check.sh 와 동일)
+_SAL=knowledge/shared/learnings/subagent_invocations_log.yaml
+_SAD=knowledge/shared/learnings/subagent_invocations
+if [[ -f "$_SAL" || -d "$_SAD" ]]; then
+  { [[ -f "$_SAL" ]] && cat "$_SAL"; [[ -d "$_SAD" ]] && cat "$_SAD"/*.yaml; } 2>/dev/null \
+    | grep -E '^[[:space:]]*-?[[:space:]]*date:' \
     | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | sort | uniq -c | while read -r n d; do
       emit_line "$d" "dispatch" "$n agent invocation(s)" "subagent_log"
   done

--- a/scripts/branch_claim.sh
+++ b/scripts/branch_claim.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# branch_claim.sh — 공유 체크아웃에서 «내가 믿는 브랜치»와 «실제 HEAD»가 갈린 채 커밋되는 것을 막는다.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# WHY (2026-08-09 실측, FH 병렬 세션 2개, 한 체크아웃)
+#   `.git/HEAD` 는 워킹트리당 하나다. 세션 A 의 `git switch` 는 세션 B 의 발밑도 옮긴다.
+#     17:35  B 가 브랜치를 땄다        (B 는 «작업 시작할 때 브랜치부터 따기»를 이미 했다)
+#     17:54  A 가 브랜치를 따며 트리 이동
+#     18:10  B 가 자기 브랜치인 줄 알고 **A 의 브랜치에 커밋**
+#   → 브랜치를 언제 따느냐는 무관하다. **HEAD 가 트리당 하나**인 게 원인이다.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# 판정 키 = «세션» 이지 «트리» 가 아니다  ★ 이게 이 스크립트의 핵심이고, 초판은 틀렸다
+#   초판은 트리 단위 claim 하나를 두고 그것과 HEAD 를 비교했다. 적대검증이 실행으로 반증:
+#   **양쪽 세션이 다 프로토콜을 지키면 정확히 그 사고를 못 잡는다** — A 가 switch 후 claim 하면
+#   claim==HEAD 가 되어 B 의 check 가 통과한다. 채택률이 오를수록 무력해지는 게이트였다.
+#   그래서 claim 을 **세션마다** 따로 둔다: `.git/fh-claims/<session_id>`.
+#   비교는 **내 claim vs HEAD** 만 한다 — 남의 claim 은 내 판정에 안 들어오므로
+#   peer 로 인한 과차단이 구조적으로 없다.
+#
+#   세션 정체성은 배관이 필요 없다. 실측(2026-08-09): git 훅은 Claude Code 가 주입한
+#   `CLAUDE_CODE_SESSION_ID` · `CLAUDE_PID` 를 그대로 상속한다.
+#
+# WHAT THIS DOES / DOESN'T
+#   막는다     : «내가 마지막으로 claim 한 브랜치» ≠ HEAD 인 채로 커밋
+#   안 막는다  : `git switch` 자체 (git 에 switch 훅이 없다 — 막을 자리가 없다)
+#   🟥 근본 해결이 아니다. 이건 **완화책**이다. 공유 체크아웃은 미커밋 워킹트리 혼입/유실도
+#      낳고(그건 커밋 게이트로 안 닫힌다), 근본 처방은 **세션당 worktree** 다.
+#      (worktree 를 쓰면 이 claim 도 자동으로 트리별로 갈린다 — `--git-dir` 이 갈리므로.
+#       단 FH 자산 커밋은 worktree 에서 4축 증거가 구조적으로 부재하다는 별개 문제가 있다.)
+#
+# 🟥 TOCTOU 잔여 (cross-family 지적, 미해결): `check` 와 git 이 실제로 ref 를 갱신하는 순간
+#    사이에 창이 있다. 그 사이 peer 가 switch 하면 이 게이트를 통과한 채 사고가 난다.
+#    창은 «35분»에서 «훅 실행시간»으로 줄지만 0 이 아니다. 정통 처방은 pre-commit 이 아니라
+#    **`reference-transaction` 훅** — 갱신 대상 ref 를 stdin 으로 받으므로 원자적으로 판정된다.
+#    지금은 짓지 않았다(별개 훅 = 별개 변경). 완화로 훅 말미에 재검사를 한 번 더 돌린다.
+#
+# DEGRADE DIRECTION
+#   claim 없음 / 손상 / detached·rebase·bisect 중  → **통과**.
+#   근거는 **«과차단은 override 를 습관화시켜 게이트를 죽인다»** 하나다(FH 실측 반복 기록).
+#   ⚠️ «커밋은 가역이니까» 를 근거로 쓰지 않는다 — 이 사고의 실제 복구는 공유 브랜치
+#   history rewrite 로 갔고, 그건 Surface-Class Degrade Invariant 가 fail-closed 로 두는 표면이다.
+#   근거를 하나로 좁히지 않으면 나중에 «가역이니 여기도 완화하자» 로 잘못 일반화된다.
+#
+#   동시성 증거 없음(살아있는 peer 세션 claim 0개) → **경고만, 차단 안 함.**
+#   1인 작업자에겐 이 게이트의 편익이 0이고 비용만 있다.
+#   불일치 + 살아있는 peer 존재 → **차단.** override = FH_BRANCH_CLAIM_OK=1 (파일에 기록된다).
+#
+# USAGE
+#   bash scripts/branch_claim.sh claim [<label>]   # 현재 HEAD 를 «내 브랜치»로 기록
+#   bash scripts/branch_claim.sh check             # pre-commit 이 부르는 것 (0=통과 1=차단)
+#   bash scripts/branch_claim.sh show | release | reap
+#
+# ENV (운영)
+#   FH_BRANCH_CLAIM_OK=1   차단 1회 우회 — override 로그에 append 된다
+# ENV (테스트 전용 — FH_CLAIM_TEST=1 없이는 전부 무시된다)
+#   FH_CLAIM_TEST=1  FH_CLAIM_DIR  FH_CLAIM_NOW  FH_CLAIM_STALE_HOURS  FH_CLAIM_SESSION
+#   ↑ 게이팅하는 이유: 초판은 이 노브들이 프로덕션에서도 먹어서 **정직한 override 보다
+#     조용한 우회가 더 쉬웠다**(FH_CLAIM_FILE=/dev/null → rc=0, 화면에 아무 표시 없음).
+#
+# bash 3.2(macOS) 호환: 연관배열·${v^^}·mapfile 안 씀.
+# `stat` 안 씀 — epoch 을 파일 안에 적는다(BSD/GNU `stat -f` 분기 회피).
+
+set -uo pipefail
+
+_test_mode() { [ "${FH_CLAIM_TEST:-}" = "1" ]; }
+_now()   { if _test_mode && [ -n "${FH_CLAIM_NOW:-}" ]; then echo "$FH_CLAIM_NOW"; else date +%s; fi; }
+_stale_hours() { if _test_mode && [ -n "${FH_CLAIM_STALE_HOURS:-}" ]; then echo "$FH_CLAIM_STALE_HOURS"; else echo 12; fi; }
+
+# 세션 정체성. Claude Code 가 주입한다(실측). 없으면 셸 PID 로 폴백 — 그 경우
+# «세션»은 사실상 «이 프로세스 트리»가 되고, 게이트는 여전히 동작하되 범위가 좁아진다.
+_session_id() {
+  if _test_mode && [ -n "${FH_CLAIM_SESSION:-}" ]; then echo "$FH_CLAIM_SESSION"; return; fi
+  if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then echo "$CLAUDE_CODE_SESSION_ID"; return; fi
+  echo "pid-${PPID:-$$}"
+}
+_session_pid() { echo "${CLAUDE_PID:-${PPID:-$$}}"; }
+
+# 절대경로 강제: 본 트리에서 `--git-dir` 은 상대 ".git" 이라, 서브디렉터리에서 실행하면
+# 엉뚱한 곳에 claim 을 만들어 «점유 없음»으로 조용히 통과한다 = 게이트 무력화.
+_git_dir() {
+  local d
+  d=$(git rev-parse --absolute-git-dir 2>/dev/null) && [ -n "$d" ] && { echo "$d"; return 0; }
+  local top; top=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+  d=$(git rev-parse --git-dir 2>/dev/null) || return 1
+  case "$d" in /*) echo "$d" ;; *) echo "$top/$d" ;; esac
+}
+
+_claim_dir() {
+  if _test_mode && [ -n "${FH_CLAIM_DIR:-}" ]; then echo "$FH_CLAIM_DIR"; return 0; fi
+  local gd; gd=$(_git_dir) || return 1
+  echo "$gd/fh-claims"
+}
+_my_claim() { local d; d=$(_claim_dir) || return 1; echo "$d/$(_session_id)"; }
+
+_head_branch() { git rev-parse --abbrev-ref HEAD 2>/dev/null; }
+_field() { sed -n "s/^$2=//p" "$1" 2>/dev/null | head -1; }
+
+# 출력하는 복구 명령에 브랜치명을 그대로 박으면 안 된다: git ref 는 공백은 못 쓰지만
+# `;` `$` `(` `)` `&` `|` 백틱은 **허용**한다. 복붙하면 주입형 사고가 난다(cross-family 지적).
+# bash 3.2 라 printf %q 대신 single-quote escape 로 감싼다.
+_shq() { printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"; }
+
+# 브랜치가 «지금 어디에 얹히는가»의 질문이 성립하지 않는 상태들.
+# 초판은 detached 를 차단해서 rebase --edit 중 커밋을 막았고, 제시한 세 선택지 중
+# 하나는 실행 불가(claim 이 detached 를 거부), 하나는 rebase 를 깨는 switch 였다.
+# 남는 게 override 뿐이면 그건 override 훈련이다.
+_inapplicable_state() {
+  local b gd; b=$(_head_branch); gd=$(_git_dir) || return 1
+  [ "$b" = "HEAD" ] && return 0
+  for m in rebase-merge rebase-apply BISECT_LOG MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD; do
+    [ -e "$gd/$m" ] && return 0
+  done
+  return 1
+}
+
+# 살아있는 **다른** 세션의 claim 개수 (동시성 증거). 죽은 세션 claim 은 안 센다.
+_live_peers() {
+  local d me n=0 f sid pid
+  d=$(_claim_dir) || { echo 0; return; }
+  [ -d "$d" ] || { echo 0; return; }
+  me=$(_session_id)
+  for f in "$d"/*; do
+    [ -f "$f" ] || continue
+    sid=$(basename "$f"); [ "$sid" = "$me" ] && continue
+    pid=$(_field "$f" pid)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then n=$((n+1)); fi
+  done
+  echo "$n"
+}
+
+_override_log() { local gd; gd=$(_git_dir) || return 1; echo "$gd/fh-branch-claim-overrides.log"; }
+
+cmd_claim() {
+  local label="${1:-${USER:-unknown}}" d f b now
+  d=$(_claim_dir) || { echo "branch-claim: git 저장소가 아니다 — 아무것도 안 한다"; return 0; }
+  b=$(_head_branch)
+  if [ -z "$b" ] || [ "$b" = "HEAD" ]; then
+    echo "branch-claim: HEAD 가 detached 라 기록하지 않는다 (브랜치 위에서 실행해라)" >&2
+    return 2
+  fi
+  mkdir -p "$d" || return 1
+  f=$(_my_claim); now=$(_now)
+  # 원자적 교체: 같은 디렉터리 내 rename. in-place truncate 는 동시 read 에서 필드가 찢어진다
+  # (실측: 동시 claim 300회 중 9회 owner 필드 파손).
+  printf 'branch=%s\nlabel=%s\npid=%s\nat_epoch=%s\n' "$b" "$label" "$(_session_pid)" "$now" \
+    > "$f.tmp.$$" && mv -f "$f.tmp.$$" "$f" || return 1
+  echo "✅ branch-claim: 이 세션의 브랜치를 '$b' 로 기록했다 (label=$label)"
+  local peers; peers=$(_live_peers)
+  [ "$peers" -gt 0 ] && echo "   살아있는 peer 세션 claim: $peers 개 — 게이트 활성"
+  return 0
+}
+
+cmd_release() {
+  local f; f=$(_my_claim) 2>/dev/null || return 0
+  if [ -f "$f" ]; then rm -f "$f"; echo "branch-claim: 이 세션의 기록을 지웠다"; else echo "branch-claim: 기록 없음"; fi
+  return 0
+}
+
+# 죽은 세션의 claim 정리
+cmd_reap() {
+  local d f sid pid n=0
+  d=$(_claim_dir) || return 0; [ -d "$d" ] || { echo "branch-claim: 기록 디렉터리 없음"; return 0; }
+  for f in "$d"/*; do
+    [ -f "$f" ] || continue
+    pid=$(_field "$f" pid)
+    if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then rm -f "$f"; n=$((n+1)); fi
+  done
+  echo "branch-claim: 죽은 세션 기록 $n 개 정리"
+}
+
+cmd_show() {
+  local d f me; d=$(_claim_dir) || { echo "(git 저장소 아님)"; return 0; }
+  me=$(_session_id)
+  echo "HEAD      $(_head_branch)"
+  echo "세션ID    $me"
+  echo "살아있는 peer claim: $(_live_peers)"
+  if [ -d "$d" ]; then
+    for f in "$d"/*; do
+      [ -f "$f" ] || continue
+      local sid pid alive; sid=$(basename "$f"); pid=$(_field "$f" pid)
+      if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then alive=live; else alive=dead; fi
+      printf '  %s %s  branch=%s label=%s (%s)\n' \
+        "$([ "$sid" = "$me" ] && echo '→' || echo ' ')" "$sid" \
+        "$(_field "$f" branch)" "$(_field "$f" label)" "$alive"
+    done
+  else echo "  (기록 없음)"; fi
+}
+
+# 0 = 통과, 1 = 차단
+cmd_check() {
+  local f b cb cl ca now age lim peers
+  f=$(_my_claim) 2>/dev/null || return 0
+  b=$(_head_branch); [ -n "$b" ] || return 0
+  if _inapplicable_state; then return 0; fi        # detached·rebase·bisect·merge 중 → 질문이 성립 안 함
+  [ -f "$f" ] || return 0                          # 이 세션의 기록 없음 → 의견 없음 (부재 ≠ 위반)
+
+  cb=$(_field "$f" branch); cl=$(_field "$f" label); ca=$(_field "$f" at_epoch)
+  if [ -z "$cb" ]; then
+    echo "  ⚠️  branch-claim: 내 기록을 파싱 못 했다 — 통과시킨다 (fail-open, 과차단 회피)"
+    return 0
+  fi
+  if [ "$cb" = "$b" ]; then
+    # 일치 → 갱신해서 나이가 «재임 기간»이 아니라 «유휴 시간»을 재게 한다.
+    # (초판은 갱신을 안 해서, 오래 붙어 있는 세션일수록 STALE 로 무방비가 됐다.)
+    now=$(_now)
+    printf 'branch=%s\nlabel=%s\npid=%s\nat_epoch=%s\n' "$cb" "$cl" "$(_session_pid)" "$now" \
+      > "$f.tmp.$$" 2>/dev/null && mv -f "$f.tmp.$$" "$f" 2>/dev/null
+    return 0
+  fi
+
+  now=$(_now); lim=$(_stale_hours)
+  if [ -n "$ca" ] && [ "$ca" -eq "$ca" ] 2>/dev/null; then
+    age=$(( (now - ca) / 3600 ))
+    if [ "$age" -ge "$lim" ]; then
+      echo "  ⚠️  branch-claim: 내 기록이 STALE(${age}h ≥ ${lim}h) — 차단하지 않는다."
+      echo "      기록='$cb' · HEAD='$b'   →  맞으면: bash scripts/branch_claim.sh claim"
+      return 0
+    fi
+  fi
+
+  peers=$(_live_peers)
+  if [ "$peers" -eq 0 ]; then
+    echo "  ⚠️  branch-claim: 기록('$cb')과 HEAD('$b')가 다르다 — 살아있는 peer 세션이 없어 차단하지 않는다."
+    echo "      의도한 전환이면:  bash scripts/branch_claim.sh claim"
+    return 0
+  fi
+
+  if [ "${FH_BRANCH_CLAIM_OK:-}" = "1" ]; then
+    local lg; lg=$(_override_log 2>/dev/null)
+    [ -n "$lg" ] && printf '%s override claim=%s head=%s session=%s peers=%s\n' \
+      "$(_now)" "$cb" "$b" "$(_session_id)" "$peers" >> "$lg" 2>/dev/null
+    echo "  ⚠️  branch-claim: 불일치인데 FH_BRANCH_CLAIM_OK=1 로 우회한다."
+    echo "      기록='$cb' · HEAD='$b' · 로그: ${lg:-<기록 실패>}"
+    return 0
+  fi
+
+  echo "  ❌ branch-claim: 이 세션은 '$cb' 로 기록돼 있는데 HEAD 는 '$b' 다."
+  echo "     살아있는 peer 세션 $peers 개가 이 체크아웃을 같이 쓴다 — 그 중 하나가 브랜치를 옮겼다."
+  echo "     ⚠️  지금 커밋하면 '$b' 브랜치에 얹힌다 — 2026-08-09 에 실제로 난 사고다."
+  echo
+  echo "     ▸ '$b' 가 맞다       :  bash scripts/branch_claim.sh claim"
+  echo "     ▸ '$cb' 로 돌아간다  :  git switch -- $(_shq "$cb")"
+  echo "        ⚠️  돌아가면 지금 '$b' 를 쓰는 세션의 발밑을 뺀다. 먼저 한 줄 알려라."
+  echo "     ▸ 근본 해결        :  세션당 worktree (이 게이트는 완화책이다)"
+  echo "     ▸ 알고도 강행      :  FH_BRANCH_CLAIM_OK=1 git commit …"
+  return 1
+}
+
+case "${1:-check}" in
+  claim)   shift; cmd_claim "${1:-}" ;;
+  release) cmd_release ;;
+  reap)    cmd_reap ;;
+  show)    cmd_show ;;
+  check)   cmd_check ;;
+  *) echo "usage: $0 {claim [label]|check|show|release|reap}" >&2; exit 2 ;;
+esac

--- a/scripts/branch_claim.sh
+++ b/scripts/branch_claim.sh
@@ -47,7 +47,8 @@
 #   불일치 + 살아있는 peer 존재 → **차단.** override = FH_BRANCH_CLAIM_OK=1 (파일에 기록된다).
 #
 # USAGE
-#   bash scripts/branch_claim.sh claim [<label>]   # 현재 HEAD 를 «내 브랜치»로 기록
+#   bash scripts/branch_claim.sh claim [<label>]              # 현재 HEAD 를 «내 브랜치»로 기록
+#   bash scripts/branch_claim.sh claim --if-absent [<label>]  # 없을 때만 (세션시작 훅용)
 #   bash scripts/branch_claim.sh check             # pre-commit 이 부르는 것 (0=통과 1=차단)
 #   bash scripts/branch_claim.sh show | release | reap
 #
@@ -132,6 +133,10 @@ _live_peers() {
 _override_log() { local gd; gd=$(_git_dir) || return 1; echo "$gd/fh-branch-claim-overrides.log"; }
 
 cmd_claim() {
+  # --if-absent: 이 세션의 기록이 이미 있으면 아무것도 하지 않는다(덮어쓰기 금지).
+  # 세션시작 훅이 부르는 형태 — 훅 안에 같은 로직을 복제하면 앵커를 못 걸어서 여기에 둔다.
+  local ifabsent=0
+  if [ "${1:-}" = "--if-absent" ]; then ifabsent=1; shift; fi
   local label="${1:-${USER:-unknown}}" d f b now
   d=$(_claim_dir) || { echo "branch-claim: git 저장소가 아니다 — 아무것도 안 한다"; return 0; }
   b=$(_head_branch)
@@ -141,6 +146,10 @@ cmd_claim() {
   fi
   mkdir -p "$d" || return 1
   f=$(_my_claim); now=$(_now)
+  if [ "$ifabsent" = "1" ] && [ -f "$f" ]; then
+    echo "branch-claim: 이 세션의 기록이 이미 있다 — 그대로 둔다 ($(_field "$f" branch))"
+    return 0
+  fi
   # 원자적 교체: 같은 디렉터리 내 rename. in-place truncate 는 동시 read 에서 필드가 찢어진다
   # (실측: 동시 claim 300회 중 9회 owner 필드 파손).
   printf 'branch=%s\nlabel=%s\npid=%s\nat_epoch=%s\n' "$b" "$label" "$(_session_pid)" "$now" \
@@ -248,7 +257,7 @@ cmd_check() {
 }
 
 case "${1:-check}" in
-  claim)   shift; cmd_claim "${1:-}" ;;
+  claim)   shift; cmd_claim "$@" ;;
   release) cmd_release ;;
   reap)    cmd_reap ;;
   show)    cmd_show ;;

--- a/scripts/fh_session_load.sh
+++ b/scripts/fh_session_load.sh
@@ -186,6 +186,26 @@ if [ -d "$_AUDIT_DIR" ] && fh_cadence_due "$_FH_HOOK_SRC"; then
   fi
 fi
 
+# ── branch-claim 자동 기록 (2026-08-09) ────────────────────────────────────────
+# WHY HERE, ABOVE THE COMPANION-STORE EARLY EXIT: 공유 체크아웃 사고는 Mode D 와 무관하다.
+# companion store 가 없는 설치에서도 병렬 세션은 돌고, 그때도 `.git/HEAD` 는 트리당 하나다.
+# 아래 `[ -d "$BE/.git" ] || exit 0` 뒤에 두면 **공개 사용자에게는 게이트가 통째로 죽는다.**
+#
+# WHY AUTO AT ALL: 게이트(templates/.git-hooks/pre-commit → scripts/branch_claim.sh)는
+# **기록이 없으면 «의견 없음»으로 통과**한다. 아무도 `claim` 을 안 하면 장식이 된다 —
+# 오늘 하루 반복해서 본 «만들고 배선 안 함» 의 얼굴. 세션 시작이 유일한 자연스러운 배선점이다.
+#
+# WHY IT IS SAFE (마찰 0):
+#   · **없을 때만 기록한다** — 이미 있으면 손대지 않는다. 남의 기록은 애초에 파일이 다르다
+#     (`.git/fh-claims/<session_id>`), 그래서 steal 이 구조적으로 불가능하다
+#   · **1인 세션은 차단을 안 만난다** — check 는 «살아있는 peer claim 0» 이면 경고만 낸다
+#   · detached/rebase/bisect 중이면 `claim` 이 스스로 거부한다(rc=2) → 무해
+#   · 실패해도 세션을 막지 않는다(|| true · 출력 억제)
+[ -x "$FH/scripts/branch_claim.sh" ] && {
+  ( cd "$FH" && bash scripts/branch_claim.sh claim --if-absent session >/dev/null 2>&1 ) || true
+  ( cd "$FH" && bash scripts/branch_claim.sh reap                     >/dev/null 2>&1 ) || true
+}
+
 # Non-Mode-D / no companion store → silent no-op (this is the majority path for public users).
 [ -d "$BE/.git" ] || exit 0
 

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -320,6 +320,34 @@ else
   fail=1
 fi
 
+# branch-claim lanes — shipped with 27 hand-run lanes and ZERO callers, so CI never ran one of them.
+# That is the exact defect its own subject guards against (a gate nobody claims against passes
+# forever), reproduced one layer up in its anchor. Same SKIP/FAIL shape: a missing subject is a
+# legitimate skip, a present subject with a missing anchor is a real failure. The lanes are hermetic
+# (per-PID temp dirs under the worktree, no network, no API spend), so running them here costs
+# nothing.
+#
+# ⚠️ Subject-absent is a FAIL here, NOT the SKIP the sibling blocks use. The SKIP arm exists for
+# subjects that may legitimately not ship; branch_claim.sh IS in package.json files[], so it is
+# present in the source checkout AND in the published package — absence can only mean deletion.
+# Nothing else catches that: measured 2026-08-09, package_coverage_check.sh returns PASS on a
+# files[] entry whose file does not exist, so a deleted subject would be green on every surface
+# (SKIP here + PASS there + npm silently omitting it). A cross-family reviewer caught this; the
+# first draft of this block used SKIP and would have silenced exactly that case.
+# Named residual, deliberately not fixed here: the sibling blocks above carry the same hole for
+# their own shipped subjects. Fixing them is a separate change with its own verification.
+if [ ! -f scripts/branch_claim.sh ]; then
+  echo "FAIL  scripts/branch_claim.sh is in package.json files[] but absent — a deleted subject, not a skip"
+  fail=1
+elif [ -f scripts/test_branch_claim_lanes.sh ]; then
+  if ! bash scripts/test_branch_claim_lanes.sh; then
+    fail=1
+  fi
+else
+  echo "FAIL  test_branch_claim_lanes.sh: branch_claim.sh present but its anchor is missing"
+  fail=1
+fi
+
 # And the ablation calibrator, for the third instance of the same reason. Its whole job is telling
 # apart states that look identical from outside — "the arm could not answer" vs "the runner is dead"
 # vs "the runner read the answer off disk" — and round 2 of its own adversarial review found that

--- a/scripts/session_close_check.sh
+++ b/scripts/session_close_check.sh
@@ -341,7 +341,18 @@ DISPATCHED=$(_int "$(grep -c "^$TODAY$" "$TALLY" 2>/dev/null | tr -d ' ' || true
 # while anything appended via yaml.dump renders `- date: '"'"'2026-08-02'"'"'`. Matching one form counted
 # half the entries as absent — a divergent-normalizer miss inside the check that exists to catch
 # missing records. Known-pair calibrated below in test_dispatch_log_lanes.sh.
-LOGGED=$(_int "$(grep -cE "^- date: *'?$TODAY'?" "$LOG" 2>/dev/null | tr -d ' ' || true)")
+# ── 전환 설계: 레거시 단일 파일 ∪ 세션별 디렉터리를 **둘 다** 읽는다 ────────────
+# WHY: 같은 파일 끝에 여러 세션이 append 하면 브랜치 병합이 확정 충돌이고, 그 해소가
+# 조용히 손상된다 — git 이 엔트리 헤더 한 줄을 공통 접두로 밀어내서 «양쪽 다 보존»이라는
+# 정답 해소가 엔트리를 흡수시킨다(2026-08-09 재현: 항목 133/정답 134, 파싱은 통과).
+# 처방은 세션당 한 파일. 다만 **마이그레이션과 배선을 같은 커밋에 묶으면** 아직 머지 안 된
+# 원장 브랜치와 대형 충돌이 나므로, 소비자를 먼저 «둘 다 읽게» 만든다. 그러면 데이터가
+# 언제 옮겨가든 이 검사는 안 깨진다. 두 상태 모두 known-pair 로 고정돼 있다.
+LOGDIR="$FH/knowledge/shared/learnings/subagent_invocations"
+_cat_logs() {  # 다중 파일에 grep -c 를 직접 걸면 파일별 `경로:개수` 를 찍어 합산이 깨진다(실측).
+  { [ -f "$LOG" ] && cat "$LOG"; [ -d "$LOGDIR" ] && cat "$LOGDIR"/*.yaml; } 2>/dev/null
+}
+LOGGED=$(_int "$(_cat_logs | grep -cE "^- date: *'?$TODAY'?" | tr -d ' ' || true)")
 if [ "${DISPATCHED:-0}" -gt 0 ] && [ "${LOGGED:-0}" -eq 0 ]; then
   echo "❌ ④-e $DISPATCHED sub-agent dispatch(es) today and ZERO invocation-log entries — the 60/40"
   echo "     promotion gate and the UAP loop both read that file; an unlogged session is invisible to"

--- a/scripts/test_branch_claim_lanes.sh
+++ b/scripts/test_branch_claim_lanes.sh
@@ -197,6 +197,21 @@ EXPECT="git switch -- '${B}'"
 _lane "⑫ metachar 브랜치명이 인용된 채 출력된다" 1 "$rc" "$EXPECT"
 rm -rf "$R"
 
+# ── ⑬ --if-absent: 없으면 만들고, 있으면 안 덮는다 (세션시작 훅이 부르는 형태) ──
+#     훅 안에 같은 로직을 복제하면 앵커가 안 걸리므로 스크립트에 두고 여기서 잡는다.
+R=$(_mkrepo)
+LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" claim --if-absent s 2>&1); rc=$?
+_ok "⑬ --if-absent: 기록 없으면 생성" \
+    "$([ "$rc" = 0 ] && [ -f "$R/.git/fh-claims/me" ] && echo 1 || echo 0)"
+git -C "$R" switch -q -c moved            # 브랜치가 옮겨진 뒤 다시 불러도
+LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" claim --if-absent s 2>&1); rc=$?
+kept=$(sed -n 's/^branch=//p' "$R/.git/fh-claims/me")
+_lane "⑬-b --if-absent: 기록 있으면 덮지 않는다" 0 "$rc" "이미 있다"
+_ok "⑬-c 기존 값 보존 (main 이어야 함 · 지금=$kept)" "$([ "$kept" = main ] && echo 1 || echo 0)"
+# ★ 이게 중요한 이유: 덮으면 「내가 믿는 브랜치」가 매 세션시작마다 HEAD 로 갱신돼
+#   게이트가 영원히 통과한다 — 자동화가 게이트를 무장해제하는 경로다
+rm -rf "$R"
+
 echo
 echo "[branch-claim] PASS=$PASS  FAIL=$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/test_branch_claim_lanes.sh
+++ b/scripts/test_branch_claim_lanes.sh
@@ -50,6 +50,17 @@ _plant_peer() { # repo branch pid
     > "$1/.git/fh-claims/session-PEER"
 }
 
+# ⚠️ 주변 환경을 흡입하지 않는다 — 이 한 줄이 없어서 이 스위트는 «거짓 초록» 이었다.
+# branch_claim.sh 의 `_session_pid() { echo "${CLAUDE_PID:-${PPID:-$$}}"; }` 때문에, 저자 셸에
+# CLAUDE_PID 가 있으면 claim 이 **살아있는 pid**(그 Claude 프로세스)를 기록한다. 레인 ③ 은
+# A 가 재-claim 해서 peer 기록을 덮는 시나리오라, 그 pid 가 살아있느냐가 판정을 통째로 뒤집는다.
+# 실측 2026-08-09 (known-pair, 같은 트리·같은 커밋):
+#   CLAUDE_PID 있음 → 24 PASS / 0 FAIL      (저자 로컬 — 초록)
+#   CLAUDE_PID 없음 → 23 PASS / 1 FAIL ③   (CI — 적색, rc=0 기대 1)
+# 즉 코드가 아니라 **저자 환경**을 재고 있었고, 그 초록이 S-1 재설계의 유일한 증명이었다.
+# 앵커가 배선되기 전까지(=호출부 0개) 이 사실은 드러날 수 없었다.
+unset CLAUDE_PID
+
 echo "[branch-claim] known-pair 앵커"
 PEERPID=$(_spawn_live)
 
@@ -74,7 +85,10 @@ R=$(_mkrepo)
 (cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=B bash "$SCRIPT" claim bee >/dev/null 2>&1)
 _plant_peer "$R" main "$PEERPID"                        # A 를 살아있는 peer 로
 git -C "$R" switch -q -c ifkakao                        # A 가 트리를 옮기고
-(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=session-PEER bash "$SCRIPT" claim ay >/dev/null 2>&1)  # 프로토콜대로 claim
+# A 는 «살아있는» 세션이다 — 그 사실을 환경에서 빌리지 말고 레인이 직접 고정한다.
+# CLAUDE_PID 를 안 주면 claim 이 곧 죽을 서브셸의 PPID 를 기록하고, B 의 check 는
+# «살아있는 peer 0» 으로 통과한다 — 시나리오가 성립하지도 않은 채 초록이 된다.
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=session-PEER CLAUDE_PID="$PEERPID" bash "$SCRIPT" claim ay >/dev/null 2>&1)  # 프로토콜대로 claim
 LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=B bash "$SCRIPT" check 2>&1); rc=$?
 _lane "③ ★S-1 회귀: 양쪽이 프로토콜을 지켜도 B 는 차단된다" 1 "$rc" \
       "이 세션은 'main' 로 기록돼 있는데 HEAD 는 'ifkakao' 다" "git switch -- 'main'"

--- a/scripts/test_branch_claim_lanes.sh
+++ b/scripts/test_branch_claim_lanes.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# test_branch_claim_lanes.sh — branch_claim.sh known-pair 앵커.
+#
+# 왜 실행 테스트인가: `bash -n` 은 계기가 아니다 — 문법만 보고 exit 0 을 내므로
+# «전부 통과»와 구분이 안 된다([[feedback_gate_verification_must_execute]]).
+# «막혔다» ≠ «옳게 막혔다» 이므로 BLOCK 레인은 **완성 문장**으로 매칭한다 —
+# 조각 매칭은 claim/HEAD 역할을 뒤집는 뮤테이션을 통과시켰다(적대검증 A-5 실측).
+# 그 역할 뒤바뀜은 사용자를 반대 브랜치로 보내므로 게이트가 사고를 만드는 쪽이 된다.
+#
+# 격리: 레인마다 임시 저장소를 새로 판다. 실제 레포는 안 건드린다.
+# 세션 시뮬레이션: FH_CLAIM_TEST=1 + FH_CLAIM_SESSION 으로 두 세션을 흉내낸다.
+#
+# usage: bash scripts/test_branch_claim_lanes.sh
+
+set -uo pipefail
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/branch_claim.sh"
+PASS=0; FAIL=0; LIVE_PID=""
+
+cleanup() { [ -n "$LIVE_PID" ] && kill "$LIVE_PID" 2>/dev/null; return 0; }
+trap cleanup EXIT
+
+_mkrepo() {
+  local d; d=$(mktemp -d "${TMPDIR:-/tmp}/bclaim.XXXXXX")
+  git -C "$d" init -q -b main
+  git -C "$d" config user.email t@t; git -C "$d" config user.name t
+  echo x > "$d/f"; git -C "$d" add f; git -C "$d" commit -qm init
+  echo "$d"
+}
+# 살아있는 peer 세션 하나를 실제 프로세스로 만든다 (kill -0 이 참이 되도록)
+# ⚠️ 반드시 fd 를 닫아서 띄운다: 백그라운드 프로세스가 stdout 을 물고 있으면
+#    이 스크립트를 파이프에 물릴 때 파이프가 안 닫혀 무한 대기한다(실측: 120s 타임아웃).
+_spawn_live() { sleep 900 >/dev/null 2>&1 & LIVE_PID=$!; echo "$LIVE_PID"; }
+
+_lane() { # name expected_rc actual_rc [must_contain...]
+  local name="$1" exp="$2" got="$3"; shift 3
+  local out="$LANE_OUT" ok=1 pat
+  [ "$got" = "$exp" ] || { ok=0; echo "  ❌ $name — rc=$got (기대 $exp)"; }
+  for pat in "$@"; do
+    case "$out" in *"$pat"*) ;; *) ok=0; echo "  ❌ $name — 출력에 «${pat}» 없음";; esac
+  done
+  if [ "$ok" = 1 ]; then echo "  ✅ $name"; PASS=$((PASS+1)); else FAIL=$((FAIL+1));
+    echo "     ── 실제 출력 ──"; echo "$out" | sed 's/^/     /'; fi
+}
+_ok() { if [ "$2" = 1 ]; then echo "  ✅ $1"; PASS=$((PASS+1)); else echo "  ❌ $1"; FAIL=$((FAIL+1)); fi; }
+
+# 세션 B(=peer)의 claim 을 살아있는 pid 로 직접 심는다
+_plant_peer() { # repo branch pid
+  mkdir -p "$1/.git/fh-claims"
+  printf 'branch=%s\nlabel=peer\npid=%s\nat_epoch=%s\n' "$2" "$3" "$(date +%s)" \
+    > "$1/.git/fh-claims/session-PEER"
+}
+
+echo "[branch-claim] known-pair 앵커"
+PEERPID=$(_spawn_live)
+
+# ── ① 기록 없음 → 통과 (부재 ≠ 위반) ───────────────────────────────────────
+R=$(_mkrepo); LANE_OUT=$(cd "$R" && bash "$SCRIPT" check 2>&1); rc=$?
+_lane "① 기록 없음 → 통과" 0 "$rc"; rm -rf "$R"
+
+# ── ② 내 기록 == HEAD → 통과, 그리고 at_epoch 이 갱신된다 (A-6) ────────────
+R=$(_mkrepo)
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me FH_CLAIM_NOW=1000 bash "$SCRIPT" claim a >/dev/null 2>&1)
+before=$(sed -n 's/^at_epoch=//p' "$R/.git/fh-claims/me")
+LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me FH_CLAIM_NOW=99000 bash "$SCRIPT" check 2>&1); rc=$?
+after=$(sed -n 's/^at_epoch=//p' "$R/.git/fh-claims/me")
+_lane "② 내 기록==HEAD → 통과" 0 "$rc"
+_ok "②-b at_epoch 갱신됨 (${before} -> ${after}) — 나이가 «유휴»를 재게 된다" "$([ "$after" = 99000 ] && echo 1 || echo 0)"
+rm -rf "$R"
+
+# ── ③ ★ S-1 회귀: 양쪽 세션이 다 프로토콜을 지켜도 잡는다 ──────────────────
+#    초판 설계는 여기서 통과했다(= 오늘 사고를 못 막았다). 이 레인이 그 반증이다.
+#    타임라인: B가 main claim → A가 switch+claim(프로토콜 준수) → B가 커밋 시도
+R=$(_mkrepo)
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=B bash "$SCRIPT" claim bee >/dev/null 2>&1)
+_plant_peer "$R" main "$PEERPID"                        # A 를 살아있는 peer 로
+git -C "$R" switch -q -c ifkakao                        # A 가 트리를 옮기고
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=session-PEER bash "$SCRIPT" claim ay >/dev/null 2>&1)  # 프로토콜대로 claim
+LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=B bash "$SCRIPT" check 2>&1); rc=$?
+_lane "③ ★S-1 회귀: 양쪽이 프로토콜을 지켜도 B 는 차단된다" 1 "$rc" \
+      "이 세션은 'main' 로 기록돼 있는데 HEAD 는 'ifkakao' 다" "git switch -- 'main'"
+rm -rf "$R"
+
+# ── ④ 불일치인데 살아있는 peer 없음 → 경고만, 통과 (A-2 과차단 방지) ───────
+R=$(_mkrepo)
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=solo bash "$SCRIPT" claim s >/dev/null 2>&1)
+git -C "$R" switch -q -c next
+LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=solo bash "$SCRIPT" check 2>&1); rc=$?
+_lane "④ 1인 세션(살아있는 peer 0) → 차단 안 함" 0 "$rc" "살아있는 peer 세션이 없어"
+rm -rf "$R"
+
+# ── ④-b 컨트롤: 같은 상황에 살아있는 peer 가 있으면 차단 ───────────────────
+R=$(_mkrepo)
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=solo bash "$SCRIPT" claim s >/dev/null 2>&1)
+_plant_peer "$R" whatever "$PEERPID"
+git -C "$R" switch -q -c next
+LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=solo bash "$SCRIPT" check 2>&1); rc=$?
+_lane "④-b 컨트롤: peer 살아있으면 차단 (④가 무조건 통과가 아님)" 1 "$rc"
+rm -rf "$R"
+
+# ── ④-c 죽은 peer 는 동시성 증거가 아니다 ──────────────────────────────────
+R=$(_mkrepo)
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=solo bash "$SCRIPT" claim s >/dev/null 2>&1)
+_plant_peer "$R" whatever 999999                        # 존재하지 않는 pid
+git -C "$R" switch -q -c next
+LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=solo bash "$SCRIPT" check 2>&1); rc=$?
+_lane "④-c 죽은 peer → 차단 안 함 (시간 상수 의존을 줄인다)" 0 "$rc"
+rm -rf "$R"
+
+# ── ⑤ STALE → 통과 / 임계 미만 → 차단 ──────────────────────────────────────
+R=$(_mkrepo)
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me FH_CLAIM_NOW=0 bash "$SCRIPT" claim s >/dev/null 2>&1)
+_plant_peer "$R" x "$PEERPID"; git -C "$R" switch -q -c other
+LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me FH_CLAIM_NOW=$((13*3600)) bash "$SCRIPT" check 2>&1); rc=$?
+_lane "⑤ STALE(13h) → 통과" 0 "$rc" "STALE"
+LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me FH_CLAIM_NOW=$((11*3600)) bash "$SCRIPT" check 2>&1); rc=$?
+_lane "⑤-b 컨트롤: 11h → 여전히 차단" 1 "$rc"
+rm -rf "$R"
+
+# ── ⑥ override → 통과 + **파일에 실제로 기록** (A-4 팬텀 주장 수리) ────────
+R=$(_mkrepo)
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" claim s >/dev/null 2>&1)
+_plant_peer "$R" x "$PEERPID"; git -C "$R" switch -q -c other
+LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me FH_BRANCH_CLAIM_OK=1 bash "$SCRIPT" check 2>&1); rc=$?
+_lane "⑥ override → 통과" 0 "$rc" "FH_BRANCH_CLAIM_OK"
+_ok "⑥-b override 로그 파일이 실제로 생성·append 됨" \
+    "$([ -s "$R/.git/fh-branch-claim-overrides.log" ] && echo 1 || echo 0)"
+rm -rf "$R"
+
+# ── ⑦ detached / rebase 중 → 통과 (A-1 과차단 수리) ────────────────────────
+R=$(_mkrepo)
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" claim s >/dev/null 2>&1)
+_plant_peer "$R" x "$PEERPID"; git -C "$R" checkout -q --detach
+LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" check 2>&1); rc=$?
+_lane "⑦ detached HEAD → 통과 (rebase/bisect 중 커밋을 막지 않는다)" 0 "$rc"
+rm -rf "$R"
+R=$(_mkrepo)
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" claim s >/dev/null 2>&1)
+_plant_peer "$R" x "$PEERPID"; git -C "$R" switch -q -c other; mkdir -p "$R/.git/rebase-merge"
+LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" check 2>&1); rc=$?
+_lane "⑦-b rebase 진행 중 → 통과" 0 "$rc"
+rm -rf "$R"
+
+# ── ⑧ 테스트 노브는 FH_CLAIM_TEST=1 없이 무시된다 (A-3 무음 우회 차단) ─────
+R=$(_mkrepo)
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" claim s >/dev/null 2>&1)
+_plant_peer "$R" x "$PEERPID"; git -C "$R" switch -q -c other
+# 테스트 모드 없이 노브만 주면 → 세션ID 폴백이 달라 기록을 못 찾아 통과할 수 있으므로,
+# 실제 세션ID를 고정해 두고 STALE/NOW 노브가 먹지 않는지만 본다
+export CLAUDE_CODE_SESSION_ID=me
+LANE_OUT=$(cd "$R" && FH_CLAIM_STALE_HOURS=0 FH_CLAIM_NOW=99999999999 bash "$SCRIPT" check 2>&1); rc=$?
+_lane "⑧ FH_CLAIM_TEST 없이 STALE/NOW 노브 → 무시되고 차단 유지" 1 "$rc"
+unset CLAUDE_CODE_SESSION_ID
+rm -rf "$R"
+
+# ── ⑨ 워크트리는 기록이 분리된다 ───────────────────────────────────────────
+R=$(_mkrepo)
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" claim s >/dev/null 2>&1)
+WT="$R-wt"; git -C "$R" worktree add -q -b wtb "$WT" >/dev/null 2>&1
+if [ -d "$WT" ]; then
+  LANE_OUT=$(cd "$WT" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" check 2>&1); rc=$?
+  _lane "⑨ 워크트리는 기록 분리 → 통과" 0 "$rc"
+  git -C "$R" worktree remove --force "$WT" >/dev/null 2>&1
+else echo "  ⚠️  ⑨ 워크트리 생성 실패 — SKIPPED(통과로 세지 않음)"; fi
+rm -rf "$R" "$WT"
+
+# ── ⑩ 서브디렉터리에서도 같은 기록을 본다 (상대 .git 절대화) ───────────────
+R=$(_mkrepo)
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" claim s >/dev/null 2>&1)
+_plant_peer "$R" x "$PEERPID"; git -C "$R" switch -q -c other; mkdir -p "$R/deep/nested"
+LANE_OUT=$(cd "$R/deep/nested" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" check 2>&1); rc=$?
+_lane "⑩ 서브디렉터리에서도 차단" 1 "$rc"
+_ok "⑩-b 기록이 저장소 .git 에만 생성됨" \
+    "$([ -d "$R/.git/fh-claims" ] && [ ! -d "$R/deep/nested/.git" ] && echo 1 || echo 0)"
+rm -rf "$R"
+
+# ── ⑪ release / reap / show 도 앵커가 있다 (B-3 무앵커 경로 수리) ──────────
+R=$(_mkrepo)
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" claim s >/dev/null 2>&1)
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" release >/dev/null 2>&1)
+_ok "⑪ release 가 실제로 기록을 지운다" "$([ ! -f "$R/.git/fh-claims/me" ] && echo 1 || echo 0)"
+_plant_peer "$R" x 999999
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" reap >/dev/null 2>&1)
+_ok "⑪-b reap 이 죽은 세션 기록을 지운다" "$([ ! -f "$R/.git/fh-claims/session-PEER" ] && echo 1 || echo 0)"
+_plant_peer "$R" zzz "$PEERPID"
+LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" show 2>&1); rc=$?
+_lane "⑪-c show 가 HEAD·세션·peer 를 낸다" 0 "$rc" "HEAD" "살아있는 peer claim: 1" "zzz"
+rm -rf "$R"
+
+# ── ⑫ 복구 명령의 브랜치명이 shell-quote 된다 (cross-family B-6) ──────────
+#     git ref 는 공백은 못 쓰지만 `;` `$` 는 허용한다. 복붙 시 주입형 사고.
+R=$(_mkrepo); B='a;touch$IFS/tmp/BCLAIM_PWNED'
+git -C "$R" branch "$B" >/dev/null 2>&1 && git -C "$R" switch -q "$B"
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" claim s >/dev/null 2>&1)
+_plant_peer "$R" x "$PEERPID"; git -C "$R" switch -q main
+LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" check 2>&1); rc=$?
+EXPECT="git switch -- '${B}'"
+_lane "⑫ metachar 브랜치명이 인용된 채 출력된다" 1 "$rc" "$EXPECT"
+rm -rf "$R"
+
+echo
+echo "[branch-claim] PASS=$PASS  FAIL=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/test_dispatch_log_lanes.sh
+++ b/scripts/test_dispatch_log_lanes.sh
@@ -33,7 +33,14 @@ if [ -z "$MATCHER" ]; then
   echo "      this lane cannot verify what it claims to. Update the lane WITH the subject."
   exit 1
 fi
+# 주어의 _cat_logs 정의를 그대로 들어온다(재작성 금지 — 재작성하면 정규화가 갈린다)
+CATLOGS_DEF=$(awk '/^_cat_logs\(\) \{/,/^\}/' "$CHECK")
+if [ -z "$CATLOGS_DEF" ]; then
+  echo "FAIL  subject 에 _cat_logs 가 없다 — 전환 설계(레거시 ∪ 디렉터리)가 사라졌거나 이름이 바뀌었다."
+  exit 1
+fi
 echo "── matcher located in the subject"
+echo "── _cat_logs lifted from the subject ($(printf '%s' "$CATLOGS_DEF" | grep -c '') lines)"
 
 T=$(mktemp -d); trap 'rm -rf "$T"' EXIT
 D=2026-08-02
@@ -123,7 +130,10 @@ _eval_subject_assign() {  # $1 = variable name; echoes what the SUBJECT computes
   [ -n "$line" ] || { echo "NOLINE"; return; }
   bash -c "set -uo pipefail
     _int() { case \"\${1:-}\" in (''|*[!0-9]*) echo 0 ;; (*) echo \"\$1\" ;; esac; }
-    TODAY=NOSUCHDATE; TALLY='$CHECK'; LOG='$CHECK'
+    # ★ LOGGED 는 주어의 _cat_logs 에 의존한다. 이걸 안 들여오면 «함수 없음 → 빈 입력 → 0»
+    #   으로 **틀린 이유로 통과**한다 — 이 파일이 경고하는 장식 앵커 그 자체다.
+    $CATLOGS_DEF
+    TODAY=NOSUCHDATE; TALLY='$CHECK'; LOG='$CHECK'; LOGDIR='$CHECK.nodir'
     $line
     printf %s \"\$$var\"" 2>/dev/null
 }
@@ -132,6 +142,30 @@ for _v in DISPATCHED LOGGED; do
   [ "$(printf %s "$_got" | grep -c '')" -le 1 ] ; chk $? "subject's \$$_v is ONE line on a zero match (was two: the disarm)"
   ( set -uo pipefail; [ "${_got:-x}" -eq 0 ] ) 2>/dev/null ; chk $? "subject's \$$_v survives \`[ -eq 0 ]\` (the disarm threw here)"
 done
+
+echo ""
+echo "── 전환 설계 레인: 레거시 단일 파일 ∪ 세션별 디렉터리 ──"
+# 주어의 _cat_logs + LOGGED 를 그대로 들어와 4가지 상태에서 센다.
+LOGGED_LINE=$(grep -E "^LOGGED=" "$CHECK" | head -1)
+_count_in() {  # $1=LOG 경로(없으면 빈문자) $2=LOGDIR 경로(없으면 빈문자)
+  bash -c "set -uo pipefail
+    _int() { case \"\${1:-}\" in (''|*[!0-9]*) echo 0 ;; (*) echo \"\$1\" ;; esac; }
+    $CATLOGS_DEF
+    TODAY='$D'; LOG='$1'; LOGDIR='$2'
+    $LOGGED_LINE
+    printf %s \"\$LOGGED\"" 2>/dev/null
+}
+LT="$T/split"; mkdir -p "$LT/dir"
+printf -- "- date: %s\n" "$D" > "$LT/legacy.yaml"                       # 1건
+printf -- "- date: %s\n- date: '%s'\n" "$D" "$D" > "$LT/dir/a.yaml"     # 2건 (두 표기 다)
+printf -- "- date: %s\n" "$D" > "$LT/dir/b.yaml"                        # 1건
+[ "$(_count_in "$LT/legacy.yaml" "$LT/nosuchdir")" = 1 ] ; chk $? "레거시 파일만 → 1"
+[ "$(_count_in "$LT/nofile.yaml" "$LT/dir")"       = 3 ] ; chk $? "디렉터리만 → 3 (파일 2개 합산)"
+[ "$(_count_in "$LT/legacy.yaml" "$LT/dir")"       = 4 ] ; chk $? "둘 다 → 4 (합집합)"
+[ "$(_count_in "$LT/nofile.yaml" "$LT/nosuchdir")" = 0 ] ; chk $? "둘 다 없음 → 0 (부재는 오류가 아니다)"
+# ★ 컨트롤: 다중 파일에 grep -c 를 직접 걸면 깨진다는 실측을 레인으로 고정
+_naive=$(grep -cE "^- date: *'?$D'?" "$LT/dir"/*.yaml 2>/dev/null | tr -d ' \n')
+[ "$_naive" != 3 ] ; chk $? "컨트롤: naive grep -c 다중파일은 3을 못 낸다 (실제='$_naive' — 경로:개수 형태)"
 
 echo ""
 if [ "$FAILED" -ne 0 ]; then echo "DISPATCH-LOG LANES: FAIL"; exit 1; fi

--- a/templates/.git-hooks/pre-commit
+++ b/templates/.git-hooks/pre-commit
@@ -188,6 +188,40 @@ LIGHT=$(echo "$LIGHT" | grep -vE '^\s*$' || true)
 # boundary, so they run on EVERY commit regardless of what is staged.
 # Body is intentionally NOT indented: it contains heredocs whose terminators must sit at column 0.
 run_universal_guards() {
+# ── Branch-claim guard — «내가 믿는 브랜치 ≠ HEAD» (2026-08-09) ───────────────
+# WHY HERE, WITH THE OTHER UNIVERSAL GUARDS: surface-scoped, not 4-axis-scoped — a commit
+# lands on a branch whether or not an FH asset is staged, so it must run before the
+# "no FH assets → exit 0" path.
+#
+# WHAT IT CATCHES (measured 2026-08-09, two parallel sessions, one checkout):
+#   `.git/HEAD` is one per working tree; session A's `git switch` moves B's ground too.
+#   B had already "cut a branch at the start of work" — that did not prevent it.
+#   Key insight: the judgment key is the SESSION, not the tree. A tree-level claim is
+#   defeated when BOTH sessions follow the protocol (A switches + re-claims → claim==HEAD →
+#   B passes) — i.e. it gets weaker as adoption rises. Per-session records
+#   (.git/fh-claims/<session_id>, keyed on CLAUDE_CODE_SESSION_ID which git hooks inherit)
+#   compare only MY record against HEAD, so peers can never over-block me.
+#
+# NOT A ROOT FIX: it does not block `git switch` (git has no switch hook) and does not
+# protect the uncommitted worktree. Root fix = one worktree per session.
+#
+# DEGRADE: no record · unparseable · detached/rebase/bisect/merge · no LIVE peer session
+#   → PASS. Sole rationale: over-blocking trains the override and kills the gate.
+#   (Deliberately NOT "a commit is reversible" — this incident's recovery went through a
+#   shared-branch history rewrite, which that invariant classes fail-closed.)
+# Anchor: scripts/test_branch_claim_lanes.sh — includes the S-1 regression lane (both
+# sessions protocol-compliant) and controls proving the pass-lanes are not unconditional.
+BCLAIM="$REPO_ROOT/scripts/branch_claim.sh"
+if [ -f "$BCLAIM" ]; then
+  if ! bash "$BCLAIM" check; then
+    FAILED=1
+  fi
+else
+  # 부재를 통과로 렌더하지 않는다 — 이웃 가드(PSA_LIB)는 부재 시 FAIL 인데 여기만 무음이면
+  # «가드가 안 돌았다»와 «가드가 통과했다»가 구분 불가해진다. 차단은 안 한다(과차단 회피).
+  echo "  ⚠️  branch-claim guard NOT INSTALLED (scripts/branch_claim.sh) — skipped, not passed"
+fi
+
 # ── Privacy guard — tracks/ staged-path allowlist (structural, name-free) ─────
 # tracks/** is local-by-default (frozen-seed policy); the only public lanes are
 # tracks/_contrib/** (consent lane) and ALREADY-TRACKED .gitkeep skeleton files.
@@ -336,6 +370,16 @@ if [ -n "$HEAVY" ]; then
   GATE_MODE="full"
 else
   GATE_MODE="lightweight"
+fi
+
+# TOCTOU 완화: 앞선 branch-claim check 이후 게이트들이 도는 동안 peer 가 브랜치를 옮길 수
+# 있다. 최종 판정 직전에 한 번 더 돌려 창을 좁힌다. (원자적 close 는 reference-transaction
+# 훅의 몫 — 이건 완화이지 해결이 아니다.)
+if [ -f "$REPO_ROOT/scripts/branch_claim.sh" ]; then
+  if ! bash "$REPO_ROOT/scripts/branch_claim.sh" check; then
+    echo "  ↑ 게이트 실행 중에 브랜치가 옮겨졌다 (TOCTOU 창에서 포착)"
+    FAILED=1
+  fi
 fi
 
 echo ""


### PR DESCRIPTION
오늘 실제로 난 사고에서 나왔다. `.git/HEAD` 는 워킹트리당 하나라 **세션 A 의 `git switch` 가 세션 B 의 발밑도 옮긴다.**

reflog 실측:
```
17:35  B 가 브랜치를 땄다
17:54  A 가 브랜치를 따며 트리 이동
18:10  B 가 자기 브랜치인 줄 알고 A 의 브랜치에 커밋
```
B 는 「작업 시작할 때 브랜치부터 따기」를 **이미 하고 있었다.** 그게 안 막았다 — 브랜치를 언제 따느냐는 무관하고, HEAD 가 트리당 하나인 게 원인이다.

## ★ 판정 키는 «세션» 이지 «트리» 가 아니다 — 초판 설계가 반증됐다

적대검증이 실행으로 반증했다: 트리 단위 claim 은 **양쪽 세션이 다 프로토콜을 지키면** 그 사고를 정확히 못 잡는다(A 가 switch 후 re-claim → `claim == HEAD` → B 통과). **채택률이 오를수록 무력해지는 게이트**였다.

그래서 세션마다 기록을 따로 둔다 — `.git/fh-claims/<session_id>`, 비교는 «내 기록 vs HEAD» 뿐. peer 로 인한 과차단이 구조적으로 없다. git 훅이 세션 ID 를 상속한다는 실측이 이 설계를 가능하게 했다.

## 활성화 배선 (`7a2499a`)

게이트는 완성돼 있었지만 **아무도 claim 을 안 하면 기록이 없어 영원히 통과**했다 — 오늘 반복해서 본 「만들고 배선 안 함」의 얼굴이라 세션시작에 붙였다.

실측으로 잡아 고친 것 3건:
1. 훅의 **조기 exit 위**에 놓아야 한다 — companion store 검사 아래면 그게 없는 공개 사용자에게 게이트가 통째로 죽는다(그쪽이 다수 경로다)
2. 로직을 훅에 복제하면 앵커가 안 걸린다 → `claim --if-absent` 를 스크립트 서브커맨드로 빼고 훅은 호출만
3. **기밀 가드가 저자를 막았다** — 주석에 사설 경로명을 그대로 썼다가 걸려 일반화. 게이트가 자기 저자를 잡은 오늘의 두 번째 사례

자기적대 지목(「자동화가 게이트를 무장해제할 수 있나」): 덮어쓰면 «내가 믿는 브랜치»가 매 세션 HEAD 로 갱신돼 영원히 통과한다 → 레인 ⑬-c 가 기존 값 보존을 기계 고정. **21 → 24레인 PASS.**

## 원장 분할 전환 배선 (`e76a535`)

데이터를 **안 옮기고 소비자를 먼저** 전환한다 — 레거시 단일 파일 ∪ 세션별 디렉터리를 둘 다 읽는다. 그러면 마이그레이션 시점이 자유로워지고, 이 PR 은 원장 통합 PR 과 순서 의존이 없다.

설계 전 실측 선행: `grep -c` 를 다중 파일에 직접 걸면 파일별 「경로:개수」를 찍어 합산이 깨진다(확인) → `cat` 으로 합쳐 한 번 세는 방식 채택, 그 실측을 컨트롤 레인으로 고정.

**★ 자체 적발 — 기존 22레인이 전부 통과했는데 「틀린 이유로」였다.** LOGGED 가 새 함수 `_cat_logs` 에 의존하는데 레인 preamble 에 그 함수가 없어 「함수 없음 → 빈 입력 → 0」으로 통과했다. **그 파일 자신이 경고하는 장식 앵커.** preamble 이 정의를 들어오게 고쳤고, 정의가 사라지면 하드 FAIL.

**앵커 22 → 27레인.** 되돌림 검증 2방향: 디렉터리 경로 무력화 → 해당 2건만 적색(정확한 국소성) · `_cat_logs` 제거 → 즉시 하드 FAIL.

## 🟥 잔여 (닫지 않았다)

- **세션 ID 없는 런타임에선 pid 폴백이라 게이트가 사실상 없다**
- 1차 NOT CONVERGED 그대로(재설계 후 재라운드 미실시)
- TOCTOU 미해결 · **커밋 표면만 본다** — 인덱스/카드 덮어쓰기/훅 배선 소실은 체크아웃 표면이라 못 잡는다
- 원장 분할 자체 미실시(파일명 규약 미정) · 산문 참조 9곳은 전환기라 단일 경로 유지
- cross-family 미실시 — 입력 집합만 넓히는 델타라 선택