### PR TITLE
fix(engine4): 압축 되주입 가드가 조용히 꺼지던 경로 4종 — 미측정을 「정상」으로 렌더하지 않는다

### DIFF
--- a/scripts/compaction_probe.sh
+++ b/scripts/compaction_probe.sh
@@ -179,17 +179,62 @@ do_digest() {
   if [ ! -f "$sealfile" ]; then return 0; fi
 
   # 신선도·세션 정합을 **주장에 반영**한다. 안 맞으면 주입은 하되 "직전 압축"이라고 말하지 않는다.
-  local _now _age _stale="" _xsess=""
-  _now=$(date +%s); _age=$(( _now - ${sealts:-$_now} ))
-  [ "$_age" -gt 43200 ] && _stale=" ⚠️ ${_age}초 전 봉인 — 이 세션의 직전 압축이 아닐 수 있다"
-  if [ -n "${sealsess:-}" ] && [ "${sealsess}" != "unknown" ] && [ -n "$DIGEST_SESSION" ] \
-     && [ "$DIGEST_SESSION" != "unknown" ] && [ "${sealsess}" != "$DIGEST_SESSION" ]; then
-    _xsess=" ⚠️ 다른 세션(${sealsess})의 봉인이다"
-  fi
-  if [ -n "$_stale$_xsess" ]; then
-    echo "🧭 [FH 압축 복구] 봉인된 포인터 원장이 있다 — 내용이 아니라 경로다.$_stale$_xsess"
+  # ⚠️ 두 가드 모두 초판에서 **조용히 꺼지는 경로**를 갖고 있었다(실측 2026-08-13, 4-arm 재현).
+  # 공통 축은 하나다 — **미측정을 「정상」으로 렌더**했다(`not found ≠ 0`).
+  # ⚠️ `_age` 초기화 = **2중 방어**. 산술이 실패하면 대입이 안 되고, 다음 줄의 `$_age` 가 `set -u`
+  #    아래 unbound 로 셸을 그 자리에서 죽인다 — 훅은 `exit 0` 에 도달 못 하고 **stdout 이
+  #    통째로 폐기**된다(비영 종료 = 무음). 이 파일이 스스로 못 박은 불변식이 거기서 깨진다.
+  #    🔍 **정직한 표시**: 아래 `case` 가 숫자만 통과시키고 `10#` 이 진법을 고정하는 한, 이 줄은
+  #    **도달 불가능하고 레인도 없다**(되돌림 arm D 실측: 이 줄만 지우면 47쌍 전부 초록).
+  #    앵커가 걸린 것은 `10#` 쪽(arm A)이다. 이 줄은 그게 지워졌을 때를 위한 두 번째 층이지,
+  #    회귀 앵커가 아니다 — 있는 척하지 않으려고 여기 적는다.
+  local _now _age=0 _stale="" _note="" _xsess="" _sessmatch=no
+  _now=$(date +%s)
+  # ⓑ 를 **먼저** 계산한다 — 나이 문구가 세션 일치 여부에 의존하기 때문이다(아래 ⓐ-3).
+  # 세션 대조는 **양쪽을 다 알 때만** 성립한다. 한쪽이라도 unknown 이면 결과는 「일치」가 아니라
+  # **「대조 불가」**다. 초판은 그 경우 경고를 껐는데, 소비자가 unknown 인 경로가 바로
+  # 주인 없는 남의 마커를 집는 경로(line 165)여서 **가장 필요한 자리에서 꺼져 있었다**.
+  if [ -n "${sealsess:-}" ] && [ "${sealsess}" != "unknown" ] \
+     && [ -n "$DIGEST_SESSION" ] && [ "$DIGEST_SESSION" != "unknown" ]; then
+    if [ "${sealsess}" = "$DIGEST_SESSION" ]; then
+      _sessmatch=yes
+    else
+      _xsess=" ⚠️ 다른 세션(${sealsess})의 봉인이다"
+    fi
   else
-    echo "🧭 [FH 압축 복구] 직전 압축 전에 봉인된 포인터 원장이 있다 — 내용이 아니라 경로다."
+    _xsess=" ⚠️ 세션 대조 불가(봉인=${sealsess:-미상} · 소비=${DIGEST_SESSION:-미상}) — 남의 원장일 수 있다"
+  fi
+  # ⓐ 봉인 시각이 없거나 숫자가 아니면 나이는 **미상**이다. 초판은 `${sealts:-$_now}` 로 「지금」을
+  #    기본값으로 써서 _age=0 을 만들었고, 구형식 pending(경로 한 줄)에서 신선도 가드가 통째로
+  #    무음 소실했다 — 실측: 5일 묵은 봉인이 "직전 압축"이라고 주장하며 나갔다.
+  case "${sealts:-}" in
+    ''|*[!0-9]*) _stale=" ⚠️ 봉인 시각 미상 — 이 세션의 직전 압축인지 확인 불가" ;;
+    # `10#` 으로 진법을 고정한다. 선행 0(`08…`)은 8진수로 읽혀 `value too great for base` 를
+    # 내고, 위에서 적은 무음 사망 경로가 정확히 그 입력으로 열린다(실측: 산술 다음 줄에 도달 못 함).
+    *) _age=$(( _now - 10#$sealts ))
+       # 미래 시각이면 _age 가 음수라 `-gt 43200` 이 거짓이 되고 가드가 **또 조용히 꺼진다** —
+       # 이 파일이 이번에 두 번 밟은 그 축의 세 번째 얼굴이다(cross-family codex/gpt-5.5 지목,
+       # 자력 적발 0). 시계 어긋남이거나 마커가 손대진 것이고, 둘 다 「방금 봉인」이 아니다.
+       if [ "$_age" -lt 0 ]; then
+         _stale=" ⚠️ 봉인 시각이 미래($(( - _age ))초 뒤) — 시계 어긋남 또는 손댄 마커, 신선도 판정 불가"
+       elif [ "$_age" -gt 43200 ]; then
+         # ⓐ-3 **세션이 일치하면 이 경고는 반증 가능하게 틀렸다.** 마커는 봉인마다 세션별로
+         #    덮어써지므로(line 150), 일치하는 마커가 가리키는 것은 정의상 그 세션의 **가장
+         #    최근** 봉인이다. 그때 나이는 주장을 낮출 근거가 아니라 부가 정보다 — 주장 정확도를
+         #    위해 만든 가드가 스스로 틀린 말을 하던 자리(Axis 2 M-4 지목).
+         if [ "$_sessmatch" = yes ]; then
+           _note=" (${_age}초 전 봉인 — 같은 세션의 가장 최근 봉인이다)"
+         else
+           _stale=" ⚠️ ${_age}초 전 봉인 — 이 세션의 직전 압축이 아닐 수 있다"
+         fi
+       fi ;;
+  esac
+  # `_note` 는 **주장을 낮추지 않는다** — 분기 조건에서 뺀 이유가 그것이다. 나이를 알려주되
+  # 「직전 압축」이 참인 경우(세션 일치)에는 그 주장을 유지한다.
+  if [ -n "$_stale$_xsess" ]; then
+    echo "🧭 [FH 압축 복구] 봉인된 포인터 원장이 있다 — 내용이 아니라 경로다.$_stale$_xsess$_note"
+  else
+    echo "🧭 [FH 압축 복구] 직전 압축 전에 봉인된 포인터 원장이 있다 — 내용이 아니라 경로다.$_note"
   fi
   echo "   정본: $sealfile"
   echo
@@ -359,6 +404,91 @@ self_test() {
   t "#4 같은 세션이면 직전-압축 주장 유지 (과경고 아님)" YES "$rc"
   case "$d4b" in *"다른 세션"*) rc=YES ;; *) rc=NO ;; esac
   t "#4 같은 세션에 교차 경고 안 뜬다" NO "$rc"
+
+  # #11 신선도 가드가 **구형식 pending(경로 한 줄)** 에서 무음으로 꺼지지 않는다.
+  # 실측 2026-08-13: 이 경로로 5일 묵은 봉인이 "직전 압축"이라고 주장하며 실제 세션에 주입됐다.
+  do_seal "$T/tr.jsonl" "$T/out11" "SESSA" >/dev/null 2>&1
+  local p11; p11="$(ls "$T/out11"/.pending_* 2>/dev/null | head -1)"
+  cut -f1 "$p11" > "$p11.t" 2>/dev/null && mv "$p11.t" "$p11"    # 구형식으로 강등 = 봉인 시각 소실
+  local d11; d11="$(do_digest "$T/out11" "SESSA" 2>/dev/null)"
+  case "$d11" in *"직전 압축 전에"*) rc=YES ;; *) rc=NO ;; esac
+  t "#11 시각 미상 봉인을 '직전 압축'이라 주장하지 않는다" NO "$rc"
+  case "$d11" in *"봉인 시각 미상"*) rc=YES ;; *) rc=NO ;; esac
+  t "#11 ★ 시각 미상이 타입으로 남는다 (0 으로 렌더 금지)" YES "$rc"
+
+  # #11 known-negative — 정상 형식엔 과경고가 붙으면 안 된다. 이게 없으면 "항상 경고"로도 통과한다.
+  do_seal "$T/tr.jsonl" "$T/out11b" "SESSA" >/dev/null 2>&1
+  local d11b; d11b="$(do_digest "$T/out11b" "SESSA" 2>/dev/null)"
+  case "$d11b" in *"봉인 시각 미상"*) rc=YES ;; *) rc=NO ;; esac
+  t "#11 known-negative: 정상 봉인엔 미상 라벨 안 붙는다" NO "$rc"
+  case "$d11b" in *"직전 압축 전에"*) rc=YES ;; *) rc=NO ;; esac
+  t "#11 known-negative: 정상 봉인은 직전-압축 주장 유지" YES "$rc"
+
+  # #11c **미래 시각**도 신선도 판정 불가다 — 음수 _age 는 `-gt 43200` 을 통과 못 해서
+  # 가드가 또 조용히 꺼진다. cross-family(codex/gpt-5.5)가 이번 수리 안에서 지목한 세 번째 얼굴.
+  do_seal "$T/tr.jsonl" "$T/out11c" "SESSA" >/dev/null 2>&1
+  local p11c; p11c="$(ls "$T/out11c"/.pending_* 2>/dev/null | head -1)"
+  awk -v ts="$(( $(date +%s) + 86400 ))" 'BEGIN{FS=OFS="\t"}{$3=ts;print}' "$p11c" > "$p11c.t" \
+    && mv "$p11c.t" "$p11c"
+  local d11c; d11c="$(do_digest "$T/out11c" "SESSA" 2>/dev/null)"
+  case "$d11c" in *"직전 압축 전에"*) rc=YES ;; *) rc=NO ;; esac
+  t "#11c 미래 시각 봉인을 '직전 압축'이라 주장하지 않는다" NO "$rc"
+  case "$d11c" in *"미래"*) rc=YES ;; *) rc=NO ;; esac
+  t "#11c ★ 미래 시각이 타입으로 남는다 (음수 나이 무음 금지)" YES "$rc"
+  case "$d11b" in *"미래"*) rc=YES ;; *) rc=NO ;; esac
+  t "#11c known-negative: 정상 시각엔 미래 라벨 안 붙는다" NO "$rc"
+
+  # #11d **묵은-봉인 가지(>43200)에 앵커가 0개였다** — 실측 발현(5일 묵은 봉인)의 정상-형식
+  # 판본인데, 레인이 수리의 어휘(미상 라벨)만 따라가고 결함의 어휘(나이)를 안 따라갔다.
+  # 검증: 이 레인 없이 `elif [ "$_age" -gt 43200 ]` 가지를 통째로 지워도 39쌍 전부 초록이었다.
+  # (Axis 2 M-3 지목. 세션 일치 케이스라 주장은 유지되고 나이는 부가정보로 붙는다 — M-4)
+  do_seal "$T/tr.jsonl" "$T/out11d" "SESSA" >/dev/null 2>&1
+  local p11d; p11d="$(ls "$T/out11d"/.pending_* 2>/dev/null | head -1)"
+  awk -v ts="$(( $(date +%s) - 432000 ))" 'BEGIN{FS=OFS="\t"}{$3=ts;print}' "$p11d" > "$p11d.t" \
+    && mv "$p11d.t" "$p11d"
+  local d11d; d11d="$(do_digest "$T/out11d" "SESSA" 2>/dev/null)"
+  case "$d11d" in *"초 전 봉인"*) rc=YES ;; *) rc=NO ;; esac
+  t "#11d ★ 묵은 봉인의 나이가 실제로 인쇄된다 (가지 삭제를 잡는 유일한 앵커)" YES "$rc"
+  case "$d11d" in *"직전 압축이 아닐 수 있다"*) rc=YES ;; *) rc=NO ;; esac
+  t "#11d 세션 일치면 '아닐 수 있다'는 거짓 주장을 안 한다" NO "$rc"
+  case "$d11b" in *"초 전 봉인"*) rc=YES ;; *) rc=NO ;; esac
+  t "#11d known-negative: 신선한 봉인엔 나이 문구 없음" NO "$rc"
+
+  # #11e 선행 0 타임스탬프가 **훅을 죽이지 않는다**. set -u 아래 산술 실패 → 다음 줄 unbound →
+  # 셸 즉시 종료 → exit 0 미도달 → stdout 통째 폐기. 이 파일의 「훅은 절대 비영 종료 안 한다」
+  # 불변식이 입력 하나로 깨지던 자리다(Axis 2 M-1, 실측 재현).
+  do_seal "$T/tr.jsonl" "$T/out11e" "SESSA" >/dev/null 2>&1
+  local p11e; p11e="$(ls "$T/out11e"/.pending_* 2>/dev/null | head -1)"
+  awk 'BEGIN{FS=OFS="\t"}{$3="08123456";print}' "$p11e" > "$p11e.t" && mv "$p11e.t" "$p11e"
+  local d11e d11e_rc
+  d11e="$(do_digest "$T/out11e" "SESSA" 2>&1)"; d11e_rc=$?
+  t "#11e ★ 선행 0 타임스탬프에도 digest 가 정상 종료한다" 0 "$d11e_rc"
+  case "$d11e" in *"정본:"*) rc=YES ;; *) rc=NO ;; esac
+  t "#11e 선행 0 에도 포인터가 실제로 인쇄된다 (무음 아님)" YES "$rc"
+
+  # #13 「다른 세션의 봉인이다」 분기는 **살아있는데 앵커가 0개**였다 — #4 는 라우팅(0바이트)만
+  # 재서 이 문자열에 도달할 수 없다. 프로덕션 도달 경로 = 구형식 단일 `.pending` 관용(line 167).
+  do_seal "$T/tr.jsonl" "$T/out13" "SESSX" >/dev/null 2>&1
+  local sf13; sf13="$(ls -t "$T/out13"/seal_*.md 2>/dev/null | head -1)"
+  printf '%s\t%s\t%s\n' "$sf13" "SESSX" "$(( $(date +%s) - 432000 ))" > "$T/out13/.pending"
+  local d13; d13="$(do_digest "$T/out13" "SESSA" 2>/dev/null)"
+  case "$d13" in *"다른 세션(SESSX)"*) rc=YES ;; *) rc=NO ;; esac
+  t "#13 ★ 교차세션 경고가 실제로 인쇄된다 (분기 무앵커 폐쇄)" YES "$rc"
+  case "$d13" in *"세션 대조 불가"*) rc=YES ;; *) rc=NO ;; esac
+  t "#13 양쪽을 아는 불일치는 '대조 불가'가 아니다" NO "$rc"
+  case "$d13" in *"초 전 봉인"*) rc=YES ;; *) rc=NO ;; esac
+  t "#13 세션 불일치 + 묵음이면 나이 경고가 붙는다" YES "$rc"
+
+  # #12 소비자 세션이 미상이면 결과는 「일치」가 아니라 **「대조 불가」**다.
+  # 그 경로(line 165)가 바로 주인 없는 남의 마커를 집는 경로여서, 초판은 가장 필요한 자리에서 꺼졌다.
+  do_seal "$T/tr.jsonl" "$T/out12" "SESSA" >/dev/null 2>&1
+  local d12; d12="$(do_digest "$T/out12" "unknown" 2>/dev/null)"
+  case "$d12" in *"세션 대조 불가"*) rc=YES ;; *) rc=NO ;; esac
+  t "#12 소비자 미상이면 대조 불가로 라벨된다" YES "$rc"
+  case "$d12" in *"직전 압축 전에"*) rc=YES ;; *) rc=NO ;; esac
+  t "#12 대조 불가면 '직전 압축' 주장 안 한다" NO "$rc"
+  case "$d11b" in *"세션 대조 불가"*) rc=YES ;; *) rc=NO ;; esac
+  t "#12 known-negative: 양쪽 아는 경로엔 대조불가 라벨 없음" NO "$rc"
 
   # #8 포인터 절은 **절대 안 잘린다** — 더티파일 목록이 길어도
   do_seal "$T/tr.jsonl" "$T/out8" "SESS8" >/dev/null 2>&1


