### PR TITLE
fix(reship): self-restatement lens + embedded --self-test detection + C2 precision

### DIFF
--- a/scripts/degrade_direction_scan.sh
+++ b/scripts/degrade_direction_scan.sh
@@ -500,11 +500,20 @@ for f in "${FILES[@]}"; do
   #   `tok in text` (paid⊂prepaid) when the variables aren't named verdict/state (M#4, steel-quench).
   #   C2 closes that: simple var-in-var (not a collection literal / range / for) = a likely
   #   containment check that should be exact/word-boundary if it grounds a verdict. Higher noise; advisory.
+  # 2026-08-14: pinned an ALL-CAPS-constant exclusion here that Probe C already carries a few lines
+  # up (`in [A-Z_]+\b`) — C2 had drifted out of sync with it. Measured on this repo's own scripts/:
+  # 6 raw C2 hits, all `if VAR in {seen,by_name,accepted,packed,PLACEHOLDERS}:` — genuine collection
+  # membership, not the substring-containment smell this probe exists to catch. Do NOT also add
+  # lowercase collection-name heuristics (`seen`/`by_name`/...) here — that class still needs a
+  # human to read the assignment and confirm it is a set/dict/list, and a naming guess would just
+  # move the false-negative risk instead of removing it. This narrows one already-established class,
+  # it does not invent a new one.
   while IFS= read -r m; do
     emit "$f" "${m%%:*}" "C2:substring-boolean" "bare 'X in Y' in if/return/assert — if this grounds a presence/verdict check, use exact/word-boundary match, not containment"
   done < <(grep -nE '^[[:space:]]*(if|elif|return|assert|while)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]+in[[:space:]]+[A-Za-z_][A-Za-z0-9_.]*[[:space:]]*[:)]?[[:space:]]*$' "$f" 2>/dev/null \
            | grep -vE '\bfor\b|in range|in enumerate|not in' \
-           | grep -vE '\b(verdict|present|ground|state|match|expected)\w*\b')
+           | grep -vE '\b(verdict|present|ground|state|match|expected)\w*\b' \
+           | grep -vE 'in [A-Z_]+[[:space:]]*[:)]?[[:space:]]*$')
 
   # Probe E — negated-falsy guard returning permissive (dominance-benchmark round-2 f2 class): an error
   # SENTINEL (None / {} / "" / []) is falsy, so `if not X: return <PASS>` treats "the check errored / never

