### PR TITLE
release: v1.4.94 — ko-tech-writer 첫 실사용 되먹임

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,13 @@
   "plugins": [
     {
       "name": "fh-meta",
-      "version": "1.4.93",
+      "version": "1.4.94",
       "description": "Hub meta-operations toolkit — 35 skills + 7 agents. New in 1.4.53: `fh-codex-doctor` (npm bin) — Codex adapter drift scanner; reads the documented M1/M2/M3 skill tier map + skill/agent source and reports codex-native/adapter-required/claude-native/unclassified per unit, wired into `npm test`/`prepublishOnly` (fail-closed on unclassified Claude-native primitives). New in 1.4.49: steel-quench gains Step 0.6 Verdict-Invariance Probe (groundedness axis — a load-bearing judged gate's verdict must track behavior, not rubric phrasing; measured flip-count over cross-family paraphrases; arXiv:2605.06161 Policy Invariance anchor); multi_model_sidecar_strategy §Vendor-native harness (a model is strongest in its own vendor CLI — Claude/CC, GPT/codex, Gemini/Antigravity; a universal router degrades all of them, so it stays an autocomplete/QA sidecar, never orchestration); predelete_check.sh fail-closed rewrite; memory-hygiene A-TMA anchor. New in 1.4.48: phantom-quench + steel-quench gain external frontier anchors (arXiv:2607.02052 package-hallucination; arXiv:2607.02057 prompt-coverage-adequacy); README model-flat claim reframed from a per-release point-curve to structural invariants (operation flattens across tiers; depth tier-order fixed within a generation). New in 1.4.47: onboarding step ① surfaces the Mode D companion-store session-start load in the auto-read salience anchor (previously only in the local binding + rules, so a greeting could skip the load). New in 1.4.46: context-doctor command-output axis (route to rtk/proxy for verbose CLI stdout, complementing .claudeignore; risk-gated to token-scarce envs). New in 1.4.41: context-doctor 2026 trigger vocab (context engineering/rot/collapse) + phantom-citation hardening; hub measurement-integrity-checklist (cross-model measurement pre-flight: display-name pin/reps≥3/discriminating probe). New in 1.4.40: install-wizard queryable-wiki scaffold (INDEX + session-start read + R/W/C ingest). New in 1.4.39: auto-decorrelation (cross-family verifier sidecar recruitment) + video-ingest (capability-routed video ingestion). New in 1.4.x: verify-axis check-class taxonomy (mandatory-pass/measured/judged), no-reinvention Tier-0 inventory, 7-class failure taxonomy, Destructive-Op Gate, Wave-T (Temper), tier-floor governance, Mode D Model Notice, FC consent lane, default-Sonnet guidance. New in 1.3.0: public-surface-audit, field-harvest Mode B auto-trigger, 4-axis gate scope ext. Validated cross-CLI: Claude Code, Codex, Gemini.",
       "source": "./plugins/fh-meta"
     },
     {
       "name": "fh-commons",
-      "version": "1.4.93",
+      "version": "1.4.94",
       "description": "Project-agnostic utility skills — 5 skills (convergence-loop · deliberation · mcp-circuit-breaker · token-budget-gate · ko-tech-writer) + 1 agent (quench-challenger). Domain-independent utilities transplantable into any project.",
       "source": "./plugins/fh-commons"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrono-meta/fh-gate",
-  "version": "1.4.93",
+  "version": "1.4.94",
   "description": "FH runtime adapters — run FH governance, skills, and agents via Claude or Codex with machine-parseable gates.",
   "license": "MIT",
   "keywords": [

--- a/plugins/fh-commons/.claude-plugin/plugin.json
+++ b/plugins/fh-commons/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-commons",
-  "version": "1.4.93",
+  "version": "1.4.94",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/.claude-plugin/plugin.json
+++ b/plugins/fh-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-meta",
-  "version": "1.4.93",
+  "version": "1.4.94",
   "engines": {
     "claudeCode": ">=1.0.0"
   },


### PR DESCRIPTION
배포 델타 **2파일 · 실행코드 변경 0건**:
`plugins/fh-commons/skills/ko-tech-writer/SKILL.md`(#333) + `subagent_invocations_log.yaml`(#334).

## Pre-Publish 게이트 (증거 캡슐)

| 검사 | 결과 |
|---|---|
| 공개표면 (`public_surface_scan_files.sh`, 배포 파일셋 전체 · full pattern set) | **PASS** (rc=0) |
| 델타 2파일 손확인 | **0건** — **known-positive 컨트롤 동반**(`CLAUDE.local.md` 12건 · 세션카드 21건 히트로 계기 생존 확인) |
| `/security-review` | 적용 표면이 실행코드를 싣지만 **v1.4.93 이후 실행코드 변경 0건** — 근거는 `git diff --name-only v1.4.93..HEAD` **기계값**이지 «docs-only» 자기선언이 아니다 |
| 버전 락스텝 (`version_lockstep_check.sh`) | **PASS** — 출하 버전 문자열 4개 전부 1.4.94 |

> 첫 스캔을 `grep … \| head` 로 돌려 파이프 끝 상태를 보는 바람에 «0건인지 계기가 죽었는지»
> 구분이 안 됐다. 비가역 표면 직전 검사라 컨트롤을 살아있는 것으로 바꿔 다시 쟀다.

머지 후 `npm publish` + `git tag v1.4.94`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)