### PR TITLE
fix(gate): «peer 없음» 과 «peer 가 claim 을 안 함» 은 다른 명제다 — 그리고 그것만으론 못 막는다

### DIFF
--- a/scripts/branch_claim.sh
+++ b/scripts/branch_claim.sh
@@ -130,6 +130,35 @@ _live_peers() {
   echo "$n"
 }
 
+# 🟥 «peer 없음» 인지 «못 가르는 것» 인지를 나누는 **독립 계수기**.
+# _live_peers 는 claim 기록만 세므로 claim 하지 않은 세션을 구조적으로 못 본다. 그 구멍의
+# 폭을 재려면 claim 과 무관한 신호가 필요하고, 이 머신에서는 세션 소켓이 그 신호다.
+#
+# 반환: 살아있는 «claim 안 한» 다른 CC 세션 수 · 또는 `unknown`(경로 없음 = 교차확인 불가).
+# ⚠️ **이건 상한이지 증거가 아니다.** 소켓은 머신 전역이라 다른 레포에서 도는 세션도 센다 —
+#    그래서 «peer 가 이 체크아웃에 있다» 를 증명하지 못한다. 증명되는 건 «구분할 수 없다» 뿐이고,
+#    그게 정확히 이 함수가 있는 이유다. 0 도 N 도 아닌 **세 번째 값**을 만든다.
+# ⚠️ 소켓 경로는 런타임 구현 세부라 바뀔 수 있다 — 그때는 `unknown` 으로 degrade 하고
+#    «peer 없음» 이라고 말하지 않는다(부재를 0으로 렌더하지 않는 것이 이 함수의 계약이다).
+_unclaimed_risk() {
+  local dir me n=0 s pid live_claims
+  dir="${FH_CLAIM_SOCK_DIR:-}"
+  if [ -z "$dir" ] || ! _test_mode; then dir=/tmp/cc-socks; fi
+  [ -d "$dir" ] || { echo unknown; return; }
+  me=$(_session_pid)
+  for s in "$dir"/*.sock; do
+    [ -e "$s" ] || continue
+    pid=$(basename "$s" .sock)
+    case "$pid" in ''|*[!0-9]*) continue;; esac
+    [ "$pid" = "$me" ] && continue
+    kill -0 "$pid" 2>/dev/null && n=$((n+1))
+  done
+  # 이미 claim 한 살아있는 peer 는 _live_peers 가 세므로 여기서 뺀다 — 중복 계상 방지.
+  live_claims=$(_live_peers)
+  n=$((n - live_claims)); [ "$n" -lt 0 ] && n=0
+  echo "$n"
+}
+
 _override_log() { local gd; gd=$(_git_dir) || return 1; echo "$gd/fh-branch-claim-overrides.log"; }
 
 cmd_claim() {
@@ -230,7 +259,30 @@ cmd_check() {
 
   peers=$(_live_peers)
   if [ "$peers" -eq 0 ]; then
-    echo "  ⚠️  branch-claim: 기록('$cb')과 HEAD('$b')가 다르다 — 살아있는 peer 세션이 없어 차단하지 않는다."
+    # 🟥 «peer 없음» 과 «peer 가 claim 을 안 함» 은 다른 명제다. _live_peers 는 **claim 기록만**
+    # 세므로 claim 하지 않은 세션을 구조적으로 못 본다 — 그걸 0 으로 렌더하면 미측정이 0이 된다.
+    # 실측 2026-08-09 (라이브, N=2): peer 세션이 커밋할 때 이 분기가 «peer 없음» 을 찍었는데
+    # 그 순간 다른 세션이 살아서 메시지를 주고받고 있었다. 원인은 판정식이 아니라 **기록 부재** —
+    # 활성화 배선은 세션 시작 때 도는데, 배선보다 먼저 시작된 세션은 영원히 claim 이 없다.
+    local unclaimed; unclaimed=$(_unclaimed_risk)
+    case "$unclaimed" in
+      unknown)
+        echo "  ⚠️  branch-claim: 기록('$cb')과 HEAD('$b')가 다르다 — 살아있는 peer claim 0."
+        echo "      🟡 교차 확인 불가(세션 소켓 경로 없음) — «peer 없음» 을 확인하지 못했다. 차단하지 않는다."
+        ;;
+      0)
+        echo "  ⚠️  branch-claim: 기록('$cb')과 HEAD('$b')가 다르다 — 살아있는 peer 세션이 없어 차단하지 않는다."
+        echo "      (교차 확인: 이 머신에 다른 CC 세션도 없다)"
+        ;;
+      *)
+        echo "  🟥 branch-claim: 기록('$cb')과 HEAD('$b')가 다른데 **판정할 수 없다.**"
+        echo "      peer claim 0 개 ↔ 이 머신에 살아있는 다른 CC 세션 ${unclaimed} 개."
+        echo "      이 게이트는 지금 «peer 가 없다» 와 «peer 가 claim 을 안 했다» 를 **구분하지 못한다.**"
+        echo "      claim 하지 않은 세션이 이 체크아웃을 같이 쓰고 있으면 지금 커밋은 남의 브랜치에 얹힌다."
+        echo "      → 확인:  bash scripts/branch_claim.sh show   ·  다른 세션에서:  claim"
+        echo "      ⚠️  차단하지 않는다(커밋은 가역 표면). 다만 이건 «안전» 이 아니라 «미판정» 이다."
+        ;;
+    esac
     echo "      의도한 전환이면:  bash scripts/branch_claim.sh claim"
     return 0
   fi

--- a/scripts/test_branch_claim_lanes.sh
+++ b/scripts/test_branch_claim_lanes.sh
@@ -16,7 +16,11 @@ set -uo pipefail
 SCRIPT="$(cd "$(dirname "$0")" && pwd)/branch_claim.sh"
 PASS=0; FAIL=0; LIVE_PID=""
 
-cleanup() { [ -n "$LIVE_PID" ] && kill "$LIVE_PID" 2>/dev/null; return 0; }
+cleanup() {
+  [ -n "$LIVE_PID" ] && kill "$LIVE_PID" 2>/dev/null
+  [ -n "${SOCK_EMPTY:-}" ] && rm -rf "$SOCK_EMPTY"
+  return 0
+}
 trap cleanup EXIT
 
 _mkrepo() {
@@ -60,6 +64,14 @@ _plant_peer() { # repo branch pid
 # 즉 코드가 아니라 **저자 환경**을 재고 있었고, 그 초록이 S-1 재설계의 유일한 증명이었다.
 # 앵커가 배선되기 전까지(=호출부 0개) 이 사실은 드러날 수 없었다.
 unset CLAUDE_PID
+
+# ⚠️ 같은 이유로 **소켓 경로도 환경에서 빌리지 않는다.** _unclaimed_risk 가 기본으로 실제
+# `/tmp/cc-socks` 를 보므로, 그대로 두면 «지금 이 머신에 CC 세션이 몇 개 떠 있나» 가 레인
+# 판정을 바꾼다 — 실측 2026-08-09: 이 수정을 넣자 레인 ④ 가 즉시 깨졌다(실제 세션 5개).
+# **위의 CLAUDE_PID 와 같은 결함을 수리 그 자체가 재생산한 것**이라, 같은 처방을 붙인다.
+# 개별 레인은 필요할 때 이 값을 인라인으로 덮는다.
+SOCK_EMPTY=$(mktemp -d "${TMPDIR:-/tmp}/bcsock0.XXXXXX")
+export FH_CLAIM_SOCK_DIR="$SOCK_EMPTY"
 
 echo "[branch-claim] known-pair 앵커"
 PEERPID=$(_spawn_live)
@@ -225,6 +237,55 @@ _ok "⑬-c 기존 값 보존 (main 이어야 함 · 지금=$kept)" "$([ "$kept" 
 # ★ 이게 중요한 이유: 덮으면 「내가 믿는 브랜치」가 매 세션시작마다 HEAD 로 갱신돼
 #   게이트가 영원히 통과한다 — 자동화가 게이트를 무장해제하는 경로다
 rm -rf "$R"
+
+# ── ⑭ «peer 없음» 과 «못 가름» 을 나눈다 (2026-08-09 라이브 거짓 음성 N=2 회귀) ──
+#     _live_peers 는 claim 기록만 센다 → claim 안 한 세션을 구조적으로 못 본다.
+#     그걸 0 으로 렌더한 게 라이브 결함이었다. 세 값이 **각각 다른 문장**을 내야 한다.
+#     ⚠️ 세 팔이 rc 는 전부 0(차단 안 함)이라 **rc 로는 구분이 안 된다** — 출력으로 잡는다.
+#        이 레인이 rc 만 봤으면 세 팔 다 통과하고 아무것도 안 잡았을 것이다.
+_sockdir() { local d; d=$(mktemp -d "${TMPDIR:-/tmp}/bcsock.XXXXXX"); echo "$d"; }
+
+# ⑭ 소켓엔 살아있는 세션이 있는데 claim 은 0 → 「판정할 수 없다」
+R=$(_mkrepo); S=$(_sockdir); : > "$S/${PEERPID}.sock"
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" claim a >/dev/null 2>&1)
+git -C "$R" switch -q -c other
+LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me FH_CLAIM_SOCK_DIR="$S" bash "$SCRIPT" check 2>&1); rc=$?
+_lane "⑭ claim 0 인데 살아있는 세션 있음 → «판정할 수 없다»" 0 "$rc" \
+      "판정할 수 없다" "구분하지 못한다" "«안전» 이 아니라 «미판정»"
+rm -rf "$R" "$S"
+
+# ⑭-b 컨트롤: 소켓 디렉터리는 있는데 살아있는 세션이 없다 → 진짜 「peer 없음」
+R=$(_mkrepo); S=$(_sockdir)
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" claim a >/dev/null 2>&1)
+git -C "$R" switch -q -c other
+LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me FH_CLAIM_SOCK_DIR="$S" bash "$SCRIPT" check 2>&1); rc=$?
+_lane "⑭-b 컨트롤: 살아있는 세션 0 → «peer 없음» 이라고 단정한다" 0 "$rc" \
+      "살아있는 peer 세션이 없어" "이 머신에 다른 CC 세션도 없다"
+_ok "⑭-b′ 그 팔엔 «판정할 수 없다» 가 없다(문장이 갈린다)" \
+    "$(printf '%s' "$LANE_OUT" | grep -q "판정할 수 없다" && echo 0 || echo 1)"
+rm -rf "$R" "$S"
+
+# ⑭-c 소켓 경로 자체가 없다 → 0 이 아니라 「교차 확인 불가」
+#     런타임이 소켓 경로를 바꾸면 여기로 떨어진다. 그때 «peer 없음» 이라고 말하면 안 된다.
+R=$(_mkrepo)
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" claim a >/dev/null 2>&1)
+git -C "$R" switch -q -c other
+LANE_OUT=$(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me FH_CLAIM_SOCK_DIR="/nonexistent-$$" bash "$SCRIPT" check 2>&1); rc=$?
+_lane "⑭-c 소켓 경로 부재 → «교차 확인 불가»(0 아님)" 0 "$rc" "교차 확인 불가"
+_ok "⑭-c′ 그 팔은 «peer 없음» 이라고 단정하지 않는다" \
+    "$(printf '%s' "$LANE_OUT" | grep -q "이 머신에 다른 CC 세션도 없다" && echo 0 || echo 1)"
+rm -rf "$R"
+
+# ⑭-d 노브 게이팅: FH_CLAIM_TEST 없이 FH_CLAIM_SOCK_DIR 를 주면 **무시돼야** 한다.
+#     안 그러면 프로덕션에서 소켓 경로를 갈아끼워 게이트를 무력화할 수 있다
+#     (이 파일이 이미 같은 결함으로 한 번 수리된 적이 있다 — 테스트 노브 6종 무음 우회).
+R=$(_mkrepo); S=$(_sockdir); : > "$S/${PEERPID}.sock"
+(cd "$R" && FH_CLAIM_TEST=1 FH_CLAIM_SESSION=me bash "$SCRIPT" claim a >/dev/null 2>&1)
+git -C "$R" switch -q -c other
+LANE_OUT=$(cd "$R" && FH_CLAIM_SESSION=me FH_CLAIM_SOCK_DIR="$S" bash "$SCRIPT" check 2>&1); rc=$?
+_ok "⑭-d 노브가 FH_CLAIM_TEST 없이는 무시된다(실경로를 본다)" \
+    "$(printf '%s' "$LANE_OUT" | grep -qF -- "$S" && echo 0 || echo 1)"
+rm -rf "$R" "$S"
 
 echo
 echo "[branch-claim] PASS=$PASS  FAIL=$FAIL"


### PR DESCRIPTION
`#301` 로 머지한 게이트가 **라이브 거짓 음성 2건**을 냈다. 병렬 세션이 커밋할 때:

> ⚠️ branch-claim: 기록과 HEAD 가 다르다 — **살아있는 peer 세션이 없어 차단하지 않는다.**

그 순간 다른 세션이 살아서 메시지를 주고받고 있었다.

## ★ 보고된 가설을 기계로 반증했다

| | |
|---|---|
| peer 지목 | `_session_pid()` 의 무음 폴백 |
| 실측 | `.git/fh-claims/` 에 pid **57505(alive)·57504(dead)** 가 **정확히** 기록돼 있었고 내 `CLAUDE_PID` 도 살아 있었다 |

**폴백이 원인이 아니다.** 진짜 원인은 **내 세션에 claim 기록이 아예 없다**는 것 — 활성화 배선은 세션 시작 때 도는데 **그 배선(#301)보다 먼저 시작된 세션은 영원히 claim 이 없다.**

게이트의 「살아있는 peer 0」은 **자기 계기 기준으로는 맞았다.** 틀린 것은 그 사실을 렌더한 **문장**이다 — `_live_peers` 는 claim 기록만 세므로 「peer 가 없다」와 「peer 가 claim 을 안 했다」를 구분할 수 없는데 전자로 단정했다.

## 수리 — 독립 계수기로 세 번째 값

`_unclaimed_risk` = 살아있는 세션 소켓(claim 과 무관한 신호) − 살아있는 claim

```
N       → 🟥 「판정할 수 없다 · 구분하지 못한다 · «안전»이 아니라 «미판정»」
0       → 기존 「peer 없음」 단정 (+ 교차 확인 문구)
unknown → 「교차 확인 불가」   ← 소켓 경로가 바뀌면 0 이 아니라 여기로
```

⚠️ **차단으로 안 올렸다** — 커밋은 가역 표면이고, 과차단은 `--no-verify` 를 습관화시켜 **같은 훅 안의 Destructive-Op 게이트까지 무장해제**한다.
⚠️ **소켓은 머신 전역이라 상한이지 증거가 아니다.** 증명되는 건 「구분할 수 없다」뿐이고 그게 이 함수의 존재 이유다.

## 🟥 이 PR 을 만드는 도중 사고가 자기 자신으로 재현됐다 — 그리고 결론이 갈렸다

이 수정을 커밋한 직후, **내 커밋이 병렬 세션의 릴리스 브랜치에 얹혔다.** 그 게이트를 고치는 중에, 그 게이트가 막는 사고가 났다. 원인은 이 PR 이 서술하는 바로 그것(내 세션에 claim 기록 없음)이다.

**그런데 더 중요한 건 그 다음이다.** peer 측 관측:

> 🟥 branch-claim: … **판정할 수 없다.** peer claim 0 개 ↔ 살아있는 다른 CC 세션 **4** 개.

**수리본이 이미 돌고 있었고, 정확히 옳은 말을 했다** — 「없다」가 아니라 「못 가른다」. **그런데도 사고는 났다.**

```
판정 정확성은 고쳤다.  그것만으로는 사고를 못 막는다.
이 게이트는 «커밋이 남의 브랜치에 얹히는 것»을 막는 게 아니라 **얹힌 뒤에 알려준다.**
확정점(브랜치 전환)이 아니라 검사점(커밋)에 붙어 있다.
```

그리고 **경고는 정확했는데 독자가 오독했다** — peer 는 그것을 *"내 브랜치 전환이 기록에 안 잡혔구나"* 로 읽고 지나갔다. 그 순간 `git status` 에 남의 편집 2개가 떠 있었고, 육안으로 보고 스테이징에서 뺐다. **게이트가 그 사실을 말해줬으면 오독할 여지가 없었다.**

→ **다음 라운드 처방(이 PR 범위 밖, 명명)**: 경고에 「지금 워킹트리에 네가 안 만든 변경이 N개 있다」를 같이 싣는다.

## 검증 — 실행으로만

| | |
|---|---|
| 진단 실측 | 소켓 **5**(전부 alive) ↔ claim **2**(살아있는 것 1) |
| 레인 | **22 → 30**. ⑭ N값 · ⑭-b 0값(+「판정할 수 없다」가 **없는지** 반대 방향으로도) · ⑭-c unknown · ⑭-d **노브 게이팅** |
| ⚠️ | **세 팔 모두 rc=0** — rc 로는 구분이 안 된다. 출력으로 잡았다. rc 만 봤으면 세 팔 다 통과하고 아무것도 안 잡았을 것이다 |
| 두 환경 팔 | `CLAUDE_PID` 유/무 **둘 다 30/30** |
| 되돌림 | 세 갈래를 한 문장으로 되돌리면 **⑭ 계열 3레인만** 적색(27 초록) · 복원 30/30 |
| selfcheck | PASS · Axis 1 = **SKIP(not-checked, 통과 아님)** |

★ **수리가 신규 결함도 만들었고 그것도 잡혔다**: `_unclaimed_risk` 가 기본으로 실제 `/tmp/cc-socks` 를 보므로 넣자마자 기존 레인 ④ 가 **양 팔 모두** 깨졌다(세션 5개 라이브). **오늘 아침에 고친 「주변 환경 흡입」을 수리 자신이 재생산**한 것 — 같은 처방을 붙였다.

## 🟥 잔여 · 별건

- **근본 원인은 안 고쳤다** — 소급 배선 부재. 이 커밋은 **보이게** 만들 뿐이다
- **확정점이 아니라 검사점에 붙어 있다**(위 참조) — 이게 더 큰 축이고 안 닫혔다
- 소켓 경로 변경 시 `unknown` degrade 는 **실제 런타임 변경에서 미측정**
- 🟡 **별건 1 — `git cherry-pick` 이 pre-commit 4축 게이트를 안 돈다.** 이 PR 을 복구하며 관측했다(게이트 출력 0줄). 우회 경로다
- 🟡 **별건 2 — 마커 검사가 날짜 스코프다.** 원 커밋 때 게이트가 확인했다고 출력한 마커가 **다른 브랜치 것**(`chore_v1.4.91`)이었다. 브랜치별 마커를 안 써도 통과한다