### PR TITLE
chore(release): v1.4.91 — field-canon 훅을 실제로 npm 으로 내보낸다

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,13 @@
   "plugins": [
     {
       "name": "fh-meta",
-      "version": "1.4.90",
+      "version": "1.4.91",
       "description": "Hub meta-operations toolkit — 35 skills + 7 agents. New in 1.4.53: `fh-codex-doctor` (npm bin) — Codex adapter drift scanner; reads the documented M1/M2/M3 skill tier map + skill/agent source and reports codex-native/adapter-required/claude-native/unclassified per unit, wired into `npm test`/`prepublishOnly` (fail-closed on unclassified Claude-native primitives). New in 1.4.49: steel-quench gains Step 0.6 Verdict-Invariance Probe (groundedness axis — a load-bearing judged gate's verdict must track behavior, not rubric phrasing; measured flip-count over cross-family paraphrases; arXiv:2605.06161 Policy Invariance anchor); multi_model_sidecar_strategy §Vendor-native harness (a model is strongest in its own vendor CLI — Claude/CC, GPT/codex, Gemini/Antigravity; a universal router degrades all of them, so it stays an autocomplete/QA sidecar, never orchestration); predelete_check.sh fail-closed rewrite; memory-hygiene A-TMA anchor. New in 1.4.48: phantom-quench + steel-quench gain external frontier anchors (arXiv:2607.02052 package-hallucination; arXiv:2607.02057 prompt-coverage-adequacy); README model-flat claim reframed from a per-release point-curve to structural invariants (operation flattens across tiers; depth tier-order fixed within a generation). New in 1.4.47: onboarding step ① surfaces the Mode D companion-store session-start load in the auto-read salience anchor (previously only in the local binding + rules, so a greeting could skip the load). New in 1.4.46: context-doctor command-output axis (route to rtk/proxy for verbose CLI stdout, complementing .claudeignore; risk-gated to token-scarce envs). New in 1.4.41: context-doctor 2026 trigger vocab (context engineering/rot/collapse) + phantom-citation hardening; hub measurement-integrity-checklist (cross-model measurement pre-flight: display-name pin/reps≥3/discriminating probe). New in 1.4.40: install-wizard queryable-wiki scaffold (INDEX + session-start read + R/W/C ingest). New in 1.4.39: auto-decorrelation (cross-family verifier sidecar recruitment) + video-ingest (capability-routed video ingestion). New in 1.4.x: verify-axis check-class taxonomy (mandatory-pass/measured/judged), no-reinvention Tier-0 inventory, 7-class failure taxonomy, Destructive-Op Gate, Wave-T (Temper), tier-floor governance, Mode D Model Notice, FC consent lane, default-Sonnet guidance. New in 1.3.0: public-surface-audit, field-harvest Mode B auto-trigger, 4-axis gate scope ext. Validated cross-CLI: Claude Code, Codex, Gemini.",
       "source": "./plugins/fh-meta"
     },
     {
       "name": "fh-commons",
-      "version": "1.4.90",
+      "version": "1.4.91",
       "description": "Project-agnostic utility skills — 4 skills (convergence-loop · deliberation · mcp-circuit-breaker · token-budget-gate) + 1 agent (quench-challenger). Domain-independent utilities transplantable into any project.",
       "source": "./plugins/fh-commons"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrono-meta/fh-gate",
-  "version": "1.4.90",
+  "version": "1.4.91",
   "description": "FH runtime adapters — run FH governance, skills, and agents via Claude or Codex with machine-parseable gates.",
   "license": "MIT",
   "keywords": [

--- a/plugins/fh-commons/.claude-plugin/plugin.json
+++ b/plugins/fh-commons/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-commons",
-  "version": "1.4.90",
+  "version": "1.4.91",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/.claude-plugin/plugin.json
+++ b/plugins/fh-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-meta",
-  "version": "1.4.90",
+  "version": "1.4.91",
   "engines": {
     "claudeCode": ">=1.0.0"
   },


### PR DESCRIPTION
`#307` 이 `files[]` 를 고쳤지만 **배포하지 않으면 npm 사용자에겐 여전히 안 간다.** 이 릴리스가 그 경로로 실제 물건을 내보낸다.

## lockstep (single-source = `package.json`)

```
package.json · .claude-plugin/marketplace.json(2항)
plugins/fh-meta/.claude-plugin/plugin.json · plugins/fh-commons/.claude-plugin/plugin.json
→ version_lockstep_check.sh: PASS — 4 shipped version string(s) all at 1.4.91
```

## 이 릴리스로 새로 출하되는 것 (`git diff v1.4.90..HEAD` 실측 · 21개 경로)

```
scripts/field_canon_preload.sh · scripts/test_field_canon_lanes.sh
templates/settings.FieldCanon.snippet.json          ← v1.4.90 까지 **0건 출하**였다
(+ peer 자산: branch_claim · residency_closure_scan · session_close_check · selfcheck 등)
```

## Pre-Publish 게이트 — 비가역 표면이라 전항 실행

```
공개표면     public_surface_scan_files.sh (전체 패턴셋, gitignored 리터럴 포함) → PASS
독립 재스캔   npm pack --dry-run --json 의 244파일을 직접 읽어 매칭 → **0 매칭**
CONTROL      같은 스캔을 비출하 CLAUDE.local.md 에 → **1건 검출** (계기 생존)
lockstep     4/4
```
🟡 초판 검사가 `grep -c … || echo 0` 이라 `"0\n0"` 을 만들어 **전건 오판**했다. 컨트롤이 같이 죽어서 잡았고 계기를 바꿔 재측정했다.

## 🟥 이 릴리스가 닫지 않는 것

1. **기존 사용자는 `install-wizard` 재실행 전까지 훅이 안 돈다** — 파일은 가지만 배선(`.claude/settings.json`)은 gitignored 라 소급이 안 된다.
2. **peer 자산의 신규 실행 코드를 내가 재검증하지 않았다** — 그쪽 게이트를 신뢰한 것이고, 릴리스 저자로서는 자기신고 의존이다.
3. close check 의 **CC→Codex 진입점 드리프트** 후보가 열린 채다(원인 = `#303`, peer 소유). **이 릴리스는 그 드리프트를 안은 채 나간다.**

Axes 2–3 마커 · Axis 4 매니페스트.