### PR TITLE
release: v1.4.96 — 전수 재출하 캠페인 출하

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,13 @@
   "plugins": [
     {
       "name": "fh-meta",
-      "version": "1.4.95",
+      "version": "1.4.96",
       "description": "Hub meta-operations toolkit — 35 skills + 7 agents. New in 1.4.53: `fh-codex-doctor` (npm bin) — Codex adapter drift scanner; reads the documented M1/M2/M3 skill tier map + skill/agent source and reports codex-native/adapter-required/claude-native/unclassified per unit, wired into `npm test`/`prepublishOnly` (fail-closed on unclassified Claude-native primitives). New in 1.4.49: steel-quench gains Step 0.6 Verdict-Invariance Probe (groundedness axis — a load-bearing judged gate's verdict must track behavior, not rubric phrasing; measured flip-count over cross-family paraphrases; arXiv:2605.06161 Policy Invariance anchor); multi_model_sidecar_strategy §Vendor-native harness (a model is strongest in its own vendor CLI — Claude/CC, GPT/codex, Gemini/Antigravity; a universal router degrades all of them, so it stays an autocomplete/QA sidecar, never orchestration); predelete_check.sh fail-closed rewrite; memory-hygiene A-TMA anchor. New in 1.4.48: phantom-quench + steel-quench gain external frontier anchors (arXiv:2607.02052 package-hallucination; arXiv:2607.02057 prompt-coverage-adequacy); README model-flat claim reframed from a per-release point-curve to structural invariants (operation flattens across tiers; depth tier-order fixed within a generation). New in 1.4.47: onboarding step ① surfaces the Mode D companion-store session-start load in the auto-read salience anchor (previously only in the local binding + rules, so a greeting could skip the load). New in 1.4.46: context-doctor command-output axis (route to rtk/proxy for verbose CLI stdout, complementing .claudeignore; risk-gated to token-scarce envs). New in 1.4.41: context-doctor 2026 trigger vocab (context engineering/rot/collapse) + phantom-citation hardening; hub measurement-integrity-checklist (cross-model measurement pre-flight: display-name pin/reps≥3/discriminating probe). New in 1.4.40: install-wizard queryable-wiki scaffold (INDEX + session-start read + R/W/C ingest). New in 1.4.39: auto-decorrelation (cross-family verifier sidecar recruitment) + video-ingest (capability-routed video ingestion). New in 1.4.x: verify-axis check-class taxonomy (mandatory-pass/measured/judged), no-reinvention Tier-0 inventory, 7-class failure taxonomy, Destructive-Op Gate, Wave-T (Temper), tier-floor governance, Mode D Model Notice, FC consent lane, default-Sonnet guidance. New in 1.3.0: public-surface-audit, field-harvest Mode B auto-trigger, 4-axis gate scope ext. Validated cross-CLI: Claude Code, Codex, Gemini.",
       "source": "./plugins/fh-meta"
     },
     {
       "name": "fh-commons",
-      "version": "1.4.95",
+      "version": "1.4.96",
       "description": "Project-agnostic utility skills — 5 skills (convergence-loop · deliberation · mcp-circuit-breaker · token-budget-gate · ko-tech-writer) + 1 agent (quench-challenger). Domain-independent utilities transplantable into any project.",
       "source": "./plugins/fh-commons"
     }

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "templates/PRE-PUBLISH-CHECKLIST.md",
     "scripts/degrade_direction_scan.sh",
     "scripts/validate_yaml.sh",
+    "scripts/test_count_check_readme_format_lanes.sh",
     "scripts/test_degrade_scan_shell_probes.sh",
     "scripts/gate_pathspec_check.sh",
     "scripts/prepush_guard_check.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrono-meta/fh-gate",
-  "version": "1.4.95",
+  "version": "1.4.96",
   "description": "FH runtime adapters — run FH governance, skills, and agents via Claude or Codex with machine-parseable gates.",
   "license": "MIT",
   "keywords": [

--- a/plugins/fh-commons/.claude-plugin/plugin.json
+++ b/plugins/fh-commons/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-commons",
-  "version": "1.4.95",
+  "version": "1.4.96",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/.claude-plugin/plugin.json
+++ b/plugins/fh-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-meta",
-  "version": "1.4.95",
+  "version": "1.4.96",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/CHANGELOG.md
+++ b/plugins/fh-meta/CHANGELOG.md
@@ -10,6 +10,42 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## Plugin Level
 
+### [1.4.96] — 2026-08-12
+
+**fix: 전수 재출하 캠페인 — 「돌았다고 보고하는데 안 도는」 계기들 · 선언이 무효였던 에이전트**
+
+스킬 40종 + 에이전트 8종 전수 적대검토 후 수리(PR #348 · #349). 지배 결함은 하나의 얼굴이었다 —
+**계기가 대상에 안 닿는데 출력은 무결**.
+
+- **`quench-challenger` 의 frontmatter 가 깨져 선언이 무효였다.** 비인용 멀티라인 `description`
+  안의 `user:`/`assistant:` 줄이 새 YAML 키로 파싱돼 그 아래 `tools: Read, Grep, Glob` 과
+  `model: opus`(HARD FLOOR) 를 **둘 다 무효화**했다. 읽기전용으로 선언된 적대 에이전트가 전체
+  도구로 돌고 있었다. `description` 을 한 줄 인용으로, 예시는 본문으로.
+- **`scripts/validate_yaml.sh`** — 스캔 대상에 **에이전트 8종 편입**(종전 SKILL.md 만). 양 surface
+  중 하나라도 0건이면 `INSTRUMENT ERROR`(exit 3) — 스캔 0을 통과로 렌더하지 않는다. **신규 출하**.
+- **`scripts/degrade_direction_scan.sh`** — **마크다운 ```bash 펜스 추출**. FH 가 실제로 실행하는
+  bash 는 대부분 SKILL.md 펜스 안에 사는데 스캐너가 `.py`/`.sh` 만 봤다. 그림자 파일이 **원본
+  줄번호를 보존**해 findings 가 `SKILL.md (```bash fence):202` 로 나온다. 펜스 없는 md 는 종전대로
+  `UNSCANNABLE`(미측정을 커버리지로 바꾸지 않는다).
+- **인용 무결성 2건 정정**(원문 직독) — arXiv 2605.00914 의 32.3pp 는 **다수결 oracle gap** 이지
+  「자기평가 시 성능저하」가 아니고(논문 결론은 *isolated self-correction prevails*), arXiv
+  2603.15255(SAGE)는 **co-evolve** 라 「Critic 격리」 근거가 될 수 없다. `harvest-loop` 의 같은
+  오귀속도 동시 수리.
+- **`salience-splitter`** — 4축 게이트가 이름으로 지목한 의무(«split 마다 목적지가 게이트 안인지
+  재질문») 를 본문에 배선 · 컷 판정 「머릿속으로」를 **레이어별 측정 2분기**로(상주=ablation
+  하네스 / SKILL.md=콜드스타트 sim) · 포인터↔헤더 대조를 실행 가능한 형태로(오탐 100% 였다) ·
+  orphan 스캔을 `^## §` → `^## ` 로(실물 헤더 139 중 97만 보던 30% 사각).
+- **죽은 명령·경로 정리** — `claude mcp search`(부재) · `codex list-agents`(부재) ·
+  `marketplace add` 인자 · `GoogleWebSearch`(존재하지 않는 도구명) · `frontier-digest` 저장 경로가
+  카덴스 글롭과 어긋나 **7일 카덴스에 영원히 안 잡히던** 것.
+- **거짓 PASS 계기들** — `harness-doctor` E7/E3/Step-11(`grep -c || echo 0` 일가가 음성 arm 을
+  통과로 렌더) · `install-doctor` 의 `except: pass`(깨진 MCP 설정이 「위험 없음」과 구별 불가) ·
+  `asset-placement-gate`(죽은 스캔과 진짜 무충돌이 둘 다 count=0) · `auto-decorrelation`(zsh 에서
+  다중 사이드카가 **무음 탈락** → single-family degrade).
+- **`AGENTS.md`** — 도구 표 누락 3종(beginner·main-player·expert) 보강 + frontmatter YAML 유효성
+  규율(비-CC 파서에서는 깨진 줄 아래 키가 전부 드롭된다). 문서↔파일 전수 대조 불일치 0.
+
+
 ### [1.4.86] — 2026-08-03
 
 **fix: 격리를 자칭하던 어블레이션 절차 + ambig 게이트 앵커 + 밀린 출하 자산 반영**

--- a/scripts/count_check.sh
+++ b/scripts/count_check.sh
@@ -114,8 +114,30 @@ if [ -r "$README_FMT_FILE" ]; then
 else
   README_FMT='%s skills · %s agents'
 fi
-# shellcheck disable=SC2059  # 템플릿은 선언 파일에서 온다 — 그게 이 기능의 요점
-[ -n "$README_FMT" ] && count_check "README header" README.md "$(printf "$README_FMT" "$total_sk" "$total_ag")"
+# 렌더 결과를 **검사한 뒤에** 패턴으로 쓴다. 렌더된 문자열이 그대로 `grep -qE` 패턴이 되므로:
+#   · 개행이 들어가면 grep -E 는 그것을 패턴 구분자로 읽어 **OR 검색**이 된다 — 실측: 템플릿
+#     `%s\n%s` 는 stale README(99/99)를 PASS 시켰다(뒷조각 `8` 이 "Node 18" 에 걸림).
+#   · printf 가 실패해도(잘못된 지시자) rc 를 안 봐서 **부분 렌더**가 패턴이 됐다.
+# 이건 mandatory-pass 게이트이고 selfcheck→prepublishOnly · pre-commit · CI 세 경계에 물려 있다.
+# 대상 독자가 하류 하네스 저자(한국어 템플릿 끝에 개행을 붙이는 건 자연스러운 실수)라 더 그렇다.
+# 기존 가드 `*%s*%s*` 는 "%s 가 둘인가" 만 보지 **렌더 결과**를 안 본다. (배포 직전 보안 패스 A-2)
+if [ -n "$README_FMT" ]; then
+  # shellcheck disable=SC2059  # 템플릿은 선언 파일에서 온다 — 그게 이 기능의 요점
+  README_STR=$(printf "$README_FMT" "$total_sk" "$total_ag") || {
+    echo "FAIL  count: README format override 를 렌더할 수 없다: '$README_FMT' ($README_FMT_FILE)"; fail=1; README_STR=""; }
+  case "$README_STR" in
+    *"
+"*) echo "FAIL  count: README format override 가 개행을 렌더한다 — grep -E 패턴이 쪼개져 OR 검색이 된다: '$README_FMT'"; fail=1; README_STR="" ;;
+  esac
+  # 두 수치가 실제로 렌더 결과에 들어갔는지(`%.0s` 류가 값을 삼키는 경우 차단)
+  if [ -n "$README_STR" ]; then
+    case "$README_STR" in *"$total_sk"*) : ;; *) echo "FAIL  count: 렌더 결과에 skills 수($total_sk)가 없다: '$README_STR'"; fail=1; README_STR="" ;; esac
+  fi
+  if [ -n "$README_STR" ]; then
+    case "$README_STR" in *"$total_ag"*) : ;; *) echo "FAIL  count: 렌더 결과에 agents 수($total_ag)가 없다: '$README_STR'"; fail=1; README_STR="" ;; esac
+  fi
+  [ -n "$README_STR" ] && count_check "README header" README.md "$README_STR"
+fi
 count_check "local_fh_context fh-meta" templates/local_fh_context.md                 "(fh-meta, ${meta_sk})"
 
 if [ "$fail" -ne 0 ]; then

