### PR TITLE
fix: pmh-dev #54 FH 몫 — G-GREET-05 문구 앵커 + remap 소유 규약 + 레인 백틱 수리

### DIFF
--- a/.claude/regression/probes.md
+++ b/.claude/regression/probes.md
@@ -18,6 +18,7 @@
 | `G-GREET-02` | any greeting response | Opens with 🐿️ followed by an identity-revealing welcome line **on the SAME line** (the invariant is same-line, not 🐿️ alone; space count is not significant) | CLAUDE.md §Active Onboarding | mandatory-pass |
 | `G-GREET-03` | returning-user greeting | Fixed 4-door menu (① map a project ② create new ③ accelerate/diagnose a mapped project — candidates composed live ④ cross-project synergy, rendered only at 2+ tracks); no hardcoded track name | CLAUDE.md §Active Onboarding | mandatory-pass |
 | `G-GREET-04` | explicit task utterance (e.g. "debug X") | Onboarding skipped entirely, work starts | CLAUDE.md §Guards | mandatory-pass |
+| `G-GREET-05` | welcome-line literals | The pinned phrases are exactly **"Welcome to FH."** · **"Welcome back to FH."** · **"The FH operator — good to see you."** — these literals are **downstream remap anchors**: forked installs (e.g. PMH) machine-map them to their own identity (pmh-dev #54). Adding or rewording ANY welcome phrase must ship with a downstream remap-set notice in the same change — a phrase change that passes G-GREET-02 (same-line) can still silently break every fork | CLAUDE.md §Active Onboarding · fh_detail_protocols.md §Onboarding-Provenance | mandatory-pass |
 
 ## B. Trigger routing (Autonomous Initiative table)
 

--- a/knowledge/shared/harness-core/fh_detail_protocols.md
+++ b/knowledge/shared/harness-core/fh_detail_protocols.md
@@ -213,6 +213,17 @@ Temporary session change: say "use light mode for this one" or "switch to max".
 > stories justify stay resident in CLAUDE.md; only the archaeology moved. Read this when you are about to
 > *change* one of those rules — the failure that produced each one is the reason it reads the way it does.
 
+**하류 remap 소유 규약 (2026-08-10, pmh-dev #54 — 임시방편이 아니라 정본 설계다)**: 인사
+발화 문구와 규약 파일명(`fh_completed_*` 등)의 **문자열 정본은 FH가 소유**하고, 분기 설치
+(조직 내부 반입 등)는 그 문자열을 자기 정체성으로 변환하는 **remap 집합을 자기 쪽에서
+소유**한다 — 공유층 본문은 불변이며, 하류가 본문을 직접 고치면 드리프트로 계상된다. 따라서
+FH에서 발화 문구·규약 파일명을 **추가하거나 바꾸는 변경은 하류 remap 통지를 같은 변경에
+동반**해야 한다 — 프로브 `G-GREET-05`가 문구 리터럴을 고정해 무음 변경을 막는다(하류
+설치에서 ④-log 검사기가 존재 불가능한 파일명을 3개월 보고 있던 오귀인이 이 규약의 실측
+근거다 — pmh-dev #54).
+갈림 판별 기준: **사용자-대면 발화이거나 게이트가 찾는 파일명이면 remap 대상, 환경변수·훅
+스크립트명·npm bin 같은 기계 결합 이름은 불변**(변환하면 파손된다).
+
 ### Why the greeting branch test is session files, never git history
 
 A fresh-clone Sonnet simulation rendered the **returning-user menu** to a brand-new install, because it

--- a/scripts/test_sidecar_calibrate_lanes.sh
+++ b/scripts/test_sidecar_calibrate_lanes.sh
@@ -53,7 +53,9 @@ for a in "\$@"; do
 done
 case "\$1" in --version) echo "stub 9.9.9"; exit 0 ;; esac
 # Scan ALL arguments for the verdict prompt — it is NOT always last. codex puts the prompt at the
-# end; agy puts it after -p with `--print-timeout 170s` trailing. A first draft read only the last
+# end; agy puts it after -p with '--print-timeout 170s' trailing. A first draft read only the last
+# (NB: this comment sits inside an UNQUOTED heredoc — a backtick here is command substitution and
+#  actually executed '--print-timeout 170s' at stub-creation, 10x per lane run. Single quotes only.)
 # argument, so the agy-shaped call never looked like a verdict request and lane5b failed against a
 # correct script. An honest runtime ANSWERS THE QUESTION ASKED: a one-token request gets one token.
 is_verdict=0


### PR DESCRIPTION
pmh-dev(chronoloy-dev/pmh-dev) 이슈 #54 의 FH 쪽 요청 3건 + 부수 1건.

- **②** `G-GREET-05` 신설 — 인사 문구 3종 리터럴 고정. 문구 변경이 G-GREET-02(same-line)를 통과하면서도 하류 fork의 remap을 무음 파손하는 경로 차단 — 변경 시 하류 통지 의무 명문
- **③** §Onboarding-Provenance에 하류 remap 소유 규약 명문화 — 문자열 정본=FH · remap 집합=하류 · 공유층 본문 불변. 갈림 판별 기준: 사용자-대면 발화/게이트 대상 파일명=remap, 기계 결합 이름(환경변수·훅 스크립트명·bin)=불변
- **①** 열거 스윕 1회 실행 — 결과는 하류 이슈 #54 코멘트(위험 클래스 신규 갈림 0 · 보류 2건)
- **부수** 레인 unquoted-heredoc 백틱이 '--print-timeout 170s'를 스텁 생성마다 실행(10회/런) — 수리 후 0회, 레인 16/16 불변 (known-pair)

evidence: 백틱 before 10/after 0 실측 · 레인 수리 전후 동일 초록 · 스윕 상위 30 토큰 분류표(하류 이슈 착지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)