### PR TITLE
fix(psa): 배포 게이트가 «스캔하지 않은 파일»에 초록을 주던 경로 폐쇄 + 단일파일 3값 스캔

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "scripts/gate_pathspec_check.sh",
     "scripts/prepush_guard_check.sh",
     "scripts/psa_scan_lib.sh",
+    "scripts/test_psa_singlefile_lanes.sh",
     "scripts/session_close_check.sh",
     "scripts/utterance_landing_check.sh",
     "scripts/test_dispatch_log_lanes.sh",

--- a/scripts/psa_scan_lib.sh
+++ b/scripts/psa_scan_lib.sh
@@ -239,3 +239,167 @@ $PSA_STREAM
 PSA_PAT
   return $hit
 }
+
+# _psa_can_assign <name> <value> — 0 = "this exact assignment will succeed", 1 = it will not.
+#
+# Rounds 4→7 walked this from a declaration parse to a proxy probe to the real thing:
+#   R4  parsed `readonly -p` for `NAME=` — missed `readonly FOO` (prints `declare -r FOO`, no `=`)
+#       and false-positived on an unrelated readonly whose VALUE contained the string.
+#   R5  replaced it with a behavioural probe — but the probe assigned the variable's OWN CURRENT
+#       VALUE, while the caller then assigns something else.
+#   R7  found the gap that leaves: `declare -i PSA_ALLOWLIST` makes the self-assignment succeed and
+#       `PSA_ALLOWLIST=/dev/null` fail. Measured — probe=writable, real=FAIL. The caller then died
+#       mid-run, and on the psa_scan_file path a hit that psa_scan_tagged WOULD have reported was
+#       lost with it.
+# So the probe now takes the value: it tests the operation that is actually about to happen, in a
+# subshell where failure cannot reach the caller. Every earlier version tested a stand-in for it.
+_psa_can_assign() {
+  case "$1" in
+    ''|*[!A-Za-z0-9_]*|[0-9]*)
+      echo "  ❌ _psa_can_assign: refusing non-identifier argument" >&2
+      return 1 ;;   # cannot-assign → the caller refuses to mutate. Degrades away from mutating.
+  esac
+  ( eval "$1=\"\$2\"" ) 2>/dev/null
+}
+
+# psa_require_live — prove the scanner actually RUNS before a 0 from it is allowed to mean "clean".
+# Returns 0 = alive, 1 = dead (and says so on stderr).
+#
+# Why this exists (measured 2026-08-12): a caller hand-built the path-tagged stream and piped it into
+# psa_scan_tagged from a shell whose PATH lacked `cat`. The function died on its first line, printed
+# `command not found` into the captured output, and returned 0 — so the caller's known-positive
+# (a file dense with operator literals) reported **0 hits**, indistinguishable from clean. The control
+# is what caught it: the run was only recognisable as dead because a file that MUST hit did not.
+# This function makes that control intrinsic instead of remembered — it does not check that binaries
+# exist (a presence check is the weaker instrument this repo keeps re-learning), it checks that a
+# synthetic token which MUST be reported IS reported, end to end through the real matcher.
+#
+# Cross-family round 1 (2026-08-12) refuted three things about the first draft; all three are fixed
+# here and named so the next reader does not re-introduce them:
+#   · it exercised only the stdin path, so a missing `awk` — the binary the file path actually needs —
+#     was outside what "alive" certified. The self-test now goes through the SAME tagging path
+#     `psa_scan_file` uses, from a real temp file.
+#   · the canary was allowlistable: a `psa/selftest<TAB>PSA_SELFTEST_CANARY` row would mute it and a
+#     healthy scanner would report itself dead. The self-test now runs with the allowlist disabled.
+#   · it was not `errexit`-safe: under `set -e` the nonzero return from the hit-reporting path exited
+#     the caller's shell before the restore line. Status capture is now inside an `if`.
+psa_require_live() {
+  local saved_stream saved_allow saved_stream_set saved_allow_set tmpd out rc _canary
+  saved_stream="${PSA_STREAM-}"; saved_allow="${PSA_ALLOWLIST-}"
+  saved_stream_set=""; saved_allow_set=""
+  [ "${PSA_STREAM+x}" = "x" ] && saved_stream_set=1
+  [ "${PSA_ALLOWLIST+x}" = "x" ] && saved_allow_set=1
+  tmpd=$(mktemp -d 2>/dev/null) || { echo "  ❌ INSTRUMENT DEAD — mktemp unavailable." >&2; return 1; }
+  # Round 4 refuted the round-3 fix: `|| :` does NOT rescue an assignment to a readonly variable —
+  # bash aborts the shell before the `||` is ever considered. So the only safe move is to REFUSE
+  # before mutating anything. Detected, reported as DEAD, and the caller survives.
+  _canary=$(printf 'HIGH\tPSA_SELFTEST_CANARY')
+  if ! _psa_can_assign PSA_STREAM "$_canary" || ! _psa_can_assign PSA_ALLOWLIST /dev/null; then
+    echo "  ❌ INSTRUMENT DEAD — PSA_STREAM/PSA_ALLOWLIST cannot take the values the self-test needs." >&2
+    echo "     (readonly, or an attribute such as \`declare -i\` that rejects the value)" >&2
+    echo "     Not attempting it: a failed assignment aborts an errexit caller outright." >&2
+    rm -rf "$tmpd" 2>/dev/null || :
+    return 1
+  fi
+  PSA_STREAM="$_canary"
+  PSA_ALLOWLIST=/dev/null
+  printf 'PSA_SELFTEST_CANARY\n' > "$tmpd/canary" 2>/dev/null
+  # Same pipeline shape as psa_scan_file: awk tags the file, psa_scan_tagged matches it.
+  if out=$(awk -v P="psa/selftest" '{print P "\t" $0}' "$tmpd/canary" 2>&1 | psa_scan_tagged 2>&1); then
+    rc=0
+  else
+    rc=$?
+  fi
+  rm -rf "$tmpd" 2>/dev/null || :
+  # Restore EXACTLY, including the difference between unset and set-empty (round 2): the first draft
+  # always re-set PSA_STREAM, turning an unset variable into an empty one — which the very guard in
+  # psa_scan_file below keys on. A restore that changes state is not a restore.
+  if [ -n "${saved_stream_set:-}" ]; then PSA_STREAM="$saved_stream"; else unset PSA_STREAM; fi
+  if [ -n "${saved_allow_set:-}" ]; then PSA_ALLOWLIST="$saved_allow"; else unset PSA_ALLOWLIST; fi
+  case "$out" in
+    *PSA_SELFTEST_CANARY*) [ "$rc" -eq 1 ] && return 0 ;;
+  esac
+  echo "  ❌ INSTRUMENT DEAD — the scanner did not report a synthetic known-positive." >&2
+  echo "     self-test rc=$rc out=[$out]" >&2
+  echo "     A 0 from this scanner is UNMEASURED, not clean — do not report or publish a count from it." >&2
+  return 1
+}
+
+# psa_scan_file <path> — scan ONE file through the shared matcher.
+#
+# Three-valued on purpose: 0 = scanned, nothing reportable · 1 = scanned, hit(s) reported ·
+# 3 = NOT SCANNED (instrument dead, bad usage, or missing file). Folding 3 into 0 is the exact defect
+# this repo keeps meeting — `not found` is not `0`, and a file that does not exist is not an empty file.
+# Callers that only branch on `if psa_scan_file f; then clean; fi` would read 3 as dirty (safe) and
+# never as clean; callers that check `-eq 0` must treat 3 as unmeasured.
+#
+# ⚠️ The caller still owns the DISPLAY. A hit line (❌) and an allowlisted line (⚪) are different
+# outcomes, and a display filter that greps only ❌ renders "allowlisted" as "no match" — measured
+# on 2026-08-12, which is how an existing operator allowlist decision was misread as an absent
+# pattern. If you filter this function's output, keep both markers or state which you dropped.
+psa_scan_file() {
+  local out rc
+  if [ "$#" -ne 1 ]; then
+    echo "  ⚠️  USAGE — psa_scan_file <path> (got $# argument(s)); NOT SCANNED" >&2
+    return 3
+  fi
+  # Patterns-not-loaded is the highest-value guard here, and it was missing from the first draft.
+  # Cross-family round 1 found it by simply following THIS FILE'S OWN advertised usage line, which
+  # said `. psa_scan_lib.sh && psa_scan_file <path>` and omitted psa_load — reproduced: a file dense
+  # with a known-positive token returned rc=0 with empty output. An empty pattern stream scans
+  # everything and reports nothing, which is the false-clean this whole change exists to remove.
+  if [ -z "${PSA_STREAM:-}" ]; then
+    echo "  ⚠️  PATTERNS NOT LOADED — call psa_load <defaults> <override> first; NOT SCANNED" >&2
+    echo "     (an empty pattern stream reports nothing, which is indistinguishable from clean)" >&2
+    return 3
+  fi
+  # A NON-EMPTY stream is not a COMPLETE one (round 2). If the committed defaults failed to load, or
+  # rows were dropped as unusable, the stream still matches *something* and a clean verdict from it
+  # is a verdict about a partial instrument.
+  #
+  # `case`, not `[ -ne ]` (round 3): a non-numeric value made `[` return 2, the `if` read that as
+  # false, and the guard fell through — reproduced with PSA_DEFAULTS_OK=x, which scanned a file to
+  # rc=0 CLEAN using a stream that did not contain the token. A guard that a garbage value walks
+  # straight past is not a guard, and the shell's own error line scrolled by unnoticed.
+  local _incomplete=""
+  case "${PSA_DEFAULTS_OK:-}" in 1) ;; *) _incomplete="defaults_ok=${PSA_DEFAULTS_OK:-unset}" ;; esac
+  case "${PSA_BAD_ROWS:-0}" in 0) ;; *) _incomplete="${_incomplete:+$_incomplete }bad_rows=${PSA_BAD_ROWS}" ;; esac
+  # The operator override carries the HIGH company/companion literals. Its absence is survivable for a
+  # single-file query (the committed defaults still apply) but the caller must never read the result as
+  # a full clean — so it is announced, not silently folded in.
+  # Round 4: this used to WARN and still return 0. That is the exact false-clean this change exists to
+  # remove — the override carries the HIGH company/companion literals, so without it the scan did not
+  # look at the highest-severity class at all, and "clean" is a claim the run cannot support. It now
+  # joins _incomplete. (No existing caller breaks: psa_scan_file is new in this change.)
+  case "${PSA_OVERRIDE_PRESENT:-}" in
+    1) ;;
+    *) _incomplete="${_incomplete:+$_incomplete }override_absent(HIGH operator literals unscanned)" ;;
+  esac
+  psa_require_live || return 3
+  if [ ! -f "$1" ]; then
+    echo "  ⚠️  MISSING — $1 : NOT SCANNED (unmeasured, not 0 hits)" >&2
+    return 3
+  fi
+  # `awk | psa_scan_tagged` hides an awk read failure when the caller has no pipefail: awk fails,
+  # psa_scan_tagged sees an empty stream and returns 0 = clean. Materialise the tagged stream first
+  # so the read is a checkable step of its own (cross-family round 1).
+  local tmpf
+  tmpf=$(mktemp 2>/dev/null) || { echo "  ⚠️  mktemp failed; NOT SCANNED" >&2; return 3; }
+  if ! awk -v P="$1" '{print P "\t" $0}' "$1" > "$tmpf" 2>/dev/null; then
+    rm -f "$tmpf" || :
+    echo "  ⚠️  READ FAILED — $1 could not be tagged for scanning; NOT SCANNED" >&2
+    return 3
+  fi
+  if out=$(psa_scan_tagged < "$tmpf"); then rc=0; else rc=$?; fi
+  rm -f "$tmpf" || :
+  # Print findings FIRST, verdict second — round 3 caught the previous order suppressing real hits:
+  # an incomplete instrument returned 3 and emitted nothing, so a token the loaded patterns DID match
+  # was lost. "I could not certify this" and "I saw nothing" are different, and the fix for the second
+  # must not create the first. Partial evidence is reported; the verdict still refuses to say clean.
+  [ -n "$out" ] && printf '%s\n' "$out"
+  if [ -n "$_incomplete" ]; then
+    echo "  ⚠️  INCOMPLETE PATTERN INSTRUMENT — $_incomplete : verdict is NOT SCANNED (any hits above are partial)" >&2
+    return 3
+  fi
+  return "$rc"
+}

