### PR TITLE
fix(gate): tarball-mode selfcheck false-FAILs — vendored-.git general fix

### DIFF
--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -1872,3 +1872,61 @@
   outcome: accepted
   evidence: "R1(diff 축) 1S·2A·5B → 전부 **재현 후** 수리 6건, B2 만 근거 명시 수용. 주장 축 10개 전부 TRUE·FALSE 0(명령+컨트롤 동반). 전량 2956 passed/43 skipped · 라이브 known-pair 유지(생성 TC 가 손 미션과 **grounds 바이트 동일**). PR qasp-dev #156"
   notes: "★**Explore 축이 인수인계의 전제를 반증했다** — 11c §4 「page↔area 를 선언 채널에 얹으면 NO_MATCH 6건이 열린다」가 틀렸다. 페이지 토큰은 매칭 키가 아니고(surface_inventory 에 `page` 0회, control `route` 36회), 같은 «p3 영역» 토큰인 TC_MT_005 는 매칭 성공·TC_MT_019 는 NO_MATCH 다. 나는 **그 위에 스키마를 이미 얹은 뒤** 실측했다 — 「남이 준 다음 할 일」도 전제부터 재야 하고, 특히 범위를 **줄이는** 방향일 때 소스 그라운딩이 제일 허술해진다([[feedback_scope_widening_needs_grounding]] 의 반대편 얼굴). 🟥 **선언 채널이 자기 실패모드를 맞았다** — 「선언 파일을 줬는데 선언이 없으면」 3가지 입력 전부 rc=0 으로 조용히 통과, cross-family 가 잡았고 자력 적발 0. 🟥 **되돌림 프로브가 내 테스트 하나를 장식으로 적발** — origin 을 spec_dictionary 로 위조해도 62건 전건 초록이었다(`anchors: []` 라 qualify_anchor 가 origin 을 보기도 전에 빠진다). 「자격이 안 나온다」를 확인했지 「origin 게이트가 산다」를 확인한 게 아니었다. 🟥 **계기가 세 번 거짓말했다**: `tail -1` 이 요약 대신 DeprecationWarning · 파이프 뒤 `$?` 가 필터 상태(훅이 잡아줌) · **pytest 색상 escape 때문에 `1 failed, 71 passed` 를 「71 passed」로 읽음**. 셋째는 실제 실패 1건을 숨겼다 — 전량 판정은 `--color=no` 필수. ★innovator 리포트의 B6(「처방 전사 검사 없음」)은 **오판** — 그 에이전트가 테스트 파일을 안 읽었다. 해당 레인은 존재하고 되돌림에서 2 적색. 남의 리포트도 대조 대상이다"
