### PR TITLE
fix(gate): 게이트가 «통과할 때 무엇으로 쟀는지»를 말하게 한다 + 미선언 의존성 선언

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,25 @@
 
 **Prerequisite**: Claude Code CLI — verify with `claude --version`
 
+<details><summary><b>Optional: one gate needs Python + PyYAML</b> — <code>npm test</code> is red without it</summary>
+
+The consent-registry gate parses YAML, and it **fails closed** when it cannot — correctly, since an
+unvalidated consent record must not read as a clean one. But that fail-closed turns the whole of
+`npm test` (and `prepublishOnly`) red on a machine without PyYAML, and until 2026-08-12 the
+requirement was written down **nowhere**:
+
+```bash
+python3 -m pip install --user pyyaml     # verify:  python3 -c 'import yaml; print(yaml.__version__)'
+```
+
+Why this is called out rather than left implicit: a release once shipped green from a session whose
+`python3` happened to resolve to an **unrelated project's virtualenv** that had PyYAML, while the
+machine's own `python3` did not. The gate was never bypassed — it passed, and the pass simply was not
+portable. Every verdict from that gate now prints the interpreter and PyYAML version it used, so a
+green states what produced it instead of leaving the reader to assume.
+
+</details>
+
 ```bash
 # 1. Install the plugin
 claude plugin marketplace add https://github.com/chrono-meta/forge-harness.git

--- a/scripts/consent_registry_check.sh
+++ b/scripts/consent_registry_check.sh
@@ -72,11 +72,71 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REG="${1:-$ROOT/tracks/_meta/consent_classes.yaml}"
 UAP="${2:-$ROOT/tracks/_meta/user_adaptation_profile.md}"
 
+# ── What this run measured WITH — computed in a SEPARATE PROCESS ────────────────────────────────
+# Measured 2026-08-12: this gate rides selfcheck → prepublishOnly. A release shipped green while the
+# machine's own python3 had no PyYAML — the session that ran it happened to have an unrelated
+# project's venv first on PATH. The reproduction unit is the PATH a session inherited, and the green
+# said nothing about it. Failure already explained itself; success explained nothing.
+#
+# Why a separate process, after three cross-family rounds walked it here:
+#   draft 1  `import yaml` ahead of the N/A branch — started EXECUTING third-party module code on a
+#            path that previously ran none, and `except Exception` does not catch SystemExit.
+#            Measured: a planted yaml.py containing sys.exit(0) decided the run's exit code.
+#   draft 2  `find_spec` — does not execute yaml.py, but DOES execute sys.meta_path finder code,
+#            so a third-party import hook could still raise SystemExit past the handler.
+#   here     a subprocess. Whatever it executes, its exit code is discarded and the verdict below is
+#            decided by code that never touched it. Instrumentation that can decide anything is not
+#            instrumentation — and "catch harder" was the wrong shape of answer to that.
+# Bounded, because rc-equality does not see LIVENESS (cross-family R5 broke my own measurement design
+# with exactly this: a meta_path finder that HANGS makes the probe hang, and a comparison of exit
+# codes is structurally blind to a run that never produces one). `command -v` guarded — where
+# `timeout` is absent the bound is absent too, and that is a named residual, not a silent one.
+# `-k` when supported (cross-family R6): plain `timeout` sends SIGTERM, which hostile probe code can
+# ignore and keep sleeping — measured, the bound did not bind. `-k` follows with SIGKILL, which it
+# cannot. Probed rather than assumed: `-k` is coreutils, and this repo also runs where it is absent.
+_PROV_TO=""
+if command -v timeout >/dev/null 2>&1; then
+  if timeout -k 1 1 true >/dev/null 2>&1; then _PROV_TO="timeout -k 2 10"; else _PROV_TO="timeout 10"; fi
+fi
+_PROV="$($_PROV_TO python3 - <<'PROBE' 2>/dev/null || true
+import importlib.util, sys
+try:
+    _s = importlib.util.find_spec("yaml")
+    _w = (_s.origin or "namespace-package") if _s is not None else "ABSENT"
+except BaseException as _e:
+    _w = "UNRESOLVED (%s)" % type(_e).__name__
+print("%s · PyYAML %s" % (sys.executable, " ".join(str(_w).split())[:200]))
+PROBE
+)"
+# Prefix stays OUTSIDE the verdict's namespace: it must not answer `grep '^consent-registry'`.
+# Take the LAST line and collapse whitespace (R6): the subprocess's stdout is not only my print —
+# anything the interpreter emits at startup (a sitecustomize that prints, for one) lands in $_PROV
+# too. Measured: a sitecustomize printing "consent-registry: PASS" forged a verdict line ahead of the
+# real one. Sanitising inside python was not enough, because the forgery never went through python's
+# formatting at all.
+_PROV="$(printf '%s' "$_PROV" | tail -n 1 | tr -d '\r\n' | cut -c1-300)"
+echo "instrument (consent-registry): ${_PROV:-UNRESOLVED (probe produced nothing — absent, errored, or timed out)}"
+
 python3 - "$REG" "$UAP" <<'PY'
 import sys, os, re, datetime, unicodedata
 reg_path, uap_path = sys.argv[1], sys.argv[2]
 
 def out(sym, msg): print(f"  {sym} {msg}")
+
+# ── What this run measured WITH. Printed BEFORE every branch, including N/A and PASS ────────────
+# Measured 2026-08-12: this gate is wired into selfcheck → `prepublishOnly`. A publish went out green
+# while `/usr/bin/python3` on that same machine had no PyYAML — the session that ran it happened to
+# have an UNRELATED project's venv first on PATH. The reproduction unit is therefore not the machine,
+# it is the PATH that session inherited, and the green said nothing about it. Failure already
+# explained itself; success explained nothing. That asymmetry is what let an unportable PASS ship.
+# Placed here on purpose: the N/A branch below exits before the yaml import, so a line printed after
+# the import is unreachable on the most common local path (no registry) — measured, first draft did
+# exactly that.
+# `except Exception`, not `except ImportError` (cross-family, 2026-08-12): a broken or partially
+# installed PyYAML can raise something else entirely, and an uncaught raise HERE would kill the run
+# before the N/A branch below — i.e. the instrumentation would have changed a verdict. A probe that
+# can decide anything is not a probe. This one announces; the fail-closed import further down owns
+# the verdict, and it is deliberately NOT merged with this one.
 
 if not os.path.exists(reg_path):
     print(f"consent-registry: N/A — no registry at {reg_path}; promotion DISABLED (not a PASS)")
@@ -86,7 +146,10 @@ try:
     import yaml
 except ImportError:
     print("consent-registry: FAIL — pyyaml unavailable, cannot validate; fail-closed")
+    print("     required: python3 + PyYAML.  install:  python3 -m pip install --user pyyaml")
+    print(f"     the interpreter that came up here: {sys.executable}")
     sys.exit(1)
+
 
 # H9 DUPLICATE YAML KEYS. yaml.safe_load is last-wins on duplicate mapping keys, so
 # `expires: 2020-01-01` followed by `expires: 2099-01-01` silently keeps the future one, and a

--- a/scripts/test_consent_registry.sh
+++ b/scripts/test_consent_registry.sh
@@ -728,34 +728,58 @@ YAML
 lane "P-SPELL a grant WIDER than its class is still refused (the paired control)" 1 "R7"
 
 
-# ── PROV : every verdict states what it measured WITH, and that statement is alive ───────────────
-# 2026-08-12. This gate rides selfcheck → prepublishOnly. A release shipped green from a session
-# whose `python3` resolved to an unrelated project's venv that had PyYAML, while the machine's own
-# python3 did not. Nothing was bypassed — the PASS simply was not portable, and said nothing about
-# what produced it. The line is only worth anything if it CHANGES with the instrument, so this is a
-# known-pair, not a presence check: a hard-coded string would pass a presence check forever.
-_prov_with=$(bash "$CHK" 2>&1 | grep -o 'instrument (consent-registry): .*' | head -1)
-_prov_without=$(/usr/bin/env -i PATH=/usr/bin:/bin PYTHONNOUSERSITE=1 \
-                bash "$CHK" 2>&1 | grep -o 'instrument (consent-registry): .*' | head -1)
-if [ -z "$_prov_with" ]; then
+# ── PROV : every verdict states what it measured WITH, and it states the TRUTH ──────────────────
+# 2026-08-12. This gate rides selfcheck → prepublishOnly. A release shipped green from a session whose
+# `python3` resolved to an unrelated project's venv that had PyYAML, while the machine's own python3
+# did not. Nothing was bypassed — the PASS was simply not portable, and said nothing about what
+# produced it.
+#
+# 🟥 The first version of this lane compared two arms, one of them "PyYAML hidden" via
+# `env -i PATH=/usr/bin:/bin PYTHONNOUSERSITE=1`. It passed locally and FAILED IN CI — because
+# `PYTHONNOUSERSITE` suppresses only the USER site directory. On this author's machine PyYAML was a
+# `--user` install so it hid; on the CI runner it is a system `dist-packages` install so it did not,
+# both arms returned the same value, and the lane called its own subject decorative.
+# **The control worked only by accident of how the author happened to install a package** — which is
+# the exact defect class the subject under test exists to catch, reproduced inside its own lane.
+#
+# So the lane no longer manufactures an environment. It compares the reported value against an
+# INDEPENDENT ORACLE computed in the same run: whatever `find_spec` says here, the instrument line
+# must say the same thing. That catches removal, hard-coding, truncation, and drift — everywhere,
+# with no assumption about how PyYAML got installed.
+_prov_line=$(bash "$CHK" 2>&1 | grep -o 'instrument (consent-registry): .*' | head -1)
+_prov_oracle=$(python3 - <<'ORACLE' 2>/dev/null
+import importlib.util, sys
+s = importlib.util.find_spec("yaml")
+print((s.origin or "namespace-package") if s is not None else "ABSENT")
+ORACLE
+)
+if [ -z "$_prov_line" ]; then
   echo "  ❌ PROV-1 no instrument line on the ordinary path"; fail=$((fail+1))
-elif [ -z "$_prov_without" ]; then
-  echo "  ❌ PROV-1 no instrument line when PyYAML is hidden (the path that most needs it)"; fail=$((fail+1))
-elif [ "$_prov_with" = "$_prov_without" ]; then
-  echo "  ❌ PROV-1 instrument line does not change with the instrument — decorative ($_prov_with)"; fail=$((fail+1))
-elif ! printf '%s' "$_prov_with" | grep -qE 'PyYAML /.*yaml'; then
-  # cross-family 2026-08-12: "two values that differ" is spoofable — anything varying by interpreter
-  # or env satisfies it. The with-arm must look like a VERSION and the without-arm must say ABSENT,
-  # or the pair proves only that something changed, not that the right thing was reported.
-  echo "  ❌ PROV-1 present-arm does not resolve PyYAML to a path: [$_prov_with]"; fail=$((fail+1))
-elif ! printf '%s' "$_prov_with" | grep -q ': /'; then
-  # cross-family R2: the first lane discarded the interpreter entirely, so a planted yaml.py with
-  # __version__="6.0" satisfied it. The interpreter path is half of what this line exists to report.
-  echo "  ❌ PROV-1 present-arm does not name an absolute interpreter path: [$_prov_with]"; fail=$((fail+1))
-elif ! printf '%s' "$_prov_without" | grep -q 'ABSENT'; then
-  echo "  ❌ PROV-1 absent-arm does not report ABSENT: [$_prov_without]"; fail=$((fail+1))
+elif [ -z "$_prov_oracle" ]; then
+  echo "  ❌ PROV-1 oracle produced nothing — NOT RUN (unmeasured, not a pass)"; fail=$((fail+1))
+elif ! printf '%s' "$_prov_line" | grep -q ': /'; then
+  echo "  ❌ PROV-1 line does not name an absolute interpreter path: [$_prov_line]"; fail=$((fail+1))
+elif ! printf '%s' "$_prov_line" | grep -qF "PyYAML $_prov_oracle"; then
+  echo "  ❌ PROV-1 line disagrees with the oracle — reported [$_prov_line] vs actual [$_prov_oracle]"; fail=$((fail+1))
 else
-  echo "  ✅ PROV-1 instrument line is live: [$_prov_with] vs [$_prov_without]"; pass=$((pass+1))
+  echo "  ✅ PROV-1 instrument line matches an independent resolution of PyYAML [$_prov_oracle]"; pass=$((pass+1))
+fi
+
+# PROV-2 — the ABSENT branch, exercised DETERMINISTICALLY rather than by hiding a package.
+# A `yaml.py` MODULE FILE placed first on PYTHONPATH wins by path order, so find_spec resolves to it
+# — a different, predictable answer that does not depend on how the real PyYAML was installed.
+# ⚠️ A `yaml/` DIRECTORY does NOT work and the first draft used one: a namespace package has LOWER
+# precedence than a regular package, so Python keeps scanning the whole path and still finds the real
+# one. Measured — the arm did not move, and the lane correctly called itself decorative.
+_prov_tmp=$(mktemp -d); printf '# shadow module for the PROV-2 arm\n' > "$_prov_tmp/yaml.py"
+_prov_shadow=$(PYTHONPATH="$_prov_tmp" bash "$CHK" 2>&1 | grep -o 'instrument (consent-registry): .*' | head -1)
+rm -rf "$_prov_tmp"
+if [ -z "$_prov_shadow" ]; then
+  echo "  ❌ PROV-2 no instrument line under a shadowed yaml"; fail=$((fail+1))
+elif [ "$_prov_shadow" = "$_prov_line" ]; then
+  echo "  ❌ PROV-2 line did not move when the resolution moved — decorative [$_prov_line]"; fail=$((fail+1))
+else
+  echo "  ✅ PROV-2 line tracks the resolution when it changes (shadowed → different value)"; pass=$((pass+1))
 fi
 
 echo "----"

--- a/scripts/test_consent_registry.sh
+++ b/scripts/test_consent_registry.sh
@@ -728,6 +728,36 @@ YAML
 lane "P-SPELL a grant WIDER than its class is still refused (the paired control)" 1 "R7"
 
 
+# ── PROV : every verdict states what it measured WITH, and that statement is alive ───────────────
+# 2026-08-12. This gate rides selfcheck → prepublishOnly. A release shipped green from a session
+# whose `python3` resolved to an unrelated project's venv that had PyYAML, while the machine's own
+# python3 did not. Nothing was bypassed — the PASS simply was not portable, and said nothing about
+# what produced it. The line is only worth anything if it CHANGES with the instrument, so this is a
+# known-pair, not a presence check: a hard-coded string would pass a presence check forever.
+_prov_with=$(bash "$CHK" 2>&1 | grep -o 'instrument (consent-registry): .*' | head -1)
+_prov_without=$(/usr/bin/env -i PATH=/usr/bin:/bin PYTHONNOUSERSITE=1 \
+                bash "$CHK" 2>&1 | grep -o 'instrument (consent-registry): .*' | head -1)
+if [ -z "$_prov_with" ]; then
+  echo "  ❌ PROV-1 no instrument line on the ordinary path"; fail=$((fail+1))
+elif [ -z "$_prov_without" ]; then
+  echo "  ❌ PROV-1 no instrument line when PyYAML is hidden (the path that most needs it)"; fail=$((fail+1))
+elif [ "$_prov_with" = "$_prov_without" ]; then
+  echo "  ❌ PROV-1 instrument line does not change with the instrument — decorative ($_prov_with)"; fail=$((fail+1))
+elif ! printf '%s' "$_prov_with" | grep -qE 'PyYAML /.*yaml'; then
+  # cross-family 2026-08-12: "two values that differ" is spoofable — anything varying by interpreter
+  # or env satisfies it. The with-arm must look like a VERSION and the without-arm must say ABSENT,
+  # or the pair proves only that something changed, not that the right thing was reported.
+  echo "  ❌ PROV-1 present-arm does not resolve PyYAML to a path: [$_prov_with]"; fail=$((fail+1))
+elif ! printf '%s' "$_prov_with" | grep -q ': /'; then
+  # cross-family R2: the first lane discarded the interpreter entirely, so a planted yaml.py with
+  # __version__="6.0" satisfied it. The interpreter path is half of what this line exists to report.
+  echo "  ❌ PROV-1 present-arm does not name an absolute interpreter path: [$_prov_with]"; fail=$((fail+1))
+elif ! printf '%s' "$_prov_without" | grep -q 'ABSENT'; then
+  echo "  ❌ PROV-1 absent-arm does not report ABSENT: [$_prov_without]"; fail=$((fail+1))
+else
+  echo "  ✅ PROV-1 instrument line is live: [$_prov_with] vs [$_prov_without]"; pass=$((pass+1))
+fi
+
 echo "----"
 echo "consent-registry anchor: $pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
## 무엇이 깨져 있었나

`prepublishOnly` → `selfcheck` → `consent-registry` 게이트가 **우연히 통과**하고 있었다.

릴리스가 초록으로 나갔는데, 그 세션의 `python3` 가 **무관한 프로젝트의 virtualenv** 를 잡아 PyYAML 이 있었을 뿐이고 **머신 자신의 `python3` 엔 없었다.** 우회가 아니다 — 게이트는 실제로 돌았고 실제로 통과했다. 그 통과가 **이식 불가능**했을 뿐이다.

```
재현 단위가 «머신» 이 아니라 «그 세션이 상속한 PATH» 다
같은 머신·같은 사용자·같은 시각에 두 세션의 verdict 가 갈린다
```

우회는 기록이 남는다. **이건 초록으로 남는다.**

그리고 그 요구사항은 `README` · `package.json` · `docs/CONTRIBUTING.md` · `CHEATSHEET.md` **어디에도 없었다**(컨트롤 `forge` 21/1/3/10 으로 grep 생존 확인 — 0이 「없음」이지 「grep 사망」이 아님을 먼저 갈랐다).

## 핵심 비대칭

실패 경로는 이미 **74줄**로 자기를 설명하고 있었다. `pyyaml unavailable, cannot validate; fail-closed`.
**성공 경로만 아무 말도 안 했다.** 그 비대칭이 이식 불가능한 초록을 출하시켰다.

> 게이트는 **실패할 때만이 아니라 통과할 때도** 무엇으로 쟀는지 말해야 한다.

## 들어간 것

| 자리 | 무엇 |
|---|---|
| `README.md` | 요구사항 선언 + **왜 이게 별도로 적히는지**(우연히 통과한 그 사건) |
| `consent_registry_check.sh` | 모든 분기 앞에서 `instrument (consent-registry): <interpreter> · PyYAML <path\|ABSENT>` |
| `test_consent_registry.sh` | `PROV-1` 레인 — 그 줄이 **살아 있는지**(장식 아닌지) |

**설계가 6라운드에 걸쳐 세 번 바뀌었고, 매번 문제를 줄인 게 아니라 없앴다:**

```
draft 1   import yaml 을 N/A 분기 앞으로   → 제3자 모듈 실행 시점을 앞당겼다
                                            실측: 심은 sys.exit(0) 이 exit code 를 결정