--- a/scripts/degrade_direction_scan.sh
+++ b/scripts/degrade_direction_scan.sh
@@ -55,11 +55,23 @@ FILES=(); UNSCANNABLE=(); MD_ORIGIN=()
 # line numbers and whose every other line is blank. Line numbers then map 1:1, so an emitted
 # finding points at the real file:line with no offset arithmetic to get wrong. A markdown file
 # with NO bash fence stays UNSCANNABLE — nothing was extracted, so nothing was measured.
-_MD_TMP="$(mktemp -d 2>/dev/null || echo /tmp/degradescan.$$)"
-trap 'rm -rf "$_MD_TMP"' EXIT
+# python3 는 이 레포의 선언된 런타임이 아니다(`package.json engines` = node 만). 부재하면 추출이
+# 불가능하고, 그때 md 를 FILES 에도 UNSCANNABLE 에도 넣지 않으면 **요약에서 통째로 사라져**
+# "no smells in N scanned files / exit 0" 이 된다 — 이 릴리스가 고치는 바로 그 클래스를 수리가
+# 재생산한 것이다(배포 직전 보안 패스가 적발, 2026-08-12). 자매 스크립트들은 이미 옳게 한다:
+# validate_yaml → UNCALIBRATED + exit 2, package_coverage → exit 1. 여기도 같은 방향으로 맞춘다.
+_MD_OK=1; command -v python3 >/dev/null 2>&1 || _MD_OK=0
+# mktemp 실패 시 예측 가능한 경로(/tmp/degradescan.$$)로 폴백하던 것을 제거했다: 그 경로를 mkdir
+# 하지 않아 정상 폴백은 100% 실패하고, 반대로 공격자가 그 이름에 심링크를 심어두면 **성공해서
+# 레포 밖에 쓴다**(실증됨). 즉 "공격받을 때만 동작하는 코드" 였다.
+_MD_TMP="$(mktemp -d 2>/dev/null)" || { _MD_TMP=""; _MD_OK=0; }
+trap '[ -n "$_MD_TMP" ] && rm -rf "$_MD_TMP"' EXIT
 _md_shadow() {   # $1 = markdown path; echoes shadow path, or nothing when no bash fence exists
   local src="$1" out
-  out="$_MD_TMP/$(echo "$src" | tr '/' '_').sh"
+  [ "$_MD_OK" = 1 ] || return 1        # 추출 불가 → 호출부가 UNSCANNABLE 로 보낸다(드롭 금지)
+  # 경로 해시를 붙인다: `tr '/' '_'` 만 쓰면 a/b.md 와 a_b.md 가 **같은 shadow** 로 매핑돼
+  # 뒤엣것이 앞엣것을 덮고, 결함 파일이 통째로 사라진 채 카운트는 2로 찍힌다(실증됨).
+  out="$_MD_TMP/$(echo "$src" | tr '/' '_')-$(printf '%s' "$src" | cksum | cut -d' ' -f1).sh"
   python3 - "$src" "$out" <<'PYEOF' || return 1
 import sys, re
 src, out = sys.argv[1], sys.argv[2]
@@ -101,7 +113,11 @@ for t in "${TARGETS[@]}"; do
       head -n1 "$f" 2>/dev/null | grep -qE '^#!.*\b(ba|z|k)?sh\b' && FILES+=("$f")
     done < <(find "$t" -type f 2>/dev/null)
     while IFS= read -r f; do
-      sh=$(_md_shadow "$f") && [ -n "$sh" ] && { FILES+=("$sh"); MD_ORIGIN+=("$sh=$f"); }
+      if sh=$(_md_shadow "$f") && [ -n "$sh" ]; then
+        FILES+=("$sh"); MD_ORIGIN+=("$sh=$f")
+      else
+        UNSCANNABLE+=("$f")   # 펜스 없음 OR 추출 불가 — 어느 쪽이든 "안 쟀다"이지 "깨끗하다"가 아니다
+      fi
     done < <(find "$t" -type f -name '*.md' 2>/dev/null)
   elif [ -f "$t" ]; then
     tb="${t##*/}"

--- a/scripts/degrade_direction_scan.sh
+++ b/scripts/degrade_direction_scan.sh
@@ -40,7 +40,14 @@ PASS='(True|"PASS"|'"'"'PASS'"'"'|"ALLOW"|'"'"'ALLOW'"'"'|"OK"|'"'"'OK'"'"'|"VAL
 # incl. this gate's own pre-push/pre-commit-hook trigger category — must not be invisibly dropped).
 # Anything else is tracked as UNSCANNABLE so a load-bearing surface in another language is reported
 # as "not covered", never silently folded into an "advisory clean" (M#2, steel-quench 2026-07-03).
-FILES=(); UNSCANNABLE=(); MD_ORIGIN=()
+FILES=(); UNSCANNABLE=(); MD_ORIGIN=(); UNMEASURED=()
+# UNSCANNABLE vs UNMEASURED — 한 통에 넣으면 S 가 살아난다(재검 2026-08-12 지목).
+#   UNSCANNABLE = 측정 대상이 아니다(펜스 없는 산문 md, py/sh 아닌 파일). 정상 상태.
+#   UNMEASURED  = 재려 했는데 **못 쟀다**(python3/cksum 부재로 추출 실패). 이건 절대 CLEAN 이 아니다.
+# 첫 수리는 둘을 UNSCANNABLE 하나에 담았고, 그 배열은 `FILES` 가 **완전히 빌 때만** exit 2 로
+# 승격된다 — 스캔 가능한 .sh 가 하나라도 섞이면 추출 실패가 note 한 줄로 강등되고 rc=0 이 나갔다.
+# 즉 「측정 못 함을 CLEAN 으로 렌더」가 지배 경로(디렉터리 스캔 → typed capability)에 그대로 남아
+# 있었다 — 이 릴리스가 고치겠다고 선언한 바로 그것이다.
 
 # ── Markdown fence extraction (2026-08-11) ────────────────────────────────────────────────────
 # The bash this harness actually EXECUTES largely does not live in .sh files — it lives in ```bash
@@ -60,7 +67,10 @@ FILES=(); UNSCANNABLE=(); MD_ORIGIN=()
 # "no smells in N scanned files / exit 0" 이 된다 — 이 릴리스가 고치는 바로 그 클래스를 수리가
 # 재생산한 것이다(배포 직전 보안 패스가 적발, 2026-08-12). 자매 스크립트들은 이미 옳게 한다:
 # validate_yaml → UNCALIBRATED + exit 2, package_coverage → exit 1. 여기도 같은 방향으로 맞춘다.
-_MD_OK=1; command -v python3 >/dev/null 2>&1 || _MD_OK=0
+_MD_OK=1
+for _dep in python3 cksum; do command -v "$_dep" >/dev/null 2>&1 || _MD_OK=0; done
+# cksum 도 미선언 의존성이다 — 첫 수리는 python3 만 가드하고 cksum 은 rc 미검사로 도입했다.
+# 부재 시 유일성 토큰이 **빈 문자열**이 돼 shadow 이름 충돌(A-1)이 그대로 부활한다(실증).
 # mktemp 실패 시 예측 가능한 경로(/tmp/degradescan.$$)로 폴백하던 것을 제거했다: 그 경로를 mkdir
 # 하지 않아 정상 폴백은 100% 실패하고, 반대로 공격자가 그 이름에 심링크를 심어두면 **성공해서
 # 레포 밖에 쓴다**(실증됨). 즉 "공격받을 때만 동작하는 코드" 였다.
@@ -115,8 +125,10 @@ for t in "${TARGETS[@]}"; do
     while IFS= read -r f; do
       if sh=$(_md_shadow "$f") && [ -n "$sh" ]; then
         FILES+=("$sh"); MD_ORIGIN+=("$sh=$f")
+      elif [ "$_MD_OK" = 1 ]; then
+        UNSCANNABLE+=("$f")   # 펜스가 없다 — 측정 대상이 아님(정상)
       else
-        UNSCANNABLE+=("$f")   # 펜스 없음 OR 추출 불가 — 어느 쪽이든 "안 쟀다"이지 "깨끗하다"가 아니다
+        UNMEASURED+=("$f")    # 추출 자체가 불가 — 못 쟀다(CLEAN 으로 접히면 안 된다)
       fi
     done < <(find "$t" -type f -name '*.md' 2>/dev/null)
   elif [ -f "$t" ]; then
@@ -126,14 +138,24 @@ for t in "${TARGETS[@]}"; do
       *.md)
         if sh=$(_md_shadow "$t") && [ -n "$sh" ]; then
           FILES+=("$sh"); MD_ORIGIN+=("$sh=$t")