### PR DESCRIPTION
## 발단 — 실물이 먼저였다

이 세션의 **첫 프롬프트**에 훅이 5일 묵은(2026-08-08) 봉인을
「직전 압축 전에 봉인된 포인터 원장」이라며 주입했고, 그 때문에 세션 초반 좌표를
5일 전 브랜치로 잘못 잡았다. 계기가 세션을 속인 걸 현장에서 잡은 건이다.

## 기전 4종 — 전부 같은 축(미측정을 「정상」으로 렌더)

| # | 기전 | 결과 |
|---|---|---|
| ⓐ | pending 이 구형식(경로 한 줄) → `${sealts:-$_now}` 가 나이를 **0(=방금)** 으로 렌더 | 신선도 가드 무음 소실 |
| ⓑ | 교차세션 경고가 `DIGEST_SESSION != unknown` 을 요구 | **주인 없는 남의 마커를 집는 그 경로에서만** 꺼짐 |
| ⓒ | 미래 시각 → `_age` 음수 → `-gt 43200` 거짓 | 또 무음 |
| ⓓ | 선행 0(`08…`) → `set -u` 아래 산술 실패 → 다음 줄 unbound → 셸 즉사 | `exit 0` 미도달 → **stdout 통째 폐기** |

ⓓ 는 이 파일이 스스로 못 박은 「훅은 절대 비영 종료하지 않는다」 불변식이
입력 하나로 깨지던 자리다. 넷 다 2값 → 3값으로 고쳤다.

