### PR TITLE
feat(gate): lane_runner 에 org 소유 선언 seam + 이 검사기의 첫 레인 스위트 11종

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "scripts/selfcheck.sh",
     "scripts/version_lockstep_check.sh",
     "scripts/test_selfcheck_state_lanes.sh",
+    "scripts/test_lane_runner_lanes.sh",
     "scripts/test_version_lockstep_lanes.sh",
     "scripts/package_coverage_check.sh",
     "scripts/lane_runner_check.sh",

--- a/scripts/lane_runner_check.sh
+++ b/scripts/lane_runner_check.sh
@@ -227,9 +227,16 @@ for i, ln in enumerate(txt.splitlines(), 1):
     sys.exit(0)
 ORGPY
 )
-  if printf '%s' "$_org_out" | grep -q '^ERR\t'; then
+  # `grep -q '^ERR'` — NOT `'^ERR\t'`. In a POSIX BRE, GNU grep reads `\t` as a literal `t`
+  # (so the pattern becomes `^ERRt` and matches nothing) while BSD grep on macOS takes it as a tab.
+  # Measured 2026-08-13: this exact line passed all 11 lanes locally and failed L6/L7/L8 in CI —
+  # the fail-closed arm was silently dead on Linux, which is the platform that gates merges.
+  # Same family as the `"$DDSCAN" "` anchor divergence a sibling harness measured the same day:
+  # a regex that means different things on the two greps is an instrument, and an instrument that
+  # answers differently per platform has not measured anything.
+  if printf '%s' "$_org_out" | grep -q '^ERR'; then
     echo "FAIL  lane-runner: $ORG_DECL exists but could not be read as declarations —"
-    printf '%s' "$_org_out" | sed 's/^ERR\t/        /'
+    printf '%s' "$_org_out" | sed 's/^ERR[[:space:]]*/        /'
     echo "      An unreadable declaration file is UNMEASURED, not empty. Fix the file or delete it."
     exit 2
   fi

--- a/scripts/lane_runner_check.sh
+++ b/scripts/lane_runner_check.sh
@@ -169,6 +169,89 @@ if [ -f scripts/selfcheck.sh ] && ! grep -qE '^[[:space:]]*(if !? ?)?bash script
   exit 1
 fi
 