--- a/scripts/public_surface_scan_files.sh
+++ b/scripts/public_surface_scan_files.sh
@@ -24,6 +24,36 @@
 
 set -uo pipefail
 
+# ── Misuse fails CLOSED, before the banner ──────────────────────────────────────────────────────
+# This script scans the npm-published file set (derived from `npm pack --dry-run`). It takes NO
+# positional arguments, and until 2026-08-12 it did not parse any either — it silently ignored them
+# and printed its normal green. That turned a misuse into a false certification: a caller who ran
+#   bash scripts/public_surface_scan_files.sh <some/path>
+# to ask "is THIS file clean?" got `✅ PASS`, about a file set that never contained <some/path>.
+# Measured known-pair: no args → rc=0 PASS; `/nonexistent/definitely_not_a_file_zzz.md` → byte-identical
+# rc=0 PASS; `PSA_PATTERNS=/nonexistent/nope` → rc=1 (so the green was a live green, not a dead one).
+# The first person to hit it was not the author but the first real user, who nearly recorded
+# "paper/forge_harness_v1.0.html is clean" from a scan that never opened that file.
+# On an irreversible surface (publish) an instrument that cannot answer the question it was asked
+# must refuse, not answer a different question in the affirmative.
+# rc=2 is deliberately distinct from rc=1 (a real leak/incomplete instrument) and rc=0 (clean):
+# "you used it wrong" and "your content is dirty" are different states and must not be collapsed.
+if [ "$#" -gt 0 ]; then
+  echo "[Pre-Publish] public-surface scan — ✋ USAGE ERROR: this script takes no arguments (got $#: $*)" >&2
+  echo "     It scans the npm-published file set only (npm pack --dry-run), never a path you pass in." >&2
+  # The psa_load call is NOT optional and is spelled out here on purpose: the first draft of this
+  # message omitted it, and cross-family review found that following it verbatim scans a
+  # known-positive file to rc=0/clean (empty pattern stream). An instruction that produces a false
+  # clean is the same defect as the guard above, one layer out.
+  echo "     To scan ONE file:" >&2
+  echo "       . scripts/psa_scan_lib.sh \\" >&2
+  echo "         && psa_load .claude/rules/.public-surface-patterns.defaults .claude/rules/.public-surface-patterns \\" >&2
+  echo "         && psa_scan_file <path>        # rc: 0 clean · 1 hit(s) · 3 NOT SCANNED" >&2
+  echo "     To scan tracked files: use the /public-surface-audit skill." >&2
+  echo "     Refusing rather than reporting a PASS about a different file set (fail-closed)." >&2
+  exit 2
+fi
+
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 PSA_DEFAULTS="$REPO_ROOT/.claude/rules/.public-surface-patterns.defaults"
 PSA_OVERRIDE="${PSA_PATTERNS:-$REPO_ROOT/.claude/rules/.public-surface-patterns}"

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -199,6 +199,22 @@ else
   fail=1
 fi
 
