### PR TITLE
fix(ship): field-canon 훅을 실제로 출하한다 — #299 는 npm 에 아무것도 안 보냈다

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,6 +172,9 @@
     "scripts/judgment_circuit_lint.sh",
     "scripts/novelty_claim_check.sh",
     "templates/settings.Compaction.snippet.json",
+    "scripts/field_canon_preload.sh",
+    "scripts/test_field_canon_lanes.sh",
+    "templates/settings.FieldCanon.snippet.json",
     ".claude/judgment_circuits.txt"
   ]
 }

--- a/templates/settings.FieldCanon.snippet.json
+++ b/templates/settings.FieldCanon.snippet.json
@@ -1,0 +1,51 @@
+{
+  "_README": [
+    "field-canon 선적재 훅 스니펫 — TRACKED 라 clone 과 함께 도착한다. 이 레포의 모든",
+    ".claude/settings*.json 경로는 gitignored 이므로(`git check-ignore -v .claude/settings.json` 으로",
+    "확인) **훅 등록 자체를 tracked 로 둘 수 없다.** 이것이 install-wizard 가 사용자 로컬 설정에",
+    "머지하는 tracked SOURCE 다. 머지 단계가 없으면 훅은 돌지 않는다 —",
+    "**스크립트를 출하하는 것과 배선하는 것은 같은 명제가 아니다.**",
+    "",
+    "이 파일이 왜 뒤늦게 생겼나 (2026-08-09 실측, 컨트롤 동반):",
+    "  PR #299 가 scripts/field_canon_preload.sh 를 심으면서 스니펫도 files[] 등재도 안 했다.",
+    "    npm pack --dry-run | grep field_canon   →  0건",
+    "    CONTROL  같은 명령 | grep compaction_probe →  1건   (계기 생존)",
+    "  즉 npm 사용자에게는 **스크립트도 배선도 아무것도 가지 않았다.** git clone 사용자는",
+    "  스크립트는 받지만 배선이 없어 훅이 안 돈다. 위 Compaction 스니펫의 _README 가 이미",
+    "  같은 문장을 적어놨는데 #299 가 그걸 안 따랐다 — 산문 규율의 한계이자, 이 스니펫이",
+    "  그 규율을 파일로 바꾸는 이유다.",
+    "",
+    "무엇을 하나: 프롬프트에 **매핑된 필드 하네스 이름**이 나오면 그 레포의 정본 경로",
+    "(README · CLAUDE.md · docs/governance/)를 **세션당 1회** 띄운다. 코드 역추론 전에 정본을",
+    "읽게 하는 것이 목적이다. 2026-08-09 실측: 한 세션이 종일 qasp 를 파면서 정본을 하나도",
+    "안 읽고 코드에서 역추론해 **네 번 정정당했고 자력 적발 0** 이었다 — 네 번 다 답이",
+    "정본에 있었고 그중 하나는 README 가 그 오해를 경고까지 하고 있었다.",
+    "",
+    "🟥 부재를 침묵으로 렌더하지 않는다. 초판 배선은 `[ -f \"$S\" ] && bash \"$S\"` 였는데,",
+    "그러면 **「이 install 에 파일이 없는 게 정상」과 「체크아웃이 옛날 컷 브랜치라 파일이",
+    "사라진 상태」가 구분되지 않는다.** 공유 체크아웃에서 후자가 실제로 반복 발생했고",
+    "(하루 6회 브랜치 이동), 그동안 훅은 exit 0 · 출력 0줄로 조용히 꺼져 있었다.",
+    "그래서 else 가지에서 **한 줄 경보**를 낸다 — 차단은 하지 않는다(UserPromptSubmit 은",
+    "차단 표면이 아니고, 사용자 앞을 막는 게이트는 꺼지는 게이트다).",
+    "",
+    "PRIVATE PATH 없음 → .claude/settings.json(프로젝트 로컬)에 속한다.",
+    "머지하되 덮어쓰지 마라: 사용자의 기존 UserPromptSubmit 엔트리를 보존하고 **스크립트",
+    "이름을 키로** FH 것만 교체해라."
+  ],
+  "project_settings_json": {
+    "hooks": {
+      "UserPromptSubmit": [
+        {
+          "matcher": "",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "bash -c 'HUB=\"${CLAUDE_PROJECT_DIR:-$HOME/projects/forge-harness}\"; S=\"$HUB/scripts/field_canon_preload.sh\"; if [ -f \"$S\" ]; then bash \"$S\"; else echo \"\"; echo \"⚠️ [field-canon] 선적재 훅 스크립트가 없다 — 이 체크아웃이 옛날 컷 브랜치이거나 설치가 불완전할 수 있다.\"; echo \"   필드 하네스 정본 안내가 **꺼져 있다**. git log --oneline -1 로 브랜치를 확인해라.\"; fi; exit 0'",
+              "timeout": 10
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## 실측 (컨트롤 동반)

```
수리 전  npm pack --dry-run | grep field_canon      →  **0건**
         CONTROL 같은 명령 | grep compaction_probe   →  1건    ← 계기 생존
```
**`#299` 는 npm 사용자에게 스크립트도 배선도 아무것도 출하하지 않았다.** git clone 사용자는 스크립트는 받지만, 배선(`.claude/settings.json`)이 gitignored 라 훅이 안 돈다.

★ **이 교훈은 이 레포에 이미 문장으로 있었다.** `templates/settings.Compaction.snippet.json` 의 `_README`:
> *"모든 `.claude/settings*.json` 경로가 gitignored 라 훅 등록 자체를 tracked 로 둘 수 없다. 이것이 install-wizard 가 머지하는 tracked SOURCE 다. … **스크립트를 출하하는 것과 배선하는 것은 같은 명제가 아니다.**"*

#299 가 그걸 안 따랐다. 산문 규율의 한계이고, 이 PR 은 그 규율을 **파일**로 바꾼다.

## 변경 — 위저드는 수정 0줄

```
templates/settings.FieldCanon.snippet.json   신규 (tracked SOURCE)
package.json files[]                          스크립트 · 레인 · 스니펫 3항
```
위저드가 `templates/settings.*.snippet.json` 을 **glob 으로 자동 발견**하고, 그 코드 주석이 *"새 스니펫은 여기 수정 0으로 잡힌다: detection 이 아니라 generation"* 이라고 주장한다. **그 주장을 실행으로 확인했다** — 재발명이 아니라 기존 패턴을 따랐다.

## 실증

위저드 python 블록을 **출하 파일에서 정규식으로 추출**해(재타이핑 금지 — divergent-copy 회피, 추출 실패는 FAIL) 임시 허브에서 실행:

```
hook registered -> UserPromptSubmit(scripts/field_canon_preload.sh)

CONTROL 1  사용자 자기 훅(my_own_hook.sh) **생존** · 총 3훅
           → survivor 필터가 남의 훅을 안 지운다
CONTROL 2  스니펫 제거 → field_canon 등록 **0** (스니펫 4→3)
           → 등록이 이 파일 때문임을 인과로 증명
출하 확인   세 파일 **각각** 1건 (일괄 grep 아님)
역방향 CTRL  tracks/_meta → 0건 (출하 금지 대상이 안 샌다)
```
🟡 초판 검증이 `grep field_canon` 이라 캐멀케이스 `FieldCanon` 스니펫을 못 잡아 **2/3 으로 오판**했다 — 대상이 아니라 계기였고 파일별 확인으로 교체했다.

## 스니펫이 출하하는 배선은 부재를 침묵으로 렌더하지 않는다

`[ -f "$S" ] &&` 대신 if/else 로 **한 줄 경보**. 「이 install 에 파일이 없는 게 정상」과 「체크아웃이 옛날 컷 브랜치」가 구분 안 되던 fail-open 을 닫는다. **차단은 안 한다** — `UserPromptSubmit` 은 차단 표면이 아니고, 사용자 앞을 막는 게이트는 꺼지는 게이트다.

## 🟥 #305 와 독립이고 **둘 다 필요하다**

- 이것만 머지 → **낡은(머신당 1회) 스크립트가 출하**된다
- #305 만 머지 → **안 도는 수리**가 남는다

순서 제약은 없다.

## 잔여

- 위저드를 **돌려야** 배선된다 — 기존 install 소급 배선은 안 닫혔다
- user-level settings 에 같은 훅이 따로 있으면 중복 발화 가능 (미측정 — 위저드 survivor 필터는 project 파일만 본다)
- 「세션당 1회」 정책 자체는 재검토 안 했다
- `crossfamily: DEGRADED_PANEL_UNUSED` — 판정 로직 0줄 + 주장이 전부 실행 검증이라 안 돌렸다. **면제가 아니라 판단**이고, 스니펫의 `command` 는 실제 실행 코드이므로 「데이터 파일」 분류가 틀렸다면 과소평가다(마커에 명시).

Axis 1 = SKIP(pathspec 밖 — 통과 아님) · Axes 2–3 마커 · Axis 4 매니페스트.