### PR TITLE
feat(gate): 마커에 「어느 축을 돌렸고 어느 축을 안 돌렸나」를 형식으로 요구한다

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "scripts/tier_census_grep.sh",
     "scripts/test_marker_floor_lanes.sh",
     "scripts/test_marker_crossfamily_lanes.sh",
+    "scripts/test_marker_axes_run_lanes.sh",
     "scripts/directional_diff_gate.sh",
     "scripts/reviewer_capability_corpus.tsv",
     "scripts/test_reviewer_capability_conformance.sh",

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -320,6 +320,21 @@ else
   fail=1
 fi
 
+# marker axes-run lanes — 훅의 4축 자기대조 형식 검사(§CLAUDE.md 3층 자기 대조)의 앵커.
+# subject 부재를 FAIL 로 두는 이유는 branch-claim 블록과 같다: 이 subject 는 pre-commit 훅
+# 자체이고 files[] 에 있으므로 «정당한 부재» 가 없다. 부재 = 삭제다.
+if [ ! -f templates/.git-hooks/pre-commit ]; then
+  echo "FAIL  templates/.git-hooks/pre-commit absent — the gate itself is missing, not a skip"
+  fail=1
+elif [ -f scripts/test_marker_axes_run_lanes.sh ]; then
+  if ! bash scripts/test_marker_axes_run_lanes.sh; then
+    fail=1
+  fi
+else
+  echo "FAIL  test_marker_axes_run_lanes.sh: pre-commit present but its axes-run anchor is missing"
+  fail=1
+fi
+
 # branch-claim lanes — shipped with 27 hand-run lanes and ZERO callers, so CI never ran one of them.
 # That is the exact defect its own subject guards against (a gate nobody claims against passes
 # forever), reproduced one layer up in its anchor. Same SKIP/FAIL shape: a missing subject is a

