### PR TITLE
feat(harvest): 교차검증 델타 2건 흡수 — 패널 부적격 판별 + verdict 확장 규칙 (역수확 PR D)

### DIFF
--- a/knowledge/shared/harness-core/return_path_gate.md
+++ b/knowledge/shared/harness-core/return_path_gate.md
@@ -114,6 +114,21 @@ This is the default failure mode when a skill chain has no return path defined. 
 
 ---
 
+## Verdict Extension (harvested from field use — pmh-dev@cbe3932, 2026-08-10)
+
+The 4-tier enum is the floor, not the ceiling. A project may extend it (field precedent:
+`WAVE_SKIP` / `WAVE_INSERT` for wave-orchestrating callers) under two rules:
+
+- the extended enum is declared in the **callee's** SKILL.md verdict section — a verdict value the
+  emitter never documents is prose, not a contract;
+- the caller maps **any verdict value it does not recognize to ESCALATE** — an unknown verdict is a
+  human-decision signal, never a silent PASS. (Same degrade direction as the typed-Verdict contract:
+  unparseable ⇒ escalate, never optimistic.)
+
+Do NOT harvest the field's `[Verdict]` block output format — FH's typed contract (final-line
+`Verdict:` literal, #318) is newer and stricter; two competing formats would reopen the
+divergent-normalizer class.
+
 ## Relation to Other Patterns
 
 - **Three-Doctor Loop** (`harness-doctor ↔ context-doctor ↔ sim-conductor`) uses return paths implicitly — each doctor's output triggers the next. A full Return-Path Gate implementation would make the fold-back explicit.

--- a/scripts/sidecar_calibrate.sh
+++ b/scripts/sidecar_calibrate.sh
@@ -42,9 +42,10 @@
 
 set -uo pipefail
 
-ONLY=""; STUB_MODEL=""; QUIET=""
+ONLY=""; STUB_MODEL=""; QUIET=""; CLASSIFY=""
 while [ $# -gt 0 ]; do
   case "$1" in
+    --classify) CLASSIFY="${2:-}"; shift 2 ;;
     --only) ONLY="${2:-}"; shift 2 ;;
     --stub-model) STUB_MODEL="${2:-}"; shift 2 ;;
     --quiet) QUIET=1; shift ;;
@@ -178,6 +179,31 @@ probe_runtime() {
   return 0
 }
 
+# nongenerative_reason <model> — adversarial review needs a model that ANSWERS IN PROSE. Embedding /
+# reranker / OCR / safeguard models accept any prompt with rc=0 and contribute nothing — counting one
+# as a panel member fakes family diversity (pmh-dev@cbe3932 crossfamily_probe 델타 흡수, 2026-08-10).
+# Unfit patterns are checked BEFORE family patterns on purpose: Qwen3-Embedding matches both.
+nongenerative_reason() {
+  local m
+  m="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  case "$m" in
+    *embed*)              echo "embedding" ;;
+    *rerank*)             echo "reranker" ;;
+    *-ocr*|*ocr-*|*ocr:*) echo "OCR" ;;
+    *guard*|*shield*)     echo "safeguard" ;;
+    *) return 1 ;;
+  esac
+}
+
+# --classify <model-id> — query surface for the unfit filter (pmh --check-model 흡수). NOTE: this
+# subcommand DOES use exit semantics (0=FIT, 1=UNFIT, 2=usage) — the always-exit-0 contract (lane 7)
+# applies to CALIBRATION runs, not to this explicit query mode.
+if [ -n "$CLASSIFY" ]; then
+  if r=$(nongenerative_reason "$CLASSIFY"); then echo "UNFIT ($r — non-generative; not a reviewer)"; exit 1
+  else echo "FIT (generative-shaped id — still needs a live pin probe)"; exit 0; fi
+fi
+
+
 probe_runtime codex "gpt-5.6-sol"
 probe_runtime agy   "Gemini 3.1 Pro (High)"
 
@@ -234,6 +260,11 @@ print(",".join(m["name"] for m in d.get("models",[])[:6]))' 2>/dev/null)
   local IFS=,
   for m in $models; do
     [ -n "$m" ] || continue
+    local unfit
+    if unfit=$(nongenerative_reason "$m"); then
+      echo "ollama/$m UNFIT ($unfit — non-generative) — excluded from panel; a prompt it rc=0-accepts is not a review"
+      continue
+    fi
     local body out env_model resp compact pin v
     body=$(python3 -c 'import json,sys; print(json.dumps({"model":sys.argv[1],"prompt":sys.argv[2],"stream":False,"options":{"num_predict":int(sys.argv[3]),"temperature":0}}))' \
            "$m" "$VERDICT_PROMPT" "$OLLAMA_NUM_PREDICT")

