### PR TITLE
fix(field-canon): 「세션당 1회」가 실제로는 「머신당 1회」였다 — 첫 실사용에서 안 떴다

### DIFF
--- a/scripts/field_canon_preload.sh
+++ b/scripts/field_canon_preload.sh
@@ -23,21 +23,62 @@
 #       `[[feedback_hook_nonzero_exit_is_silent]]`.)
 set -uo pipefail
 
-HUB="${CLAUDE_PROJECT_DIR:-$HOME/projects/forge-harness}"
-PROJ_ROOT="${FIELD_CANON_PROJECT_ROOT:-$HOME/projects}"
-SENT_DIR="${FIELD_CANON_SENTINEL_DIR:-${TMPDIR:-/tmp}/fh_field_canon_$$}"
-[ -n "${FIELD_CANON_SENTINEL_DIR:-}" ] || SENT_DIR="${TMPDIR:-/tmp}/fh_field_canon_${CLAUDE_SESSION_ID:-shared}"
-mkdir -p "$SENT_DIR" 2>/dev/null || true
-
+HUB="${CLAUDE_PROJECT_DIR:-${HOME:-}/projects/forge-harness}"
+PROJ_ROOT="${FIELD_CANON_PROJECT_ROOT:-${HOME:-}/projects}"
+# ★ `${HOME:-}` — `set -u` 아래서 HOME 부재 시 여기가 unbound 로 죽어 rc=1 이 됐다.
+#   비영 종료는 stdout 이 폐기되므로 헤더의 "항상 0" 계약이 깨진다(cross-family 지적, 재현됨).
+[ -n "${HUB:-}" ] && [ "$HUB" != "/projects/forge-harness" ] || exit 0
 # stdin 은 훅 페이로드(JSON). prompt 를 못 뽑아도 **조용히 죽지 않는다** — 원문 전체로 폴백한다.
+# ★ `session_id` 를 **같은 페이로드에서** 뽑는다. 센티넬 키가 여기 달려 있다(바로 아래).
+# 🟥 SID 는 **자르거나 치환하지 않고 해시한다.** 초판 수리가 슬래시 치환 + 64자 절단이었는데
+#    cross-family(gpt-5.5)가 재현했다: 'A/B' 와 'A_B' 가 같은 키 · 65자 이상은 접두 충돌 ·
+#    session_id 에 개행이 들어오면 아래 「1행=SID · 2행이후=PROMPT」 프로토콜이 깨져
+#    **프롬프트까지 오염**된다(무관 프롬프트로 발화 실증). 원래 버그(전 세션이 한 칸 공유)와
+#    **같은 일가를 수리가 다시 연** 것이다. 해시가 충돌·개행·길이·경로문자를 한 번에 없앤다.
+# ⚠️ 아래 python 은 **큰따옴표 문자열**이다 — 주석에 백틱을 넣으면 bash 명령치환이 터진다
+#    (이 파일에서 실제로 터뜨렸다. 설명은 여기 bash 주석에 둔다).
 RAW=$(cat 2>/dev/null || true)
