### PR TITLE
fix(release): CHANGELOG 이 락스텝 밖이었다 — 1.4.97 항목 신설 + 렌즈 추가

### DIFF
--- a/plugins/fh-meta/CHANGELOG.md
+++ b/plugins/fh-meta/CHANGELOG.md
@@ -10,6 +10,30 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## Plugin Level
 
+### [1.4.97] — 2026-08-13
+
+**fix: 죽어 있던 게이트 캘리브레이션 배선 · 참조를 「선언」이 아니라 「실제 tarball」과 대조**
+
+- **아무 데서도 실행되지 않던 레인 스위트를 배선했다** (PR #360). 실측: `scripts/` 의 43개 스위트
+  중 12개가 selfcheck·git 훅·CI 어디서도 안 돌았고, **그중 9개는 이 패키지에 실린다** — 소비자가
+  받아 놓고 아무것도 부르지 않던 테스트 9종이다. 가장 아픈 둘은 **커밋을 하드 차단하는 게이트의
+  캘리브레이션**이었다(`test_marker_crossfamily_lanes.sh` · `test_marker_floor_lanes.sh`).
+  진척 지표 **DEBT 12 → 2**. 남은 2건은 「돌면 진다, 사유는 머신 전제」로 사유가 측정돼 있다.
+- **vendored git 트리에서의 거짓 FAIL 을 닫았다** — 세 스위트가 `git rev-parse --show-toplevel`
+  로 루트를 잡아, 설치 후 `git init` 한 트리나 node_modules 를 커밋하는 모노레포에서 **바깥 레포**
+  를 보고 HARNESS-ERROR 를 냈다. 스크립트 상대경로로 수리.
+- **`package_coverage_check.sh --vs-tarball`** (PR #361) — 참조 대조의 오라클을 `package.json`
+  `files[]`(**선언**)에서 `npm pack --dry-run --json`(**실제 출하 파일셋**)으로 바꾸는 모드.
+  npm 부재·비영 종료·파싱 실패 시 **fail-closed**(rc=2 UNMEASURED, 약한 오라클로 폴백하지 않는다).
+  `prepublishOnly` 에 배선됐다.
+- **참조 추출기가 `.json` 을 못 보고 있었다** — 정규식 교대가 leftmost-first 라 `.js` 가 `.json`
+  안에서 먼저 물렸고, 모든 JSON 참조가 존재하지 않는 경로로 잘려 조용히 버려졌다. 수리 후 즉시
+  드러난 것 하나가 **소비자-대면 결함**이다: `templates/goal-quench-hook-setup.md` 가
+  `cp templates/goal-quench-settings-merged.json .claude/settings.json` 을 지시하는데 **그 JSON 이
+  패키지에 없었다.** 이제 실린다.
+- **`selfcheck.sh` 의 timeout 가드가 한 번도 설치된 적이 없었다** — `local` 이 함수 밖에 있어
+  bash 가 대입을 거부했고, 매 실행 stderr 로 자기 실패를 알렸으나 아무도 읽지 않았다. 수리.
+
 ### [1.4.96] — 2026-08-12
 
 **fix: 전수 재출하 캠페인 — 「돌았다고 보고하는데 안 도는」 계기들 · 선언이 무효였던 에이전트**

--- a/scripts/version_lockstep_check.sh
+++ b/scripts/version_lockstep_check.sh
@@ -22,7 +22,7 @@ ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 command -v python3 >/dev/null 2>&1 || { echo "LOCKSTEP: HARNESS-ERROR — python3 unavailable"; exit 2; }
 
 python3 - "$ROOT" <<'PY'
-import json, sys, glob, os
+import json, sys, glob, os, re
 root = sys.argv[1]
 pkg_path = os.path.join(root, 'package.json')
 try:
@@ -68,6 +68,39 @@ for p in targets:
         checked += 1
         if got != want:
             drift.append(f"  {rel} :: {label} = {got}  (package.json = {want})")
+
+# ── CHANGELOG is a shipped version surface too, and it was outside this check ─────────────────
+# Measured 2026-08-13, by a peer session, AFTER 1.4.97 was already published: the four JSON
+# manifests all read 1.4.97 and plugins/fh-meta/CHANGELOG.md's newest entry was still [1.4.96].
+# So the tarball a consumer downloads carries a changelog with no entry for the version they just
+# installed — six merged PRs invisible on the record surface. This check reported PASS while that
+# was true, because its target list was "manifests carrying a JSON version field" rather than
+# "surfaces that state which version this is".
+# ★ That is the half-fix propagation boundary in its purest form: the version was updated
+# everywhere the CHECK looked, which is not the same set as everywhere it MATTERS.
+# Non-blocking is deliberate and narrow: a missing entry is a documentation gap, not a broken
+# package, and turning a publish red on prose would train the override this repo has already
+# measured people reaching for. It is LOUD, it names the file, and it is impossible to miss in the
+# publish output — which is what the JSON drift arms could not have been, since those genuinely
+# break installs.
+CHANGELOGS = sorted(glob.glob(os.path.join(root, 'plugins', '*', 'CHANGELOG.md')))
+for p in CHANGELOGS:
+    rel = os.path.relpath(p, root)
+    try:
+        txt = open(p, encoding='utf-8', errors='replace').read()
+    except OSError as e:
+        print(f"LOCKSTEP: HARNESS-ERROR — cannot read {rel}: {e}")
+        sys.exit(2)
+    # The heading form this repo uses: `### [x.y.z] — DATE`. Absence of ANY such heading means the
+    # extractor stopped matching the file's real shape — report that rather than a clean run.
+    heads = re.findall(r'^#+\s*\[(\d+\.\d+\.\d+)\]', txt, re.M)
+    if not heads:
+        print(f"LOCKSTEP: HARNESS-ERROR — {rel} has no `[x.y.z]` heading; the extractor is blind, "
+              f"which is not the same as the changelog being current")
+        sys.exit(2)
+    if want not in heads:
+        print(f"LOCKSTEP: ⚠️  {rel} has no entry for {want} (newest is {heads[0]}) — the published "
+              f"tarball would carry a changelog that does not mention the version it ships")
 
 if drift:
     print(f"LOCKSTEP: DRIFT — {len(drift)} of {checked} shipped version string(s) do not match package.json")


### PR DESCRIPTION
peer 세션이 **1.4.97 출하 직후** 실측했다:
```
package.json · plugin.json ×2 · marketplace.json ×2   →  전부 1.4.97
plugins/fh-meta/CHANGELOG.md 최신 항목                →  [1.4.96]
```
즉 소비자가 받는 tarball 이 **자기 버전이 없는 CHANGELOG** 를 싣고 있고, 머지된 6건(#353·#355·#356·#357·#360·#361)이 기록면에서 통째로 빈다.

`version_lockstep_check.sh` 는 그동안 **PASS** 를 냈다. 대상 목록이 **「JSON `version` 필드를 가진 매니페스트」**였고 CHANGELOG 는 버전을 말하지만 그 형태가 아니다.

★ **버전은 검사기가 보는 곳 전부에서 갱신됐고, 그건 중요한 곳 전부와 같은 집합이 아니다.** 반쪽-픽스 전파경계의 가장 순수한 형태다.

## 둘

1. `[1.4.97]` 항목 신설.
2. 락스텝에 **CHANGELOG 렌즈** — **비차단 경고**. 문서 갭은 설치를 깨지 않고, 산문으로 publish 를 빨갛게 만들면 이 레포가 이미 여러 번 관측한 override 습관을 훈련시킨다. 대신 **파일명과 최신값을 함께** 찍는다. 추출기는 `[x.y.z]` 헤딩이 **하나도 없으면 rc=2 HARNESS-ERROR** — 「못 찾았다」와 「최신이다」는 다른 답이다.

```
known-pair
  항목 제거  → ⚠️  plugins/fh-meta/CHANGELOG.md has no entry for 1.4.97 (newest is 1.4.96)
  복원       → 경고 0건
```

## 🟥 정직한 범위

- **1.4.97 은 이미 출하됐고 그 tarball 은 못 고친다.** 이 수리는 레포를 고치는 것이고, 정정된 CHANGELOG 는 **1.4.98 에** 닿는다. 「고쳤다」로 적으면 그게 이 레포가 계속 잡아온 그 주장이다.
- **내가 못 찾았다.** publish 전에 돌린 게이트 4종(lockstep · `--vs-tarball` · public-surface · selfcheck)이 **전부 통과하는 동안** 이게 참이었다. 그 체인의 **커버리지 사실**이지 릴리스에 대한 판정은 아니다.
- 렌즈 범위는 `plugins/*/CHANGELOG.md` 뿐이다. 버전을 말하는 **다섯 번째 표면**이 또 나오면 렌즈를 늘릴 게 아니라 **「버전 표면 열거」 자체를 도출형으로** 바꿔야 한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jcEeXyVpeUp6jTwE1ZteX