+# The public-surface scanner's SINGLE-FILE and MISUSE paths. Same subject-present/anchor-gone shape:
+# the scanner is a fail-closed gate on an irreversible surface, and its failure mode is a green that
+# was never earned — a misuse, an unloaded pattern set, or dead plumbing all used to render as clean.
+# Wired here on purpose (cross-family round 2): the lane file existed and was syntax-checked only, so
+# `npm test` and `prepublishOnly` never executed it. A checker nobody calls is prose.
+if [ ! -f scripts/psa_scan_lib.sh ]; then
+  echo "SKIP  psa single-file lanes (subject scripts/psa_scan_lib.sh absent)"
+elif [ -f scripts/test_psa_singlefile_lanes.sh ]; then
+  if ! bash scripts/test_psa_singlefile_lanes.sh; then
+    fail=1
+  fi
+else
+  echo "FAIL  psa single-file lanes: psa_scan_lib.sh present but its anchor is missing"
+  fail=1
+fi
+
 # package-coverage — a shipped doc must not point at a file the tarball omits. Distinct from the
 # ref-path check below: that one asks "does this path exist at all", this one asks "does the
 # CONSUMER get it". Measured 2026-07-28: 35 paths existed, were named by a shipped doc, and were

--- a/scripts/test_psa_singlefile_lanes.sh
+++ b/scripts/test_psa_singlefile_lanes.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# test_psa_singlefile_lanes.sh — known-pair lanes for the public-surface scanner's SINGLE-FILE and
+# MISUSE paths.
+#
+# What these lanes exist to hold (all measured 2026-08-12, all found by a control and not by review):
+#   L1  `public_surface_scan_files.sh <path>` used to IGNORE the argument and print its normal green,
+#       so a caller asking "is THIS file clean?" got a PASS about a file set that never contained it.
+#   L3/L4  `psa_scan_tagged` piped from a shell without `cat` died on its first line and returned 0 —
+#       a known-positive scanned as 0 hits. "The scanner ran" and "the scanner said clean" are
+#       different claims and were indistinguishable.
+#   L7  a missing file returned 0 hits, i.e. `not found` rendered as `0`.
+#   L9  a display that greps only ❌ renders an ALLOWLISTED token (⚪) as "no match" — that is how an
+#       existing operator allowlist decision got misread as an absent pattern.
+#
+# HERMETIC BY CONSTRUCTION: every lane builds its own pattern/allowlist files under a temp dir. It
+# must NOT read `.claude/rules/.public-surface-patterns` (gitignored, operator-private) — a lane that
+# depends on an operator-local file is unrunnable on a fresh clone and in CI, and would silently
+# degrade to "0 lanes ran" there, which is the same not-measured-is-not-zero shape these lanes guard.
+#
+# Verdict is the exit code. Never parse a summary line for it.
+
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+LIB="$REPO_ROOT/scripts/psa_scan_lib.sh"
+PUB="$REPO_ROOT/scripts/public_surface_scan_files.sh"
+TMP=$(mktemp -d) || exit 9
+trap 'rm -rf "$TMP"' EXIT
+
+# HERMETIC BINDING (cross-family round 1 refuted the original claim of hermeticity): lanes that did
+# not set PSA_ALLOWLIST fell through to the library default, which is the operator's GITIGNORED
+# allowlist. A lane whose verdict depends on a file that does not exist on a fresh clone is not
+# hermetic — it is silently a different test there. Bound once, for every lane.
+export PSA_ALLOWLIST="$TMP/allowlist"
+# Environment hermeticity (round 2): PUBLIC_SURFACE_OK is an operator override that converts the
+# publish scanner's fail-closed exit into a proceed. Inherited from the caller's shell it silently
+# flips L2's expected verdict — a lane whose result depends on an ambient env var is measuring the
+# environment, not the code.
+unset PUBLIC_SURFACE_OK
+
+pass=0; fail=0
+ok()   { pass=$((pass+1)); printf '  ✅ %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  ❌ %s\n' "$1"; }
+# check <name> <expected_rc> <actual_rc> [substring_that_must_appear] [output]
+check() {
+  local name="$1" want="$2" got="$3" need="${4:-}" out="${5:-}"
+  if [ "$got" != "$want" ]; then bad "$name — rc want=$want got=$got"; return; fi
+  if [ -n "$need" ]; then
+    case "$out" in *"$need"*) ;; *) bad "$name — rc ok but output lacks '$need'"; return ;; esac
+  fi
+  ok "$name"
+}
+
+# ── fixtures ────────────────────────────────────────────────────────────────────────────────────
+printf 'HIGH\tPSA_LANE_SECRET\nHIGH\tPSA_LANE_ALLOWED\n' > "$TMP/defaults"
+printf '# empty operator override is still "present + non-empty" for these lanes\nLOW\tPSA_LANE_LOW\n' > "$TMP/override"
+printf 'fixtures/allowed.md\tPSA_LANE_ALLOWED\n' > "$TMP/allowlist"
+mkdir -p "$TMP/fixtures"
+printf 'harmless line\ncontact PSA_LANE_SECRET here\n' > "$TMP/fixtures/positive.md"
+printf 'nothing to see\njust prose\n'                  > "$TMP/fixtures/negative.md"
+printf 'this names PSA_LANE_ALLOWED on purpose\n'       > "$TMP/fixtures/allowed.md"
+
+echo "[psa single-file lanes]"
+
+# ── L1/L2 : misuse of the publish scanner fails CLOSED, and the no-arg path is untouched ────────
+out=$("$PUB" /nonexistent/definitely_not_a_file_zzz.md 2>&1); rc=$?
+check "L1 publish-scanner: positional arg → rc=2 refuse" 2 "$rc" "USAGE ERROR" "$out"
+
+# Control for L1: prove the guard did NOT swallow the normal no-arg path. A deliberately unresolvable
+# pattern source makes the no-arg run exit at the instrument check (rc=1) BEFORE `npm pack`, so this
+# stays fast and still proves the run got past the argument guard.
+# Cross-family round 1: the first version only rejected rc=2, so a scanner that wrongly exited 0 PASS
+# on an unresolvable pattern source would still have shown green. A control that cannot fail in the
+# direction you care about is not a control. It now demands the specific fail-closed outcome.
+out=$(PSA_PATTERNS=/nonexistent/nope "$PUB" 2>&1); rc=$?
+check "L2 publish-scanner: no-arg path reaches the instrument check and fails closed" 1 "$rc" "incomplete confidentiality instrument" "$out"
+
+# ── L3/L4 : the liveness self-test separates "ran and found nothing" from "never ran" ────────────
+out=$(
+  . "$LIB"; psa_load "$TMP/defaults" "$TMP/override" >/dev/null 2>&1
+  psa_require_live 2>&1
+); rc=$?
+check "L3 psa_require_live: healthy shell → alive" 0 "$rc"
+
+# The reproduction: a shell whose PATH has no `cat`. psa_scan_tagged dies on its first line and would
+# otherwise return 0 — which is what made a known-positive read as clean.
+out=$(/usr/bin/env -i PATH=/nonexistent/bin /bin/bash -c "
+  . '$LIB'; psa_load '$TMP/defaults' '$TMP/override' >/dev/null 2>&1
+  psa_require_live
+" 2>&1); rc=$?
+check "L4 psa_require_live: PATH without cat → DEAD, not clean" 1 "$rc" "INSTRUMENT DEAD" "$out"
+
+# ── L5/L6 : ordinary single-file verdicts ───────────────────────────────────────────────────────
+out=$(
+  . "$LIB"; psa_load "$TMP/defaults" "$TMP/override" >/dev/null 2>&1
+  PSA_ALLOWLIST="$TMP/allowlist" psa_scan_file "$TMP/fixtures/positive.md" 2>&1
+); rc=$?
+check "L5 psa_scan_file: known-positive → rc=1 + reports the token" 1 "$rc" "PSA_LANE_SECRET" "$out"
+
+out=$(
+  . "$LIB"; psa_load "$TMP/defaults" "$TMP/override" >/dev/null 2>&1
+  PSA_ALLOWLIST="$TMP/allowlist" psa_scan_file "$TMP/fixtures/negative.md" 2>&1
+); rc=$?
+check "L6 psa_scan_file: known-negative → rc=0" 0 "$rc"
+
+# ── L7/L8 : unmeasured is its own value, never 0 ────────────────────────────────────────────────
+out=$(
+  . "$LIB"; psa_load "$TMP/defaults" "$TMP/override" >/dev/null 2>&1
+  psa_scan_file "$TMP/fixtures/does_not_exist.md" 2>&1
+); rc=$?
+check "L7 psa_scan_file: missing file → rc=3 NOT SCANNED (not 0)" 3 "$rc" "NOT SCANNED" "$out"
+
+out=$(
+  . "$LIB"; psa_load "$TMP/defaults" "$TMP/override" >/dev/null 2>&1
+  psa_scan_file 2>&1
+); rc=$?
+check "L8 psa_scan_file: no argument → rc=3 usage (not 0)" 3 "$rc" "USAGE" "$out"
+
+# ── L9 : allowlisted (⚪) is a THIRD outcome and must remain visible ─────────────────────────────
+# This is the regression anchor for the display-collapse: rc is 0 like a clean file, so a caller that
+# only inspects rc — or greps only ❌ — cannot tell "an operator decided to permit this token here"
+# from "this pattern never matched". The ⚪ line is the only thing that separates them.
+out=$(
+  cd "$TMP" || exit 9
+  . "$LIB"; psa_load "$TMP/defaults" "$TMP/override" >/dev/null 2>&1
+  PSA_ALLOWLIST="$TMP/allowlist" psa_scan_file "fixtures/allowed.md" 2>&1
+); rc=$?
+check "L9 psa_scan_file: allowlisted token → rc=0 AND an explicit ⚪ line" 0 "$rc" "⚪ allowlisted" "$out"
+
+# L9b asserts the ABSENCE of a ❌ — and an absence assertion passes for free when nothing ran at all.
+# Caught by the revert probe on 2026-08-12: against the pre-fix tree `psa_scan_file` did not exist,
+# the output was a shell "command not found", there was no ❌ in it, and L9b went green. A lane that
+# is green because the subject never executed is decorative — the same `not found ≠ 0` shape these
+# lanes were written to hold, reproduced inside the lane file. So the absence claim is gated on
+# positive evidence that the scan actually produced its allowlist verdict.
+case "$out" in
+  *"⚪ allowlisted"*)
+    case "$out" in
+      *"❌"*) bad "L9b allowlisted token must not also report ❌" ;;
+      *)      ok  "L9b allowlisted token reports no ❌ (and the ⚪ verdict proves the scan ran)" ;;
+    esac ;;
+  *) bad "L9b UNMEASURED — no ⚪ verdict in the output, so 'no ❌' proves nothing" ;;
+esac
+
+# ── L10 : patterns not loaded is NOT clean ──────────────────────────────────────────────────────
+# Reproduced from this repo's own advertised usage line, which omitted psa_load. An empty pattern
+# stream matches nothing and reports nothing — identical output to a clean file.
+out=$(
+  . "$LIB"
+  psa_scan_file "$TMP/fixtures/positive.md" 2>&1
+); rc=$?
+check "L10 psa_scan_file: patterns never loaded → rc=3 NOT SCANNED (not clean)" 3 "$rc" "PATTERNS NOT LOADED" "$out"
+
+# ── L11 : liveness covers the FILE path, not just stdin (missing awk) ────────────────────────────
+# The tagging step needs awk; the first liveness draft only exercised the stdin path, so "alive"
+# certified a pipeline the file scan does not use.
+mkdir -p "$TMP/bin"
+for b in cat grep mktemp rm printf sed; do
+  src=$(command -v "$b" 2>/dev/null) && ln -sf "$src" "$TMP/bin/$b" 2>/dev/null
+done
+out=$(/usr/bin/env -i PATH="$TMP/bin" /bin/bash -c "
+  . '$LIB'
+  PSA_STREAM=\$(printf 'HIGH\tPSA_LANE_SECRET')
+  PSA_ALLOWLIST=/dev/null
+  psa_require_live
+" 2>&1); rc=$?
+check "L11 psa_require_live: PATH without awk → DEAD (file path is covered)" 1 "$rc" "INSTRUMENT DEAD" "$out"
+
+# ── L12 : errexit safety — the library must not kill its caller ─────────────────────────────────
+# The library's documented contract is that it REPORTS state and never exits. Capturing a nonzero
+# status outside an `if` broke that under `set -e`.
+out=$(bash -c "
+  . '$LIB'; psa_load '$TMP/defaults' '$TMP/override' >/dev/null 2>&1
+  set -e
+  psa_require_live
+  echo SURVIVED
+" 2>&1); rc=$?
+check "L12 psa_require_live: safe under set -e (caller survives)" 0 "$rc" "SURVIVED" "$out"
+
+# ── L13 : a NON-EMPTY pattern stream is not a COMPLETE one ──────────────────────────────────────
+printf 'HIGH\tPSA_ONLY_IN_DEFAULTS\n' > "$TMP/defaults2"
+printf 'default-only token PSA_ONLY_IN_DEFAULTS here\n' > "$TMP/fixtures/partial.md"
+out=$(
+  . "$LIB"; psa_load "$TMP/missing_defaults_file" "$TMP/override" >/dev/null 2>&1
+  psa_scan_file "$TMP/fixtures/partial.md" 2>&1
+); rc=$?
+check "L13 psa_scan_file: defaults failed to load → rc=3 (partial instrument is not clean)" 3 "$rc" "INCOMPLETE PATTERN INSTRUMENT" "$out"
+
+# ── L14 : missing operator override is NOT a clean ───────────────────────────────────────────────
+# Flipped in round 4. It used to warn and return 0; the override is where the HIGH company/companion
+# literals live, so without it the highest-severity class was never looked at. "Warned but clean" is
+# the false-clean shape with a comment attached.
+out=$(
+  . "$LIB"; psa_load "$TMP/defaults" "$TMP/missing_override_file" >/dev/null 2>&1
+  psa_scan_file "$TMP/fixtures/negative.md" 2>&1
+); rc=$?
+check "L14 psa_scan_file: override absent → rc=3 (HIGH literals unscanned is not clean)" 3 "$rc" "override_absent" "$out"
+
+# ── L15 : a GARBAGE guard value must not walk past the guard ────────────────────────────────────
+# Round 3: `[ "$PSA_DEFAULTS_OK" -ne 1 ]` with a non-numeric value returns 2, the `if` reads that as
+# false, and the guard falls through — measured rc=0 CLEAN on a file whose token was not even in the
+# loaded stream. The shell printed "integer expression expected" and nothing consumed it.
+out=$(
+  . "$LIB"
+  PSA_STREAM=$(printf 'HIGH\tSOMETHING_ELSE'); PSA_DEFAULTS_OK=x; PSA_BAD_ROWS=0; PSA_OVERRIDE_PRESENT=1
+  psa_scan_file "$TMP/fixtures/positive.md" 2>&1
+); rc=$?
+check "L15 psa_scan_file: garbage PSA_DEFAULTS_OK → rc=3 (guard is not walked past)" 3 "$rc" "INCOMPLETE PATTERN INSTRUMENT" "$out"
+
+# ── L16 : an incomplete instrument still REPORTS what it saw ─────────────────────────────────────
+# Round 3 caught the round-2 fix suppressing real hits: the guard returned 3 and emitted nothing, so a
+# token the loaded patterns DID match was lost. "I cannot certify this" must not become "I saw nothing".
+out=$(
+  . "$LIB"
+  PSA_STREAM=$(printf 'HIGH\tPSA_LANE_SECRET'); PSA_DEFAULTS_OK=0; PSA_BAD_ROWS=0; PSA_OVERRIDE_PRESENT=1
+  psa_scan_file "$TMP/fixtures/positive.md" 2>&1
+); rc=$?
+check "L16 incomplete instrument still reports the hit it saw (verdict 3, evidence kept)" 3 "$rc" "PSA_LANE_SECRET" "$out"
+
+# ── L17 : readonly caller vars → DEAD, not a corrupted abort ─────────────────────────────────────
+# Round 4 refuted the round-3 `|| :`: bash aborts on assignment to a readonly variable before `||` is
+# considered. The function now refuses BEFORE mutating anything.
+# Scope note, stated because the round-3 claim over-reached: under `set -e` a bare call to a function
+# that RETURNS nonzero still exits the caller — that is correct shell semantics, not a defect. What is
+# fixed is dying mid-mutation with the caller's state half-swapped and no diagnostic. So the lane
+# checks the guarded call, which is how a `set -e` caller is supposed to invoke a fallible function.
+out=$(bash -c "
+  . '$LIB'
+  PSA_STREAM=x; readonly PSA_STREAM
+  set -e
+  if psa_require_live; then echo UNEXPECTED_ALIVE; else echo REFUSED_CLEANLY; fi
+  echo SURVIVED
+" 2>&1); rc=$?
+check "L17 readonly PSA_STREAM → refuses without mutating; guarded set -e caller survives" 0 "$rc" "SURVIVED" "$out"
+case "$out" in *"INSTRUMENT DEAD"*) ok "L17b the refusal is diagnosed, not silent" ;; *) bad "L17b refusal produced no INSTRUMENT DEAD line" ;; esac
+
+# ── L18/L19/L21 : the assign guard, in BOTH directions + the ATTRIBUTE case ─────────────────────────────────────────────
+# L17's fixture used `PSA_STREAM=x; readonly PSA_STREAM` — the one spelling the round-4 glob happened
+# to handle. Round 5 found the other: `readonly PSA_STREAM` with no value prints `declare -r PSA_STREAM`
+# (no `=`), the glob missed it, and the caller died with a bare "readonly variable". A control that
+# only exercises the passing spelling measures the fixture, not the guard.
+out=$(bash -c "
+  . '$LIB'
+  readonly PSA_STREAM
+  set -e
+  if psa_require_live >/dev/null 2>&1; then echo ALIVE; else echo REFUSED; fi
+  echo SURVIVED
+" 2>&1); rc=$?
+check "L18 VALUELESS readonly is detected too (guard tests the property, not the declaration)" 0 "$rc" "REFUSED" "$out"
+case "$out" in *SURVIVED*) ok "L18b caller survives the valueless case" ;; *) bad "L18b caller died on valueless readonly" ;; esac
+
+# The other direction: the round-4 glob also matched an unrelated readonly variable whose VALUE
+# contained the string. Over-blocking here would make every such shell report a healthy scanner dead.
+out=$(bash -c "
+  . '$LIB'; psa_load '$TMP/defaults' '$TMP/override' >/dev/null 2>&1
+  readonly PSA_UNRELATED='PSA_STREAM=junk PSA_ALLOWLIST=junk'
+  if psa_require_live >/dev/null 2>&1; then echo ALIVE; else echo REFUSED; fi
+" 2>&1); rc=$?
+check "L19 unrelated readonly whose VALUE names the vars → no false positive" 0 "$rc" "ALIVE" "$out"
+
+# ── L20 : the readonly helper is not a shell-injection surface ──────────────────────────────────
+# Round 6. Reachable only via a non-literal argument, which no current call site passes — but the
+# function is in the instrument that decides what may be published, and the guard is one line.
+rm -f "$TMP/pwned"
+out=$(bash -c ". '$LIB'; _psa_can_assign 'X; touch $TMP/pwned; #' v; echo rc=\$?" 2>&1); rc=$?
+if [ -f "$TMP/pwned" ]; then bad "L20 eval injection — the payload executed"
+else ok "L20 non-identifier argument is refused before eval (no injection)"; fi
+case "$out" in *"refusing non-identifier"*) ok "L20b the refusal is diagnosed" ;; *) bad "L20b refusal was silent" ;; esac
+
+# ── L21 : an ATTRIBUTE that rejects the value, not just readonly ─────────────────────────────────
+# Round 7. The R5 probe assigned the variable's OWN CURRENT VALUE while the caller then assigns
+# something else. Measured: `declare -i PSA_ALLOWLIST` → self-assignment succeeds, `=/dev/null` fails.
+# The probe said writable, the real assignment killed the caller, and on the psa_scan_file path a hit
+# psa_scan_tagged WOULD have reported went with it. The probe now takes the value it will assign.
+out=$(bash -c "
+  . '$LIB'
+  declare -i PSA_ALLOWLIST
+  set -e
+  if psa_require_live >/dev/null 2>&1; then echo ALIVE; else echo REFUSED; fi
+  echo SURVIVED
+" 2>&1); rc=$?
+check "L21 declare -i (attribute rejects the value) → REFUSED, caller survives" 0 "$rc" "REFUSED" "$out"
+case "$out" in *SURVIVED*) ok "L21b caller survives the attribute case" ;; *) bad "L21b caller died on the attribute case" ;; esac
+
+echo "[psa single-file lanes] pass=$pass fail=$fail"
+[ "$fail" -eq 0 ] || exit 1
+[ "$pass" -ge 26 ] || { echo "  ❌ INSTRUMENT ERROR — only $pass lanes ran; expected >=26"; exit 3; }
+exit 0


