### PR TITLE
docs(gate): 엔진은 이름으로만 부른다 — 번호가 두 방향으로 디코드되던 것을 닫는다

### DIFF
--- a/knowledge/shared/harness-core/ship_readiness_gate.md
+++ b/knowledge/shared/harness-core/ship_readiness_gate.md
@@ -140,6 +140,23 @@ engine was precisely that **an identity declaration is not a judgment circuit** 
 net loss; removing it recovered +0.67 on the weak tier). A one-word translation re-fuses exactly what the
 measurement separated.
 
+**Numbering rule — engines are named, never numbered.** Write `context-continuity`, not "engine ④".
+There is no canonical engine order: the table above reads *external-grounding · judgment-circuit ·
+ship-gate · context-continuity*, and the prose further down this same file reads *judgment-circuit ·
+ship-gate · context-continuity · external-grounding*. A number derived from one decodes to a different
+engine under the other — and the two candidates for "④" are **context-continuity and
+external-grounding**, which currently hold different grades, so the ambiguity is not cosmetic.
+The collision is worse than one file's internal disagreement: **the identities are numbered ①–⑤ and the
+engines are not numbered at all**, so a bare ① in any record is undecidable without its sentence. This
+file shows it — a paragraph enumerating engines sits four lines above `③⑤ are 🟢, ①②④ are 🔵 RC`,
+where those numerals mean *identities*.
+
+> **Legacy decode (do not delete — session records already use numbers).** Records written before
+> 2026-08-13 say 엔진 ①~④. They decode by the **engine table order above**:
+> ① external-grounding(물어보기) · ② judgment-circuit(영혼) · ③ ship-gate(품질게이트) ·
+> ④ context-continuity(맥락유지). That is the ordering those records were written under; it is
+> recorded here so they stay readable, **not** to make the numbering canonical. New writing uses names.
+
 **Why engines gate the advertised capabilities**: the harness's most-advertised surfaces — incubating a new
 project, orchestrating a multi-harness cluster — are simultaneously *long, autonomous, novel and shipping*.
 They therefore load all four engines at once, which is why a harness with a mature ship-gate and little


### PR DESCRIPTION
## 발단

운영자 질문 한 줄: **«엔진4는 qasp 의 엔진인가 FH 4대 엔진인가»**
**물어봤다는 것 자체가 모호성의 증거다.** 실측해보니 예상보다 나빴다.

## 실측

```
«엔진 ①~④» 번호  →  공개 정본에 0건   (컨트롤: knowledge/ 에 «엔진» 자체는 3파일 히트)
                     gitignored tracks/ 3파일에만 존재
```

그리고 **같은 파일 안에서 순서가 갈린다**:

| 위치 | 순서 | 이 순서로 센 「④」 |
|---|---|---|
| 엔진 표 | external-grounding · judgment-circuit · ship-gate · context-continuity | **context-continuity** (🔵 RC) |
| §267 산문 | judgment-circuit · ship-gate · context-continuity · external-grounding | **external-grounding** (🟡) |

**두 후보의 등급이 다르다.** 장식적 모호성이 아니라 판정이 갈리는 모호성이다.

## 더 나쁜 층 — 두 번호 체계가 한 화면에서 부딪힌다

**정체성은 ①~⑤ 로 번호가 있고, 엔진은 번호가 없다.** 그래서 어떤 기록의 bare `①` 은
문장 없이는 디코드 불가다. 이 파일이 그걸 직접 보인다 — 엔진을 나열하는 문단 **네 줄 아래**에

```
③⑤ are 🟢, **①②④ are 🔵 RC**
```

가 나오고, 그 숫자는 **정체성**이다.

## 수리

1. **명명 규칙**: 엔진은 이름으로만 부른다. `context-continuity` 라고 쓰지 "engine ④" 라고 쓰지 않는다.
2. **옛 기록 해독표**: 번호를 그냥 폐기하면 **이미 번호로 적힌 세션 기록 3파일이 해독 불가**가 된다.
   표 순서 기준으로 해독표를 남기되, **«정본화가 아님»을 같은 블록에 명시**했다.

⚠️ **두 순서를 일부러 안 맞췄다.** 맞추면 번호가 «정본처럼» 보이기 시작하고,
이 수리의 요지는 **순서를 고르는 게 아니라 번호를 안 쓰는 것**이다.

## 명시 잔여

**기계 앵커가 없다.** 「새 글에 번호를 쓰지 마라」는 산문 규칙이고 훅이 안 잡는다.
해독표가 사실상 번호를 정본화하는 것으로 읽힐 위험도 산문으로만 막았다.
둘 다 재발이 측정되면 그때 기계화 대상이지, 지금 짓는 건 증거-임계 미만이다.

## 범위

`ship_readiness_gate.md` 1파일. **#363(엔진 등급 행)과 별 PR** — 그쪽은 등급을 기록하는 job 이고
이건 명명 규칙이라 다른 job 이다(Added-Scope Gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3RiuSFiKyWsJH73qVsTsv