+# ── ORG SEAM — a downstream org declares ITS OWN suites in ITS OWN file ───────────────────────
+# Why this exists (requested 2026-08-13 by a downstream org fork of this harness, with evidence):
+# EXEMPT and DEBT above are hardcoded arrays in a SHARED-LAYER file. A downstream fork carries
+# suites this repo has never heard of (`test_rest_push_lanes.sh`, `test_company_delta_lanes.sh` …),
+# and all three remedies this check offers land in files that fork does not own:
+#     wire into selfcheck.sh   → shared layer   · EXEMPT array → this file, shared layer
+#     DEBT array               → this file, shared layer
+# So the fork's only choices were "violate the sync boundary" or "live at rc=1 forever". Measured:
+# 5 such suites on their first run of this check. That is not a preference — a permanently red
+# check stops being read, and one of those five suites had just caught a real regression when it
+# was run by hand.
+#
+# Shape: OPTIONAL file, absent by default. This repo ships none, so the no-op arm is the arm that
+# runs here — verified by the known-pair in scripts/test_lane_runner_lanes.sh.
+#
+# 🟥 A MALFORMED FILE IS FAIL-CLOSED, a stale entry is advisory. Those are different failures:
+#   · cannot parse   → the instrument did not look. Reporting "no declarations" would render
+#                      UNMEASURED as ZERO, which is the exact family this repo keeps closing.
+#   · names a suite that no longer exists → hygiene, same as a stale DEBT entry above, so it warns
+#                      with the same voice. Making the downstream rule STRICTER than the upstream
+#                      one it mirrors would just train people to delete the file.
+ORG_DECL="company/lane_declarations.yaml"
+ORG_EXEMPT=(); ORG_DEBT=()
+if [ -f "$ORG_DECL" ]; then
+  _org_out=$(python3 - "$ORG_DECL" <<'ORGPY'
+import re, sys
+path = sys.argv[1]
+try:
+    txt = open(path, encoding='utf-8').read()
+except OSError as e:
+    print(f"ERR\tcannot read {path}: {e}"); sys.exit(0)
+sect = None; seen = {}
+for i, ln in enumerate(txt.splitlines(), 1):
+    s = ln.split('#', 1)[0].rstrip()
+    if not s.strip():
+        continue
+    m = re.match(r'^([A-Za-z_]+):\s*$', s)
+    if m:
+        sect = m.group(1)
+        if sect not in ('exempt', 'debt'):
+            print(f"ERR\t{path}:{i}: unknown section '{sect}' (expected 'exempt' or 'debt')")
+            sys.exit(0)
+        continue
+    m = re.match(r'^\s+-\s+(\S+)\s*$', s)
+    if m:
+        if sect is None:
+            print(f"ERR\t{path}:{i}: entry before any section header"); sys.exit(0)
+        name = m.group(1)
+        if name in seen and seen[name] != sect:
+            print(f"ERR\t{path}:{i}: '{name}' declared both exempt and debt — ambiguous")
+            sys.exit(0)
+        seen[name] = sect
+        print(f"{sect}\t{name}")
+        continue
+    print(f"ERR\t{path}:{i}: unparseable line: {s.strip()[:60]}")
+    sys.exit(0)
+ORGPY
+)
+  if printf '%s' "$_org_out" | grep -q '^ERR\t'; then
+    echo "FAIL  lane-runner: $ORG_DECL exists but could not be read as declarations —"
+    printf '%s' "$_org_out" | sed 's/^ERR\t/        /'
+    echo "      An unreadable declaration file is UNMEASURED, not empty. Fix the file or delete it."
+    exit 2
+  fi
+  while IFS=$'\t' read -r _k _v; do
+    [ -z "${_v:-}" ] && continue
+    case "$_k" in
+      exempt) ORG_EXEMPT+=("$_v") ;;
+      debt)   ORG_DEBT+=("$_v") ;;
+    esac
+  done <<< "$_org_out"
+  # Stale-entry warning, same voice as the DEBT hygiene warnings below.
+  for _n in "${ORG_EXEMPT[@]+"${ORG_EXEMPT[@]}"}" "${ORG_DEBT[@]+"${ORG_DEBT[@]}"}"; do
+    [ -f "scripts/$_n" ] || echo "⚠️  lane-runner: $ORG_DECL declares '$_n' but scripts/$_n does not exist (renamed/deleted?)"
+  done
+  # Visibility: an org-declared suite must never be indistinguishable from an upstream one. A
+  # reader who sees "0 debt" has to be able to tell whether that is this repo's zero or a fork's
+  # declaration absorbing its own list.
+  echo "      lane-runner: $ORG_DECL — ${#ORG_EXEMPT[@]} exempt · ${#ORG_DEBT[@]} debt (org-declared)"
+  EXEMPT+=("${ORG_EXEMPT[@]+"${ORG_EXEMPT[@]}"}")
+  DEBT+=("${ORG_DEBT[@]+"${ORG_DEBT[@]}"}")
+fi
+
 # `"${ARR[@]+"${ARR[@]}"}"` and not the plain `"${ARR[@]}"`: on bash 3.2 (stock macOS) `set -u`
 # treats an EMPTY array's expansion as an unbound variable and aborts. DEBT is now empty by design,
 # which is exactly the state the plain form cannot survive — measured here 2026-08-13, and it

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -1001,6 +1001,23 @@ if [ -f scripts/test_selfcheck_state_lanes.sh ]; then
   fi
 fi
 
+# test_lane_runner_lanes.sh — the checker that finds unrun suites had no suite of its own until
+# 2026-08-13. It guarded its own WIRING (it fails when selfcheck stops calling it) and nothing
+# measured its BEHAVIOUR — the shape it exists to catch, one level up. Wired in the same change
+# that ships it, for the reason the block above states: a suite landed unwired is the defect.
+if [ -f scripts/test_lane_runner_lanes.sh ]; then
+  if _out=$(bash scripts/test_lane_runner_lanes.sh 2>&1); then
+    echo "PASS  test_lane_runner_lanes.sh (org seam: no-op · suppression · fail-closed · controls)"
+  else
+    echo "FAIL  test_lane_runner_lanes.sh: the unrun-suite detector's own verdicts have drifted"
+    _show_failure "$_out"
+    fail=1
+  fi
+elif _ships_per_files "scripts/test_lane_runner_lanes.sh"; then
+  echo "FAIL  test_lane_runner_lanes.sh is DECLARED SHIPPED but absent — deletion or broken install"
+  fail=1
+fi
+
 # sync_from_be_lanes.sh — the RETURN path's anchor. Wired in the same change that ships it: the
 # script had an operator-side caller (a SessionStart hook outside this repo) while its 70 lanes had
 # NO caller anywhere, which is the shape this repo keeps re-finding — a transport that writes into

