### PR TITLE
fix(gate): 참조를 «선언»이 아니라 «실제 tarball»과 대조하는 오라클 — 재출하 잔여 G 일반해

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "prepare": "chmod +x bin/fh-gate.js bin/fh-run.js bin/fh-goal.js bin/fh-codex-doctor.js scripts/fh-gate.sh scripts/fh-run.sh scripts/fh-goal.sh",
     "test": "bash scripts/selfcheck.sh",
-    "prepublishOnly": "bash scripts/version_lockstep_check.sh && bash scripts/selfcheck.sh && bash scripts/public_surface_scan_files.sh",
+    "prepublishOnly": "bash scripts/version_lockstep_check.sh && bash scripts/selfcheck.sh && bash scripts/package_coverage_check.sh --vs-tarball && bash scripts/public_surface_scan_files.sh",
     "release": "bash scripts/public_surface_scan_files.sh && npm publish"
   },
   "engines": {
@@ -84,6 +84,7 @@
     "templates/temper_check.sh",
     "templates/contrib_session.md",
     "templates/goal-quench-hook-setup.md",
+    "templates/goal-quench-settings-merged.json",
     "templates/.claude/rules/session.md",
     "scripts/below_floor_scan.sh",
     "scripts/capability_registry_check.sh",

--- a/scripts/package_coverage_check.sh
+++ b/scripts/package_coverage_check.sh
@@ -85,6 +85,17 @@ ACCEPTED_ABSENT=(
   "scripts/test_frontier_digest_retry.sh"
   "scripts/residency_closure_scan.py"
   "scripts/test_residency_closure_lanes.sh"
+  # ── The two settings destinations, surfaced 2026-08-13 by fixing this file's own extractor ────
+  # These were invisible until the `js|json` alternation below was corrected: every `.json`
+  # reference in every shipped doc was being truncated to `.js`, a path that exists nowhere, so
+  # `os.path.exists()` dropped it in silence. `.claude/settings.json` alone is named by TWENTY-SIX
+  # shipped documents and had never once been examined by the check that exists to examine exactly
+  # this. Both are INSTALL DESTINATIONS the consumer owns — the whole point of the docs that name
+  # them is "put this in YOUR settings" — so shipping either would overwrite the reader's own
+  # configuration with this harness's. Same reasoning as .claude/rules/local_fh_context.md above:
+  # the template is what ships, the destination is what the user creates.
+  ".claude/settings.json"
+  ".claude/settings.local.json"
   # Its only input is `.claude/regression/probes.md`, itself ACCEPTED_ABSENT above (a consumer's
   # regression run must not compare against this harness's probe set). Shipping the reader without
   # its corpus would put a script in the package that can only ever report "instrument error".
@@ -140,6 +151,17 @@ if [ "${1:-}" = "--list-accepted" ]; then
   exit 0
 fi
 
+# `--vs-tarball` swaps the coverage oracle from package.json files[] (a DECLARATION about the
+# tarball) to `npm pack --dry-run --json` (the tarball). See the two-oracle comment in the python
+# block. Kept as a flag rather than made the default for one reason: the default runs anywhere,
+# offline, in ~1s, while this one shells out to npm and takes seconds — so the strict oracle belongs
+# on the publish path, where the question "what does the consumer actually receive" is the one being
+# asked, and the cheap one stays on every commit.
+if [ "${1:-}" = "--vs-tarball" ]; then
+  export FH_PKG_ORACLE=tarball
+  shift
+fi
+
 # Source-checkout test uses `-e`, not `-d`. In a git WORKTREE `.git` is a FILE (a gitdir pointer),
 # so the old `-d` test read every worktree as "installed package" and skipped the check entirely —
 # silently, with exit 0. Measured 2026-07-31: a worktree created specifically to approximate CI
@@ -162,28 +184,92 @@ if [ ! -f package.json ]; then
   exit 1
 fi
 
-out=$(python3 - "${ACCEPTED_ABSENT[@]}" <<'PY'
-import re, os, json, sys
+out=$(FH_PKG_ORACLE="${FH_PKG_ORACLE:-declaration}" python3 - "${ACCEPTED_ABSENT[@]}" <<'PY'
+import re, os, json, sys, subprocess
 accepted = set(sys.argv[1:])
 files = json.load(open('package.json'))['files']
 
+# ── TWO ORACLES, and the difference between them is the whole reason the second one exists ────
+# `declaration` (default): a path is covered if package.json files[] says so. That is a CLAIM about
+#     the tarball, checkable without npm, and it is what every caller before 2026-08-13 used.
+# `tarball`: a path is covered if it is actually in `npm pack --dry-run --json`. That is the tarball
+#     ITSELF.
+# They come apart, and this repo has measured them coming apart (card §🔱⑮ G/C: repo ✅ / files[] ❌
+# for two paths). A files[] entry can name a file that does not pack — .npmignore precedence, a
+# pattern that no longer matches, a file deleted while its declaration stayed. In every one of those
+# the declaration oracle says PASS and the consumer gets a broken reference, because the consumer
+# receives the tarball and not the manifest. This is the general solution the campaign card has
+# carried as open under "참조 ↔ 실제 출하 파일셋": the earlier repairs (A–D) routed AROUND it by
+# consulting declarations, which was correct for those cases and is not the same thing as building
+# it.
+# FAIL-CLOSED, and deliberately not "fall back to the declaration": npm missing, a non-zero exit, or
+# JSON that does not parse means the tarball is UNKNOWN, and a lenient fallback would silently
+# convert the stricter oracle back into the weaker one — while still printing the stricter one's
+# name. That is the "미측정을 통과로 렌더" class this whole file is an instrument against.
+ORACLE = os.environ.get('FH_PKG_ORACLE', 'declaration')
+packed = None
+if ORACLE == 'tarball':
+    try:
+        r = subprocess.run(['npm', 'pack', '--dry-run', '--json'],
+                           capture_output=True, text=True, timeout=180)
+        if r.returncode != 0:
+            print(f"ORACLE_UNAVAILABLE\tnpm pack exited {r.returncode}")
+            raise SystemExit(2)
+        packed = {f['path'] for f in json.loads(r.stdout)[0]['files']}
+    except FileNotFoundError:
+        print("ORACLE_UNAVAILABLE\tnpm is not on PATH — the tarball cannot be read")
+        raise SystemExit(2)
+    except (json.JSONDecodeError, KeyError, IndexError) as e:
+        print(f"ORACLE_UNAVAILABLE\tnpm pack --json did not parse ({type(e).__name__})")
+        raise SystemExit(2)
+    except subprocess.TimeoutExpired:
+        print("ORACLE_UNAVAILABLE\tnpm pack timed out")
+        raise SystemExit(2)
+    # An empty or absurdly small packed set means the instrument broke, not that the package is
+    # empty — same impossible-zero rule the shipped-doc guard below applies to its own extractor.
+    if not packed or len(packed) < 10:
+        print(f"ORACLE_UNAVAILABLE\tnpm pack reported {len(packed or [])} files — implausible")
+        raise SystemExit(2)
+
 def covered(p):
+    if packed is not None:
+        return p in packed
     return any(p == f or p.startswith(f.rstrip('/') + '/') for f in files)
 
 shipped = []
-for f in files:
-    if os.path.isfile(f):
-        shipped.append(f)
-    elif os.path.isdir(f):
-        for root, _, names in os.walk(f):
-            shipped.extend(os.path.join(root, n) for n in names)
+if packed is not None:
+    # In tarball mode the set of SCANNED documents is the tarball too, not the declaration. Both
+    # halves have to move together: scanning a doc that does not actually ship would report a
+    # phantom no consumer can encounter, and that false positive is what would get the stricter
+    # oracle switched back off.
+    shipped = sorted(packed)
+else:
+    for f in files:
+        if os.path.isfile(f):
+            shipped.append(f)
+        elif os.path.isdir(f):
+            for root, _, names in os.walk(f):
+                shipped.extend(os.path.join(root, n) for n in names)
 
 # Only text surfaces can carry a reference a human or agent would follow.
 shipped = [s for s in shipped if s.endswith(('.md', '.sh', '.js', '.json', '.yaml', '.yml'))]
 
 pat = re.compile(
     r'(?<![\w/.-])((?:scripts|templates|bin|docs|knowledge|plugins|\.claude)'
-    r'/[A-Za-z0-9_./-]+\.(?:sh|py|js|md|yaml|yml|json|defaults))'
+    # LONGEST-FIRST, and the order is the whole fix. Python's `|` is leftmost-first, not
+    # longest-match, so the previous order `sh|py|js|md|yaml|yml|json|defaults` matched `.js`
+    # inside `.json` and truncated every JSON reference: `templates/settings.json` was extracted as
+    # `templates/settings.js`, a path that exists nowhere, so `os.path.exists()` said False and the
+    # reference was dropped in silence. This check has therefore NEVER examined a shipped doc's
+    # JSON references. Same trap in `yml|yaml` (harmless by luck: neither is a prefix of the other)
+    # and it would bite again for any future pair like `md`/`mdx`.
+    # Known-pair, run before the fix: `templates/settings.json` → `templates/settings.js` (broken)
+    # while `scripts/foo.sh` → `scripts/foo.sh` (control, intact). After: both intact.
+    # The `(?![A-Za-z0-9])` tail is the belt to the longest-first braces: it stops a correct
+    # alternative from matching a PREFIX of a longer real extension that nobody listed yet, so the
+    # next person who adds an extension cannot silently reintroduce this by putting it in the wrong
+    # place. Ordering alone is a convention; the lookahead is the mechanism.
+    r'/[A-Za-z0-9_./-]+\.(?:defaults|json|yaml|yml|sh|py|js|md)(?![A-Za-z0-9]))'
 )
 
 phantom = {}
@@ -239,6 +325,19 @@ raise SystemExit(1 if phantom else 0)
 PY
 )
 rc=$?
+
+case "$out" in
+  ORACLE_UNAVAILABLE*)
+    # Only reachable with --vs-tarball. The stricter oracle could not be read, and the ONLY wrong
+    # answer here is to quietly re-run with the weaker one and print a pass — the caller asked
+    # "what does the consumer actually receive", and "I could not look" is not an answer to that.
+    echo "FAIL  package-coverage (--vs-tarball): the tarball oracle is UNAVAILABLE, so coverage"
+    echo "      against the real packed file set is UNMEASURED — not clean."
+    printf '%s\n' "$out" | sed 's/^ORACLE_UNAVAILABLE\t/      reason: /'
+    echo "      Re-run without --vs-tarball to check against package.json files[] instead, but note"
+    echo "      that is a DIFFERENT and weaker question (a declaration, not the tarball)."
+    exit 2 ;;
+esac
 
 if [ "$rc" -eq 2 ] || [ "$out" = "EXTRACTOR_BROKE" ]; then
   echo "FAIL  package-coverage: extractor scanned 0 shipped docs — the check broke, it did not pass"


### PR DESCRIPTION
카드 §🔱⑮ G 가 *「참조 ↔ 실제 출하 파일셋 대조는 **안 지었다**. A~D 는 선언을 조회해 **우회**한 것」* 으로 열어둔 항목. 운영자 승인(「일반해 체크 후 지어도 된다」)으로 착공.

## 먼저 — 파일이 스스로 적어둔 선결 조건

`package_coverage_check.sh` 주석:
> fix the `js|json` alternation first, re-measure, then decide. **Until then this check's true coverage is UNQUANTIFIED**

파이썬 `|` 는 leftmost-first. 순서가 `sh|py|js|md|yaml|yml|json` 이라 **`.js` 가 `.json` 안에서 먼저 물렸다** — `templates/settings.json` → `templates/settings.js`. 존재하지 않는 경로가 되니 `os.path.exists()` 가 조용히 버렸다.
🟥 **이 검사는 출하 문서의 JSON 참조를 한 번도 본 적이 없다.**

known-pair 로 실증(`.json` 깨짐 / `.sh` 컨트롤 온전) → 최장일치 순서 + `(?![A-Za-z0-9])` 꼬리. 순서만으로 두면 다음 사람이 같은 함정을 다시 판다.

## 고치자마자 나온 3건 — 하나는 진짜 소비자 결함

| 경로 | 판정 |
|---|---|
| `templates/goal-quench-settings-merged.json` | 🟥 출하 문서가 `cp` 하라는데 **미출하** → 출하(tarball 263→264) |
| `.claude/settings.json` | 출하 문서 **26개**가 이름을 댄다 → 설치 목적지, ACCEPTED_ABSENT |
| `.claude/settings.local.json` | 같은 이유 |

첫 건은 **이 검사기가 애초에 만들어진 그 클래스**다 — *"CLAUDE.md 가 `predelete_check.sh` 를 돌리라는데 그 파일이 안 실렸다"*.

## 일반해 — `--vs-tarball`

커버리지 오라클을 `files[]`(**선언**) → `npm pack --dry-run --json`(**tarball 실물**)로 교체. 스캔 대상 문서 집합도 같이 이동한다(안 실리는 문서의 팬텀은 소비자가 만날 수 없는 오탐이고, 그 오탐이 결국 오라클을 다시 끄게 만든다).

**fail-closed · 폴백 없음**: npm 부재 · 비영 종료 · JSON 파싱 실패 · 비현실적 파일수 → `rc=2 UNMEASURED`. 약한 오라클로 조용히 되돌아가면 **더 센 오라클의 이름으로 다른 질문에 답하는 것**이고, 그게 이 파일이 계기로서 막으려는 결함 그 자체다.

`prepublishOnly` 에 배선 — selfcheck 이 아니다. 「소비자가 실제로 무엇을 받나」는 publish 시점 질문이고, 싼 선언 오라클은 매 커밋에 남는다.

## 캘리브레이션 — 판별력을 논증 대신 전시

```
templates/.git-hooks/._oracle_probe.md   files[] 가 디렉토리 선언 · npm 은 `._*` 를 무조건 제외
  declaration  rc=0 PASS   ← 구 검사는 구조적으로 못 본다
  tarball      rc=1 FAIL   ← 경로 지목 (named by 1 shipped doc, e.g. README.md)
  제거 후       양쪽 PASS   ← 항상-빨강 아님 (known-negative)
  npm 제거      rc=2        ← fail-closed, 폴백 아님
```

★ **성공한 known-positive 는 세 번째 시도다.** 「files[] 디렉토리 안 gitignored 파일은 안 실린다」·「`.npmignore` 가 files[] 를 이긴다」 — 내 기전 가설 **둘 다 실측이 반증**했다(둘 다 그냥 실린다). **캘리브레이션이 계기를 재기 전에 내 이해를 먼저 고쳤다.**

## 잔여 (명명)

1. **cross-family 미발주** — `crossfamily: DEGRADED_PANEL_UNUSED`, 사유는 마커에 typed. 판정이 전부 기계 실측이고 그 기계의 known-pair 를 같은 세션에 돌렸다.
2. 기본 오라클은 여전히 선언이라 **커밋 시점엔 divergence 를 못 잡는다** — 의도된 비용/커버리지 교환이고 그래서 플래그다.
3. tarball 모드는 스캔 대상도 tarball 이라 **미출하 문서 안의 깨진 참조는 이 모드에서 안 보인다**(선언 모드가 본다 — 두 모드는 서로를 대체하지 않는다).
4. 이 레포 `.npmignore` 가 `templates/`·`plugins/`·`.claude/` 를 제외 목록에 두는데 **전부 실린다**(files[] 가 이긴다). 캘리브레이션 중 부수 실측. 그 파일은 상당 부분 무력이며 여기서 **안 건드린다**.
5. 🟥 **절차 사고**: 프로브를 만들며 `> .npmignore` 를 **추적 여부 확인 없이** 썼다. 추적 파일이었고 덮어쓴 뒤 내 정리가 지웠다. `git status` 를 읽어 잡고 `git checkout --` 로 복원. 잃은 건 없으나 **잃지 않은 이유는 절차가 안전해서가 아니라 내가 봤기 때문**이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jcEeXyVpeUp6jTwE1ZteX