### PR TITLE
chore(release): 1.4.96 → 1.4.97 락스텝

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,13 @@
   "plugins": [
     {
       "name": "fh-meta",
-      "version": "1.4.96",
+      "version": "1.4.97",
       "description": "Hub meta-operations toolkit — 35 skills + 7 agents. New in 1.4.53: `fh-codex-doctor` (npm bin) — Codex adapter drift scanner; reads the documented M1/M2/M3 skill tier map + skill/agent source and reports codex-native/adapter-required/claude-native/unclassified per unit, wired into `npm test`/`prepublishOnly` (fail-closed on unclassified Claude-native primitives). New in 1.4.49: steel-quench gains Step 0.6 Verdict-Invariance Probe (groundedness axis — a load-bearing judged gate's verdict must track behavior, not rubric phrasing; measured flip-count over cross-family paraphrases; arXiv:2605.06161 Policy Invariance anchor); multi_model_sidecar_strategy §Vendor-native harness (a model is strongest in its own vendor CLI — Claude/CC, GPT/codex, Gemini/Antigravity; a universal router degrades all of them, so it stays an autocomplete/QA sidecar, never orchestration); predelete_check.sh fail-closed rewrite; memory-hygiene A-TMA anchor. New in 1.4.48: phantom-quench + steel-quench gain external frontier anchors (arXiv:2607.02052 package-hallucination; arXiv:2607.02057 prompt-coverage-adequacy); README model-flat claim reframed from a per-release point-curve to structural invariants (operation flattens across tiers; depth tier-order fixed within a generation). New in 1.4.47: onboarding step ① surfaces the Mode D companion-store session-start load in the auto-read salience anchor (previously only in the local binding + rules, so a greeting could skip the load). New in 1.4.46: context-doctor command-output axis (route to rtk/proxy for verbose CLI stdout, complementing .claudeignore; risk-gated to token-scarce envs). New in 1.4.41: context-doctor 2026 trigger vocab (context engineering/rot/collapse) + phantom-citation hardening; hub measurement-integrity-checklist (cross-model measurement pre-flight: display-name pin/reps≥3/discriminating probe). New in 1.4.40: install-wizard queryable-wiki scaffold (INDEX + session-start read + R/W/C ingest). New in 1.4.39: auto-decorrelation (cross-family verifier sidecar recruitment) + video-ingest (capability-routed video ingestion). New in 1.4.x: verify-axis check-class taxonomy (mandatory-pass/measured/judged), no-reinvention Tier-0 inventory, 7-class failure taxonomy, Destructive-Op Gate, Wave-T (Temper), tier-floor governance, Mode D Model Notice, FC consent lane, default-Sonnet guidance. New in 1.3.0: public-surface-audit, field-harvest Mode B auto-trigger, 4-axis gate scope ext. Validated cross-CLI: Claude Code, Codex, Gemini.",
       "source": "./plugins/fh-meta"
     },
     {
       "name": "fh-commons",
-      "version": "1.4.96",
+      "version": "1.4.97",
       "description": "Project-agnostic utility skills — 5 skills (convergence-loop · deliberation · mcp-circuit-breaker · token-budget-gate · ko-tech-writer) + 1 agent (quench-challenger). Domain-independent utilities transplantable into any project.",
       "source": "./plugins/fh-commons"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrono-meta/fh-gate",
-  "version": "1.4.96",
+  "version": "1.4.97",
   "description": "FH runtime adapters — run FH governance, skills, and agents via Claude or Codex with machine-parseable gates.",
   "license": "MIT",
   "keywords": [

--- a/plugins/fh-commons/.claude-plugin/plugin.json
+++ b/plugins/fh-commons/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-commons",
-  "version": "1.4.96",
+  "version": "1.4.97",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/.claude-plugin/plugin.json
+++ b/plugins/fh-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-meta",
-  "version": "1.4.96",
+  "version": "1.4.97",
   "engines": {
     "claudeCode": ">=1.0.0"
   },


### PR DESCRIPTION
운영자 승인(2026-08-13 「퍼블리시 출하승인」). 미출하 머지분을 소비자에게 내보낸다.

## 실리는 것

| PR | 내용 |
|---|---|
| #353 | 게이트가 «통과할 때 무엇으로 쟀는지»를 verdict 에 싣는다 + 미선언 의존성 선언 |
| #355 | tarball-mode selfcheck 거짓 FAIL — vendored-`.git` 일반 수리 + 회귀 레인 |
| #356 | 실행되지 않는 레인 12개 + 삭제된 게이트가 초록이던 경로 |
| #357 | 삭제된 게이트가 초록 SKIP 이던 18곳 — 선언을 오라클로 |
| #360 | 아무 데서도 안 돌던 레인 스위트 배선 (**DEBT 12 → 2**, 적대검증 9수리) |
| #361 | 참조를 «선언»이 아니라 «실제 tarball»과 대조하는 오라클 (**G 일반해**) |

## 락스텝

`package.json` · `.claude-plugin/marketplace.json`(×2) · `plugins/{fh-commons,fh-meta}/.claude-plugin/plugin.json` — **5문자열 / 4파일 전부 1.4.97**. Codex 는 `plugin.json` 버전으로 캐시하므로 다섯이 갈리면 진입점이 stale 해진다.

## 🟥 publish 절차 변경 — 공유 워킹트리에서 publish 하지 않는다

이번 Pre-Publish 게이트가 **실제 누출을 잡았다**:
```
❌ LOW leak — knowledge/shared/learnings/subagent_invocations_log.yaml:
              'fh-be'(운영자 동반자 저장소명) would ship to the registry
```
귀속 결과:
```
커밋된 내용   fh-be 0건  → 현재 출하본(1.4.96)은 깨끗하다
워킹트리      fh-be 1건  → **다른 세션의 미커밋 원장 엔트리**
```
★ **`npm publish` 는 커밋이 아니라 워킹트리를 팩한다.** 이 레포는 지금 6개 병렬 세션이 **한 체크아웃**을 공유하므로, 그중 누구의 미커밋 초안이든 레지스트리로 나갈 수 있다. 오늘 처음 실측된 위험이고, 처방은 토큰을 지우는 게 아니라 **커밋 상태에서 publish 하는 것**이다.

→ 이 PR 머지 후 **깨끗한 worktree** 를 머지된 main 에서 만들어 거기서 `prepublishOnly` 게이트를 돌리고 publish 한다.

## Pre-Publish 게이트 현황

- ✅ `--vs-tarball` (신설 오라클, **첫 실전 게이트 통과**) — rc=0
- ✅ lockstep 1.4.97 4문자열
- ⏸ public-surface — 위 누출 때문에 rc=1. **워킹트리 오염이 원인이고 커밋 상태는 0건**이므로 깨끗한 트리에서 재실행이 정답이다(무시가 아니라 재측정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jcEeXyVpeUp6jTwE1ZteX