### PR TITLE
feat(harvest): rtk gross 실측기 역수확 — 벤더 주장을 로컬 실측으로 (역수확 PR C)

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
     "scripts/knowledge_seam_check.sh",
     "scripts/test_knowledge_seam_lanes.sh",
     "tests/seam_absence_probes.md",
-    "scripts/gate_anchor_check.sh"
+    "scripts/gate_anchor_check.sh",
+    "scripts/rtk_gross_ablation.sh"
   ]
 }

--- a/plugins/fh-meta/skills/context-doctor/SKILL.md
+++ b/plugins/fh-meta/skills/context-doctor/SKILL.md
@@ -212,6 +212,10 @@ The reductions above all act on the **context-footprint** axis (files, history r
 **Two ways to reduce, safest first:**
 1. **Per-call narrow flags (default — non-lossy, no install).** Prefer narrow commands: `git log --oneline -N` over bare `git log`, `--quiet` on noisy tools, `head`/`tail` on long output. The agent chooses what to drop, per call — no blind heuristic. This suffices for almost every session.
 2. **A command-output proxy/hook (only under token scarcity).** A **Claude Code hook that rewrites verbose commands through a token-reducing proxy**, transparent (0 prompt-side overhead). Recommended tool: **`rtk` (Rust Token Killer)**, a CLI proxy that filters dev-command output (the tool reports ~60–90% savings on dev operations), wired so `git status` → `rtk git status` happens automatically.
+   - **Measure, don't quote**: `bash scripts/rtk_gross_ablation.sh [repo]` measures the actual gross
+     cut on YOUR env's command-output slice (instrument-check first — a dead filter emits stubs that
+     fake 82–100% cuts). The vendor band above is a claim; the script returns a local measurement — a char/4 approximation whose error direction is toward OVER-stating the cut
+     (e.g. 68.3% on the FH repo slice, 2026-08-10 — your number will differ; measure yours). NET (context-loss) stays unmeasured either way.
    - ⚠️ **Name collision**: there is an unrelated `reachingforthejack/rtk` (Rust Type Kit). Verify the Token-Killer build — `rtk gain` (savings analytics) should work; "command not found" means the wrong binary.
    - **No-reinvention**: FH **routes to** this tool; it does not rebuild a token-killer. Install + hook wiring live in the user's own config (global `CLAUDE.md` / `settings.json`), never reimplemented here.
    - ⚠️ **Never filter a command whose output a mechanical gate parses.** FH gates read raw command output (a pre-commit hook greps, `regression_guard` diffs). A filtered `git diff` / `git log` feeding a gate gives the gate wrong input — the same trap as grepping filtered prose for a verdict (typed-verdict-channel). Keep filtering off gate-input paths, and keep a raw escape hatch (`rtk proxy <cmd>`).

