### PR TITLE
fix(security): 배포 전 보안 패스 A급 4건 — 담요 뮤트·인젝션·무음 드롭 폐쇄

### DIFF
--- a/scripts/capability_registry_check.sh
+++ b/scripts/capability_registry_check.sh
@@ -49,8 +49,10 @@ CLOSED_KEYS="id entry requires_cwd verdict_channel verdict_enum verdict_stdout_k
 # 「안 돌았다」를 뜻하는 이름들 — 추가조항(§ⓑ.4 B1)이 요구하는 구분항
 DIDNOTRUN_NAMES="DID_NOT_RUN DIDNOTRUN NOT_RUN NO_TARGET SKIPPED UNMEASURED NOT_CONFIGURED HARNESS_ERROR"
 
-FAILED=0
-_fail() { printf '  ❌ %s — %s\n' "$1" "$2"; FAILED=1; }
+FAILED=0        # 전 파일 누적 (종료코드용)
+FILE_FAILED=0   # 현재 capfile 한정 — 파일마다 초기화한다. 이게 없으면 앞 파일의 실패가
+                # 뒤 파일의 M4 를 SKIPPED 로 만들어, 뒤 파일의 실제 결함이 안 보인다(보고 결함).
+_fail() { printf '  ❌ %s — %s\n' "$1" "$2"; FAILED=1; FILE_FAILED=1; }
 _ok()   { printf '  ✅ %s — %s\n' "$1" "$2"; }
 _die()  { printf '❌ HARNESS_ERROR: %s\n' "$*" >&2; exit "$RC_HARNESS"; }
 
@@ -89,6 +91,21 @@ _enum_name_of() {   # $1=exit code, $2=enum string → 이름 or ""
   printf ''
 }
 