--- a/scripts/test_sidecar_calibrate_lanes.sh
+++ b/scripts/test_sidecar_calibrate_lanes.sh
@@ -213,6 +213,18 @@ PATH="$TMP/bin:/usr/bin:/bin:/usr/sbin:/sbin" bash "$CAL" >/dev/null 2>&1
 [ $? -eq 0 ] && ok "lane7 exits 0 even with an empty panel (detector, not gate)" \
              || bad "lane7 non-zero exit on empty panel" "exit=$?"
 
+# LANE 8 — nongenerative unfit filter (pmh crossfamily_probe 델타 흡수): an embedding/OCR model id
+# must classify UNFIT (rc=1) BEFORE family patterns could claim it; a generative id stays FIT (rc=0).
+out=$(bash "$CAL" --classify "Qwen3-Embedding-8B" 2>&1); rc=$?
+[ $rc -eq 1 ] && case "$out" in *"UNFIT (embedding"*) true;; *) false;; esac \
+  && ok "lane8 embedding id → UNFIT rc=1" || bad "lane8 embedding not UNFIT" "rc=$rc $out"
+out=$(bash "$CAL" --classify "GLM-OCR" 2>&1); rc=$?
+[ $rc -eq 1 ] && case "$out" in *"UNFIT (OCR"*) true;; *) false;; esac \
+  && ok "lane8b OCR id → UNFIT (unfit-before-family order)" || bad "lane8b OCR not UNFIT" "rc=$rc $out"
+out=$(bash "$CAL" --classify "llama3.3:70b" 2>&1); rc=$?
+[ $rc -eq 0 ] && case "$out" in *"FIT (generative"*) true;; *) false;; esac \
+  && ok "lane8c generative id → FIT rc=0 (과차단 대칭 · 출력 검증)" || bad "lane8c generative misclassified" "rc=$rc $out"
+
 printf '\nsidecar-calibrate lanes: %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1
 exit 0


### PR DESCRIPTION
## 무엇

pmh-dev 역수확 마지막 묶음(R-tier 델타 — **완전 이식이 아니라 델타만**, 중복 회피 판정 포함):

1. **패널 부적격 판별** — 임베딩·리랭커·OCR·safeguard 모델은 어떤 프롬프트에도 rc=0 을 내지만 적대검토가 불가능한 종류다. 이들이 패널원으로 계상되면 «3/3 성공»인데 실기여는 그보다 적은 **눈에 안 보이는 오답**이 된다. → `sidecar_calibrate` ollama 레그 필터 + `--classify` 질의 표면(0=FIT·1=UNFIT — 캘리브레이션 런의 always-exit-0 계약은 무접촉)
2. **verdict 확장 규칙** (`return_path_gate.md`) — 프로젝트 확장 enum 허용 조건 2개 + **미지 verdict → ESCALATE**(낙관 방향 금지)

**SKIP 판정 2건 명문화**: rc=1/10 분리는 sidecar_calibrate 의 «detector, always exit 0» 설계와 충돌 · pmh 의 `[Verdict]` 블록 형식은 FH #318 typed 계약이 신본이라 역이식 금지(경쟁 형식 = divergent-normalizer 재개방)

## 검증 캡슐

- `--classify` 3종 실측: embedding/OCR → UNFIT rc=1 · generative → FIT rc=0 · 레인 **16/16**
- **레인이 내 구현 결함 2건을 즉발** — 분기 위치가 톱레벨 프로브 호출 뒤(트레이스로 실측) · 기존 파서의 `*)shift` 인자 소비 → 수리 후 정확히 그 레인만 초록 전환. lane8c 는 출력 검증 추가로 공허 rc=0 통과 봉인
- 부적격-먼저 순서(Qwen3-Embedding 이 qwen 가족에도 매치) 는 원본의 codex 3R 실측 앵커(A27·A30)를 그대로 승계
- crossfamily: **DEGRADED_PANEL_UNUSED** — 원본이 codex 3R 을 거친 로직의 축소 이식·비게이트 경로, 신규 라운드 미배정(근거: 원본 앵커 승계)

## 잔여

부적격 denylist(새 비생성 모델류 미탐 — 원본과 동일) · ollama 실서버 UNFIT 발화 미실측(분류 표면만 레인 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K84s4QHJmHrX574wwmfCYC