+
+
+- date: 2026-08-12
+  session: ifkakao-deck-notes-parallel
+  agents_summary: "3 dispatches: general-purpose×3 — ⓐ 챔버 런 원장 1차기록 재측정(승격 후보) · ⓑ 창작 도메인 «죽인 것» 1차기록 대조(승격 후보) · ⓒ 창작 대체안 B 5건 커밋 diff 직독"
+  dispatch_count: 3
+  outcome: accepted
+  evidence: "세 리포트의 load-bearing 주장을 거버너가 **전건 원문·컨트롤로 재검증**했다.
+    ⓐ 런#10 판정문:31 «10런 중 9 KILL» 오기 확인 · 디렉터리 9 ↔ 판정파일 9 대응 ·
+    `chamber_ordering_witness.yaml` 부재(컨트롤 = 같은 디렉터리 `subagent_invocations_log.yaml` 존재) ·
+    #5 «5/5 false-positive on 111 real source files» 축자 확인.
+    ⓑ `codex_decorrelation_audit_2026-07-25.md:14` 축자 · 신호 `:52` «독트린화는 여전히 보류» ·
+    `tracks/noblewriter/` 대상 grep rc=1 + **컨트롤 rc=0(10파일)**.
+    ⓒ `fh_completed_2026-08-01.md:76` 축자 · 캐논 검사기 부재(target rc=1, control rc=0) ·
+    커밋 `7046798` diff 축자.
+    산출: 원장 승격 1(인큐베이션) · 기각 2(창작 A·B) · 발표 출하 1장(S18-b)"
+  notes: "★**ⓒ가 내 중계 오류를 반증했다 — 이 세션 최대 소득이고 자력 적발 0이다.**
+    ⓑ의 요약을 받아 «typed 캐논이 저자를 잡은 3건»으로 운영자에게 **원문을 안 열고 중계**했는데,
+    요약 로그 원문은 그중 **둘을 «운영자 캐치»로 명시**한다 — 게이트가 *놓친* 것이라 실적으로 세면
+    논지가 뒤집힌다. 「대화에서 말한 것도 publish 다」(§Instrument-Calibration publish-order)가
+    always-loaded 인데도 뚫렸고, 잡은 건 후속 격리 에이전트다.
+    ★**세 리포트 모두 «부재»를 주장할 때 컨트롤을 스스로 동반했다** — 브리프에 명시한 결과이고,
+    ⓒ는 첫 컨트롤 실행이 파이프 오염($? 가 head 를 읽음)이었음을 **스스로 적발**해 rc 캡처로 재실행했다.
+    ★**ⓐ가 손 집계와 자동 grep 이 갈리는 지점을 지목**: `grep -c 'EMIT|KILL'` 은 27/43 을 뱉는데
+    그건 파일 내 토큰 계수이지 런별 판정이 아니다(#2·#3 이 `KILL / PARTIAL-EMIT` 형태).
+    ★**분모가 셋 다 방어 가능하다는 것을 ⓐ가 먼저 말했다** — 원장 행 전체(10, #1 오염) vs
+    완주 런(9, 권고) vs 아티팩트 완비(8). 어느 걸 쓰는지가 정직성 갈림길이라는 지적이 그대로
+    발표 인용 형태 결정(계수 대신 한 건)의 입력이 됐다.
+    🟥 **리포트를 그대로 옮기지 않은 것이 세 번 다 옳았다** — 세 건 모두 거버너 재검증에서
+    라벨/귀속이 교정됐다(ⓐ 「첫 정식 런 #10」 기계 미판별 · ⓑ 도메인 라벨 · ⓒ 캐치 주체)."
+
+- date: 2026-08-12
+  agent: general-purpose
+  task: "qasp 상류 라우팅 축 — 1.5막 질문 게이트 + 이관 처분 상태 신설 (설계·구현·cross-family 수렴·PR·머지까지 완주)"
+  dispatcher: FH 세션 (qasp+psa 축)
+  tier: opus-5[1m]
+  duration: "약 3.5시간 (bg, 재개 2회)"
+  outcome: accepted
+  evidence: "qasp-dev PR #157 MERGED (squash → main 8ff549e) · 파일 19 · +2735/-26 · CI 4/4 SUCCESS · 회귀 3043 passed/43 skipped (기준선 2967 대비 +76) · cross-family 7R CONVERGED(codex/gpt-5.5). 자기 반증 5건을 스스로 보고했고 그중 하나(자리표시자 18→17)는 내 독립 측정과 일치했다. 전수 되돌림 프로브로 **자기 수리 24종 중 4건이 장식**임을 스스로 적발. 시험관(나)의 몫은 메타감사·정본 지시·머지 조건(사설 companion-store 매니페스트) 강제였고, 실제 설계·구현·수렴은 에이전트가 완주했다."
+  note: "④-e 훅은 이 세션에서 47 dispatch 를 셌는데, 그중 대부분은 이 에이전트 자신의 하위 디스패치(cross-family 7R + 되돌림 프로브)다. 한 클래스로 묶어 1 엔트리로 기록한다 — 규율이 허용하는 형태이고 총 미기록을 막는 것이 훅의 목적이다."
+
+- date: 2026-08-12
+  invoker: FH 재출하 축 병렬세션 (Opus 5 1M)
+  subagent: codex/gpt-5.5 (cross-family 사이드카, headless `codex exec -m gpt-5.5 -`)
+  count: 6
+  purpose: v1.4.96 npm publish 게이트 — 독립검증. 채널 3종으로 나눠 발주(diff 리뷰 · 클레임 13건 검증 · 동결 게이트리뷰 4회)
+  outcome: accepted
+  evidence: "S 22건 회수 중 실건 19 수리 · 2건은 기계로 반증(count_check 이스케이프 known-pair · 되돌림 프로브 2pass/3fail) · 1건 미수리 잔여(B, 의도). 실건 벡터 3→6→5→2→3. **자력 적발 0 이었던 결함 5건을 잡았다** — 그중 3건이 직전 라운드 수리 산물. 레인 20→46 은 전부 이 회수분의 앵커다."
+  cost_note: "1라운드 killed(내가 레인 전수 스윕을 시켜 시간초과 — 발주자 결함, 범위 축소 후 재주행). 1라운드 절반 무효(WRONG-TARGET — 발주 후 트리 수정)."
+
+- date: 2026-08-12
+  invoker: FH ifkakao 병렬세션 (Sonnet 5 → Opus 5 중도 전환)
+  subagent: fh-commons:quench-challenger (Axis 2 적대검증, in-session)
+  count: 1
+  purpose: CLAUDE.md §257·§331 stale 브랜치보호 서술 정정본의 사실성·내부정합 검증
+  outcome: accepted
+  evidence: "S 1건 + A 2건 회수, 전부 실건이고 **자력 적발 0**. S = `validate` 필수체크를 «Axis 1 워크플로»로 오귀속(실제로는 별개 잡 — regression-guard.yml 은 여전히 필수 아니고 paths: 필터로 4축 대상 자산 다수에 돌지도 않는다). A1 = «PR 오픈 시점» 과잉주장(실제 synchronize 마다 재실행). A2 = «both layers» 근거 미인용. 셋 다 수정 후 워크플로 YAML + 라이브 gh api 재대조. PR #354 머지(main f62a5a9)."
+  note: "정정이 원 서술보다 더 틀릴 수 있다는 사례 — stale 한 것은 `contexts=[]` 라는 «목록»이었지 «Axis 1 이 필수가 아니다»라는 «귀속»이 아니었는데, 초안이 후자까지 지웠다. 적대검증이 그 구분을 복원했다."

--- a/scripts/compaction_probe.sh
+++ b/scripts/compaction_probe.sh
@@ -327,8 +327,21 @@ self_test() {
   local dg; dg="$(do_digest "$T/out3b" 2>/dev/null)"
   case "$dg" in *"열어야 할 정본"*) r=YES ;; *) r=NO ;; esac
   t "#3 digest 가 정본 포인터를 주입한다" YES "$r"
-  case "$dg" in *"브랜치:"*) r=YES ;; *) r=NO ;; esac
-  t "#3 digest 가 git 상태를 주입한다" YES "$r"
+  # ⚠️ 이 레인은 한때 "브랜치:" 등장을 무조건 YES 로 기대했다. **REPO_ROOT 가 git 저장소인지는
+  # self-test 가 통제하지 않는 환경 조건**이다(스크립트 위치로 계산되는 값이지 $T 픽스처가 아니다) —
+  # 그래서 non-git 트리(예: 소비자가 tarball 을 git 밖 스크래치 디렉터리에 풀어 실행)에서는 항상
+  # FAIL 했다. known-pair 로 확인: 레포 rc=0 · non-git tmp rc=1 · **같은 tmp 에 `git init` 만 해도
+  # rc=0**(2026-08-12, 재출하 축). do_seal 자신은 두 경우 다 올바르게 렌더한다("브랜치: …" 또는
+  # "(git 레포 아님)") — 결함은 self-test 가 그 중 한쪽만 정답으로 하드코딩한 것이었다. 지금 실제
+  # 상태를 물어 그 상태에 맞는 렌더를 기대한다 — 두 분기 다 계측한다(브랜치 있음일 때만 잰 것이
+  # 아니라 없음일 때도 "(git 레포 아님)" 이 실제로 나오는지 검증).
+  if git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+    case "$dg" in *"브랜치:"*) r=YES ;; *) r=NO ;; esac
+    t "#3 digest 가 git 상태를 주입한다 (REPO_ROOT=git repo)" YES "$r"
+  else
+    case "$dg" in *"(git 레포 아님)"*) r=YES ;; *) r=NO ;; esac
+    t "#3 digest 가 git 상태를 주입한다 (REPO_ROOT=non-git, graceful render)" YES "$r"
+  fi
 
   # #4 세션 교차 주입 — 다른 세션의 봉인을 "직전 압축"이라고 주장하면 안 된다
   # ⚠️ 이 레인은 1차 수리 때 "라벨하면 된다"는 전제로 썼다가 **갱신됐다**. 라벨은 오배달을