+# 🟥 capfile 은 **실행 신뢰경계**다 — M4 는 선언된 arm 을 «실제로 실행» 하는 것이 요점이므로,
+#    검사기에 넘긴 capfile 은 그 자체로 "이 명령을 돌려도 된다"는 선언이다. 신뢰하지 않는
+#    capfile 을 이 검사기에 넘기지 마라. 배포 전 보안 패스가 실증한 것: `entry: /usr/bin/touch`
+#    + cal args 로 **REJECTED 판정이 나는 와중에도 부작용이 이미 발생**했다(판정 전에 arm 이 돈다).
+#    아래 검문은 그 경계를 없애지 못한다 — 우발적 형태만 막는다.
+_validate_arm_args() {   # $1=args → 셸 메타문자/상위경로 탈출을 거부
+  case "$1" in
+    *'|'*|*';'*|*'&'*|*'>'*|*'<'*|*'`'*|*'$('*|*$'\n'*)
+      _fail "M4" "캘리브레이션 args 에 셸 메타문자가 있다(entry 와 같은 인젝션 표면): $1"; return 1 ;;
+    *'../'*)
+      _fail "M4" "캘리브레이션 args 가 상위 경로로 탈출한다: $1"; return 1 ;;
+  esac
+  return 0
+}
+
 _run_arm() {   # $1=extra args → ARM_RC / ARM_NAME. 파이프로 읽지 않는다(PIPE-VERDICT).
   ( cd "$CAP_requires_cwd" 2>/dev/null || exit 127
     # shellcheck disable=SC2086  # argv 토큰 분리는 의도 (noglob 로 확장은 막혀 있다)
@@ -101,6 +118,7 @@ _check_one() {
   local f="$1"
   [ -r "$f" ] || _die "capfile 도달 불가: $f"
   _parse "$f"
+  FILE_FAILED=0
   printf '\n── %s (%s)\n' "${CAP_id:-<id 미선언>}" "$f"
 
   [ -n "$UNKNOWN_KEYS" ] && _fail "SCHEMA" "닫힌 키 목록 밖:$UNKNOWN_KEYS (오타 축 무음드롭 방지 — 무시하지 않는다)"
@@ -166,8 +184,10 @@ _check_one() {
   # ── M4 캘리브레이션 쌍 — 선언 + **실행** ──────────────────────────────────
   if [ -z "$CAP_cal_pos_expect" ] || [ -z "$CAP_cal_neg_expect" ]; then
     _fail "M4" "캘리브레이션 쌍 미선언(양성·음성 expect 둘 다 필요) — 답을 아는 케이스를 못 가르는 계기는 재는 게 아니다"
-  elif [ "$FAILED" -eq 1 ] && [ -z "${CRC_FORCE_M4:-}" ]; then
+  elif [ "$FILE_FAILED" -eq 1 ] && [ -z "${CRC_FORCE_M4:-}" ]; then
     printf '  ⏭  M4 — 앞선 축이 실패해 실행 생략(SKIPPED, PASS 아님)\n'
+  elif ! _validate_arm_args "$CAP_cal_pos_args" || ! _validate_arm_args "$CAP_cal_neg_args"; then
+    printf '  ⏭  M4 — args 검문 실패로 arm 을 실행하지 않았다(SKIPPED, PASS 아님)\n'
   else
     local pos_name neg_name pos_rc neg_rc pos_name2
     _run_arm "$CAP_cal_pos_args"; pos_rc="$ARM_RC"; pos_name="$ARM_NAME"

--- a/scripts/psa_probe_capability.sh
+++ b/scripts/psa_probe_capability.sh
@@ -31,6 +31,7 @@ trap _cleanup EXIT
 
 MODE="${1:-}"
 IN="$OWNED_TMP/in"
+SCAN_NOTE=""
 
 # 합성 양성 토큰은 **조각으로 보관하고 실행 시 조립**한다. 통짜 리터럴을 두면 이 파일 자체가
 # MED 히트가 되어 pre-commit 기밀 스캔에 걸린다 — 실제로 걸렸고(2026-08-11), 그 차단은 옳았다.
@@ -43,12 +44,19 @@ case "$MODE" in
   --known-negative)   # 답을 아는 음성: 어떤 패턴에도 안 걸리는 합성 입력
     printf 'synthetic_fixture.md\tperfectly ordinary documentation line\n' > "$IN" ;;
   --tracked|'')       # 실사용: 이 레포의 tracked 파일 전량
-    git -C "$REPO_ROOT" ls-files > "$OWNED_TMP/files" 2>/dev/null || { echo "psa-probe: git 도달 불가"; exit 10; }
-    : > "$IN"
-    while IFS= read -r f; do
-      [ -f "$REPO_ROOT/$f" ] || continue
-      awk -v p="$f" '{printf "%s\t%s\n", p, $0}' "$REPO_ROOT/$f" 2>/dev/null >> "$IN"
-    done < "$OWNED_TMP/files" ;;
+    # `-z` (NUL 구분) 필수: 기본 `core.quotePath=true` 는 비-ASCII 파일명을 따옴표+8진
+    # 이스케이프로 내보내므로, 줄 단위로 읽으면 그 파일들이 **무음으로 스캔에서 빠지고**
+    # 결과는 CLEAN 이 된다(못 잰 것을 0으로 렌더). 드롭은 세어서 보고한다.
+    git -C "$REPO_ROOT" ls-files -z > "$OWNED_TMP/files" 2>/dev/null || { echo "psa-probe: git 도달 불가"; exit 10; }
+    : > "$IN"; scanned=0; dropped=0
+    while IFS= read -r -d '' f; do
+      if [ ! -f "$REPO_ROOT/$f" ]; then dropped=$((dropped+1)); continue; fi
+      if awk -v p="$f" '{printf "%s\t%s\n", p, $0}' "$REPO_ROOT/$f" >> "$IN" 2>/dev/null; then
+        scanned=$((scanned+1))
+      else dropped=$((dropped+1)); fi
+    done < "$OWNED_TMP/files"
+    SCAN_NOTE=" (스캔 $scanned 파일$([ "$dropped" -gt 0 ] && printf ', 드롭 %s' "$dropped"))"
+    [ "$dropped" -gt 0 ] && { echo "psa-probe: HARNESS_ERROR — 읽지 못한 tracked 파일 $dropped 개(부분 스캔은 CLEAN 을 증명하지 못한다)"; exit 10; } ;;
   *) echo "psa-probe: 알 수 없는 모드 '$MODE'"; exit 10 ;;
 esac
 
@@ -64,7 +72,7 @@ fi
 
 psa_scan_tagged < "$IN"; hit_rc=$?     # verdict 는 직접 취한다(PIPE-VERDICT)
 case "$hit_rc" in
-  0) echo "psa-probe: CLEAN"; exit 0 ;;
-  1) echo "psa-probe: LEAK"; exit 1 ;;
+  0) echo "psa-probe: CLEAN${SCAN_NOTE}"; exit 0 ;;
+  1) echo "psa-probe: LEAK${SCAN_NOTE}"; exit 1 ;;
   *) echo "psa-probe: HARNESS_ERROR — scan_tagged 가 enum 밖 $hit_rc 반환"; exit 10 ;;
 esac

