### PR TITLE
chore(ledger): qasp 앵커 출처 증명 — codex 6R 통합 엔트리

### DIFF
--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -1725,3 +1725,19 @@
   outcome: accepted
   evidence: "조사① runner 5지점+정직술어 지목→#139 그대로 채택 · 조사② B1~B12 판정표→NOT READY 판정 근거 · 감사③ 핵심수치 전건 CONFIRMED+정정 8건→핸드오프 반영 · codex 5R 반증 12건 전건 수리(S→S→S/A→A/B→B 소진, #137·#138 머지)"
   notes: "sidecar 수치 액면 미인용 — S급 전건 governor 소스 재판정(재현 후 수리). 조사 에이전트 위치주장은 구현 중 파일 직독으로 교차확인"
+
+- date: 2026-08-10
+  session: ifkakao-numeric-recheck
+  agents_summary: "1 dispatch: general-purpose 격리 원문 대조(덱 수치-서사 32행, 읽기전용·재측정금지·대상동결 bc487df, bg)"
+  dispatch_count: 1
+  outcome: accepted
+  evidence: "32행 판정(CONFIRMED 25·MISMATCH 2·PARTIAL 3·SNF 1) — MISMATCH 2건 전부 실물 확인 후 덱 수리(열세개 stale·행위자 귀속) · 착지 = ifkakao26_numeric_recheck_2026-08-10.md + CANON_LEDGER 3일차"
+  notes: "에이전트 계기한계 자기신고(기록 대 기록·미러 최심부·grep 사각) 그대로 기록에 병기. MISMATCH 는 governor 가 마커/캡처 원문 재확인 후 수리"
+
+- date: 2026-08-10
+  session: qasp-anchor-provenance-day2
+  agents_summary: "6 dispatches (consolidated): codex gpt-5.5 sidecar×6 (앵커 출처 증명 적대 6라운드 — R1 전면 · R2~R3 수리 반증 · R4~R6 수렴 확인, 전부 bg)"
+  dispatch_count: 6
+  outcome: accepted
+  evidence: "반증 23건 → 수리 21 · 기각 1(A-4: List[str] 선재 크래시 + p35 fail-safe — R2 에서 실행 재현으로 반박받아 dict-repr 유출로 재분류 수용) · 명명 2. 곡선 S1A5B2→S1A3B3→A2B1→A1B1→A1→0 CONVERGED. 전건 governor 소스 재판정 후 수리 · R6 «S/A 소진» 명시 후 머지(qasp-dev #141, af244fa)"
+  notes: "R2 S(오라클 반전)·R3 A2·R5 A1 은 전부 직전 수리의 산물 — «수리가 결함의 주된 출처» 재확증. degrade_direction_scan 은 사후 실행(advisory 620, 순서 위반 기록) — 종국 판정은 6R 이 담당"


### PR DESCRIPTION
qasp 병렬축 2일차 디스패치 원장 통합 등재(6 dispatches, 반증 23건 처리 상세). 원장 규율 이행 — 코드 무접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjWfrcqFrgWKS1pdkGEo2y