--- a/scripts/lane_runner_check.sh
+++ b/scripts/lane_runner_check.sh
@@ -398,10 +398,21 @@ _st_names = [os.path.basename(f)[:-3] for f in _st_candidates if any(_form in _r
 selftest_subjects = sorted(set(_st_names))
 
 def selftest_dispatched(bare_name, txt):
-    """bare_name (no .sh) sits in a `for VAR in ... bare_name ...; do` loop whose body dispatches
-    $VAR with --self-test — mirrors the indirect-branch reasoning of runner_dispatches: the literal name
-    is in a list construct, the invocation runs through the loop variable, so a direct
-    `bash bare_name.sh --self-test` grep structurally cannot see it (scripts/selfcheck.sh:478)."""
+    """Two shapes, both real in this repo. Cross-family review (2026-08-14) caught the first draft
+    shipping only the second — it read scripts/selfcheck.sh:478's `_subj` for-loop but missed
+    :898/:933's direct `bash scripts/probe_scope_check.sh --self-test` / `bash scripts/
+    utterance_landing_check.sh --self-test`, so those two subjects were reported UNDECLARED while
+    selfcheck.sh runs them every time. This is the exact failure the header above names by cite —
+    a reader trusting the count over the source would have been told a false thing with confidence.
+
+    Shape 1 (direct): `bash scripts/<name>.sh ... --self-test` on one line — mirrors
+    runner_dispatches' direct branch, structurally simpler than the indirect case below.
+    Shape 2 (indirect): bare_name sits in a `for VAR in ... bare_name ...; do` loop whose body
+    dispatches $VAR with --self-test — mirrors the indirect-branch reasoning of runner_dispatches:
+    the literal name is in a list construct, the invocation runs through the loop variable, so a
+    direct-dispatch grep alone structurally cannot see it (scripts/selfcheck.sh:478)."""
+    if re.search(rf'\bbash\s+scripts/{re.escape(bare_name)}\.sh\b[^\n]*--self-test', txt):
+        return True
     in_loop = False; loop_var = None; has_name = False
     for ln in txt.split('\n'):
         s = ln.strip()

--- a/scripts/lane_runner_check.sh
+++ b/scripts/lane_runner_check.sh
@@ -353,6 +353,88 @@ def runner_dispatches(suite, txt):
 
 wired = {s for s in suites if has_runner(s)}
 
+# ── Embedded --self-test dispatchers — a class the name-pattern `suites` glob cannot see ──────
+# Measured 2026-08-13, the header of this file, §WHAT DEBT:0 DOES NOT MEAN: a lane suite that
+# lives INSIDE its subject as a `--self-test` flag — not a separate `test_*.sh`/`*_lanes.sh` file
+# — is structurally invisible to the glob above. 4 scripts carry one — chamber_witness.sh ·
+# capability_registry_check.sh · digest_landing_check.sh · directional_diff_gate.sh — and none
+# showed up as WIRED or UNWIRED anywhere in this report; the wiring line for the 3 that ARE wired,
+# the `for _subj in ...` loop at scripts/selfcheck.sh:478, could be deleted and nothing here would
+# go red. found→extend, not a new file: same idiom as `suites`/`has_runner` above — discover
+# subjects, detect dispatch, report undeclared — new predicates for the shape this pattern uses.
+#
+# 🟥 A PARENTHESIS TRAP LIVES IN THIS SPECIFIC HEREDOC, READ BEFORE ADDING A LINE HERE.
+# Measured 2026-08-14: a single heredoc-body line whose own paren count was unbalanced — one more
+# close-paren than open-paren, from a regex needing a literal close-paren character — broke bash's
+# parse of every line after it, on THIS file only. The reason is that the heredoc below sits inside
+# a command-substitution wrapper, and that wrapper's own close-paren-matching scan turned out not
+# to be fully heredoc-blind in the bash build this repo has tested. `bash -n` then failed dozens of
+# lines later with an unrelated-looking error, because by then the parser believed the heredoc had
+# already closed. Reproduced in isolation: a bare regex assignment needing a literal close-paren,
+# spliced into this file at this exact position, alone, with nothing else added. The fix is
+# structural, not "be careful" — every line added inside this heredoc must carry a matched
+# open-paren and close-paren count on that same line, and a matched pair spanning two lines is
+# exactly the shape that tripped this the first time. Collapse it back to one line, or spell the
+# literal paren out as an escape sequence instead of a bare character, rather than splitting it
+# across lines.
+# A bare substring match on --self-test would also catch prose that only DISCUSSES the flag
+# (measured: scripts/selfcheck.sh:482 has a comment naming it as an example of what NOT to grep
+# for, which is exactly the false positive this narrower check exists to avoid). Require one of
+# the two real dispatcher shapes instead: `"--self-test"` in a quoted comparison, or `--self-test)`
+# as a bare case-pattern. The close-paren is built via chr — see the paren-trap note above; a
+# literal `)` character on this line, however it is spelled, throws this file's parser off.
+_CP = chr(41)
+SELFTEST_DISPATCH_FORMS = ('"--self-test"', '--self-test' + _CP)
+
+def _read(path):
+    try:
+        return open(path, encoding='utf-8', errors='replace').read()
+    except OSError:
+        return ''
+
+# One line on purpose — see the paren-trap note above the SELFTEST_PAT definition.
+_st_candidates = [f for f in glob.glob('scripts/*.sh') if os.path.basename(f) not in suites and os.path.basename(f) != 'lane_runner_check.sh']
+_st_names = [os.path.basename(f)[:-3] for f in _st_candidates if any(_form in _read(f) for _form in SELFTEST_DISPATCH_FORMS)]
+selftest_subjects = sorted(set(_st_names))
+
+def selftest_dispatched(bare_name, txt):
+    """bare_name (no .sh) sits in a `for VAR in ... bare_name ...; do` loop whose body dispatches
+    $VAR with --self-test — mirrors the indirect-branch reasoning of runner_dispatches: the literal name
+    is in a list construct, the invocation runs through the loop variable, so a direct
+    `bash bare_name.sh --self-test` grep structurally cannot see it (scripts/selfcheck.sh:478)."""
+    in_loop = False; loop_var = None; has_name = False
+    for ln in txt.split('\n'):
+        s = ln.strip()
+        m = re.match(r'for\s+(\w+)\s+in\b(.*)', s)
+        if m:
+            loop_var = m.group(1)
+            has_name = bool(re.search(rf'\b{re.escape(bare_name)}\b', m.group(2)))
+            in_loop = True
+            continue
+        if in_loop:
+            if has_name and '--self-test' in ln and re.search(rf'\${{?{re.escape(loop_var)}\b', ln):
+                return True
+            if s == 'done':
+                in_loop = False; loop_var = None; has_name = False
+    return False
+
+def has_selftest_runner(bare_name):
+    return any(selftest_dispatched(bare_name, _read(r)) for r in runners)
+
+selftest_wired = {s for s in selftest_subjects if has_selftest_runner(s)}
+selftest_undeclared = sorted(s for s in selftest_subjects if s not in selftest_wired)
+
+# Minimal known-pair — proportionate to the size of this addition, not the full CTL apparatus
+# below, but a dead predicate must still be caught rather than trusted on read-through alone.
+_ST_POS_FIXTURE = 'for _subj in alpha beta; do\n  bash "scripts/$_subj.sh" --self-test\ndone\n'
+_ST_NEG_FIXTURE = 'for _subj in alpha beta; do\n  bash "scripts/$_subj.sh" --normal-run\ndone\n'
+if not selftest_dispatched('alpha', _ST_POS_FIXTURE):
+    print("CONTROL_FAILED\tself-test known-positive fixture read as undispatched — detector is blind")
+    raise SystemExit(2)
+if selftest_dispatched('alpha', _ST_NEG_FIXTURE):
+    print("CONTROL_FAILED\tself-test known-negative fixture with no --self-test flag read as dispatched")
+    raise SystemExit(2)
+
 # ── CONTROL: the instrument must be able to see a suite known to be wired, and must NOT see one
 # known to be dead. Without both arms a broken detector reports "all clean" or "all broken" and
 # either reads as a verdict. [[feedback_absence_measurement_needs_control]]
@@ -457,6 +539,9 @@ for s in resolved:
     print(f"RESOLVED\t{s}")
 for s in gone:
     print(f"GONE\t{s}")
+print(f"SELFTEST_COUNTS\t{len(selftest_subjects)}\t{len(selftest_wired)}")
+for s in selftest_undeclared:
+    print(f"SELFTEST_UNDECLARED\t{s}")
 PY
 )
 rc=$?
@@ -518,5 +603,24 @@ if [ "$N_DEBT" -gt 0 ]; then
   echo "    only go down; a new one fails the check rather than joining the list silently."
 fi
 
-echo "PASS  lane-runner: ${TOTAL} suites — ${WIRED} wired · ${N_EXEMPT} exempt · ${N_DEBT} declared debt"
+SELFTEST_COUNTS=$(printf '%s\n' "$out" | awk -F'\t' '$1=="SELFTEST_COUNTS"{print $2" "$3}')
+set -- $SELFTEST_COUNTS
+ST_TOTAL="${1:-0}"; ST_WIRED="${2:-0}"
+SELFTEST_UNDECLARED=$(printf '%s\n' "$out" | awk -F'\t' '$1=="SELFTEST_UNDECLARED"{print $2}')
+ST_UNDECLARED_N=0
+if [ -n "$SELFTEST_UNDECLARED" ]; then
+  ST_UNDECLARED_N=$(printf '%s\n' "$SELFTEST_UNDECLARED" | wc -l | tr -d ' ')
+  # Advisory, not blocking — these are pre-existing (measured 2026-08-13, before this check saw
+  # them at all), not something introduced by whatever change is running this check right now.
+  # Same DEBT philosophy as above: loudly counted, never silent, must only go down from here.
+  echo "⚠️  lane-runner: ${ST_UNDECLARED_N} embedded --self-test subject(s) with no --self-test"
+  echo "    dispatcher anywhere (self-test code exists, nothing calls it — see this file's own"
+  echo "    §Embedded --self-test comment for why the suites glob above cannot see this class):"
+  printf '%s\n' "$SELFTEST_UNDECLARED" | sed 's/^/        /'
+  echo "    Fix by wiring \`bash scripts/<name>.sh --self-test\` into scripts/selfcheck.sh's"
+  echo "    _subj for-loop (scripts/selfcheck.sh:478), same shape as the 3 already there."
+fi
+
+echo "PASS  lane-runner: ${TOTAL} suites — ${WIRED} wired · ${N_EXEMPT} exempt · ${N_DEBT} declared debt" \
+     "· self-test: ${ST_WIRED}/${ST_TOTAL} wired"
 exit 0

--- a/scripts/test_degrade_scan_shell_probes.sh
+++ b/scripts/test_degrade_scan_shell_probes.sh
@@ -661,6 +661,50 @@ else
   bad "SCOPE2 control failed — the scanner found neither file, so SCOPE1 proved nothing"
 fi
 
+# ── C2: bare X-in-Y substring boolean, with the ALL-CAPS exclusion (2026-08-14) ────────────────
+# Cross-family review found this exclusion shipped with zero fixtures anywhere in this repo —
+# deleting the exclusion left every existing lane green, which is exactly the "advisory noise
+# reduction with no anchor" class this repo's own 4-axis doctrine requires a mechanical test for.
+# Two arms: the probe's own headline example (paid⊂prepaid style substring check) must still
+# fire, and an ALL-CAPS collection-membership check — the shape the exclusion targets — must not.
+_c2_pos="$TMP/c2_pos.sh"; _c2_neg="$TMP/c2_neg.sh"
+printf 'if tok in text:\n    pass\n' > "$_c2_pos"
+printf 'if name in PLACEHOLDERS:\n    pass\n' > "$_c2_neg"
+out=$(bash "$SCAN" "$_c2_pos" 2>&1)
+if printf '%s' "$out" | grep -q 'C2:substring-boolean'; then
+  ok "C2-KP substring-boolean on a bare string var still fires"
+else
+  bad "C2-KP the probe's own headline shape (tok in text) no longer fires"
+fi
+out=$(bash "$SCAN" "$_c2_neg" 2>&1)
+if ! printf '%s' "$out" | grep -q 'C2:substring-boolean'; then
+  ok "C2-KN ALL-CAPS collection membership (name in PLACEHOLDERS) stays silent"
+else
+  bad "C2-KN the ALL-CAPS exclusion is not wired — a legitimate collection check still fires"
+fi
+# Revert probe, run inline rather than trusted by inspection: replace the exclusion clause's line
+# in a COPY of the scanner with a bare closing paren (deleting the line outright would strand the
+# preceding line's trailing backslash continuation and break the pipe chain) and confirm C2-KN
+# flips to a hit — proves the exclusion is load-bearing for this specific fixture, not just
+# present somewhere in the file.
+_scan_reverted="$TMP/scan_reverted.sh"
+_excl_line=$(grep -n "grep -vE 'in \[A-Z_\]" "$SCAN" | head -1 | cut -d: -f1)
+if [ -z "$_excl_line" ]; then
+  bad "C2-REVERT could not locate the exclusion line by its known text — fixture cannot run"
+else
+  sed "${_excl_line}s/.*/           )/" "$SCAN" > "$_scan_reverted"
+  chmod +x "$_scan_reverted"
+  # Captured, not piped directly — under `set -o pipefail` (this file's own top line) the scanner's
+  # own advisory exit code (non-zero on any finding) would override grep's match result in a direct
+  # pipe, reporting FAIL even when the fixture worked exactly as intended.
+  _revert_out=$(bash "$_scan_reverted" "$_c2_neg" 2>&1)
+  if printf '%s' "$_revert_out" | grep -q 'C2:substring-boolean'; then
+    ok "C2-REVERT removing the exclusion line makes C2-KN fire again (the exclusion is load-bearing)"
+  else
+    bad "C2-REVERT removing the exclusion line did not flip C2-KN — the fixture proves nothing"
+  fi
+fi
+
 echo "----"
 echo "degrade-scan shell probes: $pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1

--- a/scripts/test_lane_runner_lanes.sh
+++ b/scripts/test_lane_runner_lanes.sh
@@ -147,6 +147,53 @@ else
   bad "L10 a commented, spaced file failed to parse"
 fi
 
+# ── L11/L12 embedded --self-test subjects (found→extend, 2026-08-14) ──────────────────────────
+# A lane suite living INSIDE its subject as a `--self-test` flag has no `test_*.sh`/`*_lanes.sh`
+# filename, so the suites glob above cannot see it at all — measured on this repo's own
+# lane_runner_check.sh header before this feature existed: 4 such subjects had zero callers and
+# nothing here said so. mkfixture without the orphan file, so these lanes isolate the self-test
+# behaviour from L1's own blocking orphan.
+mkfixture_clean() { # $1 = dir
+  local d="$1"
+  mkdir -p "$d/scripts"
+  cp "$CHECK" "$d/scripts/lane_runner_check.sh"
+  # A wired ordinary suite so the `suites` set is non-empty — an empty tree fails EXTRACTOR_BROKE
+  # before the self-test report section runs at all, which would make L11/L12 pass vacuously.
+  printf '#!/usr/bin/env bash\n: wired lane suite\n' > "$d/scripts/test_ok_lanes.sh"
+  printf '#!/usr/bin/env bash\nbash scripts/lane_runner_check.sh\nbash scripts/test_ok_lanes.sh\n' > "$d/scripts/selfcheck.sh"
+}
+
+# L11 known-POSITIVE: an unwired --self-test subject is reported, advisory (rc stays 0).
+D="$T/l11"; mkfixture_clean "$D"
+printf '#!/usr/bin/env bash\n[ "${1:-}" = "--self-test" ] && { echo ok; exit 0; }\n' > "$D/scripts/orphan_probe.sh"
+out=$(run "$D"); rc=$(rcof "$D")
+if [ "$rc" = "0" ] && printf '%s' "$out" | grep -q 'orphan_probe'; then
+  ok "L11 known-positive: unwired --self-test subject named, advisory (rc=0)"
+else
+  bad "L11 known-positive did not fire (rc=$rc) — self-test subject not reported"
+  printf '%s\n' "$out" | sed 's/^/       │ /'
+fi
+
+# L12 known-NEGATIVE: the SAME subject, wired through selfcheck.sh's _subj for-loop idiom, is
+# NOT reported — the exact shape scripts/selfcheck.sh:478 actually uses.
+D="$T/l12"; mkfixture_clean "$D"
+printf '#!/usr/bin/env bash\n[ "${1:-}" = "--self-test" ] && { echo ok; exit 0; }\n' > "$D/scripts/orphan_probe.sh"
+cat > "$D/scripts/selfcheck.sh" <<'SC'
+#!/usr/bin/env bash
+bash scripts/lane_runner_check.sh
+bash scripts/test_ok_lanes.sh
+for _subj in orphan_probe; do
+  bash "scripts/$_subj.sh" --self-test
+done
+SC
+out=$(run "$D")
+if ! printf '%s' "$out" | grep -q 'orphan_probe'; then
+  ok "L12 known-negative: --self-test subject wired via _subj for-loop is not reported"
+else
+  bad "L12 known-negative: wired subject still reported as unwired"
+  printf '%s\n' "$out" | sed 's/^/       │ /'
+fi
+
 echo "----"
 echo "lane-runner lanes: $pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1

--- a/scripts/test_lane_runner_lanes.sh
+++ b/scripts/test_lane_runner_lanes.sh
@@ -194,6 +194,28 @@ else
   printf '%s\n' "$out" | sed 's/^/       │ /'
 fi
 
+# L13 known-NEGATIVE: the SAME subject, wired through a DIRECT dispatch line — the shape
+# scripts/selfcheck.sh:898/933 actually use (`bash scripts/<name>.sh ... --self-test`), no
+# for-loop at all. Cross-family review 2026-08-14 caught the first draft shipping only the
+# for-loop branch, which meant probe_scope_check.sh and utterance_landing_check.sh — both wired
+# directly, both real — were reported UNDECLARED. This lane pins that class so it cannot silently
+# come back: without it, L11/L12 alone only ever exercise the for-loop shape.
+D="$T/l13"; mkfixture_clean "$D"
+printf '#!/usr/bin/env bash\n[ "${1:-}" = "--self-test" ] && { echo ok; exit 0; }\n' > "$D/scripts/orphan_probe.sh"
+cat > "$D/scripts/selfcheck.sh" <<'SC'
+#!/usr/bin/env bash
+bash scripts/lane_runner_check.sh
+bash scripts/test_ok_lanes.sh
+bash scripts/orphan_probe.sh --self-test >/dev/null 2>&1
+SC
+out=$(run "$D")
+if ! printf '%s' "$out" | grep -q 'orphan_probe'; then
+  ok "L13 known-negative: --self-test subject wired via direct dispatch is not reported"
+else
+  bad "L13 known-negative: directly-wired subject still reported as unwired"
+  printf '%s\n' "$out" | sed 's/^/       │ /'
+fi
+
 echo "----"
 echo "lane-runner lanes: $pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1

--- a/scripts/test_version_lockstep_lanes.sh
+++ b/scripts/test_version_lockstep_lanes.sh
@@ -74,6 +74,68 @@ T=$(_fixture he4 1.4.89 1.4.89 1.4.89 1.4.89 1.4.89); printf '{"name":"fh-meta"}
 _expect "HE-4 manifest with no version → exit 2, NOT 0" 2 "$T"
 _says   "HE-4 → says which file carries none" "carries no version string" 1
 
+# ── Self-restatement — found→extend into this lens (2026-08-14) ──────────────────────────────
+# RS-KN pins the exact false positive the naive first draft threw against its OWN calibration
+# target (scripts/lane_runner_check.sh): a loose \D{0,12} gap matched across an unrelated
+# exit-code legend entry ("declared DEBT · 1 =") and across a before→after transition narration
+# ("DEBT 2 → 0"). Both shapes are known-negatives — they describe history/enumeration, not a
+# live contradiction — and must stay silent.
+
+T=$(_fixture rs1 1.4.89 1.4.89 1.4.89 1.4.89 1.4.89)
+mkdir -p "$T/scripts"
+cat > "$T/scripts/some_lane.sh" <<'EOF'
+#!/usr/bin/env bash
+# Exit: 0 = every suite is WIRED, EXEMPT, or declared DEBT · 1 = an undeclared suite has no runner
+# THE TWO THAT WERE HERE ARE RE-WIRED (2026-08-14) — DEBT 2 → 0.
+# WHAT `DEBT: 0` DOES NOT MEAN — read before quoting the number anywhere.
+DEBT=()
+EOF
+_expect "RS-KN historical DEBT narration (2→0, exit-code legend) → exit 0" 0 "$T"
+_says   "RS-KN → does not fire on the transition/legend shapes" "self-restatement drift" 0
+
+T=$(_fixture rs2 1.4.89 1.4.89 1.4.89 1.4.89 1.4.89)
+mkdir -p "$T/scripts"
+cat > "$T/scripts/broken_lane.sh" <<'EOF'
+#!/usr/bin/env bash
+# DEBT: 12 unwired suites remain, tracked below.
+# ... (later, uncorrected after a partial fix) ...
+# still DEBT 9 by last count.
+DEBT=()
+EOF
+_expect "RS-KP shell comment restates DEBT with two different numbers → exit 0 (advisory)" 0 "$T"
+_says   "RS-KP → names the file and the disagreeing values" \
+        'broken_lane.sh :: comments state DEBT as \[9, 12\]' 1
+
+T=$(_fixture rs3 1.4.89 1.4.89 1.4.89 1.4.89 1.4.89)
+mkdir -p "$T/plugins/fh-commons/skills/fake-skill"
+cat > "$T/plugins/fh-commons/skills/fake-skill/SKILL.md" <<'EOF'
+---
+name: fake-skill
+description: uses v1.4.95 of the reference build
+---
+# fake-skill
+
+Body text never restates a version number, so there is nothing to cross-check against.
+EOF
+_expect "RS-KN2 SKILL.md frontmatter version, body silent → exit 0, no drift" 0 "$T"
+_says   "RS-KN2 → does not fire when body has zero version mentions" "self-restatement drift" 0
+
+T=$(_fixture rs4 1.4.89 1.4.89 1.4.89 1.4.89 1.4.89)
+mkdir -p "$T/plugins/fh-commons/skills/fake-skill2"
+cat > "$T/plugins/fh-commons/skills/fake-skill2/SKILL.md" <<'EOF'
+---
+name: fake-skill2
+description: ships as part of v1.4.95
+---
+# fake-skill2
+
+Elsewhere in this doc we note the shipped build is v1.4.92, which is the value users should
+actually expect to see when they check their installed version.
+EOF
+_expect "RS-KP2 SKILL.md frontmatter v1.4.95 vs body v1.4.92 → exit 0 (advisory)" 0 "$T"
+_says   "RS-KP2 → names the file and the drifted version" \
+        'fake-skill2/SKILL.md :: frontmatter states v{1.4.95}' 1
+
 echo
 echo "──────────────────────────────────────────────"
 if [ "$FAIL" -gt 0 ]; then

--- a/scripts/version_lockstep_check.sh
+++ b/scripts/version_lockstep_check.sh
@@ -109,5 +109,97 @@ if drift:
     print("so a stale entry ships as 'already installed' on the runtime that cannot report it.")
     sys.exit(1)
 
+# ── Self-restatement — a file that states its own count/version twice can drift from itself ──
+# Measured 2026-08-13 (peer session, reship axis): N=2 on two DIFFERENT surfaces, both real —
+#   (a) a memory file's YAML frontmatter `description:` stated an npm version differently from
+#       its own body (1.4.95 vs 1.4.92 — a lockstep drift, just in prose instead of JSON)
+#   (b) lane_runner_check.sh's own header comment stated "11/8" while a later comment said the
+#       DEBT count was 12 — caught by cross-family review, not by re-reading (see that file's own
+#       header for the incident write-up; it has since self-corrected into a historical note).
+# «타표면 재발 = 기계화 의무» (recurrence on a second, different surface obligates mechanizing) —
+# found→extend into THIS lens rather than a new scanner: same idiom (extract candidate values,
+# compare, collect drift, report), new target surfaces.
+#
+# Advisory (like the CHANGELOG check above), same reasoning: a stale self-count is a documentation
+# defect, not a broken package, and turning publish red on prose trains the override this repo has
+# already measured people reaching for.
+#
+# Scope, deliberately narrow — the two false-positive traps that would have made this noise instead
+# of signal, both avoided on purpose:
+#   1. tracks/**/*.md and this repo's session cards are EXCLUDED. Those are running logs that
+#      legitimately cite dozens of historical version numbers across dated sessions — scanning them
+#      for "two differing v-numbers in one file" would fire on nearly every one. The mission here is
+#      "does a single-snapshot doc contradict itself", not "every version ever mentioned".
+#   2. The DEBT counter only fires on 2+ DISTINCT values for the SAME literal label ("DEBT") within
+#      comment lines of one file — not on any two numbers that happen to appear near each other. A
+#      one-off historical narration ("this said 11/8 until it was fixed") does not by itself carry
+#      two live DEBT-labeled claims, so it does not false-positive as an active contradiction.
+def _self_restate_md():
+    hits = []
+    candidates = [os.path.join(root, 'CLAUDE.md'), os.path.join(root, 'AGENTS.md')]
+    candidates += sorted(glob.glob(os.path.join(root, 'plugins', '*', 'skills', '*', 'SKILL.md')))
+    VERPAT = re.compile(r'\bv(\d+\.\d+\.\d+)\b')
+    for p in candidates:
+        if not os.path.exists(p):
+            continue
+        try:
+            txt = open(p, encoding='utf-8', errors='replace').read()
+        except OSError:
+            continue
+        m = re.match(r'^---\n(.*?)\n---\n(.*)$', txt, re.S)
+        if not m:
+            continue
+        fm, body = m.group(1), m.group(2)
+        fm_vers = set(VERPAT.findall(fm))
+        body_vers = set(VERPAT.findall(body))
+        drifted = fm_vers - body_vers
+        if fm_vers and body_vers and drifted:
+            rel = os.path.relpath(p, root)
+            hits.append(f"  {rel} :: frontmatter states v{{{','.join(sorted(drifted))}}} not "
+                        f"found anywhere in body (body has v{{{','.join(sorted(body_vers))}}})")
+    return hits
+
+def _self_restate_sh():
+    hits = []
+    # Tight: DEBT immediately followed by (optional :/=, whitespace) a number — not "any digit
+    # within 12 chars" (that matched an unrelated exit-code legend entry across a bullet, «DEBT ·
+    # 1»). A number immediately followed by an arrow (→ / ->) is a before→after transition
+    # narration ("DEBT 2 → 0"), not a live claim about the current count — excluded on purpose,
+    # calibrated against this repo's own lane_runner_check.sh (known-negative: 3 raw matches with
+    # the loose form, 1 real match with this form — verified by hand, 2026-08-14).
+    DEBTPAT = re.compile(r'\bDEBT\b\s*[:=]?\s*(\d+)\b(?!\s*(?:→|->))')
+    # test_*.sh / *_lanes.sh are excluded — measured 2026-08-14 on this check's own test file:
+    # a known-pair fixture legitimately embeds two differing DEBT numbers as heredoc TEST DATA
+    # (proving the detector can tell them apart), and that heredoc text is also literal source in
+    # the test file itself. Those are fixtures, not a claim about the test file's own state — same
+    # distinction the `suites` glob elsewhere in this repo already draws between subject scripts
+    # and the test scripts that exercise them.
+    for p in (sorted(f for f in glob.glob(os.path.join(root, 'scripts', '*.sh'))
+                      if not re.match(r'^(test_.*|.*_lanes)\.sh$', os.path.basename(f)))
+              + sorted(f for f in glob.glob(os.path.join(root, 'templates', '*.sh'))
+                        if not re.match(r'^(test_.*|.*_lanes)\.sh$', os.path.basename(f)))):
+        try:
+            txt = open(p, encoding='utf-8', errors='replace').read()
+        except OSError:
+            continue
+        # Comment lines only — a live `DEBT=()` array literal is code computing the fact, not a
+        # restated claim about it, and must not be treated as a second (possibly stale) copy.
+        vals = set()
+        for ln in txt.splitlines():
+            if not re.match(r'^\s*#', ln):
+                continue
+            vals |= {int(m) for m in DEBTPAT.findall(ln)}
+        if len(vals) > 1:
+            rel = os.path.relpath(p, root)
+            hits.append(f"  {rel} :: comments state DEBT as {sorted(vals)} — pick one number, "
+                        f"or point the stale comment at the live count instead of a literal")
+    return hits
+
+restate_hits = _self_restate_md() + _self_restate_sh()
+if restate_hits:
+    print(f"LOCKSTEP: ⚠️  self-restatement drift — {len(restate_hits)} file(s) state their own "
+          f"version/count more than once and the copies disagree:")
+    print("\n".join(restate_hits))
+
 print(f"LOCKSTEP: PASS — {checked} shipped version string(s) all at {want}")
 PY

--- a/scripts/version_lockstep_check.sh
+++ b/scripts/version_lockstep_check.sh
@@ -138,7 +138,13 @@ def _self_restate_md():
     hits = []
     candidates = [os.path.join(root, 'CLAUDE.md'), os.path.join(root, 'AGENTS.md')]
     candidates += sorted(glob.glob(os.path.join(root, 'plugins', '*', 'skills', '*', 'SKILL.md')))
-    VERPAT = re.compile(r'\bv(\d+\.\d+\.\d+)\b')
+    # v-prefix optional — cross-family review found the real incident that motivated this arm
+    # (a memory file's frontmatter `latest v1.4.97` vs body `latest **1.4.97**`) does not carry the
+    # prefix on the body side, so the mandatory-v form never fires on the actual shape it exists
+    # to catch. Bare N.N.N is noisier (could match an unrelated dependency version), but the
+    # candidate list above is narrow enough (CLAUDE.md/AGENTS.md/SKILL.md only) that this stays
+    # advisory-tolerable rather than explosive.
+    VERPAT = re.compile(r'\bv?(\d+\.\d+\.\d+)\b')
     for p in candidates:
         if not os.path.exists(p):
             continue

--- a/templates/degrade_direction_scan.sh
+++ b/templates/degrade_direction_scan.sh
@@ -500,11 +500,20 @@ for f in "${FILES[@]}"; do
   #   `tok in text` (paid⊂prepaid) when the variables aren't named verdict/state (M#4, steel-quench).
   #   C2 closes that: simple var-in-var (not a collection literal / range / for) = a likely
   #   containment check that should be exact/word-boundary if it grounds a verdict. Higher noise; advisory.
+  # 2026-08-14: pinned an ALL-CAPS-constant exclusion here that Probe C already carries a few lines
+  # up (`in [A-Z_]+\b`) — C2 had drifted out of sync with it. Measured on this repo's own scripts/:
+  # 6 raw C2 hits, all `if VAR in {seen,by_name,accepted,packed,PLACEHOLDERS}:` — genuine collection
+  # membership, not the substring-containment smell this probe exists to catch. Do NOT also add
+  # lowercase collection-name heuristics (`seen`/`by_name`/...) here — that class still needs a
+  # human to read the assignment and confirm it is a set/dict/list, and a naming guess would just
+  # move the false-negative risk instead of removing it. This narrows one already-established class,
+  # it does not invent a new one.
   while IFS= read -r m; do
     emit "$f" "${m%%:*}" "C2:substring-boolean" "bare 'X in Y' in if/return/assert — if this grounds a presence/verdict check, use exact/word-boundary match, not containment"
   done < <(grep -nE '^[[:space:]]*(if|elif|return|assert|while)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]+in[[:space:]]+[A-Za-z_][A-Za-z0-9_.]*[[:space:]]*[:)]?[[:space:]]*$' "$f" 2>/dev/null \
            | grep -vE '\bfor\b|in range|in enumerate|not in' \
-           | grep -vE '\b(verdict|present|ground|state|match|expected)\w*\b')
+           | grep -vE '\b(verdict|present|ground|state|match|expected)\w*\b' \
+           | grep -vE 'in [A-Z_]+[[:space:]]*[:)]?[[:space:]]*$')
 
   # Probe E — negated-falsy guard returning permissive (dominance-benchmark round-2 f2 class): an error
   # SENTINEL (None / {} / "" / []) is falsy, so `if not X: return <PASS>` treats "the check errored / never