--- a/scripts/package_coverage_check.sh
+++ b/scripts/package_coverage_check.sh
@@ -21,28 +21,6 @@ set -uo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT" || exit 1
 
-# Source-checkout test uses `-e`, not `-d`. In a git WORKTREE `.git` is a FILE (a gitdir pointer),
-# so the old `-d` test read every worktree as "installed package" and skipped the check entirely —
-# silently, with exit 0. Measured 2026-07-31: a worktree created specifically to approximate CI
-# reported PASS while this check had not run at all, i.e. the instrument used to justify wiring CI
-# was itself fail-open on the surface it was standing in. `-e` covers both the ordinary checkout
-# (dir) and the worktree (file); genuine package mode has no `.git` of either kind, so it still
-# skips. Anchored by scripts/test_package_coverage_lanes.sh.
-if [ ! -e .git ]; then
-  echo "SKIP  package-coverage (not a source checkout)"
-  exit 0
-fi
-# PREDICATE SPLIT (cross-family review, 2026-07-31). These were one condition, and folding them
-# together meant `.git` present + manifest missing returned SKIP + exit 0 — "we are in a checkout
-# and cannot read what ships" reported as "nothing to check here". Absence of the input is not
-# absence of the defect; `not found != 0` (CLAUDE.md §Instrument-Calibration). Only the no-.git
-# case is a legitimate skip (an installed package, where the un-shipped files are correctly gone).
-if [ ! -f package.json ]; then
-  echo "FAIL  package-coverage: source checkout with no package.json — the shipped file list is"
-  echo "      unreadable, so coverage is UNMEASURED, not clean"
-  exit 1
-fi
-
 # ── Accepted-absent, with the reason each one is NOT a defect ────────────────────────────────
 # Adding a line here is a decision, not a silencer: each entry states why shipping it would be
 # wrong. If you cannot write that sentence, the file probably belongs in files[].
