### PR TITLE
feat(identity-1): 등록 시점 검사기 + 진짜 다른 두 capability 경유 런

### DIFF
--- a/knowledge/shared/harness-core/capability_composition_contract.md
+++ b/knowledge/shared/harness-core/capability_composition_contract.md
@@ -353,10 +353,31 @@ Split honestly by moment; only one of the three is closable today.
 
 - **Registration moment — reachable.** The reviewer is inside the registry when it applies. Pointers
   from `.claude/registry/README.md` and `fh_detail_protocols.md §1-c` put the M1–M5 bar in front of
-  them. **Named residual, not built**: a `scripts/capability_registry_check.sh` that validates the
-  schema and runs each declared M4 pair would make registration *measured* rather than reviewed. It
-  does not exist. Until it does, M1–M5 is a reviewed bar, and this file says so rather than implying a
-  floor it does not have.
+  them. ~~**Named residual, not built**: a `scripts/capability_registry_check.sh`…~~ → **built
+  2026-08-11.** `scripts/capability_registry_check.sh` validates the schema (closed key list — an
+  unknown key is a failure, never an ignore) and **runs each declared M4 pair**, so registration is
+  now *measured* on those axes rather than reviewed. Known-pair calibrated, 7 lanes, BLOCK/PASS
+  symmetric. Two capabilities are registered through it (`fh_psa_leak.cap` · `fh_degrade_verdict.cap`).
+
+  🟥 **What the checker measures, and the axis it provably does NOT — learned by being bitten.**
+  M1–M5 answer *"is the declaration well-formed, and does the instrument separate a case whose
+  answer we already know?"*. They do **not** answer *"is the declaration true"*, and one axis made
+  that concrete the same day it was built: a capability declaring **`writes: read-only`** passed all
+  five criteria — executable entry, closed enum with a did-not-run value, `judge: mechanical`, M4
+  known-pair green ×2, valid `requires_cwd` — and its entry point then **`rm -rf`'d this repo's
+  `scripts/` directory** on a no-argument invocation (a cleanup `trap` whose variable was reassigned
+  to a real path after the trap was installed). Tracked files were recovered by `git checkout`;
+  three untracked new scripts were not, and the recovery checkout also reverted an unrelated
+  in-flight edit. Nothing in the bar could have caught it: M4 exercised the two *declared* arms, and
+  the destructive path was the *undeclared* default arm.
+  - **Partial fix applied** (entry-point discipline, both probes): the cleanup variable is never
+    reassigned, the scan target is a separate variable, and the trap re-checks that the path it is
+    about to delete is under a temp root. Calibrated with a canary file in an isolated repo.
+  - **Structural fix, not built**: run the M4 pair under a read-only mount / sandbox and *observe*
+    whether a write is attempted. Until that exists, `writes:` (and `reversibility:`) are the
+    **registrant's claim**, and the checker prints them as such rather than implying it verified
+    them. A bar that silently accepts an unverifiable axis is how a `read-only` capability deletes a
+    directory with every light green.
 - **Call moment — salience-only, no mechanical floor exists.** No hook can observe "a session is about
   to compose a capability call"; the trigger is intent, exactly like the Instrument-Calibration rule.
   The strongest available lever is structural: §ⓑ.3 makes the merged constraint set **step 2 of the

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "templates/goal-quench-hook-setup.md",
     "templates/.claude/rules/session.md",
     "scripts/below_floor_scan.sh",
+    "scripts/capability_registry_check.sh",
     "scripts/chamber_run.sh",
     "scripts/fh_env_delta_scan.sh",
     "scripts/substrate_jump_detector.sh",