### PR DESCRIPTION
## Summary
재출하 캠페인 카드 「다음 세션 우선순위」 3건 완주:

1. **자기-재진술 렌즈 확장** — `version_lockstep_check.sh`에 markdown frontmatter-vs-body 버전 드리프트 + 셸 DEBT주석 드리프트 검출(advisory) 신설. tracks/**는 역사로그라 제외, test_*.sh/*_lanes.sh는 픽스처라 제외(이 세션 자신의 테스트파일이 자기 픽스처를 오탐으로 잡아서 발견함)
2. **도출형 `_subj`** — `lane_runner_check.sh`에 임베디드 `--self-test` 디스패처 검출 신설(advisory). `suites` glob이 못 보는 자기-내장형 self-test를 발견하고 selfcheck.sh의 `_subj` for-loop 배선 여부 판정
3. **B(오탐 36) 분리** — `degrade_direction_scan.sh` C2 프로브에 ALL-CAPS 상수 제외 추가(Probe C엔 이미 있던 걸 C2로 확장). 카드의 스탤값 「36/34」를 현재 실측(6→5)으로 대체

**부수 발견**: `lane_runner_check.sh` 편집 중 재현 가능한 bash heredoc 파싱 버그를 체계적 이분탐색으로 발견·고립·수정(quote-escape 정규식 대신 plain substring + `chr(41)`).

## Cross-family review (codex/gpt-5.5) — 진짜 결함 2건 잡음
같은 계열(Sonnet) 챌린저가 30분+ 안 끝나 포기하고 codex로 전환. 결과:

- **S-1(실결함, 직접확인 후 수리)**: `selftest_dispatched()`가 for-loop 간접배선만 보고 직접배선(`selfcheck.sh:898/933`)을 못 봐서 실제 배선된 3개 스크립트를 "미배선"으로 오보(7건 중 3건 거짓). 직접배선 정규식 분기 추가 + L13 known-negative 신규.
- **A-2(실행으로 확인)**: C2 ALL-CAPS 제외에 회귀테스트 0개(빼도 48/48 초록). C2-KP/KN/REVERT 3건 신규 — REVERT는 실제로 그 줄을 지운 사본을 만들어 재실행해서 확인.
- **A-1(부분수리)**: markdown VERPAT이 `v` 접두어 필수라 실제 동기 사건(memory 파일, 접두어 없음)을 못 잡음 — 접두어 선택화.
- **A-3 + B-1~B-5**: named residual로 마커에 기록, 이번 라운드에서 미수리(시간상 범위 밖, 이유 각각 명시).

## Test plan
- [x] 3개 known-pair 스위트 88 assertions 전부 green (14 lane-runner · 23 version-lockstep · 51 degrade-scan)
- [x] 전체 selfcheck.sh 1회 완주 확인(중간 커밋 시점)
- [x] `bash -n` 신택스 체크 통과(bash 파서 버그 수정 후)
- [x] 4-axis pre-commit 게이트 통과(양쪽 커밋)
- [x] pre-push Load-Bearing Change Gate — crossfamily: panel(codex/gpt-5.5) 기록됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)