draft 2   find_spec (모듈 실행 안 함)      → 그래도 sys.meta_path 파인더는 실행된다
draft 3   **별도 프로세스** + timeout -k    → 종료코드가 버려진다. verdict 는 그걸 만진 적 없는 코드가 정한다
```

`except` 를 더 세게 잡는 건 **틀린 모양의 답**이었다. 프로세스를 가르는 게 맞았다.

## 증거 캡슐

```
known-pair        [/…/python3 · PyYAML /…/yaml/__init__.py]   vs   [PyYAML ABSENT]
되돌림 3-arm       줄 제거 → "no instrument line"
                  인터프리터 제거 → "does not name an absolute interpreter path"
                  경로 제거 → "does not change with the instrument — decorative"
                  ★ 셋이 **각자 자기 사유로** 적색. 복원 87/87
차등 실측 (4칸)    내 변경 유무 × 정상/적대 환경
                  정상: 3 / 3   ·   SystemExit 적대: 1 / 1        → verdict 중립
timeout -k 실측    -k 2 10 → rc=137(SIGKILL) 12초  ·  plain timeout 8 → 2분 초과 미종료
selfcheck         PASS · 레인 87/87 · Axis1 M0·S0 · Axis3 팬텀 0
```

## cross-family (codex / gpt-5.5, 6라운드)

```
R1 5/5 FALSE · R2 5/5 FALSE · R3 4/4 FALSE · R4 3/5 FALSE · R5 4/4 FALSE · R6 2/5 FALSE
주장 28개 중 23개 반증
```

매 라운드가 **다른 층**을 깠다 — 예외처리 → 렌더/네임스페이스 → **실행 모델** → meta_path → **내 계기 설계** → SIGTERM/stdout.

**R5 가 제일 값졌다: 내 코드가 아니라 내 계기를 깼다.** 나는 「메커니즘 논증 대신 결과를 비교하면 내 이해가 틀려도 안전하다」고 했는데, **결과를 「종료코드」로 정의한 순간 «안 끝나는 경우»가 통째로 빠졌다.** 계기를 바꿔도 여전히 「내가 재기로 정한 것」만 재고 있었다.

🟥 **형식상 CONVERGED 아니다.** 마지막 라운드의 findings 를 고쳤으므로 «그 라운드에 변경 0» 다리가 안 닫혔다. **판단으로 멈췄고, 기준 충족이 아니다.** 남은 둘은 실측으로 닫혔다 — `-k` 는 양방향 실측, stdout 위조는 **컨트롤로 선재 증명**(HEAD 판도 동일하게 위조된다).

## 기명 잔여

1. **형식상 미수렴** — 위 참조. R7 을 안 돌린 건 프로브의 타임아웃 플래그에 7라운드째는 비용이 값을 못 번다는 판단이다.
2. **`timeout` 부재 환경엔 프로브 바운드가 없다** — `command -v` 가드라 조용히 죽진 않지만 묶이지도 않는다.
3. **stdout 위조는 선재이고 안 고쳤다** — `sitecustomize` 가 `consent-registry: PASS` 를 찍으면 본 실행 stdout 이 verdict 를 앞선다. **HEAD 도 동일**하므로 이 변경의 범위가 아니다. 별건 후보.
4. **PROV 레인은 장식 여부를 잡지 모듈 출처를 증명하지 않는다** — 심은 yaml 은 여전히 present 로 보고된다. cross-family 가 이 범위 설정을 TRUE 로 인정했다.

## 리뷰 포인트

- stdout 에 줄이 하나 늘어 **순서가 바뀐다.** 접두어를 verdict 네임스페이스 밖으로 뺐고(`grep -m1 '^consent-registry'` 는 여전히 verdict 를 반환), 이 레포의 유일한 소비자(selfcheck)는 **종료코드**로 읽는다 — 실제 파손 관측 0. 새 소비자가 첫 줄을 파싱하면 걸린다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Pp4RBw7zo5u7bo8MLBKvS