--- a/scripts/test_lane_runner_lanes.sh
+++ b/scripts/test_lane_runner_lanes.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# test_lane_runner_lanes.sh — behavioural lanes for scripts/lane_runner_check.sh
+#
+# Why this file exists at all: until 2026-08-13 the checker that detects unrun lane suites had
+# **no lane suite of its own**. It guarded its own WIRING (it fails if selfcheck.sh stops calling
+# it) but nothing measured its BEHAVIOUR. That is the same shape it exists to catch, one level up —
+# a check whose verdicts nobody exercises is prose with an exit code.
+#
+# The lanes below drive it against SYNTHETIC fixture trees, not against this repo. Driving it
+# against the live tree would make every lane depend on today's suite list, so a lane would go red
+# for reasons that have nothing to do with the predicate under test.
+#
+# Script-relative, NOT `git rev-parse --show-toplevel`: in a vendored tree rev-parse returns the
+# OUTER repo and this suite would then test someone else's checkout.
+set -uo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK="$REPO_ROOT/scripts/lane_runner_check.sh"
+T=$(mktemp -d); trap 'rm -rf "$T"' EXIT
+pass=0; fail=0
+ok()  { printf '  ✅ %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  ❌ %s\n' "$1"; fail=$((fail+1)); }
+
+# ── fixture: a tree with ONE unwired suite and a selfcheck.sh that calls the checker ──────────
+# The `bash scripts/lane_runner_check.sh` line is load-bearing: the checker refuses to run in a
+# tree whose selfcheck.sh does not invoke it (its self-reference guard).
+mkfixture() { # $1 = dir
+  local d="$1"
+  mkdir -p "$d/scripts"
+  cp "$CHECK" "$d/scripts/lane_runner_check.sh"
+  printf '#!/usr/bin/env bash\nbash scripts/lane_runner_check.sh\n' > "$d/scripts/selfcheck.sh"
+  printf '#!/usr/bin/env bash\n: orphan lane suite\n'  > "$d/scripts/test_orphan_lanes.sh"
+}
+run() { ( cd "$1" && bash scripts/lane_runner_check.sh 2>&1 ); }
+rcof() { ( cd "$1" && bash scripts/lane_runner_check.sh >/dev/null 2>&1; echo $? ); }
+
+# ── L1 known-POSITIVE: an undeclared orphan suite must FAIL ───────────────────────────────────
+# Without this arm every lane below proves nothing: a checker that passed unconditionally would
+# satisfy all the "declaration suppresses it" lanes.
+D="$T/l1"; mkfixture "$D"
+out=$(run "$D"); rc=$(rcof "$D")
+if [ "$rc" = "1" ] && printf '%s' "$out" | grep -q 'test_orphan_lanes.sh'; then
+  ok "L1 known-positive: undeclared orphan suite → rc=1 and it is named"
+else
+  bad "L1 known-positive did not fire (rc=$rc) — every lane below is meaningless without it"
+fi
+
+# ── L2 NO-OP: no declaration file → behaviour is exactly the L1 behaviour ─────────────────────
+# This is the arm that protects THIS repo, which ships no company/ directory.
+D="$T/l2"; mkfixture "$D"
+out=$(run "$D")
+if ! printf '%s' "$out" | grep -q 'lane_declarations'; then
+  ok "L2 no-op: absent declaration file is silent (no mention in output)"
+else
+  bad "L2 no-op: output mentions the declaration file when none exists"
+fi
+
+# ── L3 org EXEMPT suppresses the orphan ───────────────────────────────────────────────────────
+D="$T/l3"; mkfixture "$D"; mkdir -p "$D/company"
+printf 'exempt:\n  - test_orphan_lanes.sh   # org-owned, runs in the org CI only\n' > "$D/company/lane_declarations.yaml"
+out=$(run "$D"); rc=$(rcof "$D")
+if [ "$rc" = "0" ] && printf '%s' "$out" | grep -q '1 exempt'; then
+  ok "L3 org exempt: declared suite no longer fails the check (rc=0, counted exempt)"
+else
+  bad "L3 org exempt did not suppress (rc=$rc) — out: $(printf '%s' "$out" | tail -1)"
+fi
+
+# ── L4 org DEBT suppresses AND is counted as debt ─────────────────────────────────────────────
+D="$T/l4"; mkfixture "$D"; mkdir -p "$D/company"
+printf 'debt:\n  - test_orphan_lanes.sh\n' > "$D/company/lane_declarations.yaml"
+out=$(run "$D"); rc=$(rcof "$D")
+if [ "$rc" = "0" ] && printf '%s' "$out" | grep -q 'declared debt'; then
+  ok "L4 org debt: declared suite suppressed and reported as debt"
+else
+  bad "L4 org debt did not land (rc=$rc)"
+fi
+
+# ── L5 VISIBILITY: an org-declared list must never look like this repo's own zero ─────────────
+D="$T/l5"; mkfixture "$D"; mkdir -p "$D/company"
+printf 'debt:\n  - test_orphan_lanes.sh\n' > "$D/company/lane_declarations.yaml"
+out=$(run "$D")
+if printf '%s' "$out" | grep -q 'org-declared'; then
+  ok "L5 visibility: output names the org file and its counts"
+else
+  bad "L5 visibility: org declarations are invisible in the output"
+fi
+
+# ── L6 FAIL-CLOSED on an unparseable file ─────────────────────────────────────────────────────
+# The load-bearing distinction. A malformed file must NOT read as "nothing declared" — that would
+# render UNMEASURED as ZERO, and it would do so on the arm where a fork is relying on the file.
+D="$T/l6"; mkfixture "$D"; mkdir -p "$D/company"
+printf 'exempt:\n  this line is not an entry\n' > "$D/company/lane_declarations.yaml"
+out=$(run "$D"); rc=$(rcof "$D")
+if [ "$rc" = "2" ] && printf '%s' "$out" | grep -q 'UNMEASURED'; then
+  ok "L6 fail-closed: unparseable declaration file → rc=2 and says UNMEASURED"
+else
+  bad "L6 fail-closed FAILED (rc=$rc) — a malformed file was read as 'no declarations'"
+fi
+
+# ── L6b control for L6: the SAME orphan tree with a WELL-FORMED file must not exit 2 ──────────
+# Without this, L6 would also pass on a checker that exits 2 for any declaration file at all.
+D="$T/l6b"; mkfixture "$D"; mkdir -p "$D/company"
+printf 'exempt:\n  - test_orphan_lanes.sh\n' > "$D/company/lane_declarations.yaml"
+if [ "$(rcof "$D")" != "2" ]; then
+  ok "L6b control: a well-formed file does NOT trip the fail-closed arm"
+else
+  bad "L6b control: every declaration file exits 2 — L6 proved nothing"
+fi
+
+# ── L7 unknown section is a parse failure, not a silent skip ──────────────────────────────────
+D="$T/l7"; mkfixture "$D"; mkdir -p "$D/company"
+printf 'allowed:\n  - test_orphan_lanes.sh\n' > "$D/company/lane_declarations.yaml"
+out=$(run "$D")
+if [ "$(rcof "$D")" = "2" ] && printf '%s' "$out" | grep -q "unknown section"; then
+  ok "L7 unknown section → rc=2 and names the section"
+else
+  bad "L7 unknown section was tolerated — a typo'd header would silently declare nothing"
+fi
+
+# ── L8 the same name in both sections is ambiguous, not last-wins ─────────────────────────────
+D="$T/l8"; mkfixture "$D"; mkdir -p "$D/company"
+printf 'exempt:\n  - test_orphan_lanes.sh\ndebt:\n  - test_orphan_lanes.sh\n' > "$D/company/lane_declarations.yaml"
+out=$(run "$D")
+if [ "$(rcof "$D")" = "2" ] && printf '%s' "$out" | grep -q "both exempt and debt"; then
+  ok "L8 same suite in both sections → rc=2 (ambiguous, not silently resolved)"
+else
+  bad "L8 double declaration was silently resolved"
+fi
+
+# ── L9 a stale entry WARNS but does not block (same voice as upstream DEBT hygiene) ───────────
+# Deliberately advisory: making the downstream mirror stricter than the upstream rule it mirrors
+# would train forks to delete the file, which costs more than a stale line.
+D="$T/l9"; mkfixture "$D"; mkdir -p "$D/company"
+printf 'exempt:\n  - test_orphan_lanes.sh\n  - test_deleted_lanes.sh\n' > "$D/company/lane_declarations.yaml"
+out=$(run "$D"); rc=$(rcof "$D")
+if [ "$rc" = "0" ] && printf '%s' "$out" | grep -q 'test_deleted_lanes.sh'; then
+  ok "L9 stale entry: warns and names it, does not block (rc=0)"
+else
+  bad "L9 stale entry handling wrong (rc=$rc)"
+fi
+
+# ── L10 comments and blank lines are not entries ──────────────────────────────────────────────
+D="$T/l10"; mkfixture "$D"; mkdir -p "$D/company"
+printf '# org lane declarations\n\nexempt:\n\n  - test_orphan_lanes.sh   # reason lives here\n' > "$D/company/lane_declarations.yaml"
+if [ "$(rcof "$D")" = "0" ]; then
+  ok "L10 comments/blank lines tolerated (a file people can annotate)"
+else
+  bad "L10 a commented, spaced file failed to parse"
+fi
+
+echo "----"
+echo "lane-runner lanes: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
## 무엇