--- a/scripts/test_marker_axes_run_lanes.sh
+++ b/scripts/test_marker_axes_run_lanes.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# test_marker_axes_run_lanes.sh — regression fixtures for pre-commit validate_marker_axes_run.
+#
+# 대상: CLAUDE.md §3층 자기 대조가 요구하는 마커 3줄 중 **기계로 볼 수 있는 두 줄** —
+#   axes-run:  네 축(ⓐ다른계열 ⓑ첫실사용 ⓒ기록그라운딩 ⓓ되돌림) 각각의 실행 여부
+#   controls:  각 축 컨트롤의 **생사**
+#
+# 🟥 이 스위트가 증명하지 않는 것 (계약을 픽스처로 못박는다):
+#   「a=codex」 라고 적혀 있을 때 codex 가 **실제로 돌았는지**는 검사하지 않는다.
+#   마커의 계약은 form + non-vacuity + auditability 이지 provenance 가 아니다 —
+#   그건 cross-family 가 마커를 읽는 일이고, 훅의 일이 아니다. 아래 lane `p3` 이
+#   그 사실을 **의도된 통과**로 고정한다(거짓말은 통과한다).
+#
+# 날짜 유예: 파일명 날짜 < AXES_RUN_GRACE_DATE 이면 요구하지 않는다. 소급 강제는
+# 진행 중인 브랜치를 전부 막고, 그 과차단이 `--no-verify` 를 습관화시켜 같은 훅 안의
+# Destructive-Op 게이트까지 무장해제한다.
+#
+# Usage: bash scripts/test_marker_axes_run_lanes.sh   Exit: 0 = all fixtures behave; 1 = regression.
+
+set -uo pipefail
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+HOOK="$REPO_ROOT/templates/.git-hooks/pre-commit"
+T=$(mktemp -d); trap 'rm -rf "$T"' EXIT
+
+# 훅에서 함수 + 유예 상수를 그대로 뽑아 쓴다. 복제하면 드리프트하므로 **소스가 하나**다.
+{
+  grep -E '^AXES_RUN_GRACE_DATE=' "$HOOK"
+  sed -n '/^validate_marker_axes_run()/,/^}/p' "$HOOK"
+} > "$T/fn.sh"
+
+# 계기 자체가 살아있는지 먼저 본다 — 추출이 실패하면 모든 레인이 «통과»로 초록이 된다.
+if ! grep -q 'validate_marker_axes_run()' "$T/fn.sh" || ! grep -q '^AXES_RUN_GRACE_DATE=' "$T/fn.sh"; then
+  echo "❌ 계기 사망: 훅에서 함수/상수 추출 실패 — 레인 결과를 신뢰하지 마라"
+  exit 1
+fi
+
+run() { bash -c "source '$T/fn.sh'; validate_marker_axes_run '$1'" >/dev/null 2>&1; }
+
+FAIL=0
+check() { # $1=fixture $2=expected(PASS|BLOCK) $3=label
+  if run "$1"; then got=PASS; else got=BLOCK; fi
+  if [ "$got" = "$2" ]; then echo "✅ $3 → $got"; else echo "❌ $3 → $got (expected $2)"; FAIL=1; fi
+}
+
+D_NEW=2026-08-11      # 유예일 이후
+D_OLD=2026-08-01      # 유예일 이전
+mk() { printf '%s\n' "$2" > "$T/.axes_23_passed_lane_$1.marker"; echo "$T/.axes_23_passed_lane_$1.marker"; }
+
+# ── 의도된 형태 ──────────────────────────────────────────────────────────────
+P1=$(mk "$D_NEW" 'axes-run: a=codex(4건) b=CI배선 c=none d=되돌림(국소성)
+controls: alive — known-positive 3히트 · known-negative 0')
+check "$P1" PASS "네 축 전부 + 컨트롤 생사 → 통과"
+
+P2=$(mk "$D_NEW" 'axes-run: a=none b=none c=none d=none
+controls: n/a — 이번 델타에 측정이 없다 (문구 수정)')
+check "$P2" PASS "전 축 none + controls n/a → 통과 (안 돌렸다고 **적는 것**은 위반이 아니다)"
+
+# ★ 계약 고정: 거짓말은 통과한다. 이 훅은 침묵을 잡지 오답을 못 잡는다.
+P3=$(mk "$D_NEW" 'axes-run: a=codex b=CI c=격리감사 d=되돌림
+controls: alive — 전부 살아있었다')
+check "$P3" PASS "★내용이 거짓이어도 통과 — provenance 는 훅의 계약이 아니다(의도된 통과)"
+
+# ── 침묵 차단 ────────────────────────────────────────────────────────────────
+B1=$(mk "$D_NEW" 'axis2-evidence: PASS no-S')
+check "$B1" BLOCK "axes-run 자체가 없음 → 차단"
+
+B2=$(mk "$D_NEW" 'axes-run: a=codex b=CI배선 d=되돌림
+controls: alive — ok')
+check "$B2" BLOCK "★c 가 빠짐 → 차단 (빠뜨리는 것 ≠ none 이라고 적는 것)"
+
+B3=$(mk "$D_NEW" 'axes-run: a=codex(4) b=CI c=none d=되돌림')
+check "$B3" BLOCK "controls 줄이 없음 → 차단"
+
+B4=$(mk "$D_NEW" 'axes-run: a=codex(4) b=CI c=none d=되돌림
+controls: 컨트롤 붙였다')
+check "$B4" BLOCK "controls 에 생사 토큰 없음(무실질) → 차단"
+
+B5=$(mk "$D_NEW" 'axes-run: a= b=CI c=none d=되돌림
+controls: alive — ok')
+check "$B5" BLOCK "축 키는 있는데 값이 빈 문자열 → 차단"
+
+# ── 날짜 유예 (컨트롤) ───────────────────────────────────────────────────────
+G1=$(mk "$D_OLD" 'axis2-evidence: PASS no-S')
+check "$G1" PASS "★유예일 **이전** 마커는 요구하지 않는다 — 소급 차단이 우회를 훈련시킨다"
+
+G2="$T/marker_without_date.marker"; printf 'axis2-evidence: PASS\n' > "$G2"
+check "$G2" PASS "파일명에 날짜가 없으면 판정 근거가 없다 → 요구하지 않는다"
+
+# ── 유예 경계 자체를 고정 (상수를 바꾸면 이 레인이 빨개진다) ─────────────────
+B6=$(mk 2026-08-10 'axis2-evidence: PASS')
+check "$B6" BLOCK "★유예일 **당일**은 요구한다 (경계가 < 이지 <= 가 아님을 고정)"
+
+# ── ★ 배선 판별자 — 위 레인들은 **함수만** 본다 ──────────────────────────────
+# 실측 2026-08-09: 훅의 호출부에서 `&& validate_marker_axes_run "$MARKER"` 를 떼고
+# 위 11 레인을 돌렸더니 **전부 초록**이었다. 함수는 멀쩡하고 아무도 안 부르는 상태를
+# 레인이 구조적으로 못 본다 — 「장식 앵커」의 6번 얼굴(호출부 우회)이다.
+# 그래서 **호출부 자체를 앵커한다.** 이 검사가 없으면 배선 제거가 무증상으로 지나간다.
+if grep -qF 'validate_marker_axes_run "$MARKER"' "$HOOK"; then
+  echo "✅ ★배선: 훅 호출부에 validate_marker_axes_run 이 실제로 걸려 있다"
+else
+  echo "❌ ★배선 소실: 함수는 있는데 **아무도 안 부른다** — 위 레인은 이걸 못 잡는다"
+  echo "   기대: pre-commit 의 마커 검증 분기에 && validate_marker_axes_run \"\$MARKER\""
+  FAIL=1
+fi
+# 컨트롤: 존재하지 않는 호출부를 같은 방식으로 찾으면 실패해야 한다(계기 생존).
+if grep -qF 'validate_marker_zzz_nonexistent "$MARKER"' "$HOOK"; then
+  echo "❌ 계기 고장: 없는 호출부를 있다고 한다"
+  FAIL=1
+else
+  echo "✅ 컨트롤: 없는 호출부는 없다고 판정한다(계기 생존)"
+fi
+
+echo
+[ "$FAIL" -eq 0 ] && echo "── all marker-axes-run lane fixtures behave ──"
+exit "$FAIL"

--- a/templates/.git-hooks/pre-commit
+++ b/templates/.git-hooks/pre-commit
@@ -651,6 +651,67 @@ validate_crossfamily_leg() { # $1 = marker path
   return 0
 }
 
+# ── 4축 자기 대조 — «어느 축을 돌렸고 어느 축을 안 돌렸나» 형식 검사 ────────────
+# CLAUDE.md §3층 자기 대조가 마커에 3줄을 요구한다. 그중 **기계로 볼 수 있는 두 줄**만 여기서
+# 강제한다. 나머지(①영혼을 «설계 전에» 썼는가)는 **원리적으로 확인 불가**라 안 넣는다 —
+# 사후 작성과 사전 작성이 파일에서 구분되지 않으므로, 넣으면 의식(ritual)만 훈련시킨다.
+#
+# 🟥 **이 검사의 스코프를 오해하지 마라 — 침묵은 잡고 오답은 못 잡는다.**
+#    「ⓐ 돌렸다」고 적었는데 안 돌렸으면 이 훅은 통과시킨다. 마커의 계약은 예전부터
+#    form + non-vacuity + auditability 이지 provenance 가 아니다. 오답을 잡는 건
+#    cross-family 가 이 마커를 읽는 것이고, 그건 이 훅의 일이 아니다(정본에 그렇게 적혀 있다).
+#
+# 날짜 유예: 마커 **파일명의 날짜**가 GRACE 이후인 것만 요구한다. 소급 강제하면 진행 중인
+# 브랜치가 전부 막히고, 그 과차단이 `--no-verify` 를 습관화시켜 같은 훅 안의 Destructive-Op
+# 게이트까지 무장해제한다(오늘 실측된 트레이드오프).
+AXES_RUN_GRACE_DATE="2026-08-10"
+validate_marker_axes_run() { # $1 = marker path
+  local m="$1" mdate line ax miss=""
+  mdate=$(basename "$m" | sed -nE 's/.*_([0-9]{4}-[0-9]{2}-[0-9]{2})\.marker$/\1/p')
+  # 날짜를 못 읽으면 요구하지 않는다 — 파일명 규약 밖의 마커를 이 검사가 판정할 근거가 없다.
+  [ -n "$mdate" ] || return 0
+  [ "$mdate" \< "$AXES_RUN_GRACE_DATE" ] && return 0
+
+  line=$(grep -m1 -E '^[[:space:]]*axes-run:' "$m" 2>/dev/null)
+  if [ -z "$line" ]; then
+    echo "  ❌ MARKER FORMAT — missing 'axes-run:' line (4축 자기 대조)"
+    echo "     CLAUDE.md §3층 자기 대조: **돌린 축과 안 돌린 축을 각각 이름으로** 적는다."
+    echo "     안 돈 축은 침묵이 아니라 'none' 이다 — 미측정을 0으로 렌더하지 않는다."
+    echo "       axes-run: a=codex(4건) b=CI배선 c=none d=되돌림(국소성 확인)"
+    echo "     (a=다른계열 · b=첫실사용 · c=기록그라운딩 · d=되돌림)"
+    return 1
+  fi
+  for ax in a b c d; do
+    echo "$line" | grep -qE "(^|[[:space:]])${ax}=[^[:space:]]" || miss="$miss $ax"
+  done
+  if [ -n "$miss" ]; then
+    echo "  ❌ MARKER — 'axes-run:' 에 빠진 축:$miss"
+    echo "     네 축을 **전부** 적는다. 안 돌린 축은 'none' 으로 명시한다 — 빠뜨리는 것과"
+    echo "     안 돌렸다고 적는 것은 다른 명제이고, 빠뜨리면 읽는 쪽이 전자를 후자로 읽는다."
+    echo "       axes-run: a=codex(4건) b=CI배선 c=none d=되돌림(국소성 확인)"
+    return 1
+  fi
+
+  line=$(grep -m1 -E '^[[:space:]]*controls:' "$m" 2>/dev/null \
+         | sed -E 's/^[[:space:]]*controls:[[:space:]]*//')
+  if [ -z "$line" ]; then
+    echo "  ❌ MARKER FORMAT — missing 'controls:' line"
+    echo "     축을 «돌렸다»의 최소 증거는 **컨트롤이 살아 있는 실행 출력**이다."
+    echo "     컨트롤 없는 측정은 실측으로 절반이 죽었다(정본 §1-c)."
+    echo "       controls: alive — known-positive 'X' 히트 3 · known-negative 0"
+    echo "       controls: n/a — 이번 델타에 측정이 없다 (<사유>)"
+    return 1
+  fi
+  # 비-vacuity: 생사 토큰이 있어야 한다. "컨트롤 붙였다" 같은 무실질 문장을 막는다.
+  if ! echo "$line" | grep -qiE 'alive|dead|살아|죽|n/a|없'; then
+    echo "  ❌ MARKER — 'controls:' 에 생사 토큰이 없다 (무실질)"
+    echo "     컨트롤이 **살았는지 죽었는지**를 적어라 — 'alive' / 'dead' / 'n/a'."
+    echo "     죽은 컨트롤 위에서 나온 수치는 측정이 아니다."
+    return 1
+  fi
+  return 0
+}
+
 validate_marker_floor() {
   local m="$1" fs model
   # Leading whitespace tolerated on field lines (defense-in-depth vs indented writes).
@@ -779,8 +840,8 @@ if [ "$GATE_MODE" = "full" ]; then
   MARKER="$MARKER_DIR/.axes_23_passed_${BRANCH_SLUG}_${TODAY}.marker"
 
   if [ -f "$MARKER" ]; then
-    if validate_marker_floor "$MARKER"; then
-      echo "  ✅ PASS (marker confirmed + floor fields valid:"
+    if validate_marker_floor "$MARKER" && validate_marker_axes_run "$MARKER"; then
+      echo "  ✅ PASS (marker confirmed + floor/axes fields valid:"
       echo "     .axes_23_passed_${BRANCH_SLUG}_${TODAY}.marker)"
     else
       FAILED=1


### PR DESCRIPTION
운영자 승인 — 자기채점 보완 3단 중 **①번(형식 검사)만** 짓는다. 나머지 둘은 **「먼저 센다」**(질문하기 감지 — 분모가 없다) · **「안 짓는다」**(①영혼 「설계 전」 검사 — 확인 불가)로 갈렸다.

## 강제하는 것 — 기계로 볼 수 있는 두 줄

```
axes-run:  a= b= c= d=      네 축 전부. 안 돌린 축은 **none 으로 명시**
controls:  alive|dead|n/a   각 축 컨트롤의 생사
```

## 🟥 강제하지 **않는** 것 — 그리고 그 계약을 픽스처가 들고 있다

- **「a=codex」가 참인지는 안 본다.** 침묵은 잡고 **오답은 못 잡는다.** 마커의 계약은 예전부터 form + non-vacuity + auditability 이지 provenance 가 아니다.
  → 픽스처 `p3` 을 **「내용이 거짓이어도 통과」로 의도된 PASS** 로 고정했다. **계약을 산문이 아니라 앵커가 들고 있게** 만든 것이다.
- **「①영혼을 *설계 전에* 썼는가」는 원리적으로 확인 불가** — 사후/사전이 파일에서 구분되지 않는다. 넣으면 **의식(ritual)만 훈련시킨다**(codex 가 상주 규칙 리뷰에서 지목한 지점). 즉 CLAUDE.md 가 요구하는 3줄 중 **2줄만** 기계가 본다.

## 날짜 유예 — `AXES_RUN_GRACE_DATE=2026-08-10`

소급 강제하면 진행 중 브랜치가 전부 막히고, 그 과차단이 `--no-verify` 를 습관화시켜 **같은 훅 안의 Destructive-Op 게이트까지 무장해제**한다. 오늘 실측된 트레이드오프다. **경계 자체를 레인이 고정**한다(유예일 **당일**은 차단 — `<` 이지 `<=` 가 아님).

## ★ 되돌림이 결함을 하나 만들어냈고 그걸 고쳤다

훅에서 배선을 떼자 **11레인이 전부 초록**이었다 — **레인이 함수만 보고 배선을 못 본다**(장식 앵커 6번 얼굴: 호출부 우회).

→ **배선 판별자 주입** + known-negative 컨트롤. 재실측: 배선 제거 시 **판별자만** 정확히 적색.

## 검증

| | |
|---|---|
| 레인 **11** | 통과 3(정상형 · 전축 none · ★거짓내용) · 차단 5(부재 · 축누락 · controls부재 · 무실질 · 빈값) · 유예 3(유예전 · 날짜없음 · ★유예당일차단) |
| 계기 생존 | 레인 스위트가 훅에서 함수/상수 추출 실패 시 **하드 FAIL** — 추출이 죽으면 전 레인이 초록이 되므로 |
| 배선 | `selfcheck` 배선(subject 부재를 **SKIP 이 아니라 FAIL** — subject 가 훅 자신이라 정당한 부재가 없다) · `package.json files[]` 등재(npm 에 안 가면 없는 것 — 오늘 같은 함정을 두 번 밟았다) |
| selfcheck | PASS · Axis 1 = **SKIP(not-checked, 통과 아님)** |
| 도그푸딩 | 이 PR 자신의 마커가 새 형식으로 작성됐고 게이트가 확인했다(`floor/axes fields valid`) |

## 🟥 잔여

- **오답 미검출** — 설계상 그렇고 픽스처가 고정한다. 닫는 방향은 **cross-family 가 마커를 읽는 것**이고 이 PR 이 아니다(운영자가 다음 세션으로 지정)
- **①영혼 필드 미강제** — 3줄 중 2줄만 기계가 본다
- **유예일 전 마커·날짜 없는 파일명은 요구 안 한다** — 후자는 규약 밖 파일명이 우회로가 될 수 있다(명명된 잔여)