### PR DESCRIPTION
## 무엇이 깨져 있었나

`scripts/public_surface_scan_files.sh` 는 `npm publish` 의 `prepublishOnly` 에 물린 fail-closed 기밀 게이트다. 이 스크립트는 **위치인자를 파싱하지 않았고, 조용히 무시했다.** 그래서 배포 전에 「이 파일 깨끗한가」를 묻는 호출

```
bash scripts/public_surface_scan_files.sh some/path
```

은 `✅ PASS` 를 받았다 — **그 파일이 한 번도 포함된 적 없는 파일셋에 대한 판정**을. 비가역 표면의 게이트에서 미사용법이 조용히 성공하는 형태다.

이 결함을 처음 밟은 것은 저자가 아니라 **첫 실사용자**였고(같은 세션에서 하마터면 「논문 파일 깨끗함」으로 기록될 뻔했다), 그게 이 결함의 실제 손해다.

## 증거 캡슐 (재현 가능)

```
known-pair — 이 초록이 «죽은 초록»이 아님을 먼저 증명한다
  인자 없음                                    → rc=0  PASS
  /nonexistent/definitely_not_a_file_zzz.md    → rc=0  PASS  (바이트 동일)
  PSA_PATTERNS=/nonexistent/nope               → rc=1        (계기는 빨개질 수 있다)

fail-before (수리 이전본으로 되돌려 실행)
  레인 13종 중 12 적색 · 컨트롤 L2 만 양쪽 초록 (하네스가 통째로 빨간 게 아님)

수리 후
  레인 26/26 · selfcheck 안에서 `[psa single-file lanes] pass=26` 실행 확인 (= 배선 증명)
  Axis1 regression_guard PASS (M-tier 0 · S-tier 0)
  Axis3 팬텀 0 (경로·심볼 6종 + 스킬 1종 실재, known-negative 컨트롤 1건이 의도대로 ❌)
```