`lane_runner_check.sh` 에 **하류 org 소유 선언 seam** 을 뚫는다. 다운스트림 fork 요청이고, 근거가 실측으로 왔다.

## 왜 — 세 remedy 가 전부 공유층이었다

이 검사기는 미배선 스위트를 만나면 셋 중 하나를 하라고 한다. fork 입장에서 **셋 다 막힌다**:

| 제시된 remedy | 실물 |
|---|---|
| `selfcheck.sh` 에 배선 | 공유층 — fork 가 편집하면 sync 경계 위반 |
| `EXEMPT` 배열 등재 | **이 파일 안 하드코딩 배열**(`:72`) — 같은 문제 |
| `DEBT` 배열 등재 | **이 파일 안 하드코딩 배열**(`:129`) — 같은 문제 |

즉 fork 는 «상류에 없는 자기 스위트»를 선언할 **합법적 자리가 없어서**, 경계를 어기거나 **상시 `rc=1` 로 사는 것** 둘 중 하나였다. 실측 5건(전부 그 fork 고유 스위트).

★ 편의 요청이 아니라는 증거도 같이 왔다 — 그 5건 중 하나를 **손으로 돌려서 실제 회귀 1건을 잡았다**(부재를 0 으로 접는 카운트 가드). 상시 빨간 검사는 읽히지 않게 되고, 그러면 그런 적발이 사라진다.

