### PR TITLE
fix(publish): 배포 경계에도 file::token allowlist — 담요 override 만 남던 비대칭

### DIFF
--- a/scripts/public_surface_scan_files.sh
+++ b/scripts/public_surface_scan_files.sh
@@ -125,6 +125,14 @@ while IFS= read -r f; do
       [ -z "$tok" ] && continue
       printf '%s' "$tok" | grep -qiE "$PSA_PLACEHOLDER" && continue
       if [ "$sev" = "LOW" ] && psa_low_allowlisted "$f"; then continue; fi
+      # file::token allowlist — the SAME rows the commit/push path honours (psa_scan_lib.sh).
+      # Before this line the publish path ignored them, so a token the operator had DELIBERATELY
+      # published had no expressible disposition **at the one boundary that matters most**: the only
+      # way past was the blanket `PUBLIC_SURFACE_OK=1` override. That is worse than a narrow row —
+      # a blanket override waves every OTHER finding through in the same run, and this repo's own
+      # doctrine says an override that becomes routine disarms the gate. Narrow, recorded, and
+      # logged beats broad and silent. (Rows are literal path + literal token, gitignored source.)
+      if psa_pair_allowlisted "$f" "$tok"; then continue; fi
       echo "  ❌ $sev leak — $f: '$tok' would ship to the registry"
       LEAK=1
       # -a forces every published file to scan as TEXT (challenger S1): -I skipped binary-classified


### PR DESCRIPTION
`#340` 보안 패스가 **A-3** 으로 지목한 비대칭을 닫는다.

## 무엇이 어긋나 있었나

```
커밋/푸시 경로   psa_scan_tagged 경유 → pair-allowlist 적용 ✅
배포 경로        public_surface_scan_files.sh 는 **자체 인라인 루프** → 미적용 ❌
```

방향은 안전쪽(publish 가 더 엄격)이라 **유출은 아니다**. 문제는 비가역 표면에서만 처분 수단이 사라진다는 것: 운영자가 의도적으로 게시한 토큰에 대해 남는 출구가 `PUBLIC_SURFACE_OK=1` **담요 override** 뿐이고, 담요 override 는 같은 런의 **다른 모든 finding 까지 통과시킨다**. 이 레포 독트린이 반복 경고하는 「override 습관화가 게이트를 무장해제」 경로다.

좁고·기록되고·로그되는 행이 넓고·조용한 override 보다 낫다.

## 검증 — known-pair 2암 (합성 패턴, 실물 유출 미생성)

| arm | 실측 |
|---|---|
| 합성 HIGH 패턴만 | **29히트 `rc=1`** — 계기 생존 |
| 같은 패턴 + `package.json` row | **억제로그 1 + 잔여 28히트 `rc=1`** — 정확히 그 파일만, 나머지는 그대로 차단 |

현행 배포셋 스캔은 수리 전후 모두 PASS(원래 히트 0이라 회귀 없음). 그래서 판별력은 합성 패턴으로 확보했다 — 실물 유출을 만들어 재현하지 않기 위한 선택이고, 그 한계를 마커에 잔여로 적었다.

## 🟥 정직 기록 — 마커 초판이 계열을 잘못 주장했다

`crossfamily: panel(fh-meta:challenger)` 로 적었다가 **게이트에 막혔다.** 옳은 차단이다: `challenger` 는 **격리는 되지만 같은 계열**이라 탈상관이 아니다. 격리(다른 컨텍스트)와 탈상관(다른 계열)을 내가 한 단어로 뭉갰다.

정정: `crossfamily: DEGRADED_SINGLE_FAMILY` + 사유. 계열 다양성은 **미확보로 남긴다** — 확보한 척하지 않는다.

## 잔여

- 판별 증거가 합성 패턴 기반(실물 히트 0)
- publish 경로의 LOW allowlist 는 여전히 커밋 경로보다 엄격 — **의도된 차이**(헤더에 기존 명시), 이 PR 은 그걸 안 건드린다
- 되돌림 레인 미구축

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWjP34N8U67vkygPJjAkv4