덤: 세션이 **일치**할 때의 나이 경고(「직전 압축이 아닐 수 있다」)는 **반증 가능하게 거짓**이었다
— 마커는 세션별로 매 봉인마다 덮어써지므로, 일치하는 마커가 가리키는 건 정의상 그 세션의
가장 최근 봉인이다. 나이를 주장-비강등 부가정보로 분리했다.

## 검증 캡슐

```
계기 재현     4-arm known-pair. ARM1(신선+주인세션)=경고없음이 정상 · ARM3(묵음+타세션)=0바이트
              라우팅 정상 · ARM4/ARM5 가 결함 발현. 컨트롤이 결함 arm 과 갈렸다
레인          29 → 47 쌍 (파일 내장 `--self-test`). bash 3.2.57 에서도 47 초록
fail-before   수리별 3회 개별 증명 — 미래시각·선행0·묵은가지 각각 제거 시 해당 레인만 적색
되돌림 4 arm  A(`10#` 제거)→#11e 적색 · B(>43200 가지 제거)→#11d·#13 적색 ·
              C(세션일치 분기 제거)→#11d 거짓주장 레인 적색 · D(`_age=0` 제거)→**초록**
              ↳ D 는 결함이 아니라 그 줄이 도달 불가 2중 방어라는 뜻. **레인 없음을 코드에 명시**했다
