### PR TITLE
fix(agents): Codex 진입점 정합 — 도구 표 3종 누락 + frontmatter 유효성 규율

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,15 @@ operations or steel-quench.
 
 Machine-readable mirror: `.claude/registry/agent_cards.json`.
 
+> **Agent frontmatter must be valid YAML — and this bites non-Claude runtimes hardest.** Claude Code's
+> loader is lenient (it accepted an unquoted `description:` containing `": "`); a strict YAML parser
+> does not, and then **every key below the bad line is silently dropped** — including `tools:` and any
+> `model:` floor. Measured 2026-08-11: one agent's multi-line unquoted `description` (with `user:` /
+> `assistant:` lines inside it) invalidated its declared `tools: Read, Grep, Glob` and its `model: opus`
+> floor; the agent ran with all tools and no pin. Keep `description:` to **one quoted line** and put
+> examples in the body. `bash scripts/validate_yaml.sh` now covers `plugins/*/agents/*.md` as well as
+> skills, and reports a zero-file scan as an instrument error rather than a pass.
+
 ### Tool restrictions
 
 | Agent | Allowed tools |
@@ -42,6 +51,15 @@ Machine-readable mirror: `.claude/registry/agent_cards.json`.
 | `hub-persona-auditor` | Read, Grep, Glob |
 | `quench-challenger` | Read, Grep, Glob |
 | `persona-innovator` | Read, Grep, Glob, WebSearch, WebFetch |
+| `beginner` | Read |
+| `main-player` | Read, Grep, Glob |
+| `expert` | Read, WebSearch, WebFetch |
+
+The table is the whole roster — all eight agents above appear here. *Three were missing until
+2026-08-11; the omission read as "unrestricted" to anyone checking this page, which is the wrong
+default for a table whose subject is restriction.* Cross-check with the files themselves rather
+than trusting either side alone: the same audit found `challenger` documented here with a tool set
+its file never declared at all.
 
 ## Runtime Boundaries
 

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "templates/predelete_check.sh",
     "templates/PRE-PUBLISH-CHECKLIST.md",
     "scripts/degrade_direction_scan.sh",
+    "scripts/validate_yaml.sh",
     "scripts/test_degrade_scan_shell_probes.sh",
     "scripts/gate_pathspec_check.sh",
     "scripts/prepush_guard_check.sh",

--- a/plugins/fh-meta/agents/challenger.md
+++ b/plugins/fh-meta/agents/challenger.md
@@ -1,7 +1,7 @@
 ---
 name: challenger
 description: Frontier-grade adversarial evaluator for harness assets, papers, designs, and code. Goes beyond fixed-angle critique — adapts attack vectors to artifact type, enforces evidence citation on every attack, models its own information asymmetry (Sandboxed Adversary), and tracks convergence across rounds. Returns structured [issue · location · severity] output consumable by steel-quench, harvest-loop, and sim-conductor. Use when you need adversarial pressure that a self-reviewing author cannot generate.
-tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+tools: Read, Grep, Glob, WebSearch, WebFetch
 version: 0.1
 ---
 


### PR DESCRIPTION
세션 마감 ④-b(진입점 drift 양방향 체크)가 후보를 띄웠고, **판정 결과 drift 가 실재**했다.
기계는 «파일 동시변경» 으로 후보만 띄우고 토픽 정합 판정은 사람 몫이라는 규약대로 판단했다.

## 무엇이 어긋나 있었나

| 축 | 실측 |
|---|---|
| 도구 표 **누락 3종** | `beginner` · `main-player` · `expert` 가 로스터 표에는 있고 **도구 표에는 없다** — 제약이 주제인 표에서 부재는 "무제한"으로 읽힌다 |
| **역방향 불일치 1건** | `AGENTS.md` 는 `challenger` 도구를 명시하는데 파일엔 `tools:` 선언 자체가 없어 **전체 상속** 중이었다 |
| 내가 만든 불일치 | 그 수리에서 `Bash` 를 넣어 이번엔 문서와 어긋나게 만들었다 → **문서를 고쳐 덮지 않고** 최소권한 쪽으로 파일을 되돌림 |

## 검증 캡슐

- 8종 전수 대조(표 ↔ frontmatter): 수리 전 **MISMATCH 4건을 이름으로 지목** → 수리 후 **0**
  (컨트롤 alive — 전부 초록이거나 전부 빨강인 계기가 아니다)
- `scripts/validate_yaml.sh` 재실행: 스킬 40 + 에이전트 8 전건 PASS
- Axis 1 pass · Axes 2–3 마커(로컬, gitignored) · Axis 4 매니페스트

## 왜 Codex 쪽에 규율을 적었나

이 결함 클래스는 **비-CC 파서를 더 세게 때린다.** CC 로더는 관대해서 `": "` 가 든 비인용
`description` 을 통과시키지만, 엄격 YAML 파서는 거기서 멈추고 **그 아래 모든 키를 조용히
버린다** — `tools:` 와 `model:` floor 포함. 같은 캠페인에서 실측된 사례: 한 에이전트의
멀티라인 `description` 이 선언한 `tools: Read, Grep, Glob` 과 `model: opus` HARD FLOOR 를
둘 다 무효화했고, 그 에이전트는 전체 도구·무핀으로 돌고 있었다.

## 정직한 잔여

- 도구 표는 **선언을 옮겨적은 것**이지 런타임이 그 제약을 실제로 거는지의 증거가 아니다.
  선언과 실행이 갈릴 수 있다는 게 이 캠페인의 발견이었고, 그 확인은 실제 디스패치해서
  도구 목록을 보는 것뿐이다.
- `.claude-plugin/marketplace.json` 에 `version` 키가 없어 락스텝 대상에서 구조적으로
  빠져 있다 — 이번 범위 밖, 기록만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)