### PR TITLE
fix(count-check): README 렌더링 per-repo override — 하류 지역화가 sync 에 덮이던 경로

### DIFF
--- a/scripts/count_check.sh
+++ b/scripts/count_check.sh
@@ -91,7 +91,31 @@ count_check() { # count_check <label> <file> <expected-string>
 count_check "fh-meta plugin.json"      plugins/fh-meta/.claude-plugin/plugin.json    "${meta_sk} skills + ${meta_ag} agents"
 count_check "fh-commons plugin.json"   plugins/fh-commons/.claude-plugin/plugin.json "${com_sk} skills"
 count_check "marketplace.json fh-meta" .claude-plugin/marketplace.json               "${meta_sk} skills + ${meta_ag} agents"
-count_check "README header"            README.md                                     "${total_sk} skills · ${total_ag} agents"
+# ── README 렌더링만 per-repo override 를 받는다 ──────────────────────────────────────────────
+# 왜 이 한 줄만 다른가: plugin.json·marketplace.json 의 문자열은 **기계 결합**(영문 고정,
+# 소비처가 파싱한다)이지만 README 헤더는 **사람이 읽는 산문**이라 하류 하네스가 자기 언어로 쓴다.
+# 이 스크립트는 공유층이라 여기에 렌더링을 하드코딩하면 다음 sync 가 하류의 지역화를 덮고,
+# 그 레인은 **이식 이후 한 번도 통과 못 하는 검사**가 된다 — 통과 불가능한 게이트는 게이트가
+# 아니라 `--no-verify` 훈련기다(실측: pmh-dev #55 가 그 상태를 손으로 되돌려야 했고, 다음
+# sync 에 다시 깨질 예정이었다. 이슈 chronoloy-dev/pmh-dev#57).
+#
+# 규약: 소비 레포는 `.claude/rules/count_readme_format` 에 printf 템플릿 한 줄을 둔다
+#       (`%s` 두 개 = skills 수, agents 수). 그 파일을 **자기 sync 제외목록에 등재**해야 한다 —
+#       등재 안 하면 이 override 자체가 덮이므로, 그 등재가 이 규약의 전제다.
+# 부재 → 영문 기본값. 즉 FH 자신과 지역화 안 한 설치는 종전과 동일하다(fail-closed 아님:
+#       README 렌더링은 가역 표면이고, 없는 파일을 요구하면 새 설치가 전부 막힌다).
+README_FMT_FILE="${COUNT_README_FORMAT_FILE:-.claude/rules/count_readme_format}"
+if [ -r "$README_FMT_FILE" ]; then
+  README_FMT=$(head -1 "$README_FMT_FILE")
+  case "$README_FMT" in
+    *%s*%s*) : ;;   # %s 두 개 필수 — 하나뿐이면 두 번째 수치가 검사에서 빠진다(무음 축소)
+    *) echo "FAIL  count: README format override 가 %s 를 두 개 갖지 않는다: '$README_FMT' ($README_FMT_FILE)"; fail=1; README_FMT="" ;;
+  esac
+else
+  README_FMT='%s skills · %s agents'
+fi
+# shellcheck disable=SC2059  # 템플릿은 선언 파일에서 온다 — 그게 이 기능의 요점
+[ -n "$README_FMT" ] && count_check "README header" README.md "$(printf "$README_FMT" "$total_sk" "$total_ag")"
 count_check "local_fh_context fh-meta" templates/local_fh_context.md                 "(fh-meta, ${meta_sk})"
 
 if [ "$fail" -ne 0 ]; then


### PR DESCRIPTION
발원: `chronoloy-dev/pmh-dev#57`.

## 진단이 이슈와 다르다 — 「자기정합 아님」이 아니라 「렌더링 하드코딩」

이슈는 `count_check` 가 공유층 숫자에 의존한다고 읽었지만, 실측하니 **이미 실측 기반**이다 — `list_skills`/`count_agents` 가 라이브 트리를 세고 선언이 그 숫자를 담는지 본다. 「선언 vs 실측」 축은 멀쩡했다.

진짜 결함은 **기대 렌더링이 공유 스크립트에 하드코딩**된 것이다:

```
FH README    "40 skills · 8 agents"      ← 이 스크립트가 들고 있는 형식
pmh README   "41 스킬 + 8 에이전트"       ← 하류는 자기 언어로 쓴다
```

pmh 는 이식 이후 그 레인이 **한 번도 통과한 적이 없었고**, `#55` 가 손으로 지역화해 초록을 만들었지만 `count_check.sh` 는 공유층이라 **다음 sync 에 다시 덮일 예정**이었다. 통과 불가능한 게이트는 게이트가 아니라 `--no-verify` 훈련기다.

## 무엇

README 레인**만** override 를 받는다. 나머지는 그대로 둔다 — 그 구분이 이 PR 의 요점이다:

| 대상 | 성격 | 처리 |
|---|---|---|
| `plugin.json` · `marketplace.json` | **기계 결합** — 소비처가 파싱한다 | 영문 고정 유지 |
| `README` 헤더 | **사람이 읽는 산문** — 하류가 자기 언어로 쓴다 | per-repo override |

- 소비 레포가 `.claude/rules/count_readme_format` 에 printf 템플릿 1줄(`%s` 둘 = skills, agents)
- **부재 → 영문 기본값.** FH 자신과 지역화 안 한 설치는 종전과 동일하다. 없는 파일을 요구해 새 설치를 막지 않는다 — README 는 가역 표면이라 fail-closed 대상이 아니다
- 템플릿에 `%s` 가 둘이 아니면 **FAIL** — 하나뿐이면 두 번째 수치가 검사에서 **무음으로 빠진다**

## 검증 — known-pair 4암

| arm | 기대 | 실측 |
|---|---|---|
| override 부재 | PASS (기존 동작 보존) | `rc=0` ✅ |
| 한국어 override | **FAIL** (FH README 는 영문이므로 이게 정답) | `rc=1` ✅ 계기 판별력 확인 |
| 말폼 (`%s` 1개) | FAIL + 사유 | `rc=1` + 명시 메시지 ✅ |
| 영문 override 명시 | PASS (override 경로 자체가 도는가) | `rc=0` ✅ |

## 이슈 #57 수치 정정 (별도 코멘트로 게시함)

| | 이슈 | 실측 (`main`) |
|---|---|---|
| pmh-meta / 총 skills | 37 / 42 | **36 / 41** |
| count_check | README 레인 FAIL | **5레인 전부 PASS** |

원인은 `#55`(00:02Z, count 37→36) 보다 **4시간 뒤(04:21Z)** 작성됐는데 pre-#55 트리를 잰 것. **다만 구조적 주장은 유효**했고 이 PR 이 그 구조를 닫는다.

## 잔여 (명명)

- 소비 레포는 이 override 파일을 **자기 sync 제외목록에 등재해야 한다**. 미등재면 override 자체가 덮인다 — 규약에 적었으나 **기계 강제는 없다**
- pmh 측 적용(파일 생성 + 제외목록 등재)은 sync 이후 별건
- cross-family 미실시(`DEGRADED_PANEL_UNUSED`) — 하류 실사용이 이미 이 결함을 발화시켜 외부 되먹임 역할을 했다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWjP34N8U67vkygPJjAkv4