무앵커 실증   이 PR 전에는 `>43200` 가지를 통째로 지워도 39쌍 전부 초록이었다
              (레인이 «수리의 어휘»만 따라가고 «결함의 어휘»(나이)를 안 따라간 상태)
실물 발화     수리 후 같은 세션에서 훅이 실제로
              「봉인 시각 미상 / 세션 대조 불가(봉인=미상 · 소비=…)」를 인쇄했다
```

## 4축

```
Axis 1  PASS (599 lines, +130)
Axis 2  PASS — quench-challenger(같은 계열) M5/R4 + codex/gpt-5.5(cross-family)
Axis 3  PASS — 주석이 인용한 줄번호 3개(150·165·167) 실물 대조 일치
Axis 4  PASS — edit_manifest 2026-08-13 엔트리
```

**cross-family = `panel(anthropic,openai)`.** codex 가 ⓒ(미래 시각)를 지목했고 자력 적발 0이었다.
두 계열이 겹친 지점은 그 하나뿐 — codex 는 산술/이식성, 같은-계열은 레인 커버리지와 주장 정확도를 봤다.

🟥 **정직한 표시**: ⓒⓓ 와 「거짓 주장」 3건은 **내가 이 세션에 방금 쓴 코드**의 결함이고
전부 적대검증이 잡았다(자력 0). 수리가 신규 결함의 주된 출처라는 기록된 패턴의 n+1 이다.

## Added-Scope 로 분리한 5건 (이 PR 밖)

① `SESSION` 복구가 `TRANSCRIPT` 빈 블록 안에만 있어 session_id 없는 페이로드에서 unknown 영구 유지(라우팅 축)
② 봉인 파일 헤더를 세션/시각의 두 번째 출처로 쓰기
③ 소비 시 `rm` → `mv .consumed_*` 로 사후 귀속 복구 — 「귀속 불가」라 적은 내 근거를 적대검증이 정확히 반증했다(결론 유지, 근거 정정)
④ 죽은 `rm -f` 줄이 소비 시점을 오독하게 하는 주석
⑤ 봉인 파일 소실이 완전 무음

## 남은 잔여

**과경고 방향** — 훅 페이로드에 session_id 가 없는 환경에선 매 digest 에 「대조 불가」가 붙는다.
차단이 아니라 라벨이고, 그 환경에서 정답은 라벨을 줄이는 게 아니라 위 ①(세션 id 해석)을 고치는 것이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3RiuSFiKyWsJH73qVsTsv