## 들어간 것

| 자리 | 무엇 |
|---|---|
| `public_surface_scan_files.sh` | 위치인자 → **rc=2 fail-closed** + usage. `2`/`1`/`0` = 「잘못 썼다」/「내용이 더럽다」/「깨끗하다」 — 접으면 안 되는 세 상태다 |
| `psa_scan_lib.sh` | `psa_scan_file`(3값 `0`/`1`/**`3` NOT SCANNED`) · `psa_require_live`(합성 known-positive 가 실제 매처를 관통해 보고되는지) · `_psa_can_assign` |
| `test_psa_singlefile_lanes.sh` | 레인 26종 — 밀폐(운영자 gitignored 파일 미의존), 라운드마다 그 라운드가 연 구멍에 하나씩 |
| `selfcheck.sh` · `package.json` | 배선 — 레인이 `npm test` 에서 **실행**된다(종전엔 syntax-check 만) |

설계 판단 하나: `psa_require_live` 는 **바이너리 존재 검사가 아니다.** 존재 검사는 이 레포가 반복해서 다시 배우는 약한 계기라, 대신 «반드시 보고돼야 하는 합성 토큰이 실제 매처를 끝까지 통과해 보고되는가»를 잰다. 근거는 실측이다 — 이 작업 중 `psa_scan_tagged` 를 `cat` 없는 셸에서 부르자 함수가 첫 줄에서 죽고 **known-positive 가 0 hits** 를 냈다. 컨트롤이 없었으면 그게 「깨끗」으로 기록됐다.

## cross-family 검증 (codex / gpt-5.5, 8라운드)

```
S/A/B   R1 3/1/2 → R2 1/1/3 → R3 1/2/2 → R4 1/1/0 → R5 0/2/1 → R6 0/0/2 → R7 0/0/1
        → R8 0S/0A/1B(기각) · 그 라운드 변경 0 = CONVERGED
```

- **내 주장 35개 중 17개가 FALSE 로 반증됐다.** diff 채널과 「내 주장」 채널을 분리해 보냈고, 반증의 대부분이 주장 채널에서 나왔다.
- **R2·R3·R5·R7 의 findings 는 전부 직전 라운드에서 내가 쓴 수리 코드였다. 자력 적발 0.** 대표적으로 R3 은 **내 R2 수리가 진짜 히트를 숨기고 있었음**을 잡았다 — 불완전 계기에서 `rc=3` 을 내면서 출력이 0이었다. 「인증 못 하겠다」를 고치다 「아무것도 못 봤다」를 만든 것이다.
- **되돌림 프로브가 내 레인 하나를 장식으로 적발했다** — `L9b` 는 「❌ 가 없다」를 주장하는데, 아무것도 안 돌아도 ❌ 는 없으므로 수리 이전본에서도 초록이었다. 부재 주장을 실행 증거에 결박하도록 고쳤다.
- **기각 2건**(근거 첨부): ⓐ 「라이브러리가 `PUBLIC_SURFACE_OK` 를 상속한다」 → 함수 내부 참조 0건 · 호출자 publish 스크립트 16건(컨트롤) = 범위 오독 ⓑ R8 의 「liveness 실패 시 히트가 보고 안 된다」 → 배관이 죽었으면 그 출력은 신뢰 대상이 아니고, 강행은 8라운드 동안 없앤 fail-open 을 되살린다.

## 기명 잔여

1. **`set -e` 에서 맨몸 호출은 셸을 종료시킨다.** false 를 1로 반환하는 술어의 본질이고 모든 셸 술어가 그렇다. 두 호출부는 전부 guarded. **수용이지 미해결이 아니며**, 그 수용 자체를 R7 에 반박 과제로 실어 보냈다(반박 없음).
2. **`psa_scan_file` 은 호출자 0개인 신규 함수다.** 적대검증은 첫 실사용이 아니다 — 이 하네스에서 오늘만 두 번 확인됐다. 다음 실사용이 진짜 검증이다.
3. `npm publish` 무인자 경로는 **변경 없음**(가드는 `$# > 0` 에서만 발화). 컨트롤 레인 L2 가 그 경로가 여전히 계기 검사까지 도달함을 확인한다.

## 리뷰 포인트

- `psa_scan_file` 의 **rc=3 을 「더럽다」로 읽는 호출자**가 나올 수 있다(안전 방향이지만 의도와 다름). 함수 주석에 명시했고 레인 L7·L8·L10·L13 이 각 경로를 잡는다.
- 레인은 **밀폐**를 요건으로 짰다 — 운영자 gitignored 패턴/allowlist 에 의존하면 fresh clone·CI 에서 조용히 다른 시험이 된다. R2 가 그걸 반증해서 전역 바인딩을 넣었다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Pp4RBw7zo5u7bo8MLBKvS