+        elif [ "$_MD_OK" = 1 ]; then
+          UNSCANNABLE+=("$t")      # no bash fence — not a measurement target
         else
-          UNSCANNABLE+=("$t")      # no bash fence extracted → genuinely not measured
+          UNMEASURED+=("$t")       # extraction impossible — could not measure
         fi ;;
       *.*) UNSCANNABLE+=("$t") ;;
       *) if head -n1 "$t" 2>/dev/null | grep -qE '^#!.*\b(ba|z|k)?sh\b'; then FILES+=("$t"); else UNSCANNABLE+=("$t"); fi ;;
     esac
   fi
 done
+# 못 잰 파일이 있으면 hits 와 무관하게 비-clean 이다. 이 블록이 FILES 비었을 때만 도는 구조가
+# S 의 정체였다 — 스캔 가능한 파일이 하나라도 있으면 「못 쟀다」가 note 로 강등되고 rc=0 이 나갔다.
+if [ ${#UNMEASURED[@]} -gt 0 ]; then
+  echo "degrade-scan: ${#UNMEASURED[@]} file(s) COULD NOT BE MEASURED (markdown fence extraction unavailable — python3/cksum missing):"
+  printf '  (unmeasured) %s\n' "${UNMEASURED[@]}"
+  echo "This is NOT 'clean' — the fence surface was not scanned at all. Install python3+cksum or scan those files elsewhere."
+  _FORCE_NONCLEAN=2
+fi
 if [ ${#FILES[@]} -eq 0 ]; then
   if [ ${#UNSCANNABLE[@]} -gt 0 ]; then
     echo "degrade-scan: ${#UNSCANNABLE[@]} changed file(s) are OUTSIDE the scannable set (py/sh) — NOT scanned, NOT 'clean':"
@@ -141,7 +163,7 @@ if [ ${#FILES[@]} -eq 0 ]; then
     echo "A load-bearing surface in another language must go straight to cross-family review."
     exit 2   # advisory non-clean — an orchestrator keying on exit code must not read this as clean
   fi
-  echo "degrade-scan: no scannable (py/sh) target files"; exit 0
+  echo "degrade-scan: no scannable (py/sh) target files"; exit "${_FORCE_NONCLEAN:-0}"
 fi
 
 hits=0
@@ -341,4 +363,4 @@ fi
 # it does NOT assert the changed load-bearing surface is safe (other languages, non-code surfaces,
 # and the lint's own recall gaps are out of scope). The load-bearing check is the cross-family review.
 echo "degrade-scan: no default-toward-PASS smells in ${#FILES[@]} scanned py/sh file(s) — does NOT cover other languages / non-code surfaces / the cross-family check (advisory)."
-exit 0
+exit "${_FORCE_NONCLEAN:-0}"   # 못 잰 파일이 있으면 0 이 아니다 — "안 쟀다"는 "깨끗하다"가 아니다

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -184,6 +184,21 @@ else
   fail=1
 fi
 
+# count_check's README format override is a mandatory-pass gate whose pattern is caller-supplied.
+# Same subject-present/anchor-gone shape as the block above: if the guard ships without its known
+# pair, a template that defeats the gate (a rendered newline turns the pattern into an OR search)
+# passes silently — measured 2026-08-12 on a stale README that the gate reported as PASS.
+if [ ! -f scripts/count_check.sh ]; then
+  echo "SKIP  count_check README-format lanes (subject scripts/count_check.sh absent)"
+elif [ -f scripts/test_count_check_readme_format_lanes.sh ]; then
+  if ! bash scripts/test_count_check_readme_format_lanes.sh; then
+    fail=1
+  fi
+else
+  echo "FAIL  count_check README-format lanes: count_check.sh present but its anchor is missing"
+  fail=1
+fi
+
 # package-coverage — a shipped doc must not point at a file the tarball omits. Distinct from the
 # ref-path check below: that one asks "does this path exist at all", this one asks "does the
 # CONSUMER get it". Measured 2026-07-28: 35 paths existed, were named by a shipped doc, and were

--- a/scripts/test_count_check_readme_format_lanes.sh
+++ b/scripts/test_count_check_readme_format_lanes.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# test_count_check_readme_format_lanes.sh — known-pair anchor for the README format override guard
+# in `scripts/count_check.sh`.
+#
+# WHY THIS EXISTS
+# `count_check.sh` is a **mandatory-pass** gate wired into selfcheck → prepublishOnly, pre-commit
+# and CI. Its README check renders a caller-supplied printf template and uses the RESULT as a
+# `grep -qE` pattern. Two ways that goes wrong, both measured 2026-08-12:
+#   · a template rendering a NEWLINE turns the pattern into an OR search — a stale README (99/99)
+#     PASSED because the trailing fragment "8" matched "Node 18" elsewhere in the file;
+#   · `printf` failure and value-swallowing directives (`%.0s`) produced partial patterns, unchecked.
+# The guard that closes this shipped with **zero** anchors in the same commit that added four
+# anchors for a sibling fix — the exact "you can delete the feature and stay green" class that
+# commit was closing. This file is that missing half.
+#
+# SCOPE, stated honestly: these lanes exercise the guard's DECISION LOGIC in isolation (render →
+# inspect → accept/reject), not the whole count_check run. The full script needs a git worktree
+# with a populated plugin tree; a fixture that lacks one fails for an unrelated reason ("0 active
+# fh-meta skills") and every arm goes red for the SAME wrong cause — which is how a first attempt
+# at this test nearly certified a guard that had not been exercised at all.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SUBJECT="$REPO_ROOT/scripts/count_check.sh"
+pass=0; fail=0
+ok()  { printf '  \342\234\205 %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  \342\235\214 %s\n' "$1"; fail=$((fail+1)); }
+
+# The guard block is extracted from the subject rather than restated here: a copy drifts from the
+# thing it claims to verify, which is the divergent-normalizer defect this repo has hit before.
+GUARD=$(awk '/^  README_STR=\$\(printf/,/^  \[ -n "\$README_STR" \] && count_check/' "$SUBJECT")
+if [ -z "$GUARD" ]; then
+  bad "guard block not found in count_check.sh — the anchor cannot verify what it cannot locate"
+  echo "----"; echo "count_check README-format lanes: $pass passed, $fail failed"; exit 1
+fi
+
+probe() {   # $1 = template ; echoes rc + a reason token
+  local fmt="$1"
+  bash -c '
+    set -uo pipefail
+    total_sk=40; total_ag=8; fail=0
+    README_FMT="$1"
+    count_check() { echo "ACCEPTED:$3"; }
+    '"$GUARD"'
+    exit $fail
+  ' _ "$fmt" 2>&1
+  return $?
+}
+
+run() {   # $1 = label ; $2 = template ; $3 = expect (accept|reject)
+  local out rc; out=$(probe "$2"); rc=$?
+  case "$3" in
+    accept) if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q 'ACCEPTED:'; then
+              ok "$1 — accepted (no over-block)"
+            else bad "$1 — legitimate template was REJECTED (rc=$rc): $out"; fi ;;
+    reject) if [ "$rc" -ne 0 ]; then ok "$1 — rejected (rc=$rc)"
+            else bad "$1 — a broken template PASSED the gate: $out"; fi ;;
+  esac
+}
+
+echo "== count_check README format override — known pair =="
+# Accept arms. Two of them on purpose: the default and a localized one. The whole point of the
+# override is downstream harnesses writing their own wording, so an English-only accept arm would
+# not notice a guard that rejects every non-ASCII template.
+run "A1 default English"      '%s skills · %s agents'   accept
+run "A2 localized (Korean)"   '스킬 %s개 · 에이전트 %s개'  accept
+run "A3 markdown decoration"  '**%s** skills / **%s** agents' accept
+# Reject arms — each must fail for its OWN reason, not a shared incidental one.
+run "R1 renders a newline"    '%s
+%s'                                                     reject
+run "R2 swallows a value"     '%.0s%s agents'           reject
+
+echo "----"
+echo "count_check README-format lanes: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1

--- a/scripts/test_degrade_scan_shell_probes.sh
+++ b/scripts/test_degrade_scan_shell_probes.sh
@@ -198,6 +198,58 @@ n=$(p_hits "$TMP/kn.py")
 [ "$n" -eq 0 ] && ok "python known-negative: still silent" \
                 || bad "python known-negative: $n hit(s) — Python probes became noisy"
 
+# ── Markdown-fence lanes (added 2026-08-12) ───────────────────────────────────────────────────
+# WHY THESE EXIST: the fence-extraction feature shipped with ZERO anchors, and a revert probe run
+# by the pre-publish security pass proved it — neutralizing `_md_shadow()` entirely left this suite
+# at "14 passed, 0 failed". A feature you can delete without reddening a lane is not covered, and
+# that gap is exactly why the python3-absence hole below reached a release candidate.
+MDT="$TMP/mdlanes"; mkdir -p "$MDT"
+printf '# t\n\n```bash\nverify() { run || return 0; }\n```\n' > "$MDT/pos.md"
+printf '# t\n\nprose only, no fence\n' > "$MDT/neg.md"
+
+# L-MD1 known-positive: a defect inside a ```bash fence is FOUND (the whole point of the feature)
+out=$(bash "$SCAN" "$MDT/pos.md" 2>&1); rc=$?
+if printf '%s' "$out" | grep -q 'bash fence'; then
+  ok "MD1 a defect inside a bash fence is detected and reported at the ORIGIN path"
+else
+  bad "MD1 fence extraction found nothing in a known-positive — feature is inert (rc=$rc)"
+fi
+
+# L-MD2 known-negative: a markdown file with NO fence must stay UNSCANNABLE, never 'clean'
+out=$(bash "$SCAN" "$MDT/neg.md" 2>&1); rc=$?
+if printf '%s' "$out" | grep -qi 'unscannable' && [ "$rc" -ne 0 ]; then
+  ok "MD2 fence-less markdown reports UNSCANNABLE (not measured != clean)"
+else
+  bad "MD2 fence-less markdown did not report UNSCANNABLE (rc=$rc) — absence rendered as pass"
+fi
+
+# L-MD3 THE REGRESSION THIS SUITE WAS MISSING: with python3 unreachable, extraction is impossible.
+# The file must land in UNSCANNABLE and the run must NOT exit 0. Before the fix it fell into
+# neither set and vanished from the summary, so the scan reported "no smells ... exit 0".
+MDBIN="$TMP/mdbin"; mkdir -p "$MDBIN"
+for c in bash grep sed awk find cksum cut tr mktemp rm cat sort head wc; do
+  src=$(command -v "$c" 2>/dev/null) && ln -sf "$src" "$MDBIN/$c"
+done
+out=$(env PATH="$MDBIN" bash "$SCAN" "$MDT/pos.md" 2>&1); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qi 'unscannable'; then
+  ok "MD3 python3 unreachable -> markdown is UNSCANNABLE and exit != 0 (never a silent clean)"
+else
+  bad "MD3 python3 unreachable produced rc=$rc without UNSCANNABLE — the not-found==0 hole is open"
+fi
+
+# L-MD4 shadow-name collision: `a/b.md` and `a_b.md` must not map to the same shadow file, or one
+# of them is silently overwritten while the scanned COUNT still says 2 (coverage counted, detection
+# impossible). Measured before the fix: the defective file disappeared and the run exited 0.
+mkdir -p "$MDT/col/a"
+printf '# c\n\n```bash\nverify() { run || return 0; }\n```\n' > "$MDT/col/a/b.md"
+printf '# c\n\n```bash\nverify() { run || return 1; }\n```\n' > "$MDT/col/a_b.md"
+out=$(bash "$SCAN" "$MDT/col/a/b.md" "$MDT/col/a_b.md" 2>&1); rc=$?
+if printf '%s' "$out" | grep -q 'a/b.md'; then
+  ok "MD4 colliding basenames keep separate shadows (the defective file is still reported)"
+else
+  bad "MD4 a/b.md vanished under collision with a_b.md — shadow name is not unique"
+fi
+
 # The field-propagated copy must not drift from the canonical one. Two copies of the same
 # normalizer diverge, and the lenient half silently drops what the strict half catches — measured
 # 2026-07-28: `templates/` was 2 lines behind BEFORE this session's fix and then a full 8 KB behind

--- a/scripts/test_degrade_scan_shell_probes.sh
+++ b/scripts/test_degrade_scan_shell_probes.sh
@@ -230,11 +230,19 @@ MDBIN="$TMP/mdbin"; mkdir -p "$MDBIN"
 for c in bash grep sed awk find cksum cut tr mktemp rm cat sort head wc; do
   src=$(command -v "$c" 2>/dev/null) && ln -sf "$src" "$MDBIN/$c"
 done
+# The stub must be CONTROLLED — a stub missing `find` makes the scan report "no scannable target
+# files" and this lane would then pass for a reason unrelated to python3.
+_mdbin_ok=$(env PATH="$MDBIN" bash -c 'command -v find >/dev/null 2>&1 && echo 1 || echo 0')
 out=$(env PATH="$MDBIN" bash "$SCAN" "$MDT/pos.md" 2>&1); rc=$?
-if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qi 'unscannable'; then
-  ok "MD3 python3 unreachable -> markdown is UNSCANNABLE and exit != 0 (never a silent clean)"
+if [ "$_mdbin_ok" != "1" ]; then
+  bad "MD3 stub PATH lacks find — lane NOT RUN (not a pass)"
+elif [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qi 'COULD NOT BE MEASURED'; then
+  # NOTE the wording: this asserts UNMEASURED, not UNSCANNABLE. The two were one bucket in the
+  # first fix and a re-verification round showed why that mattered — "no fence here" (a normal
+  # state) and "extraction impossible" (a blind spot) must not share an exit path.
+  ok "MD3 python3 unreachable -> markdown reports COULD-NOT-MEASURE and exit != 0 (never a silent clean)"
 else
-  bad "MD3 python3 unreachable produced rc=$rc without UNSCANNABLE — the not-found==0 hole is open"
+  bad "MD3 python3 unreachable produced rc=$rc without a could-not-measure signal — the not-found==0 hole is open"
 fi
 
 # L-MD4 shadow-name collision: `a/b.md` and `a_b.md` must not map to the same shadow file, or one
@@ -248,6 +256,43 @@ if printf '%s' "$out" | grep -q 'a/b.md'; then
   ok "MD4 colliding basenames keep separate shadows (the defective file is still reported)"
 else
   bad "MD4 a/b.md vanished under collision with a_b.md — shadow name is not unique"
+fi
+
+# L-MD5/MD6 — THE DIRECTORY ARM. MD3 only exercises the single-file path, and a re-verification
+# round proved that mattered: the first fix promoted "could not measure" to exit 2 ONLY when FILES
+# was empty, so a directory containing one scannable .sh demoted the failure to a note line and the
+# run exited 0 = CLEAN. That is the dominant path (typed capability scans directories), i.e. the
+# defect this release claims to fix was still live where it actually runs.
+# The stub PATH is CONTROLLED first: `command -v` under zsh can return a bare name, which produces
+# a self-referential symlink and a stub with no `find` — then the scan reports "no scannable target
+# files" and the lane would pass for a reason that has nothing to do with python3.
+MDD="$TMP/mddir"; mkdir -p "$MDD/repo" "$MDD/bin"
+printf '# t\n\n```bash\nverify() { run || return 0; }\n```\n' > "$MDD/repo/SKILL.md"
+printf '#!/usr/bin/env bash\necho ok\n' > "$MDD/repo/helper.sh"
+for c in bash sh grep sed awk find cut tr mktemp rm cat sort head wc printf cksum dirname basename; do
+  p=$(command -v "$c" 2>/dev/null); case "$p" in /*) ln -sf "$p" "$MDD/bin/$c" ;; esac
+done
+_stub_md=$(env PATH="$MDD/bin" find "$MDD/repo" -type f -name '*.md' 2>/dev/null | grep -c .)
+if [ "$_stub_md" != "1" ]; then
+  bad "MD5/MD6 stub PATH is unusable (find missing) — lanes NOT RUN, which is not a pass"
+else
+  out=$(env PATH="$MDD/bin" bash "$SCAN" "$MDD/repo" 2>&1); rc=$?
+  if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qi 'COULD NOT BE MEASURED'; then
+    ok "MD5 directory scan + python3 unreachable -> non-clean exit (not demoted to a note)"
+  else
+    bad "MD5 directory scan with python3 unreachable exited $rc — 'could not measure' rendered as clean"
+  fi
+  # cksum is the OTHER undeclared dependency: without it the uniqueness token is empty and the
+  # shadow-name collision (MD4) silently returns, so it must gate the same way python3 does.
+  cp -R "$MDD/bin" "$MDD/bin2"
+  p=$(command -v python3 2>/dev/null); case "$p" in /*) ln -sf "$p" "$MDD/bin2/python3" ;; esac
+  rm -f "$MDD/bin2/cksum"
+  out=$(env PATH="$MDD/bin2" bash "$SCAN" "$MDD/repo" 2>&1); rc=$?
+  if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qi 'COULD NOT BE MEASURED'; then
+    ok "MD6 cksum unreachable -> non-clean exit (collision guard cannot silently degrade)"
+  else
+    bad "MD6 cksum unreachable exited $rc — the A-1 collision returns without any signal"
+  fi
 fi
 
 # The field-propagated copy must not drift from the canonical one. Two copies of the same

--- a/templates/degrade_direction_scan.sh
+++ b/templates/degrade_direction_scan.sh
@@ -55,11 +55,23 @@ FILES=(); UNSCANNABLE=(); MD_ORIGIN=()
 # line numbers and whose every other line is blank. Line numbers then map 1:1, so an emitted
 # finding points at the real file:line with no offset arithmetic to get wrong. A markdown file
 # with NO bash fence stays UNSCANNABLE — nothing was extracted, so nothing was measured.
-_MD_TMP="$(mktemp -d 2>/dev/null || echo /tmp/degradescan.$$)"
-trap 'rm -rf "$_MD_TMP"' EXIT
+# python3 는 이 레포의 선언된 런타임이 아니다(`package.json engines` = node 만). 부재하면 추출이
+# 불가능하고, 그때 md 를 FILES 에도 UNSCANNABLE 에도 넣지 않으면 **요약에서 통째로 사라져**
+# "no smells in N scanned files / exit 0" 이 된다 — 이 릴리스가 고치는 바로 그 클래스를 수리가
+# 재생산한 것이다(배포 직전 보안 패스가 적발, 2026-08-12). 자매 스크립트들은 이미 옳게 한다:
+# validate_yaml → UNCALIBRATED + exit 2, package_coverage → exit 1. 여기도 같은 방향으로 맞춘다.
+_MD_OK=1; command -v python3 >/dev/null 2>&1 || _MD_OK=0
+# mktemp 실패 시 예측 가능한 경로(/tmp/degradescan.$$)로 폴백하던 것을 제거했다: 그 경로를 mkdir
+# 하지 않아 정상 폴백은 100% 실패하고, 반대로 공격자가 그 이름에 심링크를 심어두면 **성공해서
+# 레포 밖에 쓴다**(실증됨). 즉 "공격받을 때만 동작하는 코드" 였다.
+_MD_TMP="$(mktemp -d 2>/dev/null)" || { _MD_TMP=""; _MD_OK=0; }
+trap '[ -n "$_MD_TMP" ] && rm -rf "$_MD_TMP"' EXIT
 _md_shadow() {   # $1 = markdown path; echoes shadow path, or nothing when no bash fence exists
   local src="$1" out
-  out="$_MD_TMP/$(echo "$src" | tr '/' '_').sh"
+  [ "$_MD_OK" = 1 ] || return 1        # 추출 불가 → 호출부가 UNSCANNABLE 로 보낸다(드롭 금지)
+  # 경로 해시를 붙인다: `tr '/' '_'` 만 쓰면 a/b.md 와 a_b.md 가 **같은 shadow** 로 매핑돼
+  # 뒤엣것이 앞엣것을 덮고, 결함 파일이 통째로 사라진 채 카운트는 2로 찍힌다(실증됨).
+  out="$_MD_TMP/$(echo "$src" | tr '/' '_')-$(printf '%s' "$src" | cksum | cut -d' ' -f1).sh"
   python3 - "$src" "$out" <<'PYEOF' || return 1
 import sys, re
 src, out = sys.argv[1], sys.argv[2]
@@ -101,7 +113,11 @@ for t in "${TARGETS[@]}"; do
       head -n1 "$f" 2>/dev/null | grep -qE '^#!.*\b(ba|z|k)?sh\b' && FILES+=("$f")
     done < <(find "$t" -type f 2>/dev/null)
     while IFS= read -r f; do
-      sh=$(_md_shadow "$f") && [ -n "$sh" ] && { FILES+=("$sh"); MD_ORIGIN+=("$sh=$f"); }
+      if sh=$(_md_shadow "$f") && [ -n "$sh" ]; then
+        FILES+=("$sh"); MD_ORIGIN+=("$sh=$f")
+      else
+        UNSCANNABLE+=("$f")   # 펜스 없음 OR 추출 불가 — 어느 쪽이든 "안 쟀다"이지 "깨끗하다"가 아니다
+      fi
     done < <(find "$t" -type f -name '*.md' 2>/dev/null)
   elif [ -f "$t" ]; then
     tb="${t##*/}"

--- a/templates/degrade_direction_scan.sh
+++ b/templates/degrade_direction_scan.sh
@@ -40,7 +40,14 @@ PASS='(True|"PASS"|'"'"'PASS'"'"'|"ALLOW"|'"'"'ALLOW'"'"'|"OK"|'"'"'OK'"'"'|"VAL
 # incl. this gate's own pre-push/pre-commit-hook trigger category — must not be invisibly dropped).
 # Anything else is tracked as UNSCANNABLE so a load-bearing surface in another language is reported
 # as "not covered", never silently folded into an "advisory clean" (M#2, steel-quench 2026-07-03).
-FILES=(); UNSCANNABLE=(); MD_ORIGIN=()
+FILES=(); UNSCANNABLE=(); MD_ORIGIN=(); UNMEASURED=()
+# UNSCANNABLE vs UNMEASURED — 한 통에 넣으면 S 가 살아난다(재검 2026-08-12 지목).
+#   UNSCANNABLE = 측정 대상이 아니다(펜스 없는 산문 md, py/sh 아닌 파일). 정상 상태.
+#   UNMEASURED  = 재려 했는데 **못 쟀다**(python3/cksum 부재로 추출 실패). 이건 절대 CLEAN 이 아니다.
+# 첫 수리는 둘을 UNSCANNABLE 하나에 담았고, 그 배열은 `FILES` 가 **완전히 빌 때만** exit 2 로
+# 승격된다 — 스캔 가능한 .sh 가 하나라도 섞이면 추출 실패가 note 한 줄로 강등되고 rc=0 이 나갔다.
+# 즉 「측정 못 함을 CLEAN 으로 렌더」가 지배 경로(디렉터리 스캔 → typed capability)에 그대로 남아
+# 있었다 — 이 릴리스가 고치겠다고 선언한 바로 그것이다.
 
 # ── Markdown fence extraction (2026-08-11) ────────────────────────────────────────────────────
 # The bash this harness actually EXECUTES largely does not live in .sh files — it lives in ```bash
@@ -60,7 +67,10 @@ FILES=(); UNSCANNABLE=(); MD_ORIGIN=()
 # "no smells in N scanned files / exit 0" 이 된다 — 이 릴리스가 고치는 바로 그 클래스를 수리가
 # 재생산한 것이다(배포 직전 보안 패스가 적발, 2026-08-12). 자매 스크립트들은 이미 옳게 한다:
 # validate_yaml → UNCALIBRATED + exit 2, package_coverage → exit 1. 여기도 같은 방향으로 맞춘다.
-_MD_OK=1; command -v python3 >/dev/null 2>&1 || _MD_OK=0
+_MD_OK=1
+for _dep in python3 cksum; do command -v "$_dep" >/dev/null 2>&1 || _MD_OK=0; done
+# cksum 도 미선언 의존성이다 — 첫 수리는 python3 만 가드하고 cksum 은 rc 미검사로 도입했다.
+# 부재 시 유일성 토큰이 **빈 문자열**이 돼 shadow 이름 충돌(A-1)이 그대로 부활한다(실증).
 # mktemp 실패 시 예측 가능한 경로(/tmp/degradescan.$$)로 폴백하던 것을 제거했다: 그 경로를 mkdir
 # 하지 않아 정상 폴백은 100% 실패하고, 반대로 공격자가 그 이름에 심링크를 심어두면 **성공해서
 # 레포 밖에 쓴다**(실증됨). 즉 "공격받을 때만 동작하는 코드" 였다.
@@ -115,8 +125,10 @@ for t in "${TARGETS[@]}"; do
     while IFS= read -r f; do
       if sh=$(_md_shadow "$f") && [ -n "$sh" ]; then
         FILES+=("$sh"); MD_ORIGIN+=("$sh=$f")
+      elif [ "$_MD_OK" = 1 ]; then
+        UNSCANNABLE+=("$f")   # 펜스가 없다 — 측정 대상이 아님(정상)
       else
-        UNSCANNABLE+=("$f")   # 펜스 없음 OR 추출 불가 — 어느 쪽이든 "안 쟀다"이지 "깨끗하다"가 아니다
+        UNMEASURED+=("$f")    # 추출 자체가 불가 — 못 쟀다(CLEAN 으로 접히면 안 된다)
       fi
     done < <(find "$t" -type f -name '*.md' 2>/dev/null)
   elif [ -f "$t" ]; then
@@ -126,14 +138,24 @@ for t in "${TARGETS[@]}"; do
       *.md)
         if sh=$(_md_shadow "$t") && [ -n "$sh" ]; then
           FILES+=("$sh"); MD_ORIGIN+=("$sh=$t")
+        elif [ "$_MD_OK" = 1 ]; then
+          UNSCANNABLE+=("$t")      # no bash fence — not a measurement target
         else
-          UNSCANNABLE+=("$t")      # no bash fence extracted → genuinely not measured
+          UNMEASURED+=("$t")       # extraction impossible — could not measure
         fi ;;
       *.*) UNSCANNABLE+=("$t") ;;
       *) if head -n1 "$t" 2>/dev/null | grep -qE '^#!.*\b(ba|z|k)?sh\b'; then FILES+=("$t"); else UNSCANNABLE+=("$t"); fi ;;
     esac
   fi
 done
+# 못 잰 파일이 있으면 hits 와 무관하게 비-clean 이다. 이 블록이 FILES 비었을 때만 도는 구조가
+# S 의 정체였다 — 스캔 가능한 파일이 하나라도 있으면 「못 쟀다」가 note 로 강등되고 rc=0 이 나갔다.
+if [ ${#UNMEASURED[@]} -gt 0 ]; then
+  echo "degrade-scan: ${#UNMEASURED[@]} file(s) COULD NOT BE MEASURED (markdown fence extraction unavailable — python3/cksum missing):"
+  printf '  (unmeasured) %s\n' "${UNMEASURED[@]}"
+  echo "This is NOT 'clean' — the fence surface was not scanned at all. Install python3+cksum or scan those files elsewhere."
+  _FORCE_NONCLEAN=2
+fi
 if [ ${#FILES[@]} -eq 0 ]; then
   if [ ${#UNSCANNABLE[@]} -gt 0 ]; then
     echo "degrade-scan: ${#UNSCANNABLE[@]} changed file(s) are OUTSIDE the scannable set (py/sh) — NOT scanned, NOT 'clean':"
@@ -141,7 +163,7 @@ if [ ${#FILES[@]} -eq 0 ]; then
     echo "A load-bearing surface in another language must go straight to cross-family review."
     exit 2   # advisory non-clean — an orchestrator keying on exit code must not read this as clean
   fi
-  echo "degrade-scan: no scannable (py/sh) target files"; exit 0
+  echo "degrade-scan: no scannable (py/sh) target files"; exit "${_FORCE_NONCLEAN:-0}"
 fi
 
 hits=0
@@ -341,4 +363,4 @@ fi
 # it does NOT assert the changed load-bearing surface is safe (other languages, non-code surfaces,
 # and the lint's own recall gaps are out of scope). The load-bearing check is the cross-family review.
 echo "degrade-scan: no default-toward-PASS smells in ${#FILES[@]} scanned py/sh file(s) — does NOT cover other languages / non-code surfaces / the cross-family check (advisory)."
-exit 0
+exit "${_FORCE_NONCLEAN:-0}"   # 못 잰 파일이 있으면 0 이 아니다 — "안 쟀다"는 "깨끗하다"가 아니다


### PR DESCRIPTION
락스텝 5개 문자열 1.4.95 → 1.4.96. **코드 변경 0** — 내용은 #348·#349 에서 이미 4축 게이트를
통과해 머지됐고, 이 PR 은 그것을 출하 가능한 상태로 만드는 것뿐이다.

## 출하되는 것

- **스킬 40종 + 에이전트 8종 재출하** — 죽은 계기(실행하면 죽는데 「대상 없음」으로 렌더) ·
  죽은 명령/경로 · 선언≠본문 · 완료조건이 산출물 아닌 문장을 재는 것
- **계기 2종** — `validate_yaml.sh`(에이전트 편입 + 스캔 0건 = INSTRUMENT ERROR, **이번에 처음 출하**) ·
  `degrade_direction_scan.sh`(SKILL.md ```bash 펜스 추출, 줄번호 1:1 보존)
- **인용 오귀속 2건 정정** — arXiv 2605.00914 의 32.3pp 는 다수결 oracle gap 이지 자기평가 저하가
  아니고, 2603.15255(SAGE)는 co-evolve 라 「Critic 격리」 근거가 될 수 없다(둘 다 원문 직독)

## Pre-Publish 게이트 (비가역 표면이므로 publish 전에 전부 실행)

| 검사 | 결과 |
|---|---|
| ① 배포 파일셋 기밀 스캔 (`public_surface_scan_files.sh`) | `rc=0` PASS — full pattern set |
| ② 전 tracked 누출 렌즈 (`psa_probe`) | `rc=0` CLEAN — 332 파일. `paper/` HTML 2건은 기존 allowlist(운영자 판단 대기 항목) |
| ③ 출하 실행코드 보안 패스 | v1.4.95 이후 변경분 **6파일 199+/10-** 를 격리 검토 — 펜스→임시 `.sh` 추출 경로 · `rm -rf` 트랩 · 소비자 머신 쓰기 부작용 · fail-open 재생산 축 |
| 락스텝 | `LOCKSTEP: PASS — 4 shipped version string(s) all at 1.4.96` |
| tarball 실물 | 257파일 3,738KB · `validate_yaml`·degrade-scan·에이전트 8종 **포함** / `tracks/`·`paper/`·회귀 코퍼스·`CLAUDE.local` **전부 제외** |

③ 의 스코프를 «현재 브랜치 diff» 로 잡으면 **버전 범프만** 보게 된다 — 그건 틀린 스코프라
`v1.4.95..HEAD` 의 출하 실행코드로 잡았다.

## 정직한 잔여

- ③ 은 **이번 릴리스에서 변경된** 실행코드가 대상이다. 그 이전부터 출하되던 스크립트 77개는
  이 패스의 대상이 아니다(전수 감사가 아니다).
- `npm PASS ≠ 공개 표면 PASS` — `paper/` 는 files[] 밖이라 tarball 에 없지만, 레포가 public 이라
  GitHub 은 이미 게시 중이다. **두 스코프는 서로를 포함하지 않는다.**
- CHANGELOG 는 1.4.87~95 구간이 비어 있다(기존 드리프트). 이번 항목만 추가했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)