--- a/scripts/psa_scan_lib.sh
+++ b/scripts/psa_scan_lib.sh
@@ -61,8 +61,18 @@ PSA_PLACEHOLDER='^(<[a-z0-9_-]+>|\{[a-z_]+\}|EXAMPLE|dummy|changeme|REDACTED|xxx
 # Why this does not weaken the floor:
 #   · rows live in a **gitignored** source (`.claude/rules/.public-surface-allowlist`), so writing one
 #     never puts an operator token on the public surface — the same two-layer discipline as patterns.
-#   · a row is `path<TAB>token-regex` and is **anchored to both**: it suppresses that token on that
-#     file only. A wildcard path is not supported — a row cannot become a blanket mute.
+#   · a row is `path<TAB>literal-token`. **Both sides are literal, whole-value comparisons** — the
+#     path with `=`, the token with `grep -qxF`. Neither is a pattern, so one row suppresses exactly
+#     one token on exactly one file.
+#     ⚠️ Two versions of this got it wrong, and the second is the instructive one. v1 claimed a row
+#     "cannot become a blanket mute" while the code used an UNANCHORED `grep -qE`: a `path<TAB>.*`
+#     row muted every hit in that file, silently, at every severity (pre-publish security pass proved
+#     it with a known pair). v2 force-anchored to `^(…)$` — and `^(.*)$` still matches everything, so
+#     the blanket mute survived the "fix". Only making the field a **literal** actually closes it.
+#     The lesson is the file's own doctrine: a claim is not a control, and neither is a repair that
+#     was not re-measured against the same known pair.
+#   · every suppression **prints a line**. A mute that leaves no trace is indistinguishable from a
+#     clean scan — the same `not found ≠ 0` shape the verdict enum exists to prevent.
 #   · absent file → no rows → behaviour is exactly as before (fail-closed by default).
 # Each row is an operator decision, recorded where it can be audited, instead of an undocumented
 # exception living in someone's head.
@@ -75,7 +85,13 @@ psa_pair_allowlisted() {   # $1=path $2=matched token
     case "$apath" in ''|'#'*) continue ;; esac
     [ -z "$atok" ] && continue
     [ "$apath" = "$1" ] || continue
-    printf '%s' "$2" | grep -qE "$atok" 2>/dev/null && return 0
+    # LITERAL, whole-token (`-x -F`). Not a regex — anchoring alone was not enough: `^(.*)$` still
+    # matches everything, so an anchored `.*` row remained a blanket mute. Treating the field as a
+    # literal is what makes "one row = one token" true rather than merely asserted.
+    if printf '%s' "$2" | grep -qxF "$atok" 2>/dev/null; then
+      echo "  ⚪ allowlisted — ${1}: '${2}' (row: ${apath} :: ${atok})"
+      return 0
+    fi
   done < "$src"
   return 1
 }


### PR DESCRIPTION
## 왜 이 PR 이 존재하나 — 배포 직전 게이트가 실제로 일했다

v1.4.95 는 `#339` 로 머지돼 배포 대기 상태였다. Pre-Publish 게이트 ③(코드 보안 패스)은 «배포 파일셋에 실행코드가 실리면 적용» 이고, `v1.4.94..HEAD` 실측 결과 **신규 3 + 변경 2 = 셸 스크립트 5건**이 실린다. 스킵하지 않고 격리 감사자에게 돌렸다.

**A급 4건이 나왔고 그중 3건이 이번 릴리스에 새로 들어간 코드다.** 승인이 났다고 알려진 결함을 실은 채 내보내는 건 승인의 범위가 아니라서, 배포 전에 닫는다.

## 🟥 가장 값어치 있는 건 **내 1차 수리가 뚫린 것**이다

`A-2` 는 이번 릴리스에서 내가 새로 넣은 `psa_pair_allowlisted` 다. 세 판을 거쳤다:

| | 코드 | 결과 |
|---|---|---|
| v1 | 비앵커 `grep -qE "$atok"` | `path<TAB>.*` 한 줄로 **그 파일 전 심각도 무음 뮤트**. 그리고 바로 위 주석이 *"a row cannot become a blanket mute"* 라고 **정반대로 적혀 있었다** |
| v2 | 정규식 강제 앵커 `^(...)$` | **여전히 뚫린다** — `^(.*)$` 는 모든 것과 매치한다. 수리했다고 적을 뻔했다 |
| v3 | **리터럴 비교** `grep -qxF` | 실제 폐쇄 |