--- a/scripts/rtk_gross_ablation.sh
+++ b/scripts/rtk_gross_ablation.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# rtk_gross_ablation.sh — RTK gross-savings ablation
+# provenance: pmh-dev@cbe3932 역수확(2026-08-10). FH 의 context-doctor 가 벤더 주장(~60-90%)만
+#   인용하던 자리에 실측 계기를 공급 — Step 0 계기검증(필터가 에러로 죽어 스텁을 뱉으면
+#   허위 절감률이 나오는 실측 사례) 내장.
+# RTK gross-savings ablation — run in an env where RTK ACTUALLY filters (rtk gain 이 실절감을 보이는 곳).
+# Measures raw vs rtk-filtered output TOKENS across representative read-only dev commands.
+#
+# ⚠️ INSTRUMENT CHECK included: FH 외부 세션(2026-07-07)서 rtk 필터가 "No such file"로
+#    에러 죽으며 46자 스텁을 뱉어 "82~100% cut" 허위결과가 나왔음. 계측기부터 검증한다.
+# ⚠️ NET(맥락손실)은 이 스크립트가 아님 — graded 품질 프로브(턴수·교정·정답률) 별도.
+# ⚠️ 판정/검증 태스크엔 RTK 미적용(verdict 오염) — 여기 태스크셋은 전부 read-only non-verdict.
+set -u
+# 근사 주의: wc -c / 4 = char 근사(밀도 균일 가정) — 필터 출력은 경로·해시 위주라 절감률이
+# **과대측 방향**으로 치우칠 수 있다. 부호는 안전하나 «밴드 정합» 판정엔 오차 감안.
+# 해석부 상수(~20-30% 슬라이스 비중 · 15-25% 밴드 · RATE)는 원 필드 보고서 유래의 «가정» — 출처: provenance 커밋.
+RTK="${RTK:-$(command -v rtk || echo "$HOME/.headroom/bin/rtk")}"
+REPO="${1:-$PWD}"
+RATE="${RATE:-1.82}"   # $/1M tokens — 측정 블렌디드(Token Checker). 필요시 override.
+cd "$REPO" 2>/dev/null || { echo "repo 없음: $REPO"; exit 1; }
+git rev-parse --git-dir >/dev/null 2>&1 || { echo "git 레포 아님: $REPO — git 커맨드 태스크셋이 무의미(과소측 방향 오결론)"; exit 1; }
+
+# --- 0. 계측기 검증: rtk가 실제로 FILTER하나 (에러 아님) ---
+praw=$(git status 2>&1); prtk=$("$RTK" git status 2>&1)
+if echo "$prtk" | grep -qiE "no such file|os error|not found|error\]" \
+   && ! echo "$praw" | grep -qiE "no such file"; then
+  echo "❌ RTK 필터 비작동 (rtk git status 에러): $prtk"
+  echo "   → rtk 설정/환경 의존. 'rtk gain' 이 실절감을 보이는 env 에서 돌려라."
+  exit 2
+fi
+echo "✅ rtk 필터 작동 확인 — 진행."; echo ""
+
+# --- 태스크셋 (read-only, non-verdict, RTK가 타깃하는 dev 출력) ---
+# ⚠️ CMDS 에 quote/pipe/glob 든 커맨드 추가 금지 — raw(eval) 와 rtk(word-split) 실행 경로가
+#    비대칭이라 다른 커맨드를 재게 된다.
+CMDS=("git status" "git log --oneline -150" "git diff HEAD~20" "git branch -a" "ls -la")
+tot_r=0; tot_k=0
+printf "%-28s %9s %9s %6s\n" "command" "raw_tok" "rtk_tok" "cut%"
+printf -- "----\n"
+for c in "${CMDS[@]}"; do
+  r=$(( $(eval "$c" 2>&1 | wc -c) / 4 ))      # ~4 chars/token 근사(헤더 주의 참조)
+  kout=$("$RTK" $c 2>&1)
+  # per-command 계기검증 — Step 0 은 env 고장만 닫는다. 행 단위 rtk 에러/스텁은 여기서 잡아
+  # 총계에서 제외(허위 절감의 역사적 형태: 에러 스텁 → 82~100% 허위 컷).
+  if echo "$kout" | grep -qiE "no such file|os error|not found|error\]|panicked at" \
+     && ! eval "$c" 2>&1 | grep -qiE "no such file|os error|not found"; then
+    printf "%-28s %9d %9s %6s\n" "$c" "$r" "FAIL" "제외"
+    continue
+  fi
+  k=$(( $(printf '%s' "$kout" | wc -c) / 4 ))
+  cut=$(awk "BEGIN{if($r>0)printf \"%.0f\",($r-$k)/$r*100;else print 0}")
+  printf "%-28s %9d %9d %5s%%\n" "$c" "$r" "$k" "$cut"
+  tot_r=$((tot_r+r)); tot_k=$((tot_k+k))
+done
+printf -- "----\n"
+gross=$(awk "BEGIN{if($tot_r>0)printf \"%.1f\",($tot_r-$tot_k)/$tot_r*100;else print 0}")
+saved_tok=$((tot_r-tot_k))
+echo "GROSS (커맨드/툴-출력 슬라이스): raw=$tot_r tok · rtk=$tot_k tok · 절감=$gross%"
+echo ""
+echo "해석:"
+echo "  • 이건 커맨드/툴-출력 *슬라이스만*의 절감률 (세션 전체의 ~20-30%)."
+echo "  • 청구서 전체 gross ≈ (슬라이스 비중) × $gross%  → 보고서 15-25% 밴드와 대조."
+echo "  • \$ 환산: 절감 토큰 × \$$RATE/1M = 슬라이스 절감액."
+echo "  • NET(맥락손실)은 미측정 — gross만으론 net+ 단정 금지(조용한 오답 리스크)."


### PR DESCRIPTION
## 무엇

pmh-dev 역수확 3건차: context-doctor 가 **벤더 주장(~60-90%)만 인용**하던 rtk 절감을 **로컬 실측**으로 접지하는 계기. Step 0 계기검증(죽은 필터의 스텁이 82-100% 허위 컷을 만든 실측 사례 차단) 내장.

- `scripts/rtk_gross_ablation.sh` + context-doctor «Measure, don't quote» 배선(호출부 실재)
- 첫 실사용: FH 레포 슬라이스 **68.3%** (계기검증 통과 · per-command FAIL 0)

## 검증 캡슐

- challenger 1R: **S2·R5 (M 0)** → S 전건 + R 3건 수리 — per-command 계기검증(루프 행 단위 rtk 에러 → 총계 제외) · char/4 근사의 과대측 방향 명기 · 비-git 가드 · eval 비대칭 주석 · 상수 가정 라벨. 불발 공격 7종 명시(files[] 실재·0-나눗셈·이식성 등 — 라이브 프로브 3건 포함)
- 수리 후 재실측 68.3% 재현
- **범위 정정 1건**: 승인 목록의 #9(skip-visibility)는 FH `self_evolution_routine.md` 에 **이미 실물 존재**(«Skip-visibility at the handoff») — 인벤토리 grep 이 어휘 차이로 «없음» 오보한 것을 이식 직전 확인, **SKIP 처리**. 인벤토리가 스스로 명명한 계기 한계의 실증

## 잔여

per-command rtk 고장 빈도 미관측(이 env 는 rtk 건강) · 에러어휘 denylist · NET(맥락손실) 미측정 유지 · crossfamily 는 DEGRADED_PANEL_UNUSED(비차단 측정 유틸 — 패널 가용했으나 배정 안 함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K84s4QHJmHrX574wwmfCYC