@@ -99,10 +77,13 @@ ACCEPTED_ABSENT=(
   # selfcheck goes red on a subject they do not have.
   "scripts/test_probe_scope_lanes.sh"
   # Measures what the LIVE `claude` CLI does with several SessionStart hooks on one matcher —
-  # so every run needs the CLI, auth, and spends tokens on the consumer's account. Same reason
-  # `ablation_calibrate.sh` is absent: shipping a script whose only effect on a consumer's
-  # machine is a bill is worse than omitting it. selfcheck reports it NOT EXERCISED (exit 2)
-  # where the CLI is missing, so the package stays green without pretending the lanes ran.
+  # so every run needs the CLI, auth, and spends tokens on the consumer's account. This anchor DOES
+  # get a live run attempt when its subject ships and the file itself is present (selfcheck reports
+  # NOT EXERCISED, exit 2, when that run finds no CLI). This entry covers the OTHER case: the anchor
+  # FILE ITSELF is not shipped, so selfcheck never gets far enough to attempt the run at all — that
+  # case renders SKIP, not NOT EXERCISED (the two are for missing-file vs. present-file-no-CLI,
+  # not interchangeable; corrected 2026-08-12, cross-family review — the two exit paths were
+  # conflated in an earlier revision of this comment).
   "scripts/test_sessionstart_multihook_lanes.sh"
   # The launchd-driven daily cadence runner. Two independent reasons it must not ship: it is half of
   # a pair whose other half is a machine-local plist (`scripts/com.forge-harness.frontier-digest.plist`),
@@ -113,6 +94,45 @@ ACCEPTED_ABSENT=(
   # of a shipped artifact — the skill's own save path works without it.
   "scripts/frontier_digest_daily.sh"
 )
+
+# `--list-accepted`: print the ACCEPTED_ABSENT paths, one per line, and exit — no git/package.json
+# dependency, deliberately callable from a context this script's own coverage scan cannot run in
+# (package mode, or a vendored tree with `.git` present but no `package.json` at this root). This is
+# the single declared source of "known-legitimately-unshipped" for OTHER checks to consult instead of
+# re-deriving the same judgment from an environment predicate (`.git` presence, directory existence)
+# that answers a different question and can diverge from this list's actual coverage. Added
+# 2026-08-12 (reship axis, cross-family review of card §🔱⑮ G/D) after selfcheck.sh's ref-path block
+# was found re-deriving "is this legitimately absent" from `[ -e .git ]` — which reproduces the
+# original bug in any git-tracked tree that vendors this package (a monorepo committing
+# node_modules, or a consumer who runs `git init` after install): `.git` exists there, so the old
+# predicate ran the check, found these exact paths missing, and FAILed — the same false-FAIL this
+# array already declares correct to omit.
+if [ "${1:-}" = "--list-accepted" ]; then
+  printf '%s\n' "${ACCEPTED_ABSENT[@]}"
+  exit 0
+fi
+
+# Source-checkout test uses `-e`, not `-d`. In a git WORKTREE `.git` is a FILE (a gitdir pointer),
+# so the old `-d` test read every worktree as "installed package" and skipped the check entirely —
+# silently, with exit 0. Measured 2026-07-31: a worktree created specifically to approximate CI
+# reported PASS while this check had not run at all, i.e. the instrument used to justify wiring CI
+# was itself fail-open on the surface it was standing in. `-e` covers both the ordinary checkout
+# (dir) and the worktree (file); genuine package mode has no `.git` of either kind, so it still
+# skips. Anchored by scripts/test_package_coverage_lanes.sh.
+if [ ! -e .git ]; then
+  echo "SKIP  package-coverage (not a source checkout)"
+  exit 0
+fi
+# PREDICATE SPLIT (cross-family review, 2026-07-31). These were one condition, and folding them
+# together meant `.git` present + manifest missing returned SKIP + exit 0 — "we are in a checkout
+# and cannot read what ships" reported as "nothing to check here". Absence of the input is not
+# absence of the defect; `not found != 0` (CLAUDE.md §Instrument-Calibration). Only the no-.git
+# case is a legitimate skip (an installed package, where the un-shipped files are correctly gone).
+if [ ! -f package.json ]; then
+  echo "FAIL  package-coverage: source checkout with no package.json — the shipped file list is"
+  echo "      unreadable, so coverage is UNMEASURED, not clean"
+  exit 1
+fi
 
 out=$(python3 - "${ACCEPTED_ABSENT[@]}" <<'PY'
 import re, os, json, sys

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -15,6 +15,21 @@ set -u
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 fail=0
 
+# Single source of "declared legitimately unshipped" — package_coverage_check.sh's ACCEPTED_ABSENT,
+# read once via its --list-accepted flag. Two blocks below (ref-path, SessionStart anchor pairs) used
+# to each re-derive "is this absence OK" from an environment predicate (`.git` presence) instead of
+# consulting this declaration — which reproduces the exact bug the declaration exists to prevent in
+# any git-TRACKED tree that vendors this package (a monorepo committing node_modules, or a consumer
+# who runs `git init` after install): `.git` is present there, so the environment predicate answered
+# "source checkout", ran the full check, and FAILed on paths the declaration had already said were
+# fine to omit. Cross-family review, 2026-08-12 (reship axis, card §🔱⑮ G). `--list-accepted` has no
+# git/package.json dependency itself, so this load is safe to attempt unconditionally.
+_PKG_ACCEPTED_ABSENT=""
+if [ -f scripts/package_coverage_check.sh ]; then
+  _PKG_ACCEPTED_ABSENT="$(bash scripts/package_coverage_check.sh --list-accepted 2>/dev/null)"
+fi
+_pkg_accepted_absent() { printf '%s\n' "$_PKG_ACCEPTED_ABSENT" | grep -qxF "$1"; }
+
 check() { # check <label> <cmd...>
   local label="$1"; shift
   if "$@" 2>/dev/null; then
@@ -484,12 +499,41 @@ else
 fi
 
 # SessionStart multi-hook + install-wizard snippet merge. Subject for both = the shipped settings
-# snippets; a clone without them is a legitimate SKIP, a clone with them and no anchor is not.
+# snippets; a clone without them is a legitimate SKIP, a clone with them and no anchor is not —
+# UNLESS the anchor itself is declared package-mode-optional. test_sessionstart_multihook_lanes.sh
+# is exactly that. Its ACCEPTED_ABSENT entry (package_coverage_check.sh) covers a DIFFERENT case than
+# this loop implements: that entry's "selfcheck reports it NOT EXERCISED (exit 2)" describes the
+# anchor RUNNING and finding no CLI (handled a few lines below, rc==2). It never claimed anything
+# about the anchor FILE being missing — a real consumer never gets to run it at all (the file is not
+# in files[]), and this loop had no branch for that at all, so every installed package hit
+# "FAIL … anchor is missing" (corrected 2026-08-12, cross-family review — an earlier revision of this
+# comment miscited the ACCEPTED_ABSENT entry as already covering the missing-file case). Fixed by
+# consulting the SAME declaration (`_pkg_accepted_absent`, loaded once near the top of this file) that
+# the ref-path block above uses — not an environment predicate — because `.git` presence answers "is
+# there a git repo here", not "was this anchor declared intentionally unshipped", and the two diverge
+# in a git-tracked vendored tree (a monorepo committing node_modules, `git init` after install): `.git`
+# exists there too, which would silently reproduce the original FAIL.
+# test_wizard_snippet_merge_lanes.sh is NOT in ACCEPTED_ABSENT (it does ship, per files[]) — routing
+# both anchors through the same declaration lookup, rather than hardcoding one as always-FAIL, means a
+# future person who genuinely needs to exempt it does so by editing ONE list, not by finding this loop.
 for _pair in \
-  "templates/settings.SessionStart.snippet.json|scripts/test_sessionstart_multihook_lanes.sh" \
-  "templates/settings.SessionStart.snippet.json|scripts/test_wizard_snippet_merge_lanes.sh"
+  "templates/settings.SessionStart.snippet.json|scripts/test_sessionstart_multihook_lanes.sh|package-optional" \
+  "templates/settings.SessionStart.snippet.json|scripts/test_wizard_snippet_merge_lanes.sh|always-shipped"
 do
-  _subj="${_pair%%|*}"; _anc="${_pair#*|}"
+  _subj="${_pair%%|*}"; _rest="${_pair#*|}"; _anc="${_rest%%|*}"; _mode="${_rest#*|}"
+  # This mode field is a gate-verdict policy value (does a missing anchor FAIL or SKIP), not free
+  # text — an unrecognized value must not silently fall through to whichever branch string-matching
+  # happens to miss. Cross-family review, 2026-08-12: the two known values were previously the only
+  # ones exercised, so a typo (e.g. "alway-shipped") landed in the `else` FAIL branch by accident of
+  # string mismatch rather than by a checked policy — fail-closed in practice, but undeclared.
+  case "$_mode" in
+    package-optional|always-shipped) ;;
+    *)
+      echo "FAIL  ${_anc##*/}: unrecognized pair mode '$_mode' (expected package-optional or always-shipped)"
+      fail=1
+      continue
+      ;;
+  esac
   if [ ! -f "$_subj" ]; then
     echo "SKIP  ${_anc##*/} (subject $_subj absent)"
   elif [ -f "$_anc" ]; then
@@ -510,6 +554,8 @@ do
     elif [ "$_rc" -ne 0 ]; then
       fail=1
     fi
+  elif [ "$_mode" = "package-optional" ] && _pkg_accepted_absent "$_anc"; then
+    echo "SKIP  ${_anc##*/} (declared ACCEPTED_ABSENT — CLI/cost-gated, see package_coverage_check.sh)"
   else
     echo "FAIL  ${_anc##*/}: $_subj present but its anchor is missing"
     fail=1
@@ -782,7 +828,28 @@ fi
 
 # Referenced-path existence is a source-tree check. The npm package intentionally
 # ships a narrower runtime surface, so package-mode selfcheck skips this section.
-if [ -d ".claude/rules" ]; then
+# ⚠️ The skip predicate used to be `[ -d ".claude/rules" ]`. That broke the moment the tarball
+# started shipping PART of that directory (`.claude/rules/fh_4axis_gate.md` etc. are in files[]) —
+# the directory then exists in BOTH source and package mode, so the check never skipped in package
+# mode at all. It ran, extracted refs from the shipped CLAUDE.md/.claude/rules/*.md (which still
+# name `.claude/regression/ablation_verdicts.md` and `scripts/probe_scope_check.sh` — both
+# deliberately unshipped, per package_coverage_check.sh's own ACCEPTED_ABSENT list), then tried
+# `git check-ignore` against a tree with no `.git` at all (a real `npm pack` tarball is not a git
+# repo) — that call errors rather than confirming "ignored", so the fallback `[ -f "$p" ]` ran and
+# correctly found nothing, and the check reported FAIL on two paths it had already been told, one
+# check over, were fine to omit. First fix (2026-08-12, reship axis, card §🔱⑮ G/D) swapped the skip
+# predicate for `[ -e .git ]`. Cross-family review then caught that `[ -e .git ]` answers a different
+# question than the one this check needs: a git-TRACKED vendor of this package (a monorepo that
+# commits node_modules, or a consumer who runs `git init` after installing) has `.git` and IS a
+# legitimate package consumer, yet the predicate would route it into the full extraction and
+# reproduce the exact original FAIL on these same two paths — the fix would have closed the bug only
+# in the one shape it was tested against. The general fix is not a better environment predicate; it
+# is not re-deriving "is this legitimately absent" from the environment at all when a DECLARED answer
+# already exists — `_pkg_accepted_absent()`, loaded once near the top of this file — this block now
+# consults it before FAILing, so the two paths render SKIP regardless of how `.git` happens to be
+# shaped in the consumer's tree. `[ -e .git ]` still gates whether the SCAN runs at all (an installed
+# package with no tracked-refs source to lint), which is a real and unrelated question.
+if [ -e ".git" ]; then
   # Backtick-quoted repo-relative file refs in the always-loaded governance surface
   # (CLAUDE.md + .claude/rules/*.md) must exist. Phantom-reference class recurred
   # N>=3 in the 2026-06-11 audit window — instrument-not-habit.
@@ -827,6 +894,8 @@ REFPY
         echo "SKIP  ref-path (gitignored): $p"
       elif [ -f "$p" ]; then
         echo "PASS  ref-path: $p"
+      elif _pkg_accepted_absent "$p"; then
+        echo "SKIP  ref-path (declared ACCEPTED_ABSENT — see package_coverage_check.sh): $p"
       else
         echo "FAIL  ref-path: $p — referenced in CLAUDE.md/.claude/rules but missing"
         fail=1
@@ -836,7 +905,7 @@ $_refs
 REFS
   fi
 else
-  echo "SKIP  ref-path (package mode: .claude/rules absent)"
+  echo "SKIP  ref-path (package mode: no .git at package root — source-tree-only check)"
 fi
 
 if [ "$fail" -ne 0 ]; then

--- a/scripts/test_selfcheck_state_lanes.sh
+++ b/scripts/test_selfcheck_state_lanes.sh
@@ -184,6 +184,75 @@ _OUT=$(_show_failure "$_MANY")
 [ "$(printf '%s\n' "$_OUT" | grep -c '════ lanes: 9 passed')" -ge 1 ]
 chk $? "the summary banner still prints when a truncated-away line quotes it"
 
+# ── ref-path + SessionStart-pair: `.git` presence is not "is this absence declared OK" ─────────
+# WHY (2026-08-12, cross-family review, card §🔱⑮ G): both blocks used to key their package-mode
+# SKIP on `[ -e .git ]`. A git-TRACKED tree that vendors this package (a monorepo committing
+# node_modules, or a consumer who runs `git init` after install) has `.git` present and is still a
+# package consumer — the predicate answered "source checkout" for it anyway, ran the full check, and
+# reproduced the exact FAIL both blocks exist to prevent. The fix routes through a single declaration
+# (`_pkg_accepted_absent`, backed by package_coverage_check.sh's ACCEPTED_ABSENT) instead. Anchored
+# here because this file is the state-lanes suite and an adversarial read is what caught the first
+# version of this same fix landing without a regression lane.
+_PA_FN=$(grep -n '^_pkg_accepted_absent()' "$SELFCHECK")
+if [ -z "$_PA_FN" ]; then
+  echo "FAIL  _pkg_accepted_absent() is no longer defined in selfcheck.sh — this lane cannot verify"
+  echo "      what it claims to. Update the lane WITH the subject."
+  exit 1
+fi
+echo "── discriminator located: selfcheck.sh:${_PA_FN%%:*}"
+
+# route_refpath(git_present, path_exists, is_accepted_absent) mirrors the real per-path decision
+# inside the `if [ -e ".git" ]` block: no .git → the whole scan is skipped regardless of any single
+# path's state (package mode); .git present → PASS if the path exists, else consult the declaration.
+route_refpath() {
+  local git="$1" exists="$2" accepted="$3"
+  if [ "$git" = 0 ]; then echo SKIP-package; return; fi
+  if [ "$exists" = 1 ]; then echo PASS; return; fi
+  if [ "$accepted" = 1 ]; then echo SKIP-accepted; return; fi
+  echo FAIL
+}
+# route_refpath_OLD is the reverted predicate: package-mode SKIP gated on .git alone, with no
+# fallback to the declaration when .git is present and the path is genuinely missing.
+route_refpath_OLD() {
+  local git="$1" exists="$2"
+  if [ "$git" = 0 ]; then echo SKIP-package; return; fi
+  if [ "$exists" = 1 ]; then echo PASS; return; fi
+  echo FAIL
+}
+[ "$(route_refpath 0 0 1)" = SKIP-package ]  ; chk $? "no .git → SKIP regardless of the individual path"
+[ "$(route_refpath 1 1 0)" = PASS ]          ; chk $? "source tree, path exists → PASS"
+[ "$(route_refpath 1 0 0)" = FAIL ]          ; chk $? "source tree, path genuinely missing, not declared → FAIL (a real defect still fails)"
+[ "$(route_refpath 1 0 1)" = SKIP-accepted ] ; chk $? "known-POSITIVE (the bug this fix closes): .git present (vendored/tracked package) + path missing + DECLARED accepted-absent → SKIP, not FAIL"
+[ "$(route_refpath_OLD 1 0)" = FAIL ]        ; chk $? "known-POSITIVE control: the reverted .git-only predicate DOES mis-route that same state to FAIL (the bug is real, not theoretical)"
+
+# The two paths this fix was written for must actually be present in the declaration it now consults
+# — otherwise the lanes above prove the routing logic works while the real inputs still fall through it.
+_PA_LIST=$(bash "$SCRIPT_DIR/package_coverage_check.sh" --list-accepted 2>/dev/null)
+printf '%s\n' "$_PA_LIST" | grep -qxF ".claude/regression/ablation_verdicts.md"
+chk $? "premise holds: .claude/regression/ablation_verdicts.md is in the live ACCEPTED_ABSENT list"
+printf '%s\n' "$_PA_LIST" | grep -qxF "scripts/probe_scope_check.sh"
+chk $? "premise holds: scripts/probe_scope_check.sh is in the live ACCEPTED_ABSENT list"
+printf '%s\n' "$_PA_LIST" | grep -qxF "scripts/test_sessionstart_multihook_lanes.sh"
+chk $? "premise holds: scripts/test_sessionstart_multihook_lanes.sh is in the live ACCEPTED_ABSENT list"
+
+# The SessionStart-pair loop's mode field: unrecognized values must FAIL closed, not fall through to
+# whichever string-match branch happens to miss (codex cross-family finding, 2026-08-12).
+_MODE_CASE=$(grep -n 'package-optional|always-shipped) ;;' "$SELFCHECK")
+if [ -z "$_MODE_CASE" ]; then
+  echo "FAIL  the pair-mode validation case is no longer in selfcheck.sh — this lane cannot verify"
+  echo "      what it claims to. Update the lane WITH the subject."
+  exit 1
+fi
+route_pair_mode() {
+  case "$1" in
+    package-optional|always-shipped) echo VALID ;;
+    *) echo FAIL-badmode ;;
+  esac
+}
+[ "$(route_pair_mode package-optional)" = VALID ]        ; chk $? "known mode 'package-optional' validates"
+[ "$(route_pair_mode always-shipped)" = VALID ]           ; chk $? "known mode 'always-shipped' validates"
+[ "$(route_pair_mode alway-shipped)" = FAIL-badmode ]     ; chk $? "known-POSITIVE: a typo'd mode is rejected, not silently treated as either known state"
+
 # ── SCOPE OF THIS ANCHOR — stated so it is not over-trusted ───────────────────
 # These lanes catch REVERSION (the run-twice form coming back, the helper being gutted, the
 # call-site redirect returning). They do NOT catch deliberate EVASION: a cross-family round