감사자가 v1 을 known-pair 로 실증했고(`.*` row → 0 출력, `rc=0`), **v2 는 내가 같은 레인에 다시 돌려서** 잡았다. 「수리가 결함의 주된 출처」가 한 함수에서 두 번 연속 재현된 사례다.

추가로 억제가 발생하면 **`⚪ allowlisted — file: 'token' (row: …)` 1줄을 출력**한다. 흔적 없는 뮤트는 깨끗한 스캔과 구분되지 않는다 — 이 파일의 verdict enum 이 존재하는 이유와 같은 축이다.

**4암 재실측**

| arm | 기대 | 실측 |
|---|---|---|
| 담요 시도 (`path<TAB>.*`) | 안 먹어야 | `rc=1` — HIGH 그대로 보고 ✅ |
| 정확 토큰 row | 억제 + 로그 | `rc=0` + `⚪` 1줄 ✅ |
| 다른 파일 row | 경로 앵커 생존 | `rc=1` ✅ |
| 빈 목록 | 종전과 동일 | `rc=1` ✅ |

## 나머지 3건

**A-1 · `capability_registry_check.sh`** — `calibration_*_args` 가 **아무 검문 없이** argv 에 붙어 실행됐다. `entry` 는 셸 메타문자를 검문하면서 args 는 안 했다. 감사자 실증: `entry: /usr/bin/touch` + args 조합이 **`REJECTED` 판정이 나는 와중에도 파일을 만들었다**(판정 전에 arm 이 돈다).
→ 메타문자·상위경로 검문 추가. 그리고 헤더에 **«capfile 은 실행 신뢰경계»**를 명시했다 — M4 는 선언된 arm 을 *실제로 실행하는 것*이 요점이므로 이 경계는 설계상 존재한다. 검문은 우발적 형태만 막고 경계를 없애지 못한다는 것을 적었다. 이 파일은 `files[]` 로 나가 남의 조직 머신에서 돈다.

**A-4 · `psa_probe_capability.sh`** — `git ls-files` 를 줄 단위로 읽었다. 기본 `core.quotePath=true` 는 비-ASCII 파일명을 따옴표+8진 이스케이프로 내보내므로 그 파일들이 **무음으로 스캔에서 빠지고 결과는 CLEAN** 이 된다. (이 레포는 현재 비-ASCII tracked 0건이라 오판을 내고 있진 않았다 — 감사자가 그 계기 보정까지 붙였다.)
→ `-z` + 스캔/드롭 카운터 + **부분 스캔은 `HARNESS_ERROR`**. verdict 에 스캔 파일 수를 동봉한다(`CLEAN (스캔 332 파일)`).

**B-1 · `capability_registry_check.sh`** — `FAILED` 가 전역이라 앞 capfile 의 실패가 뒤 capfile 의 M4 를 `SKIPPED` 로 만들었다. 판정은 안 느슨해지지만(둘 다 exit 1) 뒤 파일의 실제 결함이 안 보인다.
→ `FILE_FAILED` 파일별 스코프.

## 재검증

```
registry self-test        7/7 (BLOCK 6 · PASS 1 대칭)
실물 capfile 2건          REGISTRABLE (M4 known-pair 실행 통과)
psa_probe 3모드           known-negative CLEAN · known-positive LEAK · tracked CLEAN (스캔 332)
Pre-Publish 표면 스캔      PASS (배포 파일셋 전량)
```

## 잔여 (명명 — 닫지 않았다)

- 🟥 **capfile = 실행 신뢰경계**. 검문은 우발 형태만 막는다. 신뢰하지 않는 capfile 을 검사기에 넘기지 마라 — 헤더에 그대로 적었다
- **A-3 비대칭**: `public_surface_scan_files.sh`(publish 경계)는 자체 인라인 루프라 pair-allowlist 가 **안 걸린다**. 방향은 안전쪽(publish 가 더 엄격)이라 leak 은 아니지만, **비가역 표면에서는 여전히 처분 수단이 `PUBLIC_SURFACE_OK=1` 담요 override 뿐**이다 — 이 레포가 반복해서 경고하는 «override 습관화» 경로다. 이번 PR 범위 밖으로 명명
- **B-2**: Linux 에서 `TMPDIR` 가 `/tmp`·`/var/folders` 밖이면 cleanup 이 거부될 수 있다(안전 방향). **이 머신에서 재현 실패** — macOS `mktemp -d` 가 TMPDIR 를 무시한다. 추론이지 실측이 아니다
- 되돌림 레인 미구축 — 신규 코드라 회귀 앵커 자체가 이번 산출물이다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWjP34N8U67vkygPJjAkv4