### PR TITLE
fix(gate): 삭제된 게이트가 초록 SKIP 이던 18곳 — 선언을 오라클로

### DIFF
--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -53,6 +53,40 @@ sys.exit(0 if any(p == f or p.startswith(f.rstrip('/') + '/') for f in files) el
 SHIPPY
 }
 
+# ── The single verdict for "my subject is not here" ───────────────────────────────────────────
+# Measured 2026-08-12 (card §🔱⑮ A2): **18 blocks in this file** rendered a green SKIP when their
+# subject was absent, and **all 18 subjects are declared in package.json files[] and present in the
+# real tarball** (verified with `npm pack --dry-run --json`, 20/20 — so routing them to FAIL cannot
+# over-block a legitimate consumer). For a subject that always ships, "absent" cannot mean "package
+# mode"; the only ways to reach it are DELETION or a broken install, and both were reported green.
+# That is the fourth face of the axis the card names three of: 미측정→clean · 미측정→findings ·
+# 해당없음→FAIL · **삭제→SKIP** — and it is the quiet one, which is why it survived longest.
+#
+# Two of the eighteen are worth naming because they read as already-handled and were not:
+#   · the gate_pathspec block printed "— not-checked, NOT a pass" and then did not set fail. The
+#     LABEL was honest and the VERDICT was green; a reader greps the message and believes it.
+#   · the --self-test loop's comment says "never a silent pass" directly above the arm that was one.
+# A comment asserting a property is not the property. Both were hand-verified by eye, not inferred.
+#
+# THE UNKNOWN ARM IS NOT A SKIP. `_ships_per_files` exits 2 when package.json is unreadable, and an
+# unreadable manifest means we cannot tell deletion from package mode — `not found != 0`, so that
+# case must not silently take the lenient branch (this repo's whole §Instrument-Calibration rule).
+# Usage:  [ -f "$subj" ] || { _absent_subject_verdict "<label>" "$subj" || fail=1; }
+_absent_subject_verdict() {
+  local label="$1" subj="$2"
+  _ships_per_files "$subj"
+  case $? in
+    0) echo "FAIL  $label: $subj is DECLARED SHIPPED (package.json files[]) but absent — that is a"
+       echo "      deletion or a broken install, not package mode. The subject itself is missing."
+       return 1 ;;
+    1) echo "SKIP  $label (subject $subj not in package.json files[], and absent)"
+       return 0 ;;
+    *) echo "FAIL  $label: cannot read package.json, so '$subj absent' is UNDECIDABLE between a"
+       echo "      deletion and package mode — unmeasured, not clean."
+       return 1 ;;
+  esac
+}
+
 check() { # check <label> <cmd...>
   local label="$1"; shift
   if "$@" 2>/dev/null; then
@@ -231,7 +265,7 @@ fi
 # (scripts/degrade_direction_scan.sh) and the anchor both ship, so this runs in package mode too;
 # only a missing SUBJECT is a legitimate skip.
 if [ ! -f scripts/degrade_direction_scan.sh ]; then
-  echo "SKIP  degrade-scan shell probes (subject scripts/degrade_direction_scan.sh absent)"
+  _absent_subject_verdict "degrade-scan shell probes" "scripts/degrade_direction_scan.sh" || fail=1
 elif [ -f scripts/test_degrade_scan_shell_probes.sh ]; then
   if ! bash scripts/test_degrade_scan_shell_probes.sh; then
     fail=1
@@ -247,7 +281,7 @@ fi
 # pair, a template that defeats the gate (a rendered newline turns the pattern into an OR search)
 # passes silently — measured 2026-08-12 on a stale README that the gate reported as PASS.
 if [ ! -f scripts/count_check.sh ]; then
-  echo "SKIP  count_check README-format lanes (subject scripts/count_check.sh absent)"
+  _absent_subject_verdict "count_check README-format lanes" "scripts/count_check.sh" || fail=1
 elif [ -f scripts/test_count_check_readme_format_lanes.sh ]; then
   if ! bash scripts/test_count_check_readme_format_lanes.sh; then
     fail=1
@@ -263,7 +297,7 @@ fi
 # Wired here on purpose (cross-family round 2): the lane file existed and was syntax-checked only, so
 # `npm test` and `prepublishOnly` never executed it. A checker nobody calls is prose.
 if [ ! -f scripts/psa_scan_lib.sh ]; then
-  echo "SKIP  psa single-file lanes (subject scripts/psa_scan_lib.sh absent)"
+  _absent_subject_verdict "psa single-file lanes" "scripts/psa_scan_lib.sh" || fail=1
 elif [ -f scripts/test_psa_singlefile_lanes.sh ]; then
   if ! bash scripts/test_psa_singlefile_lanes.sh; then
     fail=1
@@ -287,7 +321,7 @@ fi
 # to reason about CI. scripts/test_package_coverage_lanes.sh pins the predicate across all four
 # tree shapes plus a known pair.
 if [ ! -f scripts/package_coverage_check.sh ]; then
-  echo "SKIP  test_package_coverage_lanes.sh (subject scripts/package_coverage_check.sh absent)"
+  _absent_subject_verdict "test_package_coverage_lanes.sh" "scripts/package_coverage_check.sh" || fail=1
 elif [ -f scripts/test_package_coverage_lanes.sh ]; then
   if ! bash scripts/test_package_coverage_lanes.sh; then
     fail=1
@@ -311,10 +345,26 @@ fi
 # unconditionally when present because its own absence is the defect class it exists to detect —
 # there is no package-mode arm to skip into (a consumer running `npm test` should learn that a
 # shipped suite of theirs is dead code just as much as we should).
+# THREE-VALUED, and the third value exists because the two-valued version was this session's own
+# instance of the defect it detects. The first draft was `if [ -f … ]; then run; fi` — an absent
+# checker fell through to nothing, silently. That is "미측정을 0으로 렌더" reproduced by the commit
+# that closed it: a 1.4.96 consumer has no lane_runner_check.sh (it was added to files[] AFTER that
+# publish), so on their machine this block would have printed nothing at all and `npm test` would
+# have reported a clean run of a check that never existed there.
+# The three states are distinguished by the DECLARATION, not by the environment (same discipline as
+# the pre-push block above): present → run · absent-but-declared-shipped → FAIL (deletion or broken
+# install) · absent-and-not-declared → SKIP, saying so. For a 1.4.96 consumer the third arm is the
+# correct and honest answer, and it names itself rather than being silent.
 if [ -f scripts/lane_runner_check.sh ]; then
   if ! bash scripts/lane_runner_check.sh; then
     fail=1
   fi
+elif _ships_per_files "scripts/lane_runner_check.sh"; then
+  echo "FAIL  lane-runner: scripts/lane_runner_check.sh is DECLARED SHIPPED but absent — deletion or"
+  echo "      broken install. The check that detects unrun lane suites is itself missing."
+  fail=1
+else
+  echo "SKIP  lane-runner (not in this package's files[] — predates the version that ships it)"
 fi
 
 # embedded --self-test suites (compaction_probe · judgment_circuit_lint · novelty_claim_check).
@@ -326,7 +376,7 @@ fi
 # but self-test missing → FAIL, never a silent pass.
 for _subj in compaction_probe judgment_circuit_lint novelty_claim_check; do
   if [ ! -f "scripts/$_subj.sh" ]; then
-    echo "SKIP  $_subj --self-test (subject scripts/$_subj.sh absent)"
+    _absent_subject_verdict "$_subj --self-test" "scripts/$_subj.sh" || fail=1
   else
     # ⚠️ **문자열 존재로 판정하지 마라.** 초판은 `grep -q -- '--self-test'` 였는데, 그 문자열은
     # 헤더 주석과 usage echo 에도 있어서 **디스패처 한 줄만 지워도 여전히 매치**한다. 그리고
@@ -382,7 +432,7 @@ fi
 # anchor was written into tests/ with ZERO callers first — the same defect this file already
 # records twice above; wiring it here is the fix, not a note about the fix.
 if [ ! -f scripts/consent_registry_check.sh ]; then
-  echo "SKIP  test_consent_registry.sh (subject scripts/consent_registry_check.sh absent)"
+  _absent_subject_verdict "test_consent_registry.sh" "scripts/consent_registry_check.sh" || fail=1
 elif [ -f scripts/test_consent_registry.sh ]; then
   if ! bash scripts/test_consent_registry.sh; then
     fail=1
@@ -397,7 +447,7 @@ fi
 # cross-family verification. The anchor's first version shipped in tests/ with ZERO callers — the
 # same defect the comment above records for test_card_drift_probe.sh, repeated one file later.
 if [ ! -f scripts/sidecar_wait.sh ]; then
-  echo "SKIP  test_sidecar_wait_stdin.sh (subject scripts/sidecar_wait.sh absent)"
+  _absent_subject_verdict "test_sidecar_wait_stdin.sh" "scripts/sidecar_wait.sh" || fail=1
 elif [ -f scripts/test_sidecar_wait_stdin.sh ]; then
   if ! bash scripts/test_sidecar_wait_stdin.sh; then
     fail=1
@@ -416,7 +466,7 @@ fi
 # states that look identical from outside ("the sidecar ran" vs "the model I pinned answered",
 # "absent" vs "unmeasured"), and its lanes are hermetic stubs, so running them costs nothing.
 if [ ! -f scripts/sidecar_calibrate.sh ]; then
-  echo "SKIP  test_sidecar_calibrate_lanes.sh (subject scripts/sidecar_calibrate.sh absent)"
+  _absent_subject_verdict "test_sidecar_calibrate_lanes.sh" "scripts/sidecar_calibrate.sh" || fail=1
 elif [ -f scripts/test_sidecar_calibrate_lanes.sh ]; then
   if ! bash scripts/test_sidecar_calibrate_lanes.sh; then
     fail=1
@@ -513,7 +563,7 @@ _gps_missing=""
 [ -f templates/.git-hooks/pre-commit ] || _gps_missing="templates/.git-hooks/pre-commit"
 [ -f templates/regression_guard.sh ] || _gps_missing="${_gps_missing:+$_gps_missing, }templates/regression_guard.sh"
 if [ -n "$_gps_missing" ]; then
-  echo "SKIP  gate_pathspec_check.sh (subject absent: $_gps_missing) — not-checked, NOT a pass"
+  _absent_subject_verdict "gate_pathspec_check.sh" "$_gps_missing" || fail=1
 elif [ -f scripts/gate_pathspec_check.sh ]; then
   if ! bash scripts/gate_pathspec_check.sh; then
     fail=1
@@ -535,7 +585,7 @@ else
 fi
 
 if [ ! -f scripts/fh_node_check.sh ]; then
-  echo "SKIP  test_node_check_lanes.sh (subject scripts/fh_node_check.sh absent)"
+  _absent_subject_verdict "test_node_check_lanes.sh" "scripts/fh_node_check.sh" || fail=1
 elif [ -f scripts/test_node_check_lanes.sh ]; then
   if ! bash scripts/test_node_check_lanes.sh; then
     fail=1
@@ -548,7 +598,7 @@ fi
 # The infra-delta half of the same subject. Separate suite, same pairing rule: it exists only because
 # fh_node_check.sh does, so its absence beside a present subject is a FAIL, not a skip.
 if [ ! -f scripts/fh_node_check.sh ]; then
-  echo "SKIP  test_node_infra_delta_lanes.sh (subject scripts/fh_node_check.sh absent)"
+  _absent_subject_verdict "test_node_infra_delta_lanes.sh" "scripts/fh_node_check.sh" || fail=1
 elif [ -f scripts/test_node_infra_delta_lanes.sh ]; then
   if ! bash scripts/test_node_infra_delta_lanes.sh; then
     fail=1
@@ -595,7 +645,7 @@ do
       ;;
   esac
   if [ ! -f "$_subj" ]; then
-    echo "SKIP  ${_anc##*/} (subject $_subj absent)"
+    _absent_subject_verdict "${_anc##*/}" "$_subj" || fail=1
   elif [ -f "$_anc" ]; then
     # THREE-valued, like the session-close anchors above — and for a third reason they do not have.
     # test_sessionstart_multihook_lanes.sh measures what the LIVE `claude` CLI does with several
@@ -626,7 +676,7 @@ done
 # 2026-07-31; the pipe-verdict lane shipped in PR #209 WITHOUT this wiring, which is itself the
 # half-fix class the second guard exists to catch — found by running that guard on this repo.
 if [ ! -f scripts/sidecar_calibrate.sh ]; then
-  echo "SKIP  test_ollama_panel_lanes.sh (subject scripts/sidecar_calibrate.sh absent)"
+  _absent_subject_verdict "test_ollama_panel_lanes.sh" "scripts/sidecar_calibrate.sh" || fail=1
 elif [ -f scripts/test_ollama_panel_lanes.sh ]; then
   if ! bash scripts/test_ollama_panel_lanes.sh; then
     fail=1
@@ -637,7 +687,7 @@ else
 fi
 
 if [ ! -f scripts/pipe_verdict_guard.sh ]; then
-  echo "SKIP  test_pipe_verdict_guard_lanes.sh (subject scripts/pipe_verdict_guard.sh absent)"
+  _absent_subject_verdict "test_pipe_verdict_guard_lanes.sh" "scripts/pipe_verdict_guard.sh" || fail=1
 elif [ -f scripts/test_pipe_verdict_guard_lanes.sh ]; then
   if ! bash scripts/test_pipe_verdict_guard_lanes.sh; then
     fail=1
@@ -648,7 +698,7 @@ else
 fi
 
 if [ ! -f scripts/halffix_propagation_scan.sh ]; then
-  echo "SKIP  test_halffix_lanes.sh (subject scripts/halffix_propagation_scan.sh absent)"
+  _absent_subject_verdict "test_halffix_lanes.sh" "scripts/halffix_propagation_scan.sh" || fail=1
 elif [ -f scripts/test_halffix_lanes.sh ]; then
   if ! bash scripts/test_halffix_lanes.sh; then
     fail=1
@@ -672,7 +722,7 @@ fi
 
 for _anchor in scripts/test_session_close_lanes.sh scripts/test_card_drift_probe.sh scripts/test_session_close_chain_lanes.sh; do
   if [ ! -f scripts/session_close_check.sh ]; then
-    echo "SKIP  ${_anchor##*/} (subject scripts/session_close_check.sh absent)"
+    _absent_subject_verdict "${_anchor##*/}" "scripts/session_close_check.sh" || fail=1
   elif [ -f "$_anchor" ]; then
     # Preserve the anchor's two failure CLASSES instead of flattening them into one `fail=1`.
     # An anchor exits 3 when a fixture's premise never obtained — "this run's verdicts prove
@@ -782,7 +832,7 @@ fi
 # tag reached the remote and a publish from the wrong tree was stopped only by npm's own collision
 # check, so an unrun anchor here would be the same luck-as-floor arrangement one layer up.
 if [ ! -f templates/.git-hooks/pre-push ]; then
-  echo "SKIP  test_tag_version_lanes.sh (subject templates/.git-hooks/pre-push absent)"
+  _absent_subject_verdict "test_tag_version_lanes.sh" "templates/.git-hooks/pre-push" || fail=1
 elif [ -f scripts/test_tag_version_lanes.sh ]; then
   # RUN-ONCE, CAPTURE (2026-08-05) — rationale in the sync_from_be_lanes block later in this file.
   if _out=$(bash scripts/test_tag_version_lanes.sh 2>&1); then
@@ -802,7 +852,7 @@ fi
 # per-plugin entries inside marketplace.json, which the tag lane never opens. Measured 2026-08-06:
 # a bump left the second marketplace entry behind and the tag lane passed 8/8 straight through it.
 if [ ! -f scripts/version_lockstep_check.sh ]; then
-  echo "SKIP  test_version_lockstep_lanes.sh (subject scripts/version_lockstep_check.sh absent)"
+  _absent_subject_verdict "test_version_lockstep_lanes.sh" "scripts/version_lockstep_check.sh" || fail=1
 elif [ -f scripts/test_version_lockstep_lanes.sh ]; then
   if _out=$(bash scripts/test_version_lockstep_lanes.sh 2>&1); then
     echo "PASS  test_version_lockstep_lanes.sh (drift blocks · aligned silent · unreadable = exit 2, not pass)"

--- a/scripts/test_selfcheck_state_lanes.sh
+++ b/scripts/test_selfcheck_state_lanes.sh
@@ -253,6 +253,110 @@ route_pair_mode() {
 [ "$(route_pair_mode always-shipped)" = VALID ]           ; chk $? "known mode 'always-shipped' validates"
 [ "$(route_pair_mode alway-shipped)" = FAIL-badmode ]     ; chk $? "known-POSITIVE: a typo'd mode is rejected, not silently treated as either known state"
 
+# ── 삭제→SKIP: the fourth face. A declared-shipped subject's absence is not "package mode" ─────
+# WHY (measured 2026-08-12, card §🔱⑮ A2): **18 blocks** in selfcheck.sh rendered a green SKIP when
+# their subject was missing, and all 18 subjects are in package.json files[] AND in the real tarball
+# (`npm pack --dry-run --json`, 20/20 — so routing them to FAIL cannot over-block a real consumer).
+# For an always-shipped subject, "absent" can only mean deletion or a broken install. Two of the 18
+# read as already-handled and were not: the gate_pathspec block printed "— not-checked, NOT a pass"
+# without setting fail, and the --self-test loop's comment claims "never a silent pass" directly above
+# the arm that was one. A comment asserting a property is not the property; both were hand-verified.
+# LIFTED, not re-spelled — same reason as the discriminators above.
+_ASV=$(sed -n '/^_absent_subject_verdict()/,/^}/p' "$SELFCHECK")
+_SPF=$(sed -n '/^_ships_per_files()/,/^}/p' "$SELFCHECK")
+if [ -z "$_ASV" ] || [ -z "$_SPF" ]; then
+  echo "FAIL  _absent_subject_verdict / _ships_per_files no longer defined in selfcheck.sh —"
+  echo "      this lane cannot verify what it claims. Update the lane WITH the subject."
+  exit 1
+fi
+echo "── 삭제→SKIP discriminator located (both helpers present)"
+
+_asv() {  # $1=subject → prints verdict, returns its rc
+  ( cd "$SCRIPT_DIR/.." && bash -c "
+$_SPF
+$_ASV
+_absent_subject_verdict 'lane' '$1'" 2>&1 )
+}
+_asv_rc() { _asv "$1" >/dev/null 2>&1; echo $?; }
+
+# known-POSITIVE: a declared-shipped subject going missing must FAIL, not SKIP. Three different
+# shapes (a script, a hook under a directory files[] entry, an anchor's subject).
+[ "$(_asv_rc scripts/count_check.sh)" = 1 ]
+chk $? "known-POSITIVE: declared-shipped script absent → FAIL (was a green SKIP for 18 blocks)"
+[ "$(_asv_rc templates/.git-hooks/pre-commit)" = 1 ]
+chk $? "known-POSITIVE: hook covered by a DIRECTORY files[] entry → FAIL (prefix match, not equality)"
+# ⚠️ Capture, THEN grep. `_asv` deliberately returns 1 here, and this file runs under `pipefail`, so
+# `_asv … | grep -q …` yields the pipeline's rightmost non-zero — i.e. the assertion failed while
+# grep had actually matched. Measured on this very lane's first run
+# ([[feedback_pipefail_fallback_disarms_guard]]: `out=$(cmd); rc=$?` is the canonical form).
+_asv_out=$(_asv scripts/count_check.sh)
+printf '%s' "$_asv_out" | grep -q 'DECLARED SHIPPED'
+chk $? "…and the message names WHY, so the verdict is diagnosable"
+
+# known-NEGATIVE: an ACCEPTED_ABSENT subject must still SKIP. Without this arm the fix would be an
+# over-block, which trains --no-verify — the trade this repo has logged explicitly.
+[ "$(_asv_rc scripts/probe_scope_check.sh)" = 0 ]
+chk $? "known-NEGATIVE: genuinely-unshipped subject absent → SKIP (no over-block)"
+[ "$(_asv_rc scripts/sync-to-be.sh)" = 0 ]
+chk $? "known-NEGATIVE: operator-private subject absent → SKIP"
+
+# The UNKNOWN arm: an unreadable manifest cannot tell deletion from package mode, so it must NOT
+# take the lenient branch. `not found != 0` applied to the oracle itself.
+_TD=$(mktemp -d)
+_urc=$( ( cd "$_TD" && bash -c "
+$_SPF
+$_ASV
+_absent_subject_verdict 'lane' 'scripts/x.sh'" >/dev/null 2>&1 ); echo $? )
+rm -rf "$_TD"
+[ "$_urc" = 1 ]
+chk $? "UNKNOWN (no readable package.json) → FAIL, not a lenient SKIP"
+
+# REVERSION: every one of the 18 call sites must route through the helper. A site that re-spells the
+# old `echo "SKIP … absent"` without setting fail has restored the defect. Counting call sites rather
+# than grepping for the old string, because the old string is what a reverter would reproduce.
+_ASV_CALLS=$(grep -c '_absent_subject_verdict "' "$SELFCHECK" || true)
+[ "$_ASV_CALLS" -ge 18 ]
+chk $? "all 18 absent-subject sites route through the helper (found $_ASV_CALLS, expected >=18)"
+# And no site may print a bare absent-SKIP for a subject that IS declared shipped.
+# ⚠️ The first draft asserted ZERO bare absent-SKIP echoes and failed with 5 — all five legitimate:
+# the helper's own SKIP arm, plus four subjects that genuinely never ship (probe_scope_check.sh,
+# ablation_calibrate.sh, sync-to-be.sh, sync-from-be.sh — all ACCEPTED_ABSENT). A green SKIP is
+# CORRECT there, and an assertion that forbids it would have forced an over-block. So the predicate
+# is the same one the fix uses — is the named subject declared shipped — not a count that would need
+# hand-tuning every time an exception is added ([[feedback_control_presence_is_not_discrimination]]:
+# a control that fires on everything measures nothing).
+_BARE=$( ( cd "$SCRIPT_DIR/.." && python3 - <<'BAREPY'
+import re, json
+sc = open('scripts/selfcheck.sh', encoding='utf-8').read().split('\n')
+files = json.load(open('package.json'))['files']
+def ships(p): return any(p == f or p.startswith(f.rstrip('/') + '/') for f in files)
+bad = []
+for i, l in enumerate(sc, 1):
+    if '_absent_subject_verdict' in l:      # the helper itself, and its call sites
+        continue
+    m = re.search(r'echo "SKIP\s+.*subject ([A-Za-z0-9_./-]+) absent', l)
+    if m and ships(m.group(1)):
+        bad.append(f"{i}:{m.group(1)}")
+print(' '.join(bad))
+BAREPY
+) )
+[ -z "$_BARE" ]
+chk $? "no bare absent-SKIP remains for a DECLARED-SHIPPED subject (found: ${_BARE:-none})"
+# Control for the line above: the predicate must be able to FIRE. If ships() ever returns False for
+# everything (unreadable manifest, changed schema), the assertion passes vacuously and certifies
+# nothing — so prove the same detector flags a planted declared-shipped subject.
+_BARE_CTL=$( ( cd "$SCRIPT_DIR/.." && python3 - <<'CTLPY'
+import re, json
+files = json.load(open('package.json'))['files']
+def ships(p): return any(p == f or p.startswith(f.rstrip('/') + '/') for f in files)
+planted = 'echo "SKIP  planted (subject scripts/count_check.sh absent)"'
+m = re.search(r'echo "SKIP\s+.*subject ([A-Za-z0-9_./-]+) absent', planted)
+print('FIRED' if (m and ships(m.group(1))) else 'DEAD')
+CTLPY
+) )
+[ "$_BARE_CTL" = FIRED ]
+chk $? "CONTROL: that detector fires on a planted declared-shipped subject (got $_BARE_CTL)"
+
 # ── SCOPE OF THIS ANCHOR — stated so it is not over-trusted ───────────────────
 # These lanes catch REVERSION (the run-twice form coming back, the helper being gutted, the
 # call-site redirect returning). They do NOT catch deliberate EVASION: a cross-family round


### PR DESCRIPTION
## 발단 — 잔여가 코드 주석에만 있었다

`scripts/selfcheck.sh:398` 이 이렇게 적어뒀다:

> *"Named residual, deliberately not fixed here: the sibling blocks above carry the same hole for their own shipped subjects."*

**저자가 스스로 인지하고 적어둔 잔여인데, 그 기록이 코드 주석에만 있었다.** 카드 §🔱⑮ 잔여 목록에는 없다 — 다음 세션은 카드를 읽지 `selfcheck.sh` 398줄을 읽지 않는다. 이노베이터 Mode F 독립 스캔이 Gap 1 로 제기했고, **자기 계수를 `UNCALIBRATED-partial`(2/16 손검증)로 정직하게 라벨**했다. 전수 재계상 = **18**.

## 실측

```
18곳   subject 부재시 초록 SKIP           (per-site 로 fail 세우는지 기계 판정)
18/18  그 subject 가 files[] 에 선언됨
20/20  선언된 subject 가 실제 tarball 에 있다   ← npm pack --dry-run --json
```

**그 20/20 이 이 수리를 안전하게 만든 것이다.** 과차단 위험을 논증이 아니라 측정으로 없앴다 — 선언만 있고 팩 안 되는 항목이 있었다면 이 수리가 정직한 소비자를 빨갛게 만들었을 것이다.

항상 출하되는 subject 의 부재는 「패키지 모드」일 수 없다. **삭제 또는 설치 파손**뿐이고, 18곳 전부 초록이었다. 그중엔 판정을 쥔 것들이 있다 — Destructive-Op 훅 · `session_close_check.sh` · `count_check.sh`.

### 둘은 이미 처리된 것처럼 읽혔고 아니었다 (육안 손검증)

- `gate_pathspec` 블록이 `— not-checked, NOT a pass` 를 찍고 **`fail` 을 안 세운다**. 라벨은 정직하고 판정은 초록이다. 메시지를 grep 한 독자는 처리됐다고 믿는다
- `--self-test` 루프의 주석이 *"never a silent pass"* 라고 **그 arm 바로 위에서** 말한다

**주석이 성질을 주장하는 것은 성질이 아니다.**

## 수리 — 헬퍼 하나, 3값

```
선언출하 + 부재      → FAIL  (삭제/설치 파손, 「패키지 모드」 아님)
미선언   + 부재      → SKIP  (사유를 말한다)
매니페스트 못 읽음    → FAIL  (UNDECIDABLE — 관대 분기 금지, not found ≠ 0)
```

환경 추론이 아니라 **선언을 오라클로** 쓴다(이 세션이 오늘 세 번째로 채택한 같은 규율).

함께 `lane_runner` 배선 가드도 3값화했다 — **2값 초판이 이 세션 자신의 같은 결함**이었다. 1.4.96 소비자에겐 `lane_runner_check.sh` 가 없어서 `if [ -f … ]` 가 아무것도 안 찍고 `npm test` 가 «존재하지 않는 검사의 깨끗한 실행»을 보고했다.

## 이 PR 이 잡은 내 레인 결함 2건 (레인이 스스로 잡았다)

1. `_asv … | grep -q` 가 `pipefail` 아래에서 헬퍼의 **의도적 rc=1** 을 파이프라인 판정으로 전파 — 통과한 단언이 실패로 읽혔다
2. 「bare absent-SKIP 0건」 단언이 **5건에 발화**했는데 다섯 다 정당했다(헬퍼 자신의 arm + 진짜 미출하 4종). 그 초안대로 갔으면 **과차단을 강요**했을 것이다 → 술어를 수리와 같은 「선언 여부」로 교체 + 그 검출기가 여전히 발화하는지 컨트롤 추가

## Test plan

- [x] 헬퍼 known-pair — 선언출하 3종 → rc=1(진단 가능한 메시지) · ACCEPTED_ABSENT 2종 → rc=0 SKIP(과차단 없음) · package.json 없는 디렉터리 → rc=1 UNDECIDABLE
- [x] 디렉터리 `files[]` 엔트리로 덮이는 훅도 prefix 매치로 FAIL(equality 아님)
- [x] 수리 후 재스캔 — 실제 잔여 **0**(플래그된 2건은 손검증 결과 스캐너 오탐: 내 pre-push else-arm, subject 가 둘 다 ACCEPTED_ABSENT 인 probe_scope)
- [x] 레인 9개 추가, `test_selfcheck_state_lanes.sh` **PASS 44/44**
- [x] **되돌림 프로브** — 1 사이트를 옛 형태로 복구 → 정확히 그 레인만 적색(`found: 284:scripts/count_check.sh`) → 복원 후 초록. 앵커가 장식이 아니다
- [x] `lane_runner_check.sh` PASS 43/31/1/12 · `package_coverage_check.sh` PASS · `version_lockstep_check.sh` PASS 4@1.4.96

## 명시 잔여

`files[]` 멤버십은 **선언**이고 tarball 이 아니다. 이번엔 20/20 일치를 실측해 위험을 없앴지만, 미래에 선언만 있고 팩되지 않는 항목이 생기면 그 소비자가 거짓 FAIL 을 본다. 헬퍼 주석에 명시했고, 그 경우의 정답은 이 검사를 무르는 것이 아니라 **`files[]` 를 고치는 것**이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)