### PR TITLE
fix(sync): companion-store node↔node scoping — pmh-dev#69

### DIFF
--- a/scripts/package_coverage_check.sh
+++ b/scripts/package_coverage_check.sh
@@ -36,6 +36,8 @@ cd "$REPO_ROOT" || exit 1
 #        a file of that name to exercise the LOW allowlist — not a pointer to this file at all.)
 #   scripts/sync_guard_check.sh             — anchor for that same operator-private mirror sync;
 #       no shipped hook invokes it.
+#   scripts/sync_to_be_lanes.sh             — forward-path lane suite for sync-to-be.sh, itself
+#       ACCEPTED_ABSENT above; added 2026-08-14, pmh-dev#69.
 ACCEPTED_ABSENT=(
   ".claude/registry/LOCAL_SKILL_REGISTRY.md"
   # An INSTALL DESTINATION the user creates (`cp templates/local_fh_context.md
@@ -57,6 +59,10 @@ ACCEPTED_ABSENT=(
   # anchor but guards on the subject's presence, so package mode SKIPs rather than falling through.
   "scripts/sync-from-be.sh"
   "scripts/sync_from_be_lanes.sh"
+  # Forward path's own lane suite (added 2026-08-14, pmh-dev#69). Same reason as its return-path
+  # sibling directly above: it exercises scripts/sync-to-be.sh, itself ACCEPTED_ABSENT — a lane
+  # suite for a script that never ships has nothing to verify on a consumer's machine either.
+  "scripts/sync_to_be_lanes.sh"
   # ── The three lane suites selfcheck.sh's DEBT-12 pair-loop names but does not ship ────────────
   # Added 2026-08-13, and the way they got here is the point: this check CAUGHT them. Before that
   # loop existed, these names lived in lane_runner_check.sh's DEBT array as bare basenames

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -1063,6 +1063,27 @@ else
   fail=1
 fi
 
+# sync_to_be_lanes.sh — the FORWARD path's anchor (added 2026-08-14, pmh-dev#69). Same shape as the
+# return-path block above and wired in the same change that ships it, for the same reason: a
+# transport with real reported defects (a real add/add conflict, a real hard-abort risk) had no
+# suite exercising it at all before this. Same subject-presence idiom, same run-once-capture
+# discipline (a lane suite discarded to /dev/null on a non-deterministic run already burned two days
+# on this exact file's sibling).
+if [ ! -f scripts/sync-to-be.sh ]; then
+  echo "SKIP  sync_to_be_lanes.sh (subject scripts/sync-to-be.sh absent)"
+elif [ -f scripts/sync_to_be_lanes.sh ]; then
+  if _out=$(bash scripts/sync_to_be_lanes.sh 2>&1); then
+    echo "PASS  sync_to_be_lanes.sh (forward-path lanes)"
+  else
+    echo "FAIL  sync_to_be_lanes.sh: forward-path lanes failed"
+    _show_failure "$_out"
+    fail=1
+  fi
+else
+  echo "FAIL  sync_to_be_lanes.sh: sync-to-be.sh present but its anchor is missing"
+  fail=1
+fi
+
 # Referenced-path existence is a source-tree check. The npm package intentionally
 # ships a narrower runtime surface, so package-mode selfcheck skips this section.
 # ⚠️ The skip predicate used to be `[ -d ".claude/rules" ]`. That broke the moment the tarball

--- a/scripts/sync-from-be.sh
+++ b/scripts/sync-from-be.sh
@@ -390,7 +390,9 @@ pull_dir() {   # $1 = companion (source) dir, $2 = hub (destination) dir, $3 = l
   listing="$(mktemp)" || { warn "mktemp failed — cannot enumerate $label"; ERRORS=$((ERRORS+1)); return 0; }
   if ! find "$src" -type f ! -name '.gitkeep' ! -name '*.marker' \
          ! -path '*/logs/*' ! -path '*/manifests/*' ! -path '*/_index/*' \
+         ! -path '*/substrate/*' \
          ! -name '.fh_node_state' ! -name 'MEMORY.md' ! -name 'edit_manifest.yaml' \
+         ! -name '.substrate_versions' \
          ! -name '.sync_from_be_held.marker' ! -name '.sync_overwrite_override_log' \
          -print0 > "$listing" 2>/dev/null; then
     warn "enumeration FAILED for $label — not treating that as 'nothing to pull'"
@@ -491,17 +493,24 @@ pull_dir() {   # $1 = companion (source) dir, $2 = hub (destination) dir, $3 = l
 #                          2026-08-02, this hub briefly carried a peer's hostname as its own.
 #   MEMORY.md            — the live auto-recall INDEX. It is machine-scoped by CONTENT (it lists what
 #   edit_manifest.yaml     THIS machine holds) while living at a SHARED path, so a path-based
-#                          exclusion cannot catch it. The forward script re-homes both into
-#                          manifests/ and _index/ and deletes the shared copy — but only on a machine
-#                          that HAS the local file, so a leftover shared copy is reachable. Excluded
-#                          by NAME. (cross-family M4, 2026-08-02.)
+#   .substrate_versions    exclusion cannot catch it. The forward script re-homes all three into
+#                          manifests/, _index/, and substrate/, and deletes the shared copy — but
+#                          only on a machine that HAS the local file, so a leftover shared copy is
+#                          reachable. Excluded by NAME. (cross-family M4, 2026-08-02 for the first
+#                          two; `.substrate_versions` added 2026-08-14, pmh-dev#69.)
+#   .close_stamps_<date> — machine-scoped in nature (a local close counter) but has no
+#                          companion-store consumer at all, so it is excluded ENTIRELY by the
+#                          forward script (SYNC_EXCLUDES) rather than re-homed — nothing to pull
+#                          back on this side either; listed here for the same reason `.fh_node_state`
+#                          is: a belt-and-suspenders name exclusion in case a stale copy ever lands.
 # ⚠️ scripts/sync_guard_check.sh asserts the forward script's two copies of this list stay
 # equivalent. This is the THIRD copy; it is covered there too — do not edit one without the others.
 
 # ── Machine-scoped return leg (same machine ONLY) ────────────────────────────
-# The forward script re-homes two files out of the shared namespace into a per-machine name:
-#   tracks/_meta/edit_manifest.yaml → tracks-meta/manifests/<MID>.yaml
-#   memory/MEMORY.md                → memory/_index/<MID>.md
+# The forward script re-homes three files out of the shared namespace into a per-machine name:
+#   tracks/_meta/edit_manifest.yaml     → tracks-meta/manifests/<MID>.yaml
+#   memory/MEMORY.md                    → memory/_index/<MID>.md
+#   tracks/_meta/.substrate_versions    → tracks-meta/substrate/<MID>
 # Excluding those trees wholesale (correct, so a PEER's copy never lands here) also made this
 # machine unable to recover ITS OWN — the one case where the companion holds the only copy, e.g. a
 # re-imaged or freshly cloned node. So: pull back only the file whose name IS this machine's id.
@@ -595,6 +604,7 @@ MID="$(machine_id)" || MID=""
 if [ -n "$MID" ]; then
   pull_machine_scoped "$BE/$TM/manifests/$MID.yaml" "$FH/tracks/_meta/edit_manifest.yaml" "edit_manifest.yaml"
   [ -n "$MEM" ] && pull_machine_scoped "$BE/$MMD/_index/$MID.md" "$MEM/MEMORY.md" "MEMORY.md"
+  pull_machine_scoped "$BE/$TM/substrate/$MID" "$FH/tracks/_meta/.substrate_versions" ".substrate_versions"
 fi
 
 # ── Report ───────────────────────────────────────────────────────────────────

--- a/scripts/sync-to-be.sh
+++ b/scripts/sync-to-be.sh
@@ -183,7 +183,14 @@ DIRTY=0   # cp-fallback mode can't count cheaply → mark work done, let git-dif
 # `.fh_node_state` 는 **기계 고유** 상태다(노드 id·마지막 세션 시각·그 노드가 본 HEAD).
 # 컴패니언 스토어로 흘려보내면 노드마다 값이 엇갈려, 역방향 sync 가 생기는 순간 NODE_ID 가
 # 번갈아 뒤집히며 모든 세션에서 재점검 배너가 뜬다(cross-family 리뷰 2026-07-30, 전방 투기적).
-SYNC_EXCLUDES=('.gitkeep' '*.marker' 'logs/' '.fh_node_state')
+# `.close_stamps_<date>` 도 같은 이유로 여기 합류한다(pmh-dev#69 리뷰가 잡은 A2) — 처음엔
+# merge=union 대상으로 분류했었는데, session_close_check.sh 가 이 파일을 **로컬 카운트**로
+# 읽는다(grep -c . → "오늘 몇 번 닫았나"). union 은 정확히 그 소비 패턴과 충돌한다: 되돌아오는
+# pull_dir 경로가 이 파일을 배제 목록에 안 넣었더니, 두 노드가 같은 날 각자 한 번씩 닫아도
+# 합집합이 내려와 "2번 닫음"으로 잘못 세고, session_close_check.sh 가 불필요한 재작업을
+# 지시한다 — 흔한 케이스가 흔하게 오탐한다는 뜻. 이 파일은 크로스머신 소비자가 아예 없으므로
+# (기계고유 카운터), .fh_node_state 처럼 통째로 sync 대상에서 뺀다 — 머신 스코프조차 불필요.
+SYNC_EXCLUDES=('.gitkeep' '*.marker' 'logs/' '.fh_node_state' '.close_stamps_*')
 
 NEWER_HITS=""
 
@@ -231,7 +238,7 @@ check_dest_newer() {   # $1 = src dir, $2 = dst dir
     # array-expanded safely here, so they are duplicated — the one place this file tolerates it.
     # Changing SYNC_EXCLUDES without changing this line reopens the false-abort/false-pass gap;
     # scripts/sync_guard_check.sh asserts the two stay equivalent.
-  done < <(find "$src" -type f ! -name '.gitkeep' ! -name '*.marker' ! -name '.fh_node_state' ! -path '*/logs/*' 2>/dev/null)
+  done < <(find "$src" -type f ! -name '.gitkeep' ! -name '*.marker' ! -name '.fh_node_state' ! -name '.close_stamps_*' ! -path '*/logs/*' 2>/dev/null)
 }
 
 # ── Mirror banner (salience layer over the guard above) ───────────────────────
@@ -346,7 +353,7 @@ sync_dir() {
   else
     # rsync absent (default Windows git-bash): tar-pipe mirror with the same excludes,
     # no --delete (append-only). Source is canonical, so overwriting be's copy is correct.
-    if ( cd "$src" && tar cf - --exclude='.gitkeep' --exclude='*.marker' --exclude='.fh_node_state' --exclude='logs' . ) \
+    if ( cd "$src" && tar cf - --exclude='.gitkeep' --exclude='*.marker' --exclude='.fh_node_state' --exclude='.close_stamps_*' --exclude='logs' . ) \
          | ( cd "$dst" && tar xf - ); then
       DIRTY=1; log "mirrored (cp mode) → $dst"; stamp_banner "$dst" "$src"
     else
@@ -400,13 +407,18 @@ sync_file() {
 
 # ── Machine-scoped files ──────────────────────────────────────────────────────
 # Most of what we mirror is machine-AGNOSTIC (signals, audits, memory topic files: every
-# machine writes the same content, and append-only rsync merges them harmlessly). Two files
-# are NOT: each hub clone keeps its OWN edit_manifest.yaml and its OWN memory index, because
-# they describe THAT machine's local state. Mirroring them to one shared path makes every
-# machine silently overwrite the others' backup — measured 2026-07-15: three machines synced
-# the same day and fh-be's manifest ended up 135 entries (one machine) while another held 175,
-# with no file actually lost but the backup rendered ambiguous. So these two are keyed by
-# machine. The session CARD is deliberately NOT keyed — it is the shared cross-machine handoff
+# machine writes the same content, and append-only rsync merges them harmlessly). Three files
+# are NOT: each hub clone keeps its OWN edit_manifest.yaml, its OWN memory index, and its OWN
+# `.substrate_versions` (installed tool versions — added 2026-08-14, pmh-dev#69), because they
+# describe THAT machine's local state. Mirroring them to one shared path makes every machine
+# silently overwrite the others' record — measured 2026-07-15 for the manifest (three machines
+# synced the same day and fh-be's manifest ended up 135 entries on one machine, 175 on another,
+# no file actually lost but the backup rendered ambiguous) and separately for `.substrate_versions`
+# on pmh-dev#69 (two nodes, silent auto-merge, one node's record overwritten with the other's — see
+# the copy block below). So these three are keyed by machine. `.close_stamps_<date>` joins
+# `.fh_node_state` in being excluded from this sync ENTIRELY instead (SYNC_EXCLUDES above) — it is
+# also machine-scoped in nature, but has no companion-store consumer at all, so there is nothing to
+# key. The session CARD is deliberately NOT keyed — it is the shared cross-machine handoff
 # ("next session = <machine>"); splitting it would kill the function it exists for.
 #
 # FH_MACHINE_ID: set it in your local env to name the machine. Default = a short digest of the
@@ -422,13 +434,39 @@ machine_id() {
 MID="$(machine_id)"
 [ -n "$MID" ] || MID="unknown"
 
+# One-time migration reap, BEFORE sync_dir runs: a companion store from before this fix may still
+# hold an unscoped `.substrate_versions` from a PEER machine (pmh-dev#69's actual pre-fix state).
+# sync_dir's destination-newer guard (check_dest_newer, above) walks tracks/_meta BEFORE rsync and
+# would see that stale peer copy as differing content newer than this node's own file (rebase-stamp
+# mtime) — and ABORT THE ENTIRE tracks/_meta SYNC, not just this one file, with a "move the edit
+# back to canonical" remedy that is actively wrong for machine-fact content (it would tell you to
+# copy a peer's tool versions into your own record). Reaping it first means the guard never sees it;
+# nothing is lost — every machine's content is already in companion git history. One-shot: after the
+# first post-fix sync on every node, no stale unscoped copy remains to reap (pmh-dev#69 review, A1).
+rm -f "$BE/$TM/.substrate_versions"
 sync_dir  "$FH/tracks/_meta"      "$BE/$TM"
-# ...then re-home the two machine-scoped files out of the shared namespace.
+# ...then re-home the machine-scoped files out of the shared namespace.
 if [ -f "$FH/tracks/_meta/edit_manifest.yaml" ]; then
   mkdir -p "$BE/$TM/manifests"
   cp "$FH/tracks/_meta/edit_manifest.yaml" "$BE/$TM/manifests/$MID.yaml" \
     && log "manifest → $TM/manifests/$MID.yaml (machine-scoped)"
   rm -f "$BE/$TM/edit_manifest.yaml"   # shared copy retired; history keeps every machine's
+fi
+# `.substrate_versions` is machine-fact content (installed tool versions), not shared state — the
+# same reason `.fh_node_state` above is excluded from this sync entirely, except this file legitimately
+# needs a companion-store record (per-machine substrate drift is worth seeing across the hub), so it
+# gets the manifest treatment instead of a bare exclude: mirror once for content, then re-home under a
+# machine-scoped name so a second node's sync can never silently overwrite this node's record with its
+# own (predicted 2026-08-14 from pmh-dev#69's measured add/add on the sibling
+# `.destructive_op_override_log` — two PMH nodes hit that log's conflict directly; PMH's report says
+# `.substrate_versions` auto-merged silently on the same run because one side was empty, which is
+# consistent with this file class corrupting the same way without ever surfacing as a visible
+# conflict — worse than the log-file case, but not independently confirmed as a corrupted value).
+if [ -f "$FH/tracks/_meta/.substrate_versions" ]; then
+  mkdir -p "$BE/$TM/substrate"
+  cp "$FH/tracks/_meta/.substrate_versions" "$BE/$TM/substrate/$MID" \
+    && log "substrate versions → $TM/substrate/$MID (machine-scoped)"
+  rm -f "$BE/$TM/.substrate_versions"   # shared copy retired; history keeps every machine's
 fi
 sync_dir  "$FH/tracks/_audit"     "$BE/$TA"
 sync_dir  "$FH/tracks/_chamber"   "$BE/$TCH"   # incubation chamber runs (INTENT/SIM_NOTES/verdict/INDEX ledger) — local-only (gitignored in public FH), made durable + cross-machine here

--- a/scripts/sync_from_be_lanes.sh
+++ b/scripts/sync_from_be_lanes.sh
@@ -76,28 +76,40 @@ new_env l5
 mkdir -p "$BEX/memory"
 printf 'peer index\n'    > "$BEX/memory/MEMORY.md"
 printf 'peer manifest\n' > "$BEX/tracks-meta/edit_manifest.yaml"
+printf 'peer substrate\n' > "$BEX/tracks-meta/.substrate_versions"
 printf 'ordinary\n'      > "$BEX/tracks-meta/normal.md"
 printf 'mem ordinary\n'  > "$BEX/memory/plain_fact.md"
 # Fixture controls: an absence assertion is only evidence if the thing could have appeared.
-[ -f "$BEX/memory/MEMORY.md" ] && [ -f "$BEX/tracks-meta/edit_manifest.yaml" ]; chk $? "CONTROL: both fixtures exist upstream"
+[ -f "$BEX/memory/MEMORY.md" ] && [ -f "$BEX/tracks-meta/edit_manifest.yaml" ] && [ -f "$BEX/tracks-meta/.substrate_versions" ]; chk $? "CONTROL: all three fixtures exist upstream"
 run --include-new >/dev/null 2>&1
 [ -f "$HUB/tracks/_meta/normal.md" ]; chk $? "CONTROL: tracks area ran (ordinary file landed)"
 [ -f "$MEMD/plain_fact.md" ]; chk $? "CONTROL: memory area ran too (ordinary memory file landed)"
 [ ! -f "$HUB/tracks/_meta/edit_manifest.yaml" ]; chk $? "peer edit_manifest.yaml not pulled"
 [ ! -f "$MEMD/MEMORY.md" ]; chk $? "peer MEMORY.md not pulled"
+[ ! -f "$HUB/tracks/_meta/.substrate_versions" ]; chk $? "peer .substrate_versions not pulled (pmh-dev#69)"
 
-echo "── L6 same-machine return leg DOES restore this machine's own two ──"
+echo "── L6 same-machine return leg DOES restore this machine's own three ──"
 new_env l6
-mkdir -p "$BEX/tracks-meta/manifests" "$BEX/memory/_index"
+mkdir -p "$BEX/tracks-meta/manifests" "$BEX/memory/_index" "$BEX/tracks-meta/substrate"
 MID="$(FH_MACHINE_ID=lanetest bash -c 'printf "%s" "$FH_MACHINE_ID"')"
 printf 'my manifest\n' > "$BEX/tracks-meta/manifests/$MID.yaml"
 printf 'my index\n'    > "$BEX/memory/_index/$MID.md"
+printf 'my substrate\n' > "$BEX/tracks-meta/substrate/$MID"
 HOME="$FAKEHOME" HUB_DIR="$HUB" BE_DIR="$BEX" FH_MACHINE_ID=lanetest bash "$SCRIPT" --no-git >/dev/null 2>&1
 [ "$(cat "$HUB/tracks/_meta/edit_manifest.yaml" 2>/dev/null)" = "my manifest" ]; chk $? "own manifest restored by machine-id match"
 [ "$(cat "$MEMD/MEMORY.md" 2>/dev/null)" = "my index" ]; chk $? "own MEMORY.md index restored"
+[ "$(cat "$HUB/tracks/_meta/.substrate_versions" 2>/dev/null)" = "my substrate" ]; chk $? "own .substrate_versions restored by machine-id match (pmh-dev#69)"
 printf 'other manifest\n' > "$BEX/tracks-meta/manifests/someoneelse.yaml"
+printf 'other substrate\n' > "$BEX/tracks-meta/substrate/someoneelse"
 HOME="$FAKEHOME" HUB_DIR="$HUB" BE_DIR="$BEX" FH_MACHINE_ID=lanetest bash "$SCRIPT" --no-git >/dev/null 2>&1
 [ "$(cat "$HUB/tracks/_meta/edit_manifest.yaml")" = "my manifest" ]; chk $? "a PEER's manifest never lands (control: mine did, above)"
+[ "$(cat "$HUB/tracks/_meta/.substrate_versions")" = "my substrate" ]; chk $? "a PEER's substrate record never lands at my own path either (pmh-dev#69)"
+# The two assertions above cannot fail even without the substrate/ path exclusion — pull_machine_scoped
+# only ever writes to $MID's own path, so a peer's file was never a candidate for landing there. The
+# real exclusion the fix added is on the GENERIC bulk-pull (--include-new), which would otherwise
+# create a peer's file under its own literal name — test that directly (pmh-dev#69, B1).
+HOME="$FAKEHOME" HUB_DIR="$HUB" BE_DIR="$BEX" FH_MACHINE_ID=lanetest bash "$SCRIPT" --no-git --include-new >/dev/null 2>&1
+[ ! -f "$HUB/tracks/_meta/substrate/someoneelse" ]; chk $? "a PEER's raw substrate file not bulk-pulled under its own name (pmh-dev#69, real exclusion test)"
 
 echo "── L7 a --quiet run that WRITES must still speak ──"
 new_env l7

--- a/scripts/sync_to_be_lanes.sh
+++ b/scripts/sync_to_be_lanes.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# sync_to_be_lanes.sh — mechanical regression lanes for scripts/sync-to-be.sh (the FORWARD path)
+#
+# WHY: sync_from_be_lanes.sh covers the RETURN path exhaustively, but nothing asserted the forward
+# path's own re-homing behavior — the exact side pmh-dev#69 reported a real defect on
+# (.substrate_versions colliding between two nodes of the same hub). Each lane below reproduces
+# one measured or predicted defect from that review and asserts it stays closed.
+#
+# CONTROL DISCIPLINE: same as sync_from_be_lanes.sh — an absence assertion is paired with a
+# known-positive in the same run, and each fixture is checked to exist before the run that is
+# supposed to consume it.
+#
+# USAGE: bash scripts/sync_to_be_lanes.sh          → runs all lanes, exit 0 = all pass, 1 = any fail
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/sync-to-be.sh"
+[ -f "$SCRIPT" ] || { echo "missing target: $SCRIPT" >&2; exit 10; }
+ROOT="$(mktemp -d)"; trap 'rm -rf "$ROOT"' EXIT
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  ✅ %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  ❌ %s\n' "$1"; }
+chk(){ if [ "$1" = "0" ]; then ok "$2"; else no "$2"; fi; }
+
+# fresh sandbox — HUB must carry the real identity header (fh_hub_identity.sh reads it), and BE
+# must be a real (if remote-less) git repo: sync-to-be.sh has no --no-git escape hatch, and a
+# non-repo BE leaves `git add`/`git diff --cached` in an undefined state. fetch/pull/push against
+# a missing remote fail silently (the script itself guards each with `2>/dev/null`), so a bare
+# local init is sufficient and never reaches out to the network.
+new_env(){
+  ENV_DIR="$ROOT/$1"; rm -rf "$ENV_DIR"
+  HUB="$ENV_DIR/hubx"; BEX="$ENV_DIR/be"
+  mkdir -p "$HUB/tracks/_meta" "$BEX"
+  printf '# forge-harness — Persistent Knowledge Hub\n' > "$HUB/CLAUDE.md"
+  git -C "$BEX" init -q
+  git -C "$BEX" config user.email "lane@test.local"
+  git -C "$BEX" config user.name "lane-test"
+}
+run(){ HOME="$ENV_DIR/home" HUB_DIR="$HUB" BE_DIR="$BEX" FH_MACHINE_ID="${MID:-lanea}" bash "$SCRIPT" --quiet "$@"; }
+
+echo "── L1 .substrate_versions is re-homed under substrate/\$MID, never left at the shared path ──"
+new_env l1
+printf 'claude=1.0\ncodex=2.0\n' > "$HUB/tracks/_meta/.substrate_versions"
+printf 'ordinary\n' > "$HUB/tracks/_meta/normal.md"
+MID=lanea run >/dev/null 2>&1
+[ -f "$BEX/tracks-meta/normal.md" ]; chk $? "CONTROL: an ordinary file synced at all (run actually executed)"
+[ -f "$BEX/tracks-meta/substrate/lanea" ]; chk $? "own substrate record landed machine-scoped"
+[ "$(cat "$BEX/tracks-meta/substrate/lanea")" = "$(printf 'claude=1.0\ncodex=2.0')" ]; chk $? "content survived the re-home intact"
+[ ! -f "$BEX/tracks-meta/.substrate_versions" ]; chk $? "shared unscoped copy retired, not left behind"
+
+echo "── L2 a second machine's sync never overwrites the first's substrate record (pmh-dev#69 known-positive) ──"
+new_env l2
+printf 'claude=1.0\n' > "$HUB/tracks/_meta/.substrate_versions"
+MID=lanea run >/dev/null 2>&1
+[ -f "$BEX/tracks-meta/substrate/lanea" ]; chk $? "CONTROL: machine A's own record landed first"
+printf 'claude=9.9-DIFFERENT\n' > "$HUB/tracks/_meta/.substrate_versions"
+MID=laneb run >/dev/null 2>&1
+[ "$(cat "$BEX/tracks-meta/substrate/lanea")" = "claude=1.0" ]; chk $? "machine A's record byte-unchanged after machine B's sync (the actual pmh-dev#69 collision, closed)"
+[ "$(cat "$BEX/tracks-meta/substrate/laneb")" = "claude=9.9-DIFFERENT" ]; chk $? "machine B got its own distinct record"
+
+echo "── L3 a PRE-FIX stale unscoped copy is reaped, not treated as a destination-newer conflict (pmh-dev#69 A1) ──"
+new_env l3
+# Wall-clock ordering, not touch -d (portability: BSD touch on macOS rejects GNU-style -d offsets —
+# the exact class of bug this repo's own mktemp GNU/BSD incident already named). The hub's file must
+# be written to its FINAL content BEFORE the companion's stale copy — writing to the hub file again
+# afterward (even to the same content) re-stamps its mtime and can collapse the ordering back to the
+# same second, silently defeating the fixture (measured while writing this lane: an earlier version
+# rewrote the hub file a third time right before `run`, and the guard never tripped — not because
+# the fix was unnecessary, but because the fixture no longer exercised it).
+printf 'claude=fresh\n' > "$HUB/tracks/_meta/.substrate_versions"
+mkdir -p "$BEX/tracks-meta"
+sleep 2
+printf 'stale-peer-content\n' > "$BEX/tracks-meta/.substrate_versions"
+git -C "$BEX" add tracks-meta/.substrate_versions; git -C "$BEX" commit -q -m seed
+[ "$BEX/tracks-meta/.substrate_versions" -nt "$HUB/tracks/_meta/.substrate_versions" ]
+chk $? "CONTROL: the companion copy really is newer than the hub's (fixture ordering worked)"
+out="$(MID=lanea run 2>&1)"
+[ -f "$BEX/tracks-meta/substrate/lanea" ] && [ "$(cat "$BEX/tracks-meta/substrate/lanea")" = "claude=fresh" ]
+chk $? "sync completed and re-homed correctly despite a stale, newer pre-fix shared copy (did not abort — pmh-dev#69 A1)"
+printf '%s' "$out" | grep -qi 'refuse\|abort\|newer'; [ $? -ne 0 ]
+chk $? "no destination-newer abort was printed for the reaped file"
+
+echo "── L4 .close_stamps_<date> never leaves the hub at all (excluded, not machine-scoped — pmh-dev#69 A2) ──"
+new_env l4
+printf '2026-08-14T00:00:00Z\n' > "$HUB/tracks/_meta/.close_stamps_2026-08-14"
+printf 'ordinary\n' > "$HUB/tracks/_meta/normal2.md"
+MID=lanea run >/dev/null 2>&1
+[ -f "$BEX/tracks-meta/normal2.md" ]; chk $? "CONTROL: an ordinary file synced (run actually executed)"
+[ ! -f "$BEX/tracks-meta/.close_stamps_2026-08-14" ]; chk $? "close-stamp file never landed in the companion store at all"
+
+echo ""
+echo "════ lanes: $PASS passed · $FAIL failed ════"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- `HUB_SUFFIX` (pmh-dev#68) separates hub↔hub but not node↔node within the same hub. PMH's first real multi-node sync hit a real add/add conflict on `.destructive_op_override_log` and would have silently corrupted `.substrate_versions` the same way (auto-merged, one side empty, no visible conflict).
- Reclassified 4 dotfiles by actual consumption pattern: `.substrate_versions` (machine-fact) → machine-scoped `substrate/$MID` (mirrors the existing `manifests/$MID.yaml` pattern); `.destructive_op_override_log`/`.psa_override_log`/`.sync_overwrite_override_log` (genuine cross-machine audit trails) → `merge=union` in fh-be's `.gitattributes` (separate repo, already pushed); `.close_stamps_<date>` (per-node counter, zero cross-machine consumer) → excluded from sync entirely, matching `.fh_node_state`.
- Adds `scripts/sync_to_be_lanes.sh` (12 lanes) — the forward path (the side this bug lives on) had zero test coverage before this.

## Verification
- Ran a live tier2(pmh-dev) standpoint review before pushing (per `field_verdict_crossfamily_gate.md §7 Sequencing`, written earlier today and self-applied here). 4 A + 6 B findings, all independently re-verified.
- The sharpest (A1: a pre-existing unscoped companion-store file would hard-abort the *entire* sync) was a static-trace claim from a reviewer with no Bash tool — verified live with a real fixture. First fixture attempt used a non-portable `touch -d` and gave a false negative; rebuilt with real wall-clock ordering and reproduced the abort for real (exit 1), confirming the fix is genuinely needed.
- Two known-negative checks (A1's migration reap, B1's decorative test assertion) both confirmed real discrimination — remove the fix, exactly the expected assertions fail; restore, everything passes.
- Full `selfcheck.sh` REAL_EXIT=0 after wiring the new suite and fixing a package-coverage gap it surfaced.

## Test plan
- [ ] CI `validate` check green
- [ ] Wait for explicit operator merge approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)