--- a/scripts/test_sessionstart_multihook_lanes.sh
+++ b/scripts/test_sessionstart_multihook_lanes.sh
@@ -77,10 +77,22 @@ EOF
 
 PROMPT='List verbatim, one per line, every line in your session-start context that contains the string MARKER. If there are none, reply exactly NONE.'
 
+# Timeout guard (2026-08-12, cross-family review flagged the unbounded call as the only genuinely
+# blocking point this suite's two `claude -p` invocations reach — a hung/slow CLI call had no upper
+# bound, so a source-tree `selfcheck.sh` run could hang indefinitely on this lane alone. `timeout` is
+# GNU coreutils and stock macOS does not ship it — same availability gap compaction_probe.sh's
+# --self-test already guards for, same fix shape: probe once, use it if present, run unguarded (the
+# pre-existing residual) if not, rather than hard-failing on a missing tool this lane does not own.
+_TO=""; command -v timeout >/dev/null 2>&1 && _TO="timeout 120"
+
 _run() {  # $1=project dir → writes $1/stream.jsonl ; sets CLI_RC
-  ( cd "$1" && claude -p "$PROMPT" --model haiku --dangerously-skip-permissions \
+  ( cd "$1" && $_TO claude -p "$PROMPT" --model haiku --dangerously-skip-permissions \
       --output-format stream-json --verbose </dev/null >"$1/stream.jsonl" 2>"$1/cli.err" )
   CLI_RC=$?   # read DIRECTLY off the subshell, never through a pipe
+  # A `timeout`-killed call exits 124 and leaves stream.jsonl empty — the existing
+  # `[ ! -s stream.jsonl ]` branches at both call sites already route that to _unexercised/_fail
+  # correctly (empty stream, not a crash to diagnose), so 124 needs no separate branch here. Named so
+  # a future reader does not add one on the mistaken belief 124 is unhandled.
 }
 
 # typed-channel query. $1=stream file $2=one of: markers|exit:<marker>|outcome:<marker>|


### PR DESCRIPTION
## Summary

카드 §🔱⑮ 재출하 캠페인 잔여 G-B/G-C+D + F 를 닫는다.

- **F**: 세 축(reship·qasp-psa·ifkakao)이 각자 얼려둔 디스패치 원장 3건을 `subagent_invocations_log.yaml`에 append (판단 불요, 글롭으로 세어 확인)
- **G-B**: `compaction_probe.sh --self-test`가 tarball 환경에서 실패하던 원인 진단 정정 — 카드는 "tracks/_meta가 gitignored라 구조적으로 출하 불가"라고 적었지만, known-pair로 직접 재현한 결과 실제 원인은 **REPO_ROOT의 git-repo 여부**(self-test lane #3이 git 없는 환경을 하드코딩된 YES로 잘못 기대). self-test를 두 분기 다 검증하도록 수정
- **G-C+D**: `selfcheck.sh`의 실결함 2건 — ① `ref-path` 체크의 package-mode skip 조건이 부분출하된 `.claude/rules` 디렉터리 존재로 무력화 ② SessionStart 앵커쌍 루프가 의도적 미출하(`test_sessionstart_multihook_lanes.sh`, CLI/비용 게이트)를 FAIL로 렌더. 실제 `npm pack` tarball로 재현·수리·검증

## Cross-family review

`fh-commons:quench-challenger`(Wave 1) + codex gpt-5.5 독립 리뷰가 같은 지점에 수렴: **"`.git` 존재를 package-mode 판별자로 쓰면, 이 패키지를 vendor하는 git-tracked 트리(모노레포, 설치 후 `git init`)에서 원래 버그가 그대로 재현된다."** 두 블록 모두 `.git` 추론 대신 `package_coverage_check.sh`의 `ACCEPTED_ABSENT` 선언을 직접 조회하는 일반해(`--list-accepted` 신규 플래그)로 수렴.

부수적으로, 이 세션에서 관측한 `selfcheck.sh` 전체 실행의 180초+ 행 문제도 원인을 특정(`test_sessionstart_multihook_lanes.sh`의 무제한 `claude -p` 호출 2회) — pre-existing이지만 timeout 가드 추가로 같이 닫음.

## 4-axis gate

전부 PASS. Axis 2+3 마커에 `crossfamily: panel(claude,openai)` + known-pair/known-negative 컨트롤 기록. 회귀 레인 11개 신설(`test_selfcheck_state_lanes.sh`, 35/35 PASS).

## Test plan

- [x] 5개 수정 스크립트 전부 `bash -n` 통과
- [x] `compaction_probe.sh --self-test` rc=0 (레포 + non-git tmp + git-init tmp 3환경)
- [x] `package_coverage_check.sh` PASS (14 accepted / 13 exercised, 구조변경 전과 동일)
- [x] `test_selfcheck_state_lanes.sh` PASS 35/35 (신규 11레인 포함)
- [x] 실물 `npm pack` tarball 3가지 환경형태(no-git / vendored-git-tracked / genuine source checkout) known-pair 전부 확인 — vendored-git 케이스가 이전엔 FAIL, 지금은 SKIP
- [x] known-negative 4건 — 실제 결함(wizard 앵커 삭제·타이포 모드·미선언 경로·self-test 자기조건 손상)은 여전히 FAIL

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>