### PR TITLE
fix(digest): §Collection-Bash 실행 폼 정본을 실측 경로(WebFetch)로 — 스펙 부채 N=13 청산

### DIFF
--- a/plugins/fh-meta/skills/frontier-digest/SKILL_detail.md
+++ b/plugins/fh-meta/skills/frontier-digest/SKILL_detail.md
@@ -12,6 +12,19 @@ load: on-demand
 
 ## §Collection-Bash
 
+> **Execution form — canonical (revised 2026-08-10, operator decision ⓑ).** The default runtime path
+> is **WebFetch (+WebSearch) against the endpoints below** — not `curl`. Measured: **13 consecutive
+> unattended runs** executed via WebFetch while this section documented only the curl form (the digest
+> reported the mismatch on every run — spec debt N=13). `curl` requires an allowlist entry that a
+> default install does not carry; the bash blocks below are kept as the **endpoint/parameter spec**
+> (query shapes, filters, item caps, refresh rules — all still authoritative), and a run applies them
+> through WebFetch on the same URLs. If an environment *does* allow the curl form, it is equivalent —
+> the transport is not the contract, the endpoints and criteria are.
+>
+> **arXiv HTTP 429 is a separate item, not part of this revision**: it is a remote rate limit
+> (N=11 consecutive, transport-independent). On 429: back off once, then fall back to per-item
+> `https://arxiv.org/abs/{id}` reads; record `FAILED (429)`, never 0 items.
+
 ### HackerNews (Algolia API)
 
 ```bash


### PR DESCRIPTION
digest 가 13런 연속 자기 스펙 미실행을 보고 — 운영자 ⓑ 결정(2026-08-10). 실행 폼 정본 = WebFetch, bash 블록 = 엔드포인트 명세 유지, arXiv 429(N=11) 분리 표기.

검증: 변경 반경 = 인용 블록 2개 · 수집 기준 무변경 · §Collection-Bash 포인터 무파손 · Axis1 PASS. 다음 무인런의 계기 노트에서 부채 카운트 소멸이 verify_next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)