### PR TITLE
fix(lanes): DEBT 2 → 0 — re-wire test_field_canon + test_stale_clone_guard

### DIFF
--- a/scripts/lane_runner_check.sh
+++ b/scripts/lane_runner_check.sh
@@ -121,30 +121,37 @@ EXEMPT=(
 # 11 not 12), and test_marker_floor_lanes.sh calibrates pre-commit's live validate_marker_floor().
 # Both are wired now.
 #
-# 🟥 THE TWO BELOW WERE WIRED, MEASURED RED IN CI, AND DELIBERATELY MOVED BACK. Making them green
-# was available and is the wrong move: their failures are TRUE — the suites really do depend on
-# things a CI runner does not have — so forcing a pass would be routing a real failure to green in
-# the same delta that spent nine repairs closing exactly that. A suite whose preconditions are
-# undeclared belongs in the todo list, not in the mandatory path.
-DEBT=(
-  # PASS 19 · FAIL 0 locally; PASS 12 · FAIL 7 in CI. Reproduced locally by pointing HOME at an
-  # empty directory — 12/7, the same split — so the dependency is exact and not a guess:
-  # field_canon_preload.sh resolves `${HOME}/projects` and seven lanes assume the operator's
-  # mapped-project layout is there. Nothing in the suite declares that precondition, so on a
-  # machine without it the suite reports a REGRESSION rather than "not exercised here".
-  # Fix before re-wiring: the suite must detect the missing layout and exit NOT-EXERCISED (the
-  # shape test_sessionstart_multihook_lanes.sh already uses for its CLI dependency), or build its
-  # own fixture HOME for those seven the way it already does for the no-HOME lane.
-  "test_field_canon_lanes.sh"
-  # 17/17 locally; 2/17 in CI. And this one was PREDICTED: the adversarial review of this very
-  # delta flagged `elapsed < 10` as a wall-clock assertion that would go falsely red on a loaded CI
-  # runner, naming this file and that line. It was filed as a low-severity residual and not acted
-  # on; CI then produced exactly it. ★ The finding named a MECHANISM (a wall-clock assertion is now
-  # on a mandatory path), and a mechanism does not become less true for being labelled R.
-  # Fix before re-wiring: give the timing assertions headroom or gate them behind an explicit
-  # opt-in, so the default run measures logic and not the runner's load.
-  "test_stale_clone_guard_lanes.sh"
-)
+# 🟢 THE TWO THAT WERE HERE ARE RE-WIRED (2026-08-14) — DEBT 2 → 0. Both entries below are
+# HISTORICAL: they record why the suites were pulled out and what the fix had to be, kept because
+# the reasoning (and the exact CI-reproduction numbers) are load-bearing evidence for the next
+# person who touches either suite, not because either is still debt.
+#
+# test_field_canon_lanes.sh — was: PASS 19 · FAIL 0 locally; PASS 12 · FAIL 7 in CI. Reproduced
+# locally by pointing HOME at an empty directory — 12/7, the same split — so the dependency was
+# exact and not a guess: field_canon_preload.sh resolves `${HOME}/projects` and seven lanes assumed
+# the operator's mapped-project layout was there. Nothing in the suite declared that precondition,
+# so on a machine without it the suite reported a REGRESSION rather than "not exercised here". Fix
+# (built the second option this entry named, not the first): the suite now carries its own fixture
+# hub+project-root (mirroring the shape lane ⑭ already used) instead of depending on the operator's
+# real filesystem — `run()`/`runD()` inject `CLAUDE_PROJECT_DIR`/`FIELD_CANON_PROJECT_ROOT` at a
+# fixed fixture path. Verified both directions: PASS 19/19 under an empty HOME (the exact CI
+# reproduction) AND a known-negative check — breaking the `-dev`-suffix repo-resolution fallback in
+# field_canon_preload.sh reproduces the identical PASS 12 / FAIL 7 split, so the fixture measures
+# real behavior, not a vacuously-green rewrite.
+#
+# test_stale_clone_guard_lanes.sh — was: 17/17 locally; 2/17 in CI. Predicted by an adversarial
+# review of the delta that introduced `elapsed < 10` as a wall-clock assertion on a mandatory path;
+# CI then produced exactly it. Fix (the first option this entry named): the wedge sleep widened
+# 30s→60s and the assertion changed from a fixed `elapsed < 10` to a relative `elapsed <
+# (wedge/2)=30s` — proving the guard's internal 0.5s budget bounded it (60x headroom) rather than an
+# absolute constant tuned to one machine's speed. Known-negative check: neutering the budget's kill
+# condition in stale_clone_guard.sh (so it waits out the full wedge instead of self-bounding)
+# correctly fails exactly this one lane, confirming the widened threshold still discriminates.
+#
+# Re-wired into scripts/selfcheck.sh's pair-loop alongside the other ten (found→extend, same shape:
+# "scripts/field_canon_preload.sh|scripts/test_field_canon_lanes.sh" and
+# "scripts/stale_clone_guard.sh|scripts/test_stale_clone_guard_lanes.sh").
+DEBT=()
 
 if [ "${1:-}" = "--list-debt" ]; then
   # Same bash-3.2 empty-array guard as the scan call below. This site was MISSED when that one was

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -413,7 +413,9 @@ for _pair in \
   "templates/.git-hooks/pre-commit|scripts/test_marker_crossfamily_lanes.sh" \
   "templates/.git-hooks/pre-commit|scripts/test_marker_floor_lanes.sh" \
   "scripts/residency_closure_scan.py|scripts/test_residency_closure_lanes.sh" \
-  "scripts/reviewer_capability_corpus.tsv|scripts/test_reviewer_capability_conformance.sh"
+  "scripts/reviewer_capability_corpus.tsv|scripts/test_reviewer_capability_conformance.sh" \
+  "scripts/field_canon_preload.sh|scripts/test_field_canon_lanes.sh" \
+  "scripts/stale_clone_guard.sh|scripts/test_stale_clone_guard_lanes.sh"
 do
   _subj="${_pair%%|*}"; _anc="${_pair##*|}"; _lbl="${_anc##*/}"
   if [ ! -f "$_subj" ]; then

--- a/scripts/test_field_canon_lanes.sh
+++ b/scripts/test_field_canon_lanes.sh
@@ -12,10 +12,32 @@ trap 'rm -rf "$TMP"' EXIT
 PASS=0; FAIL=0
 ok(){ PASS=$((PASS+1)); printf '  ✅ %s\n' "$1"; }
 no(){ FAIL=$((FAIL+1)); printf '  ❌ %s — %s\n' "$1" "$2"; }
+
+# ── DEBT fix (2026-08-14) — several lanes below depended on the OPERATOR'S REAL
+# `${HOME}/projects/qasp-dev` mapping to resolve a repo and emit anything at all. On a
+# machine/CI runner without that exact local layout, `repo` resolution in field_canon_preload.sh
+# silently fails (`continue`), `emitted` stays 0, and EVERY assertion that checks "is output
+# non-empty" trivially reads as the WRONG kind of empty — reproduced locally: PASS 12 / FAIL 7 with
+# HOME pointed at an empty dir, exactly the CI split. The fix reuses the fixture shape lane ⑭
+# already demonstrates below (a throwaway hub + a throwaway project root with a real `.git` and
+# README.md) instead of depending on the operator's real filesystem — `found→extend`, not a new
+# mechanism. This also turns ⑧'s prior "PASS" honest: before this fix it passed because repo
+# resolution ALWAYS failed (output always empty regardless of dedup), not because dedup worked
+# ([[feedback_anchor_can_be_decorative]]) — with a real resolvable repo, ⑧ now exercises the actual
+# same-session dedup path.
+FHUB="$TMP/fhub"; mkdir -p "$FHUB/tracks/qasp"
+FPROJ="$TMP/fproj"; mkdir -p "$FPROJ/qasp-dev/.git" "$FPROJ/qasp-dev/docs/governance"
+printf '# qasp fixture\n' > "$FPROJ/qasp-dev/README.md"
+printf 'x\n' > "$FPROJ/qasp-dev/docs/governance/g1.md"
+
 # ★`${3:+VAR=v}` 는 파라미터 확장이라 bash 가 **환경 할당으로 안 읽는다** — env 로 넘긴다.
 #   (이 파일 초판이 그렇게 써서 「레포 부재」 레인이 거짓 적색을 냈다. 계기 결함이었다.)
-run(){ local extra=""; [ -n "${3:-}" ] && extra="FIELD_CANON_PROJECT_ROOT=$3"
-  printf '%s' "$1" | env FIELD_CANON_SENTINEL_DIR="$2" $extra bash "$H" 2>&1; }
+# $3, when given, overrides FIELD_CANON_PROJECT_ROOT (the "레포 부재" control at line ~35 uses this
+# to deliberately point at /nonexistent — CLAUDE_PROJECT_DIR still resolves via the fixture so that
+# control lane is testing "repo absent", not accidentally "mapped name absent" too).
+run(){ local root="$FPROJ"; [ -n "${3:-}" ] && root="$3"
+  printf '%s' "$1" | env CLAUDE_PROJECT_DIR="$FHUB" FIELD_CANON_PROJECT_ROOT="$root" \
+    FIELD_CANON_SENTINEL_DIR="$2" bash "$H" 2>&1; }
 
 echo "== field-canon preload 레인 =="
 
@@ -47,12 +69,14 @@ printf '' | FIELD_CANON_SENTINEL_DIR="$TMP/6" bash "$H" >/dev/null 2>&1
 #    (`[[feedback_anchor_can_be_decorative]]` — 레인이 결함 지점을 비켜 가면 초록은 정보가 아니다.)
 # ⚠️ macOS 는 bash **3.2** 다. `set -u` 아래서 빈 배열 `"${a[@]}"` 는 unbound variable 로 죽는다
 #    — 초판 레인이 정확히 그렇게 죽어 ⑦⑨⑩ 이 **거짓 적색**을 냈다(대상이 아니라 계기의 사망).
-#    배열 없이 분기한다.
+#    배열 없이 분기한다. (FHUB/FPROJ fixture — see the DEBT-fix comment near the top of this file.)
 runD(){ # $1=payload  $2=TMPDIR  [$3=CLAUDE_SESSION_ID 를 환경에 심을지]
   if [ -n "${3:-}" ]; then
-    printf '%s' "$1" | env TMPDIR="$2" CLAUDE_SESSION_ID="$3" bash "$H" 2>&1
+    printf '%s' "$1" | env TMPDIR="$2" CLAUDE_PROJECT_DIR="$FHUB" FIELD_CANON_PROJECT_ROOT="$FPROJ" \
+      CLAUDE_SESSION_ID="$3" bash "$H" 2>&1
   else
-    printf '%s' "$1" | env TMPDIR="$2" bash "$H" 2>&1
+    printf '%s' "$1" | env TMPDIR="$2" CLAUDE_PROJECT_DIR="$FHUB" FIELD_CANON_PROJECT_ROOT="$FPROJ" \
+      bash "$H" 2>&1
   fi; }
 T7="$TMP/def"; mkdir -p "$T7"
 

--- a/scripts/test_stale_clone_guard_lanes.sh
+++ b/scripts/test_stale_clone_guard_lanes.sh
@@ -58,7 +58,7 @@ git clone -q "$WORK/origin.git" "$WORK/C" 2>/dev/null
 run "non-origin remote name still fires"  HIT   "$WORK/C/newfile.py"
 
 # Throttle: SAME marker dir, two calls — second must be silent.
-mdir=$(mktemp -d "$WORK/marker.throttle")
+mdir=$(mktemp -d "$WORK/marker.throttle.XXXXXX")
 o1=$(payload "$WORK/B/x.py" | FH_STALE_CLONE_NO_FETCH=1 FH_STALE_CLONE_MARKER_DIR="$mdir" bash "$G" 2>&1)
 o2=$(payload "$WORK/B/y.py" | FH_STALE_CLONE_NO_FETCH=1 FH_STALE_CLONE_MARKER_DIR="$mdir" bash "$G" 2>&1)
 if printf '%s' "$o1" | grep -q STALE-CLONE && [ -z "$o2" ]; then
@@ -68,7 +68,7 @@ else
 fi
 
 # Contract: HIT emits one JSON object with both channels and no permissionDecision.
-mdir=$(mktemp -d "$WORK/marker.json")
+mdir=$(mktemp -d "$WORK/marker.json.XXXXXX")
 jo=$(payload "$WORK/B/z.py" | FH_STALE_CLONE_NO_FETCH=1 FH_STALE_CLONE_MARKER_DIR="$mdir" bash "$G" 2>/dev/null)
 if printf '%s' "$jo" | python3 -c '
 import json,sys
@@ -135,7 +135,7 @@ for a in "\$@"; do [ "\$a" = "fetch" ] && sleep $WEDGE_SLEEP; done
 exec "$REALGIT" "\$@"
 EOF
 chmod +x "$SHIM/git"
-mdir=$(mktemp -d "$WORK/marker.wedge")
+mdir=$(mktemp -d "$WORK/marker.wedge.XXXXXX")
 t0=$(date +%s)
 w_out=$(payload "$WORK/B/wedge.py" | PATH="$SHIM:$PATH" FH_STALE_CLONE_FETCH_BUDGET_TENTHS=5 \
         FH_STALE_CLONE_MARKER_DIR="$mdir" bash "$G" 2>&1); w_rc=$?

--- a/scripts/test_stale_clone_guard_lanes.sh
+++ b/scripts/test_stale_clone_guard_lanes.sh
@@ -114,11 +114,24 @@ run "slashed remote name still fires"     HIT   "$WORK/D/newfile.py"
 # budget, exit 0, arm the day-throttle — instead of letting the RUNNER's 20s timeout kill it
 # (which skipped the marker write and re-stalled every Write of the day). PATH shim makes `git
 # fetch` hang; budget is set to 0.5s; the real git serves every other subcommand.
+#
+# DEBT fix (2026-08-14): `elapsed -lt 10` was a bare wall-clock assertion on a mandatory path — a
+# loaded CI runner's fork/exec + scheduling overhead can push actual elapsed time past a fixed
+# small constant even when the guard's OWN 0.5s internal budget fired correctly (named and
+# predicted by an adversarial review of the original delta; CI then reproduced it, 2/17 lanes red
+# where local was 17/17). What this lane actually needs to prove is RELATIVE, not absolute: the
+# guard returned because its budget bounded it, not because the wedge itself woke up (30s) or an
+# external timeout killed the process. So: widen the wedge to 60s (cheap — the guard should never
+# come close to waiting it out) and assert elapsed is well under HALF of that, not a small fixed
+# number. This keeps strong discriminating power (a guard that stopped bounding itself would still
+# blow well past 30s) while absorbing CI-runner overhead that has nothing to do with the guard's
+# own logic.
+WEDGE_SLEEP=60
 SHIM="$WORK/shim"; mkdir -p "$SHIM"
 REALGIT=$(command -v git)
 cat > "$SHIM/git" <<EOF
 #!/bin/bash
-for a in "\$@"; do [ "\$a" = "fetch" ] && sleep 30; done
+for a in "\$@"; do [ "\$a" = "fetch" ] && sleep $WEDGE_SLEEP; done
 exec "$REALGIT" "\$@"
 EOF
 chmod +x "$SHIM/git"
@@ -128,11 +141,12 @@ w_out=$(payload "$WORK/B/wedge.py" | PATH="$SHIM:$PATH" FH_STALE_CLONE_FETCH_BUD
         FH_STALE_CLONE_MARKER_DIR="$mdir" bash "$G" 2>&1); w_rc=$?
 t1=$(date +%s)
 elapsed=$((t1 - t0))
+elapsed_cap=$((WEDGE_SLEEP / 2))
 marker_count=$(ls "$mdir" 2>/dev/null | wc -l | tr -d ' ')
-if [ "$w_rc" -eq 0 ] && [ -z "$w_out" ] && [ "$elapsed" -lt 10 ] && [ "$marker_count" -ge 1 ]; then
-  printf '  ✅ %-52s OK (%ss)\n' "wedged fetch: bounded, silent, throttle armed" "$elapsed"; pass=$((pass+1))
+if [ "$w_rc" -eq 0 ] && [ -z "$w_out" ] && [ "$elapsed" -lt "$elapsed_cap" ] && [ "$marker_count" -ge 1 ]; then
+  printf '  ✅ %-52s OK (%ss < %ss)\n' "wedged fetch: bounded, silent, throttle armed" "$elapsed" "$elapsed_cap"; pass=$((pass+1))
 else
-  printf '  ❌ %-52s rc=%s elapsed=%ss markers=%s out=%s\n' "wedged fetch: bounded, silent, throttle armed" "$w_rc" "$elapsed" "$marker_count" "$w_out"; fail=$((fail+1))
+  printf '  ❌ %-52s rc=%s elapsed=%ss(cap %ss) markers=%s out=%s\n' "wedged fetch: bounded, silent, throttle armed" "$w_rc" "$elapsed" "$elapsed_cap" "$marker_count" "$w_out"; fail=$((fail+1))
 fi
 
 # Budget cap (terra round 2): an all-digit literal wider than the shell's integer width made the


### PR DESCRIPTION
## Summary

Both DEBT entries in `lane_runner_check.sh` (measured 2026-08-13) had already named their own fix. This branch implements them, closing DEBT 2 → 0.

- **`test_field_canon_lanes.sh`** — 7/19 lanes depended on the operator's real `${HOME}/projects/qasp-dev` mapping (PASS 19 locally, PASS 12/FAIL 7 in CI). Fixed with a self-contained fixture (mirrors the shape lane ⑭ already used) instead of the real filesystem.
- **`test_stale_clone_guard_lanes.sh`** — a fixed wall-clock assertion (`elapsed -lt 10`) flaked on loaded CI runners (predicted by prior review, reproduced: 17/17 locally, 2/17 in CI). Fixed with a relative assertion (`elapsed < wedge/2`) instead of an absolute constant.
- Both suites re-wired into `selfcheck.sh`'s existing pair-loop; `lane_runner_check.sh`'s `DEBT` array emptied.

## Verification

Known-pair AND known-negative for both fixes (not just "it passes now"):
- field_canon: PASS 19/19 under empty HOME (the exact CI reproduction) *and* a known-negative (breaking the `-dev`-suffix fallback reproduces PASS 12/FAIL 7 exactly) — proves the fixture measures real behavior.
- stale_clone_guard: 17/17 with the wedge lane at ~1s (well under the new 30s cap) *and* a known-negative (neutering the guard's own budget-kill condition reproduces exactly 1/17 failing) — proves the threshold still discriminates.
- `lane_runner_check.sh` itself: planted a fresh unwired test file at `DEBT=0` and confirmed it still FAILs — not vacuously passing because the list emptied.
- Full `selfcheck.sh` run end-to-end: PASS.

4-axis gate: sonnet-floor (every judged claim bound to an executed known-pair + known-negative check, not read-only review — see marker `axis2-anchor`). Not load-bearing (no verdict/gate/safety-invariant change) so no cross-family recruited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)