## 설계 — 두 결정이 대칭이 아니다

```
company/lane_declarations.yaml    옵셔널. 부재 = 완전 no-op
파싱 실패                          🟥 rc=2 fail-closed
stale 선언(파일 없음)              ⚠️ advisory, 비차단
```

- **파싱 실패를 fail-closed 로 둔 이유**: 「못 읽음」을 「선언 없음」으로 렌더하면 **UNMEASURED 를 ZERO 로 렌더**하는 것이고, 하필 fork 가 그 파일에 의존하는 팔에서 그렇게 된다.
- **stale 을 advisory 로 둔 이유**: 상류 DEBT 위생 경고와 **같은 수위로 맞췄다.** 하류 규칙을 상류보다 엄격하게 만들면 파일을 지우게 훈련시킨다.
- **환경변수 오버라이드를 일부러 안 넣었다** — 선언 파일은 원리적으로 남용 경로이고, 유일한 방어가 「레포 안에 있어 리뷰된다」다. 레포 밖을 가리킬 수 있으면 그 방어마저 사라진다.
- **출력이 org 선언분을 따로 표기** — 상류의 `0 debt` 와 하류의 흡수가 구분되어야 한다.

## 🟥 같이 발견된 것 — 이 검사기엔 레인 스위트가 없었다

안 도는 스위트를 잡는 검사기가 **자기 행동은 무검증**이었다. 자기 **배선**만 지키고 있었다(자기 참조 가드 `:161`). 그래서 seam 과 같은 커밋에 **첫 스위트 11종**을 신설하고 배선했다.

```
11 passed / 0 failed
L1  known-positive   미선언 orphan → rc=1        ← 이게 없으면 이하 전부 무의미
L6b 컨트롤            정상 파일은 fail-closed 팔을 안 건드림
되돌림 실측           ORG_DECL 경로 주입 → 8 레인 적색 → 복원 11/11
                     (L1·L2·L6b 3개는 seam 경로 밖이라 주입에도 초록 = 구조 확인)
no-op 실측            삽입 전후 43 suites / 41 wired / 1 exempt / 2 debt **불변**
                     배선 후 44/42 로 새 스위트만 증가
```

## 잔여 (숨기지 않고 적는다)

- **파일명·위치는 내가 정했다.** 소비자 선호를 아직 못 받았다 — 바꾸려면 상수 한 줄이다.
- **억제 팔의 첫 실사용은 상류에서 안 일어난다.** 여기엔 소비자가 없어 no-op 팔만 실행된다. 진짜 첫 사용은 하류 쪽이고 아직이다.
- **남용 방어가 기계적이지 않다** — 「레포 안이라 리뷰된다」 하나뿐이다.

## 부수 — 이 PR 작성 중 게이트가 나를 잡았다

confidentiality 스캔이 내 주석에서 **사내 자산 실명 1건**을 잡았다(공개 레포에 들어갈 뻔했다). 중립 표현으로 교체. 자력 적발 0.