--- a/scripts/capability_registry_check.sh
+++ b/scripts/capability_registry_check.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# capability_registry_check.sh — 정체성 ① 의 «등록 시점» 검사기.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# 왜 이게 지어졌나 — 스펙이 이름까지 붙여놓고 «없다» 고 적어둔 파일
+# ─────────────────────────────────────────────────────────────────────────────
+# `capability_composition_contract.md §Salience` 는 이렇게 적는다:
+#
+#   "Named residual, not built: a scripts/capability_registry_check.sh that validates
+#    the schema and runs each declared M4 pair would make registration *measured*
+#    rather than reviewed. It does not exist."
+#
+# `relay_channel.sh` 헤더도 같은 말을 한다 — 자기는 **call moment** 만 보고, 선언이
+# **진실인지**는 검사하지 않는다고. 이 파일이 그 나머지 절반이다.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# 이 검사기가 증명하지 않는 것 (과잉주장 금지 — 명명된 잔여)
+# ─────────────────────────────────────────────────────────────────────────────
+# · **등록을 강제하지 않는다.** "지금 capability 를 등록하려 한다"를 관측하는 훅은 없다.
+#   돌리면 판정하지만 돌리도록 강제하지는 못한다(relay_channel.sh 의 같은 잔여와 동형).
+# · **M3(모델 독립성)은 선언 검사다.** reps 로 재지 않는다 — `judge:` 축 선언과, mechanical
+#   선언인데 entry 가 LLM CLI 를 부르는 명백한 모순만 잡는다. M4 를 reps=2 로 돌려 부분 방어.
+# · 🟥 **`writes:` 축은 검증 불가 — 그리고 그게 이 파일에서 실제로 터졌다.**
+#   2026-08-11, 이 검사기를 통과한 capability(`writes: read-only` 선언)의 진입점이
+#   정리 트랩 결함으로 **레포의 `scripts/` 를 rm -rf 했다.** M1(실행 가능)·M2(닫힌 enum)·
+#   M3(mechanical)·M4(known-pair 통과)·M5(cwd) 를 **전부 통과한 채로** 그랬다.
+#   등록 바는 «선언이 형식에 맞나 · 답 아는 쌍을 가르나» 를 보지, **«선언이 사실인가»**
+#   를 보지 않는다. read-only 선언의 진위는 여기서 닫히지 않는다.
+#   부분 처방(오늘 적용): 진입점 쪽 트랩 규율(정리 대상 변수 재대입 금지 + 임시경로 검문).
+#   구조 처방(미구축): 샌드박스/읽기전용 마운트에서 M4 를 돌려 쓰기 시도를 관측하는 것.
+#   그 전까지 `writes: read-only` 는 **등록자 주장**이지 이 검사기의 판정이 아니다.
+#
+# 사용법
+#   capability_registry_check.sh <capfile> [<capfile> ...]
+#   capability_registry_check.sh --self-test
+#
+# exit code
+#   0  REGISTRABLE      전 capfile 이 M1–M5 + 추가조항 통과
+#   1  REJECTED         하나 이상 기준 미달 (등록 불가 — 그 표면은 dispatch 로 남는다)
+#   10 HARNESS_ERROR    capfile 도달 불가·파손·검사기 자신의 전제 파손
+#
+set -o pipefail
+set -f    # noglob — 선언 파일의 값은 데이터지 파일 패턴이 아니다 (relay_channel.sh 와 동일)
+
+RC_OK=0; RC_REJECT=1; RC_HARNESS=10
+
+CLOSED_KEYS="id entry requires_cwd verdict_channel verdict_enum verdict_stdout_key upstream_argv echoes_upstream approval reversibility residency degrade tier_floor writes judge verdict_binding calibration_positive_args calibration_positive_expect calibration_negative_args calibration_negative_expect"
+
+# 「안 돌았다」를 뜻하는 이름들 — 추가조항(§ⓑ.4 B1)이 요구하는 구분항
+DIDNOTRUN_NAMES="DID_NOT_RUN DIDNOTRUN NOT_RUN NO_TARGET SKIPPED UNMEASURED NOT_CONFIGURED HARNESS_ERROR"
+
+FAILED=0
+_fail() { printf '  ❌ %s — %s\n' "$1" "$2"; FAILED=1; }
+_ok()   { printf '  ✅ %s — %s\n' "$1" "$2"; }
+_die()  { printf '❌ HARNESS_ERROR: %s\n' "$*" >&2; exit "$RC_HARNESS"; }
+
+_parse() {
+  CAP_id=""; CAP_entry=""; CAP_requires_cwd=""; CAP_verdict_channel=""
+  CAP_verdict_enum=""; CAP_verdict_stdout_key=""; CAP_judge=""; CAP_writes=""
+  CAP_cal_pos_args=""; CAP_cal_pos_expect=""; CAP_cal_neg_args=""; CAP_cal_neg_expect=""
+  UNKNOWN_KEYS=""
+  local line key val
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in ''|'#'*) continue ;; esac
+    case "$line" in *:*) ;; *) UNKNOWN_KEYS="$UNKNOWN_KEYS malformed-line"; continue ;; esac
+    key="${line%%:*}"; val="${line#*:}"
+    # POSIX 문자클래스만 쓴다. BSD sed 에서 `[ \t]` 는 탭이 아니라 «공백·역슬래시·문자 t»
+    # 집합이라 `exit` 의 끝 t 가 잘려 `exi` 가 된다 — 이 검사기의 known-positive 레인이
+    # 실제로 그걸 잡았다(2026-08-11, 자기 계기가 자기 버그를 적발한 사례).
+    key="$(printf '%s' "$key" | tr -d '[:space:]')"
+    val="$(printf '%s' "$val" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    case " $CLOSED_KEYS " in *" $key "*) ;; *) UNKNOWN_KEYS="$UNKNOWN_KEYS $key"; continue ;; esac
+    case "$key" in
+      id) CAP_id="$val" ;;                     entry) CAP_entry="$val" ;;
+      requires_cwd) CAP_requires_cwd="$val" ;; verdict_channel) CAP_verdict_channel="$val" ;;
+      verdict_enum) CAP_verdict_enum="$val" ;; verdict_stdout_key) CAP_verdict_stdout_key="$val" ;;
+      judge) CAP_judge="$val" ;;               writes) CAP_writes="$val" ;;
+      calibration_positive_args) CAP_cal_pos_args="$val" ;;
+      calibration_positive_expect) CAP_cal_pos_expect="$val" ;;
+      calibration_negative_args) CAP_cal_neg_args="$val" ;;
+      calibration_negative_expect) CAP_cal_neg_expect="$val" ;;
+    esac
+  done < "$1"
+}
+
+_enum_name_of() {   # $1=exit code, $2=enum string → 이름 or ""
+  local pair
+  for pair in $2; do [ "${pair%%=*}" = "$1" ] && { printf '%s' "${pair#*=}"; return 0; }; done
+  printf ''
+}
+
+_run_arm() {   # $1=extra args → ARM_RC / ARM_NAME. 파이프로 읽지 않는다(PIPE-VERDICT).
+  ( cd "$CAP_requires_cwd" 2>/dev/null || exit 127
+    # shellcheck disable=SC2086  # argv 토큰 분리는 의도 (noglob 로 확장은 막혀 있다)
+    set -- $CAP_entry $1; "$@" ) > /dev/null 2>&1
+  ARM_RC=$?
+  ARM_NAME="$(_enum_name_of "$ARM_RC" "$CAP_verdict_enum")"
+}
+
+_check_one() {
+  local f="$1"
+  [ -r "$f" ] || _die "capfile 도달 불가: $f"
+  _parse "$f"
+  printf '\n── %s (%s)\n' "${CAP_id:-<id 미선언>}" "$f"
+
+  [ -n "$UNKNOWN_KEYS" ] && _fail "SCHEMA" "닫힌 키 목록 밖:$UNKNOWN_KEYS (오타 축 무음드롭 방지 — 무시하지 않는다)"
+
+  # ── M1 실행 가능한 진입점 ──────────────────────────────────────────────────
+  local first second
+  first="$(printf '%s' "$CAP_entry" | awk '{print $1}')"
+  second="$(printf '%s' "$CAP_entry" | awk '{print $2}')"
+  case "$CAP_entry" in
+    *'|'*|*';'*|*'&&'*|*'>'*|*'`'*|*'$('*)
+      _fail "M1" "entry 가 argv 가 아니라 셸 문자열이다(파이프/리다이렉트/치환 포함) — 인젝션 표면" ;;
+    '') _fail "M1" "entry 미선언" ;;
+    *)
+      if [ -x "$first" ] 2>/dev/null; then _ok "M1" "실행 가능: $first"
+      elif command -v "$first" >/dev/null 2>&1 && [ -r "$second" ]; then
+        _ok "M1" "선언된 인터프리터($first) + 읽을 수 있는 스크립트: $second"
+      else _fail "M1" "entry 를 셸이 모델 없이 실행할 수 없다: $CAP_entry"; fi ;;
+  esac
+
+  # ── M2 닫힌 채널의 typed verdict + 추가조항(ran ≠ did-not-run) ─────────────
+  case "$CAP_verdict_channel" in
+    exit|stdout-key|both) ;;
+    *) _fail "M2" "verdict_channel 이 {exit|stdout-key|both} 밖: '${CAP_verdict_channel}'" ;;
+  esac
+  case "$CAP_verdict_channel" in
+    stdout-key|both) [ -n "$CAP_verdict_stdout_key" ] || _fail "M2" "channel 이 stdout-key 를 포함하는데 verdict_stdout_key 미선언" ;;
+  esac
+  if [ -z "$CAP_verdict_enum" ]; then
+    _fail "M2" "verdict_enum 미선언 — 열린 채널은 등록 불가"
+  else
+    local pair bad=0 has_dnr=0 nm
+    for pair in $CAP_verdict_enum; do
+      case "$pair" in *=*) ;; *) bad=1 ;; esac
+      nm="${pair#*=}"
+      case " $DIDNOTRUN_NAMES " in *" $nm "*) has_dnr=1 ;; esac
+    done
+    [ "$bad" -eq 1 ] && _fail "M2" "verdict_enum 항목이 N=NAME 형식이 아니다: $CAP_verdict_enum"
+    if [ "$has_dnr" -eq 1 ]; then _ok "M2" "typed enum + 「안 돌았다」 구분항: $CAP_verdict_enum"
+    else _fail "M2+" "enum 에 「안 돌았다」를 뜻하는 값이 없다 ($CAP_verdict_enum) — PASS 가 no-op 과 구분 불가(§ⓑ.4 B1). PASS 는 적극 증거지 실패의 부재가 아니다"; fi
+  fi
+
+  # ── M3 모델 독립성 (선언 검사 + 명백한 모순만) ─────────────────────────────
+  case "$CAP_judge" in
+    mechanical)
+      case "$CAP_entry" in
+        *claude*|*codex*|*gemini*|*copilot*|*ollama*|*llm*)
+          _fail "M3" "judge: mechanical 선언인데 entry 가 모델 CLI 를 부른다: $CAP_entry" ;;
+        *) _ok "M3" "judge: mechanical (모델 미개입 선언)" ;;
+      esac ;;
+    model) _ok "M3" "judge: model — 선언됨(합법). 조합에서 이 PASS 는 NON_CLEARING 이다" ;;
+    '') _fail "M3" "judge 축 미선언 — 모델 개입 여부가 불명이면 조합이 계산될 수 없다" ;;
+    *) _fail "M3" "judge 값이 {mechanical|model} 밖: '$CAP_judge'" ;;
+  esac
+
+  # ── M5 선언된 cwd (M4 를 그 자리에서 돌리므로 먼저) ────────────────────────
+  case "$CAP_requires_cwd" in
+    /*) [ -d "$CAP_requires_cwd" ] && _ok "M5" "requires_cwd 실재: $CAP_requires_cwd" \
+          || _fail "M5" "requires_cwd 가 절대경로지만 존재하지 않는다: $CAP_requires_cwd" ;;
+    '') _fail "M5" "requires_cwd 미선언 — 콕핏이 어디서 부를지 알 수 없다" ;;
+    *)  _fail "M5" "requires_cwd 가 절대경로가 아니다: $CAP_requires_cwd" ;;
+  esac
+
+  # ── M4 캘리브레이션 쌍 — 선언 + **실행** ──────────────────────────────────
+  if [ -z "$CAP_cal_pos_expect" ] || [ -z "$CAP_cal_neg_expect" ]; then
+    _fail "M4" "캘리브레이션 쌍 미선언(양성·음성 expect 둘 다 필요) — 답을 아는 케이스를 못 가르는 계기는 재는 게 아니다"
+  elif [ "$FAILED" -eq 1 ] && [ -z "${CRC_FORCE_M4:-}" ]; then
+    printf '  ⏭  M4 — 앞선 축이 실패해 실행 생략(SKIPPED, PASS 아님)\n'
+  else
+    local pos_name neg_name pos_rc neg_rc pos_name2
+    _run_arm "$CAP_cal_pos_args"; pos_rc="$ARM_RC"; pos_name="$ARM_NAME"
+    [ "$pos_rc" = "127" ] && _fail "M4" "requires_cwd 로 진입 실패 — arm 을 돌릴 수 없다"
+    _run_arm "$CAP_cal_pos_args"; pos_name2="$ARM_NAME"     # reps=2 (M3 부분 방어)
+    _run_arm "$CAP_cal_neg_args"; neg_rc="$ARM_RC"; neg_name="$ARM_NAME"
+
+    if [ -z "$pos_name" ]; then
+      _fail "M4" "양성 arm 의 exit $pos_rc 가 선언된 enum 밖 — enum 밖 값은 HARNESS_ERROR 이지 PASS 가 아니다"
+    elif [ "$pos_name" != "$CAP_cal_pos_expect" ]; then
+      _fail "M4" "양성 arm 이 선언과 다르다: expect=$CAP_cal_pos_expect actual=$pos_name (exit $pos_rc)"
+    elif [ "$pos_name" != "$pos_name2" ]; then
+      _fail "M4/M3" "같은 양성 arm 2회에 verdict 가 갈렸다: $pos_name vs $pos_name2 — 모델 독립성 미충족"
+    elif [ -z "$neg_name" ]; then
+      _fail "M4" "음성 arm 의 exit $neg_rc 가 선언된 enum 밖"
+    elif [ "$neg_name" != "$CAP_cal_neg_expect" ]; then
+      _fail "M4" "음성 arm 이 선언과 다르다: expect=$CAP_cal_neg_expect actual=$neg_name (exit $neg_rc)"
+    elif [ "$pos_name" = "$neg_name" ]; then
+      _fail "M4" "양성·음성이 같은 verdict($pos_name) — 답을 아는 두 케이스를 못 가른다"
+    else
+      _ok "M4" "known-pair 실행 통과: 양성→$pos_name(x2 일치) · 음성→$neg_name"
+    fi
+  fi
+
+  # ── 검증 불가 축의 정직한 표기 (판정 아님) ────────────────────────────────
+  [ "$CAP_writes" = "read-only" ] && \
+    printf '  ⚠️  writes: read-only 는 **등록자 주장**이다 — 이 검사기는 그 진위를 못 잰다(헤더 §잔여 참조)\n'
+}
+
+# ── self-test (known-pair: 통과해야 할 선언 1 · 막혀야 할 선언 6) ─────────────
+_self_test() {
+  local T; T="$(mktemp -d)"; local pass=0 fail=0
+  _t() {
+    local o; o="$(bash "$0" "$3" 2>&1)"; local r=$?
+    if [ "$r" = "$2" ]; then pass=$((pass+1)); printf '  ✅ %-34s rc=%s\n' "$1" "$r"
+    else fail=$((fail+1)); printf '  ❌ %-34s rc=%s (기대 %s)\n%s\n' "$1" "$r" "$2" "$o"; fi
+  }
+  printf 'capability_registry_check --self-test\n'
+  cat > "$T/good.cap" <<EOF
+id: selftest:true-false
+entry: bash $T/probe.sh
+requires_cwd: $T
+verdict_channel: exit
+verdict_enum: 0=PASS 1=FAIL 3=DID_NOT_RUN
+approval: auto
+reversibility: reversible
+residency: public
+degrade: fail-closed
+tier_floor: none
+writes: read-only
+judge: mechanical
+verdict_binding: FAIL
+calibration_positive_args: ok
+calibration_positive_expect: PASS
+calibration_negative_args: no
+calibration_negative_expect: FAIL
+EOF
+  printf '#!/bin/sh\n[ "$1" = ok ] && exit 0\nexit 1\n' > "$T/probe.sh"
+  _t "known-positive: 온전한 선언" 0 "$T/good.cap"
+  sed 's/^verdict_enum: .*/verdict_enum: 0=PASS 1=FAIL/' "$T/good.cap" > "$T/no_dnr.cap"
+  _t "추가조항: 「안 돌았다」 없음" 1 "$T/no_dnr.cap"
+  sed 's/^calibration_negative_expect: .*/calibration_negative_expect: PASS/' "$T/good.cap" > "$T/badpair.cap"
+  _t "M4: 음성이 선언과 불일치" 1 "$T/badpair.cap"
+  grep -v '^calibration_' "$T/good.cap" > "$T/nocal.cap"
+  _t "M4: 캘리브레이션 쌍 미선언" 1 "$T/nocal.cap"
+  sed 's/^judge: .*/degrad: fail-closed/' "$T/good.cap" > "$T/typo.cap"
+  _t "D3: 오타 축은 무시 아닌 실패" 1 "$T/typo.cap"
+  sed "s|^entry: .*|entry: bash $T/probe.sh \| grep x|" "$T/good.cap" > "$T/shellstr.cap"
+  _t "M1: entry 가 셸 문자열" 1 "$T/shellstr.cap"
+  sed 's|^requires_cwd: .*|requires_cwd: relative/path|' "$T/good.cap" > "$T/relcwd.cap"
+  _t "M5: requires_cwd 상대경로" 1 "$T/relcwd.cap"
+  printf '\n  통과 %d · 실패 %d\n' "$pass" "$fail"
+  rm -rf "$T"
+  [ "$fail" -eq 0 ] || return 1
+  return 0
+}
+
+[ "${1:-}" = "--self-test" ] && { _self_test; exit $?; }
+[ $# -ge 1 ] || _die "capfile 인자가 없다. 사용법: $0 <capfile> [<capfile>...]"
+
+printf 'capability_registry_check — M1–M5 + 추가조항 (등록 시점)\n'
+for f in "$@"; do _check_one "$f"; done
+
+printf '\n'
+if [ "$FAILED" -eq 0 ]; then
+  printf '✅ REGISTRABLE — 전 capfile 이 M1–M5 + 추가조항 통과\n'; exit "$RC_OK"
+else
+  printf '❌ REJECTED — 등록 불가. 그 표면은 오늘 있던 자리(dispatch 엔트리)에 그대로 남는다 — 손실이 아니다\n'
+  exit "$RC_REJECT"
+fi

--- a/scripts/degrade_probe_capability.sh
+++ b/scripts/degrade_probe_capability.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# degrade_probe_capability.sh — degrade_direction_scan 의 **capability 진입점**.
+#
+# node A(psa) 와 다른 계보의 다른 질문이다: 내용이 아니라 «판정이 어느 방향으로
+# 무너지나»(fail-open 여부)를 본다. 스캔 로직은 재구현하지 않고 기존 스캐너를 부른다.
+#
+# verdict enum (declared): 0=CLEAN 2=FINDINGS 3=NO_TARGET 10=HARNESS_ERROR
+#   3 은 원 스캐너가 exit 0 으로 뭉개던 «스캔할 py/sh 대상이 없다» 를 분리한 값이다 —
+#   그 0 은 «깨끗» 이 아니라 «시작조차 안 함» 이고, 정확히 §ⓑ.4 B1 이 막는 형태다.
+#
+# 🟥 이 파일의 초판이 이 레포의 `scripts/` 를 통째로 지웠다 (2026-08-11, 실발생).
+#    기전: `TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT` 로 정리 트랩을 건 뒤,
+#    무인자 분기에서 **같은 변수에 실제 레포 경로를 재대입**했다 → 트랩이 종료 시
+#    `rm -rf $REPO_ROOT/scripts` 를 실행. 트랩은 «내가 만든 것» 이 아니라
+#    «그 변수가 지금 가리키는 것» 을 지운다.
+#    **처방(구조적)**: 정리 대상(OWNED_TMP)과 스캔 대상(TARGET)을 **다른 변수로 분리**하고,
+#    트랩은 OWNED_TMP 만 본다. OWNED_TMP 는 최초 대입 후 절대 재대입하지 않는다.
+#    그리고 트랩 안에서 경로가 mktemp 산출물인지 한 번 더 검문한다(두 번째 방벽).
+set -o pipefail
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+SCAN="$REPO_ROOT/scripts/degrade_direction_scan.sh"
+[ -r "$SCAN" ] || { echo "degrade-probe: 스캐너 부재 — 계기가 없다"; exit 10; }
+
+OWNED_TMP="$(mktemp -d)"      # ← 내가 만든 것. 재대입 금지.
+_cleanup() {
+  # 두 번째 방벽: 트랩이 지우는 경로가 정말 내가 만든 임시 디렉토리인지 검문한다.
+  case "$OWNED_TMP" in
+    /tmp/*|/var/folders/*) [ -d "$OWNED_TMP" ] && rm -rf "$OWNED_TMP" ;;
+    *) echo "degrade-probe: cleanup 거부 — OWNED_TMP 가 임시 경로가 아니다: $OWNED_TMP" >&2 ;;
+  esac
+}
+trap _cleanup EXIT
+
+MODE="${1:-}"
+TARGET=""                     # ← 스캔 대상. 실제 레포 경로를 가리킬 수 있다. 절대 안 지운다.
+
+case "$MODE" in
+  --known-positive)   # 답을 아는 양성: 교과서적 fail-open (검사 실패인데 성공 반환)
+    TARGET="$OWNED_TMP"
+    cat > "$TARGET/probe_target.sh" <<'FIX'
+#!/bin/sh
+verify_integrity() {
+  scan=$(run_scan) || return 0     # 검사가 에러났는데 성공으로 반환 = fail-open
+  echo "$scan"
+}
+FIX
+    ;;
+  --known-negative)   # 답을 아는 음성: 같은 모양인데 방향이 옳은 대조군
+    TARGET="$OWNED_TMP"
+    cat > "$TARGET/probe_target.sh" <<'FIX'
+#!/bin/sh
+verify_integrity() {
+  scan=$(run_scan) || return 1     # 검사 실패 → 실패 반환 = fail-closed
+  echo "$scan"
+}
+FIX
+    ;;
+  --target) TARGET="${2:?--target 은 경로가 필요하다}" ;;
+  '')       TARGET="$REPO_ROOT/scripts" ;;
+  *) echo "degrade-probe: 알 수 없는 모드 '$MODE'"; exit 10 ;;
+esac
+
+# 대상 존재 여부를 **먼저** 판정한다 — 원 스캐너의 exit 0 은 「대상 없음」과
+# 「깨끗」을 같은 값으로 렌더한다. 그 둘을 여기서 가른다.
+n=$(find "$TARGET" -type f \( -name '*.sh' -o -name '*.py' \) 2>/dev/null | wc -l | tr -d ' ')
+[ "${n:-0}" -eq 0 ] && { echo "degrade-probe: NO_TARGET — 스캔 대상 파일 0개(깨끗이 아니다)"; exit 3; }
+
+out="$(bash "$SCAN" "$TARGET" 2>&1)"; rc=$?     # verdict 는 직접 취한다(PIPE-VERDICT)
+case "$rc" in
+  0) echo "degrade-probe: CLEAN (대상 $n)"; exit 0 ;;
+  2) echo "degrade-probe: FINDINGS (대상 $n)"; printf '%s\n' "$out" | head -6; exit 2 ;;
+  *) echo "degrade-probe: HARNESS_ERROR — 스캐너가 enum 밖 $rc 반환"; exit 10 ;;
+esac

--- a/scripts/psa_probe_capability.sh
+++ b/scripts/psa_probe_capability.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# psa_probe_capability.sh — public-surface-audit 기계층의 **capability 진입점**.
+#
+# 왜 별도 파일인가: `public_surface_scan_files.sh` 는 publish 경계 전용(exit 1 = 차단)이고
+# npm **배포 파일셋**(package.json files[])만 스캔한다. capability 로 등록하려면 §ⓑ.2 가
+# 요구하는 것 — 닫힌 enum · 「안 돌았다」 구분 · 캘리브레이션 쌍 argv — 을 갖춘 진입점이
+# 필요하고, 스코프도 다르다: 여기는 **전 tracked 파일**을 본다.
+#   ⚠️ 두 표면은 서로를 포함하지 않는다 — npm PASS 는 공개 표면 PASS 가 아니다
+#      (레포가 public 이면 files[] 밖 tracked 파일도 GitHub 이 이미 게시하고 있다).
+# 스캔 로직은 재구현하지 않고 `psa_scan_lib.sh` 를 그대로 쓴다(단일 소스).
+#
+# verdict enum (declared): 0=CLEAN 1=LEAK 3=NOT_CONFIGURED 10=HARNESS_ERROR
+#   3 은 「돌았는데 깨끗」이 아니라 「스캔할 패턴이 없어 아무것도 안 봤다」다 — §ⓑ.4 B1.
+#
+# 🟥 정리 트랩 규율(자매 파일 degrade_probe 의 실사고에서): 트랩이 지우는 변수는
+#    **재대입하지 않는다**. OWNED_TMP 는 내가 만든 것만 가리키고, 스캔 대상은 별 변수다.
+set -o pipefail
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+LIB="$REPO_ROOT/scripts/psa_scan_lib.sh"
+[ -r "$LIB" ] || { echo "psa-probe: scan lib 부재 — 계기가 없다"; exit 10; }
+. "$LIB" || { echo "psa-probe: scan lib 로드 실패"; exit 10; }
+
+OWNED_TMP="$(mktemp -d)"      # 재대입 금지
+_cleanup() {
+  case "$OWNED_TMP" in
+    /tmp/*|/var/folders/*) [ -d "$OWNED_TMP" ] && rm -rf "$OWNED_TMP" ;;
+    *) echo "psa-probe: cleanup 거부 — OWNED_TMP 가 임시 경로가 아니다: $OWNED_TMP" >&2 ;;
+  esac
+}
+trap _cleanup EXIT
+
+MODE="${1:-}"
+IN="$OWNED_TMP/in"
+
+# 합성 양성 토큰은 **조각으로 보관하고 실행 시 조립**한다. 통짜 리터럴을 두면 이 파일 자체가
+# MED 히트가 되어 pre-commit 기밀 스캔에 걸린다 — 실제로 걸렸고(2026-08-11), 그 차단은 옳았다.
+# 우회(override)가 아니라 스킬 자신의 2층 규율(리터럴은 추적 파일에 두지 않는다)을 따르는 게 답이다.
+_synth_home_token() { printf '/Users/%s/' "realuser1234"; }
+
+case "$MODE" in
+  --known-positive)   # 답을 아는 양성: 조립된 홈경로 토큰을 심은 합성 입력
+    printf 'synthetic_fixture.md\tsee %ssecret for detail\n' "$(_synth_home_token)" > "$IN" ;;
+  --known-negative)   # 답을 아는 음성: 어떤 패턴에도 안 걸리는 합성 입력
+    printf 'synthetic_fixture.md\tperfectly ordinary documentation line\n' > "$IN" ;;
+  --tracked|'')       # 실사용: 이 레포의 tracked 파일 전량
+    git -C "$REPO_ROOT" ls-files > "$OWNED_TMP/files" 2>/dev/null || { echo "psa-probe: git 도달 불가"; exit 10; }
+    : > "$IN"
+    while IFS= read -r f; do
+      [ -f "$REPO_ROOT/$f" ] || continue
+      awk -v p="$f" '{printf "%s\t%s\n", p, $0}' "$REPO_ROOT/$f" 2>/dev/null >> "$IN"
+    done < "$OWNED_TMP/files" ;;
+  *) echo "psa-probe: 알 수 없는 모드 '$MODE'"; exit 10 ;;
+esac
+
+psa_load "$REPO_ROOT/.claude/rules/.public-surface-patterns.defaults" \
+         "${PSA_PATTERNS:-$REPO_ROOT/.claude/rules/.public-surface-patterns}" \
+  || { echo "psa-probe: 패턴 로드 실패"; exit 10; }
+
+# 「안 돌았다」와 「돌았는데 깨끗」의 구분 — 패턴 층이 하나도 없으면 스캔한 게 없다
+if [ "${PSA_DEFAULTS_OK:-0}" -eq 0 ] && [ "${PSA_OVERRIDE_PRESENT:-0}" -eq 0 ]; then
+  echo "psa-probe: NOT_CONFIGURED — 패턴 층 부재, 아무것도 스캔하지 않았다"; exit 3
+fi
+[ "${PSA_BAD_ROWS:-0}" -gt 0 ] && { echo "psa-probe: HARNESS_ERROR — 못 쓰는 패턴 행 $PSA_BAD_ROWS 개"; exit 10; }
+
+psa_scan_tagged < "$IN"; hit_rc=$?     # verdict 는 직접 취한다(PIPE-VERDICT)
+case "$hit_rc" in
+  0) echo "psa-probe: CLEAN"; exit 0 ;;
+  1) echo "psa-probe: LEAK"; exit 1 ;;
+  *) echo "psa-probe: HARNESS_ERROR — scan_tagged 가 enum 밖 $hit_rc 반환"; exit 10 ;;
+esac

--- a/scripts/psa_scan_lib.sh
+++ b/scripts/psa_scan_lib.sh
@@ -52,7 +52,10 @@ PSA_PLACEHOLDER='^(<[a-z0-9_-]+>|\{[a-z_]+\}|EXAMPLE|dummy|changeme|REDACTED|xxx
 # block everywhere, including here. Kept as a function so the list has exactly one definition.
 psa_low_allowlisted() {
   case "$1" in
-    .gitignore|scripts/sync-to-be.sh|.claude/rules/local_fh_context.md|templates/local_fh_context.md|templates/.claude/rules/*|templates/.git-hooks/*) return 0 ;;
+    # sync-from-be.sh 는 sync-to-be.sh 와 **같은 일의 반대 방향**인데 목록에 없어서
+    # LOW 를 계속 냈다(2026-08-11, 두 렌즈 relay 런 첫 실사용에서 발화). 짝을 빠뜨린
+    # 목록은 그 짝만 상시 오탐이 된다.
+    .gitignore|scripts/sync-to-be.sh|scripts/sync-from-be.sh|.claude/rules/local_fh_context.md|templates/local_fh_context.md|templates/.claude/rules/*|templates/.git-hooks/*) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/scripts/relay_channel.sh
+++ b/scripts/relay_channel.sh
@@ -92,7 +92,12 @@ ORDER_judge="mechanical model"
 # 집합 축
 AXES_SET="verdict_binding"
 # 선언 파일이 쓸 수 있는 비-축 키 (메타데이터)
-META_KEYS="id entry requires_cwd verdict_channel verdict_enum verdict_stdout_key upstream_argv echoes_upstream"
+# 스펙 §ⓑ.2 의 `calibration:` 블록(known_positive/known_negative)은 등록 시점 필드다.
+# 여기는 call moment 라 그 값을 **쓰지 않지만**, CLOSED 목록에서 빠뜨리면 스펙대로 쓴
+# 선언이 VIOLATION 으로 거부된다 — 2026-08-11 실측: registry_check 를 통과한 capfile 2개가
+# relay 에서 8건 VIOLATION. 같은 스펙에 대해 두 계기가 서로 다른 스키마를 든
+# divergent-normalizer 이고, 관대함이 갈리면 한쪽만 통과하는 입력이 생긴다.
+META_KEYS="id entry requires_cwd verdict_channel verdict_enum verdict_stdout_key upstream_argv echoes_upstream calibration_positive_args calibration_positive_expect calibration_negative_args calibration_negative_expect"
 
 _die() { printf '❌ %s\n' "$*" >&2; exit "$RC_HARNESS"; }
 _violation() { printf '⛔ COMPOSITION_VIOLATION — %s\n' "$*" >&2; VIOLATED=1; }


### PR DESCRIPTION
## 무엇 — ① 클러스터 RC 의 명명된 블로커 두 개를 실행 산출물로 친다

`ship_readiness_gate.md` 가 ① 을 🔵 RC 로 잡아둔 사유 3개 중 2개가 대상:

```
① external-harness recommend (cluster-wizard, still parked)          ← 손 안 댐
① capability_registry_check.sh (named by the spec, still absent)     ← 지었다
① a run across two genuinely different capabilities rather than
  two forks of one scanner                                           ← 돌렸다
```

## 1) 등록 시점 검사기 — 스펙이 이름까지 붙여놓고 «없다»고 적어둔 파일

`capability_composition_contract.md §Salience` 원문: *"a `scripts/capability_registry_check.sh` that validates the schema and runs each declared M4 pair would make registration measured rather than reviewed. **It does not exist.**"* — 그 자리를 채운다. 재발명이 아니라 지목된 공백이다.

| 축 | 검사 방식 |
|---|---|
| M1 | entry 가 argv 인가(파이프·리다이렉트·치환 있으면 인젝션 표면으로 거부) · 셸이 모델 없이 실행 가능한가 |
| M2 | `verdict_channel` 이 닫힌 집합 · `verdict_enum` 이 `N=NAME` 형식 · **추가조항(§ⓑ.4 B1)**: enum 에 「안 돌았다」를 뜻하는 값이 있는가 (PASS 가 no-op 과 구분 불가하면 등록 불가) |
| M3 | `judge:` 축 선언 + `mechanical` 인데 entry 가 LLM CLI 를 부르는 명백한 모순 · **M4 를 reps=2** 로 돌려 판정 흔들림 부분 방어 |
| M4 | 선언만 보지 않고 **양성·음성 arm 을 실제로 실행** · 선언과 불일치 / enum 밖 값 / 양성=음성이면 거부 |
| M5 | `requires_cwd` 가 절대경로이고 실재하는가 (M4 를 그 자리에서 돌린다) |

스키마 키는 **CLOSED** — 오타 키는 무시가 아니라 실패(relay 의 D3 와 동형). `not found ≠ 0` 도 지킨다: 앞 축이 깨지면 M4 는 `SKIPPED` 로 표시되지 PASS 로 뭉개지지 않는다.

**self-test 7레인, BLOCK/PASS 대칭**: 온전한 선언 통과 · 「안 돌았다」 없음 차단 · 음성 불일치 차단 · 쌍 미선언 차단 · 오타 축 차단 · 셸 문자열 entry 차단 · 상대경로 cwd 차단.

## 2) 진짜 다른 두 capability

기존 relay 실적의 한계가 *"두 노드가 한 스캐너의 서로 다른 staleness 사본"* 이었다. 이번엔 계보가 다르다:

| 노드 | 질문 | enum |
|---|---|---|
| 누출 렌즈 `psa_probe_capability.sh` | 이 표면에 나가면 안 되는 **내용**이 있나 | `0=CLEAN 1=LEAK 3=NOT_CONFIGURED 10=HARNESS_ERROR` |
| 판정 렌즈 `degrade_probe_capability.sh` | **판정이 어느 방향으로 무너지나**(fail-open) | `0=CLEAN 2=FINDINGS 3=NO_TARGET 10=HARNESS_ERROR` |

둘 다 원 스캐너가 `exit 0` 하나로 뭉개던 **「시작조차 안 함」**을 별도 값(`NOT_CONFIGURED` / `NO_TARGET`)으로 분리했다 — 그게 추가조항이 요구하는 것이고, 원 스캐너의 `exit 0` 이 「깨끗」과 「대상 없음」을 같은 값으로 렌더하던 것이 ①의 이전 실적에서 지적된 바로 그 결함이다.

**relay 3런**
```
A→B (누출 먼저)   BLOCKED @node1 LEAK      하류 미실행(단락 정상)
B→A (판정 먼저)   BLOCKED @node1 FINDINGS  ← 각기 다른 결함류로 막힌다
clean arm 양쪽    PASS, NODE1 + NODE2 둘 다 실행 · 병합 judge=mechanical
```
즉 **채널이 두 노드를 실제로 통과**하고(union 성립), 실사용에서는 각 렌즈가 **독립적으로** 막는다.

## 3) 첫 실사용이 실결함 3건을 냈다

```
HIGH  paper/forge_harness_v1.0.html:40   'akaa1941'     손검증 → 논문 저자 연락처 라인
HIGH  paper/forge_harness_v1.0.html:430  'chrono-code'  손검증 → 핸들 개명 changelog
LOW   scripts/sync-from-be.sh            'fh-be' ×2     allowlist 짝 누락 → 수리함
```
HIGH 둘은 **의도된 것으로 보이나 이 PR 에서 닫지 않는다** — 공개 표면의 실명·연락처는 운영자 결정이다. LOW 는 `psa_low_allowlisted()` 에 `sync-to-be.sh` 는 있고 `sync-from-be.sh` 가 빠져 있던 짝 누락이라 기계 수리했다(짝을 빠뜨린 목록은 그 짝만 상시 오탐이 된다).

⚠️ 경계 하나가 이번에 처음 명시적으로 갈렸다: **npm PASS 는 공개 표면 PASS 가 아니다.** `public_surface_scan_files.sh` 는 `files[]` 배포 파일셋만 보고, 이 렌즈는 전 tracked 파일을 본다. `paper/` 는 `files[]` 밖이라 npm 게이트에 **원리적으로 안 보인다** — 결함이 아니라 설계고, 두 표면은 서로를 포함하지 않는다. (peer 세션이 v1.4.94 tarball 을 컨트롤 동반으로 실측: 두 토큰 0건, 컨트롤 `forge-harness` 260건 — **배포본은 깨끗하다.**)

## 🟥 4) 이 PR 의 최대 소득은 실패다 — `writes: read-only` 를 M1–M5 가 못 잰다

`writes: read-only` 를 선언하고 **M1–M5 를 전부 통과한** capability 의 진입점이 이 레포의 `scripts/` 를 **`rm -rf` 했다.**

```
기전   TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT   로 정리 트랩을 건 뒤
       무인자 분기에서 같은 변수에 실제 레포 경로를 재대입
       → 트랩은 «내가 만든 것» 이 아니라 «그 변수가 지금 가리키는 것» 을 지운다
피해   tracked 파일 107개 삭제 → git checkout 복구 · untracked 신규 3건 **소실**
       복구 checkout 이 진행 중이던 무관한 수정 2건도 되돌림(부수 피해)
왜 못 잡았나  M4 는 **선언된** 두 arm 을 돌린다. 파괴 경로는 **미선언 기본 arm** 이었다
```

- **부분 처방(적용)**: 두 진입점 모두 정리 대상 변수(`OWNED_TMP`)를 재대입하지 않고, 스캔 대상은 별 변수(`TARGET`)로 분리하고, 트랩이 삭제 직전 임시경로인지 재검문한다. **격리 레포 + CANARY 파일로 검증**(실물에 재실행하지 않음).
- **구조 처방(미구축)**: 읽기전용 마운트/샌드박스에서 M4 를 돌려 쓰기 시도를 관측하는 것.
- **계약 문서에 명기**: 그 전까지 `writes:`·`reversibility:` 는 **등록자 주장**이고, 검사기는 그렇게 출력한다(`⚠️ writes: read-only 는 등록자 주장이다`). 검증 못 하는 축을 조용히 통과시키는 바가 정확히 read-only 가 디렉토리를 지우는 경로다.

## 검증 (증거 캡슐)

- self-test 7/7 (BLOCK 6 · PASS 1 — 대칭이라 «전부 막는 게이트»도 걸린다)
- 실물 capfile 2건 `REGISTRABLE`, M4 실행: psa 양성 CLEAN×2 / 음성 LEAK · degrade 양성 CLEAN×2 / 음성 FINDINGS
- relay 3런(위 표) · 파괴 버그 CANARY 격리 검증
- **되돌림 실측**은 짝 수리 쪽에 있다(fh-be `ceacb60` index_sync untracked 필터: 되돌림 arm 적색 1 / 수리 arm 초록 0)
- 자기 게이트가 자기 픽스처를 차단 → **우회하지 않고** 스킬 자신의 2층 규율(리터럴을 추적 파일에 두지 않음)로 수리

## 잔여 (명명)

- 🟥 `writes`/`reversibility` 검증 불가 — 구조 처방 미구축
- 등록을 **강제**하는 훅 없음(트리거가 의도 — relay 의 같은 잔여와 동형)
- M3 는 선언 검사 + reps=2 부분 방어이지 모델 독립성 실측이 아님
- cross-family 이번 라운드 미실시(`DEGRADED_PANEL_UNUSED`, 마커에 typed 기록) — 이번 최대 결함이 적대검토가 아니라 **실행**으로 드러나 실행 증거를 우선했다. 미실시를 미도달로 표기하지 않는다
- HIGH 2건 운영자 판단 대기

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWjP34N8U67vkygPJjAkv4