-PROMPT=$(printf '%s' "$RAW" | python3 -c "
+FIELDS=$(printf '%s' "$RAW" | python3 -c "
 import json,sys
-try: print(json.load(sys.stdin).get('prompt',''))
-except Exception: print('')
+try:
+    d = json.load(sys.stdin)
+    import hashlib
+    sid = d.get('session_id') or ''
+    print(hashlib.sha1(sid.encode('utf-8','surrogatepass')).hexdigest()[:16] if sid else '')
+    print(d.get('prompt') or '')
+except Exception:
+    print(''); print('')
 " 2>/dev/null)
+SID=$(printf '%s' "$FIELDS" | sed -n '1p')
+PROMPT=$(printf '%s' "$FIELDS" | sed -n '2,$p')
 [ -n "$PROMPT" ] || PROMPT="$RAW"
 [ -n "$PROMPT" ] || exit 0
+
+# ── 센티넬 키 — 초판이 여기서 틀렸다 (2026-08-09 첫 실사용 실측으로 수리) ──
+# 초판: `${TMPDIR}/fh_field_canon_${CLAUDE_SESSION_ID:-shared}`
+#   🟥 **훅 환경에 `CLAUDE_SESSION_ID` 가 없다.** 전 세션이 literal `shared` 한 칸으로 접혔고
+#      TMPDIR 는 재부팅까지 산다 → "프로젝트당 **세션당** 1회" 가 실제로는 **"머신당 1회"** 였다.
+#      실측: 21:18 의 세션이 qasp 센티넬을 소비 → 21:40 에 실제로 qasp 를 파기 시작한 세션은
+#      안내를 **못 받았다**. 이 훅이 막으려던 바로 그 상황에서 침묵했다.
+#   ★ 같은 얼굴이 같은 날 다른 스크립트에서도 났다(`branch_claim.sh` 의 `CLAUDE_PID` — 저자 셸엔
+#     있고 CI 엔 없어 검사가 무력화). **환경변수 부재가 조용한 폴백으로 접히고 그 폴백이 검사를
+#     무력화한다** — 처방은 같다: **페이로드에서 읽고 환경에서 빌리지 않는다.**
+#     (`session_id` 는 훅 페이로드 필드다 — `compaction_probe.sh:415` 가 이미 그렇게 읽는다.)
+#
+# 폴백 방향은 **과다 알림 쪽**이다: 세션을 못 가르면 `$PPID`(CC 프로세스별로 갈린다)로,
+# 그것도 없으면 dedup 을 **포기**한다. 침묵보다 중복이 낫다 — 초판 폴백은 조용한 쪽이었고
+# 그래서 실패가 안 보였다(`[[feedback_not_found_is_not_zero_family]]`).
+# 🟥 **literal 상수로 폴백하지 마라.** 그 순간 전 세션이 한 칸을 공유한다.
+if [ -n "${FIELD_CANON_SENTINEL_DIR:-}" ]; then
+  SENT_DIR="$FIELD_CANON_SENTINEL_DIR"
+elif [ -n "$SID" ]; then
+  SENT_DIR="${TMPDIR:-/tmp}/fh_field_canon_sid_${SID}"
+elif [ -n "${PPID:-}" ] && [ "${PPID:-0}" != "0" ]; then
+  SENT_DIR="${TMPDIR:-/tmp}/fh_field_canon_ppid_${PPID}"
+else
+  SENT_DIR=""                       # 못 가른다 → dedup 포기(매번 알린다). 침묵 금지.
+fi
+[ -z "$SENT_DIR" ] || mkdir -p "$SENT_DIR" 2>/dev/null || true
 
 # 매핑된 프로젝트 = tracks/ 하위 디렉토리(언더스코어 접두는 메타라 제외)
 mapped=$(ls -d "$HUB"/tracks/*/ 2>/dev/null | while read -r d; do
@@ -50,8 +91,8 @@ done)
 emitted=0
 for name in $mapped; do
   # 프롬프트에 이름이 나오는가 (대소문자 무시). 짧은 이름의 오탐은 감수 — 과소보다 낫다.
-  printf '%s' "$PROMPT" | grep -qi -- "$name" || continue
-  [ -e "$SENT_DIR/$name" ] && continue          # 이 세션에서 이미 띄웠다
+  printf '%s' "$PROMPT" | grep -qiF -- "$name" || continue   # -F: 이름의 regex 문자 오탐/미탐 방지
+  [ -n "$SENT_DIR" ] && [ -e "$SENT_DIR/$name" ] && continue   # 이 세션에서 이미 띄웠다
 
   # 레포 해석: tracks 이름 그대로 → 없으면 `-dev` 접미 (qasp → qasp-dev 실측 사례)
   repo=""
@@ -75,7 +116,7 @@ for name in $mapped; do
   fi
   echo "  ▸ $name  →  $repo"
   printf '%b\n' "$lines"
-  : > "$SENT_DIR/$name" 2>/dev/null || true
+  [ -z "$SENT_DIR" ] || : > "$SENT_DIR/$name" 2>/dev/null || true
 done
 
 if [ "$emitted" -eq 1 ]; then

--- a/scripts/test_field_canon_lanes.sh
+++ b/scripts/test_field_canon_lanes.sh
@@ -40,5 +40,103 @@ printf 'not-json' | FIELD_CANON_SENTINEL_DIR="$TMP/5" bash "$H" >/dev/null 2>&1
 printf '' | FIELD_CANON_SENTINEL_DIR="$TMP/6" bash "$H" >/dev/null 2>&1
 [ $? = 0 ] && ok "빈 입력 rc=0" || no "빈 입력" "rc≠0"
 
+# ── ⑦~⑩ 기본 센티넬 경로 (2026-08-09 추가) ─────────────────────────────────────
+# 🟥 **위 ①~⑥ 은 전부 `FIELD_CANON_SENTINEL_DIR` 를 명시로 주입한다** — 즉 실제로 깨져 있던
+#    **기본 경로를 구조적으로 우회**했고, 그래서 결함이 초록으로 출하됐다. 여기서부터는 그 변수를
+#    **주지 않고** `TMPDIR` 만 격리해 기본 키 산출 로직 자체를 때린다.
+#    (`[[feedback_anchor_can_be_decorative]]` — 레인이 결함 지점을 비켜 가면 초록은 정보가 아니다.)
+# ⚠️ macOS 는 bash **3.2** 다. `set -u` 아래서 빈 배열 `"${a[@]}"` 는 unbound variable 로 죽는다
+#    — 초판 레인이 정확히 그렇게 죽어 ⑦⑨⑩ 이 **거짓 적색**을 냈다(대상이 아니라 계기의 사망).
+#    배열 없이 분기한다.
+runD(){ # $1=payload  $2=TMPDIR  [$3=CLAUDE_SESSION_ID 를 환경에 심을지]
+  if [ -n "${3:-}" ]; then
+    printf '%s' "$1" | env TMPDIR="$2" CLAUDE_SESSION_ID="$3" bash "$H" 2>&1
+  else
+    printf '%s' "$1" | env TMPDIR="$2" bash "$H" 2>&1
+  fi; }
+T7="$TMP/def"; mkdir -p "$T7"
+
+a=$(runD '{"session_id":"AAAA","prompt":"qasp 가자"}' "$T7")
+b=$(runD '{"session_id":"BBBB","prompt":"qasp 가자"}' "$T7")
+if [ -n "$a" ] && [ -n "$b" ]; then ok "⑦ 세션이 다르면 **둘 다** 안내한다(머신당 1회가 아니다)"
+else no "⑦ 세션별 분리" "두 번째 세션이 침묵했다 — 센티넬이 세션을 안 가른다"; fi
+
+c=$(runD '{"session_id":"AAAA","prompt":"qasp 또"}' "$T7")
+[ -z "$c" ] && ok "⑧ 같은 세션 2회차는 조용(재나그 없음)" || no "⑧ 동일 세션 dedup" "또 출력"
+
+# ★ peer 조언 채택 — 다만 **판별력 있는 형태로** 짠다.
+#   초안은 두 팔을 **다른 TMPDIR** 에서 돌렸는데, 그러면 수리 전 코드도 두 팔 다 발화해서
+#   레인이 **원본에서도 초록**이었다(되돌림 실측으로 잡았다 — 존재만 재고 관계를 안 보는 형태).
+#   진짜 판별자: **같은 TMPDIR · 같은 payload `session_id` · 다른 환경변수** → 키를 페이로드가
+#   정한다면 **두 번째는 침묵**해야 한다. 환경을 읽고 있으면 키가 갈려서 또 발화한다.
+T9="$TMP/env"; mkdir -p "$T9"
+e1=$(runD '{"session_id":"CCCC","prompt":"qasp 환경팔"}' "$T9")
+e2=$(runD '{"session_id":"CCCC","prompt":"qasp 환경팔"}' "$T9" "ZZZZ-환경에서-온-값")
+if [ -n "$e1" ] && [ -z "$e2" ]; then ok "⑨ ★키를 페이로드가 정한다(환경변수를 바꿔도 같은 세션)"
+else no "⑨ 환경 의존" "환경변수를 바꾸니 같은 세션이 다른 세션으로 갈렸다 — 환경을 읽고 있다"; fi
+
+# session_id 가 아예 없는 페이로드 → **침묵하면 안 된다**(과다 알림 쪽으로 폴백).
+# 🟡 명명된 한계: 이 레인은 수리 전 코드에서도 초록이다(literal `shared` 도 첫 발화는 한다).
+#    폴백 **방향**만 못박고 **키의 유일성**은 못 잰다 — 그건 ⑦ 과 아래 컨트롤이 맡는다.
+T10="$TMP/nosid"; mkdir -p "$T10"
+f1=$(runD '{"prompt":"qasp sid 없음"}' "$T10")
+[ -n "$f1" ] && ok "⑩ session_id 부재에도 안내한다(폴백 방향 = 과다알림)" \
+              || no "⑩ sid 부재 폴백" "조용히 삼켰다 — 초판이 실패한 방향 그대로다"
+
+# ★컨트롤: 기본 경로 레인이 **실제로 기본 경로를 탄다**는 증명.
+#   (안 그러면 위 넷은 여전히 우회 레인이다.)
+if find "$T7" -maxdepth 1 -name 'fh_field_canon_sid_*' | grep -q . ; then
+  ok "★컨트롤: 기본 센티넬 디렉토리가 TMPDIR 아래 실제로 생성됨(우회 아님)"
+else
+  no "★컨트롤 기본경로" "센티넬이 TMPDIR 에 안 생겼다 — 이 레인들이 무엇을 쟀는지 불명"
+fi
+if find "$T7" -maxdepth 1 -name 'fh_field_canon_shared' | grep -q . ; then
+  no "★컨트롤 literal shared" "전 세션 공유 키가 다시 생겼다(초판 결함 재발)"
+else
+  ok "★컨트롤: literal 'shared' 키가 생기지 않는다"
+fi
+
+# ── ⑪~⑭ cross-family(gpt-5.5) 가 **이 수리에서** 잡은 4건의 회귀 앵커 ──────────────
+# 자력 적발 0 이었다. 넷 다 재현된 것이고, 특히 ⑪ 은 **원래 버그와 같은 일가를 수리가 다시 연** 것이다.
+
+# ⑪ [S] 키 충돌 — 정규화/절단이 서로 다른 세션을 같은 칸으로 접으면 안 된다.
+T11="$TMP/coll"; mkdir -p "$T11"
+x1=$(runD '{"session_id":"A/B","prompt":"qasp 충돌"}' "$T11")
+x2=$(runD '{"session_id":"A_B","prompt":"qasp 충돌"}' "$T11")
+if [ -n "$x1" ] && [ -n "$x2" ]; then ok "⑪ ★'A/B' 와 'A_B' 는 다른 세션이다(치환 충돌 없음)"
+else no "⑪ 키 충돌" "정규화가 두 세션을 같은 센티넬로 접었다 — 원래 버그 재개방"; fi
+L1=$(printf 'S%.0s' $(seq 1 70))"-alpha"; L2=$(printf 'S%.0s' $(seq 1 70))"-beta"
+y1=$(runD "{\"session_id\":\"$L1\",\"prompt\":\"qasp 길이\"}" "$T11")
+y2=$(runD "{\"session_id\":\"$L2\",\"prompt\":\"qasp 길이\"}" "$T11")
+if [ -n "$y1" ] && [ -n "$y2" ]; then ok "⑪-b ★긴 session_id 의 접두 절단 충돌 없음"
+else no "⑪-b 절단 충돌" "앞 N자가 같은 두 세션이 한 칸을 공유한다"; fi
+
+# ⑫ [A] 개행 오염 — session_id 의 개행이 프롬프트 파싱으로 새면 안 된다.
+T12="$TMP/nl"; mkdir -p "$T12"
+z=$(runD '{"session_id":"AA\nqasp","prompt":"오늘 날씨 어때"}' "$T12")
+[ -z "$z" ] && ok "⑫ ★session_id 의 개행이 프롬프트로 새지 않는다" \
+             || no "⑫ 개행 오염" "무관 프롬프트인데 발화했다 — SID 개행이 PROMPT 로 샜다"
+
+# ⑬ [A] HOME 부재에서도 rc=0 (헤더의 "항상 0" 계약)
+env -u HOME -u CLAUDE_PROJECT_DIR -u FIELD_CANON_PROJECT_DIR TMPDIR="$TMP/nh" \
+  bash "$H" </dev/null >/dev/null 2>&1
+[ $? = 0 ] && ok "⑬ ★HOME 부재에서도 rc=0(set -u unbound 로 안 죽는다)" \
+            || no "⑬ HOME 부재" "rc≠0 — 비영종료는 stdout 폐기라 무음 실패가 된다"
+
+# ⑭ [B] 매핑 이름의 regex 문자 — 고정문자열 매칭이어야 한다.
+# ⚠️ 초판 ⑭ 는 **양쪽에서 초록**이었다(약한 레인) — grep 이 매칭돼도 그 다음 «레포 해석» 단계가
+#    막아서 결과가 안 드러났다. 레포와 README 까지 실제로 만들어 **grep 이 유일한 판별 지점**이 되게 한다.
+HUB14="$TMP/hub14"; mkdir -p "$HUB14/tracks/q.sp"
+P14="$TMP/proj14"; mkdir -p "$P14/q.sp/.git"; printf 'x\n' > "$P14/q.sp/README.md"
+w=$(printf '%s' '{"session_id":"RX","prompt":"qXsp 를 보자"}' \
+    | env TMPDIR="$TMP/rx" CLAUDE_PROJECT_DIR="$HUB14" FIELD_CANON_PROJECT_ROOT="$P14" bash "$H" 2>&1)
+[ -z "$w" ] && ok "⑭ ★'q.sp' 트랙이 'qXsp' 에 오탐하지 않는다(grep -F)" \
+             || no "⑭ regex 오탐" "이름의 '.' 가 임의문자로 매칭됐다"
+# ★컨트롤 — 정확히 일치하는 이름은 **반드시** 잡혀야 한다(위 침묵이 공허하지 않음을 증명).
+w2=$(printf '%s' '{"session_id":"RX2","prompt":"q.sp 를 보자"}' \
+    | env TMPDIR="$TMP/rx2" CLAUDE_PROJECT_DIR="$HUB14" FIELD_CANON_PROJECT_ROOT="$P14" bash "$H" 2>&1)
+[ -n "$w2" ] && ok "⑭-b ★컨트롤: 정확히 'q.sp' 는 잡힌다(⑭ 의 침묵이 공허하지 않다)" \
+              || no "⑭-b 컨트롤" "정확한 이름도 못 잡는다 — ⑭ 는 무엇도 증명하지 않는다"
+
 echo "── PASS $PASS · FAIL $FAIL"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## 무엇이 틀렸나

`#299` 로 심은 선적재 훅이 **정작 필요한 세션에 안 떴다.** 이 PR 을 만든 세션이 그 케이스다 — 프롬프트에 `qasp` 가 있었고 매핑도 있었는데 안내가 0줄이었다.

```
SENT_DIR = ${TMPDIR}/fh_field_canon_${CLAUDE_SESSION_ID:-shared}
훅 환경에 CLAUDE_SESSION_ID 가 없다  → 전 세션이 literal `shared` 한 칸 공유
TMPDIR 는 재부팅까지 산다            → "세션당 1회" 가 사실상 "머신당 1회"
```
실물 확인: `fh_field_canon_shared` 단일 디렉토리, 세션별 디렉토리 **0개**.

★ 같은 날 같은 얼굴이 형제 스크립트에서도 났다(`branch_claim.sh` 의 `CLAUDE_PID` — 저자 셸엔 있고 CI 엔 없어 게이트가 무력화, #301). **환경변수 부재가 조용한 폴백으로 접히고 그 폴백이 검사를 무력화한다.** 처방도 같다: **페이로드에서 읽고 환경에서 빌리지 않는다.**

## 수리

| 항목 | 내용 |
|---|---|
| 센티넬 키 | 페이로드 `session_id` 의 **sha1[:16]** (`compaction_probe.sh:415` 와 같은 출처) |
| 폴백 방향 | sid → ppid → **dedup 포기**. 침묵보다 중복. **literal 상수 폴백 제거** |
| `settings.json` | `[ -f "$S" ] &&` 무음 가드 → **부재 경보** (⚠️ gitignored — 아래 잔여 참조) |
| `grep -qiF` | 트랙 이름의 regex 문자 오탐/미탐 |
| `${HOME:-}` | `set -u` 아래 HOME 부재 시 unbound → rc=1 → stdout 폐기(=무음) 방지 |

## 레인 7 → 19

🟥 **기존 7레인이 전부 `FIELD_CANON_SENTINEL_DIR` 를 명시 주입해서, 정작 깨져 있던 기본 키 산출 경로를 구조적으로 안 탔다.** 그래서 결함이 초록으로 출하됐다. 신설분은 그 경로를 정면으로 때리고, 「레인이 실제로 그 경로를 타는가」를 컨트롤로 증명한다.

**3-arm 되돌림 실측**: 원본 **4적색** · 중간본 **5적색** · 수리본 **0적색**.
약한 레인 2개를 되돌림이 드러냈다 — ⑨는 판별자를 교체해 살렸고(같은 TMPDIR·같은 payload sid·다른 환경변수 → 두 번째는 침묵해야 함), ⑭는 컨트롤(⑭-b)을 붙였다. ⑩은 **못 가른다고 파일에 명시**했다. 초록 개수는 지표가 아니다.

## cross-family — 내 수리에서 4건이 나왔다 (자력 적발 0)

`codex gpt-5.5`, 전건 채택·수리·회귀 레인화:

- **[S]** `'A/B'` 와 `'A_B'` 가 같은 키 · 65자 이상 접두 충돌 → **원래 버그와 같은 일가를 수리가 다시 연 것**. 치환·절단을 버리고 해시로 교체
- **[A]** `session_id` 개행이 「1행=SID·2행이후=PROMPT」를 깨 **프롬프트 오염**(무관 프롬프트로 발화 실증)
- **[A]** HOME 부재 → unbound → "항상 0" 계약 위반
- **[B]** 트랙 이름 regex 매칭

## 🟥 이 PR 이 닫지 않는 것

1. **지배적 실패모드는 센티넬이 아니라 브랜치다.** 공유 체크아웃이 #299 이전 컷 브랜치에 서 있으면 스크립트가 **없다**. 이 세션의 케이스는 센티넬이 신선했어도 안 떴다 — **충분원인이 둘**이었고 초판 진단은 하나만 지목했다(격리 그라운딩 감사가 지적).
2. **`.claude/settings.json` 은 gitignored 이고, 훅 배선을 출하하는 tracked 파일이 없다.** 즉 `#299` 는 스크립트만 출하했고 **다른 install 엔 이 훅이 애초에 없다.** 이 PR 도 「스크립트+레인」을 출하하지 「동작하는 훅」을 출하하지 않는다. → 후속 PR 로 분리.
3. B급 3건 미수리(도달불가 `SENT_DIR=""` 분기 · `: > "$f" 2>/dev/null` 의 stderr 누수 · 컨트롤이 인과까지는 미증명).

## 게이트

`Axis 1` staged 모드 **PASS**(M 0 · S 0) / `--pr` 모드는 SKIP(pathspec 밖 — 통과 아님) · `Axes 2–3` 마커(`crossfamily: panel(codex-gpt5.5)`) · `Axis 4` 매니페스트. 커밋 훅 전축 PASS.