### PR TITLE
fix(gate): version_lockstep self-restatement comment overclaimed memory-file scope

### DIFF
--- a/scripts/version_lockstep_check.sh
+++ b/scripts/version_lockstep_check.sh
@@ -120,6 +120,17 @@ if drift:
 # found→extend into THIS lens rather than a new scanner: same idiom (extract candidate values,
 # compare, collect drift, report), new target surfaces.
 #
+# 🟥 (a) IS NOT CLOSED BY THIS ARM, AND THAT IS DELIBERATE — cross-family review (2026-08-14)
+# caught an earlier draft of this comment reading as though citing incident (a) meant this scan
+# reaches it. It does not: the memory store lives under the operator's home directory
+# (~/.claude/projects/.../memory/), outside this repo's `root` entirely, so the candidate glob
+# below structurally cannot see it — this script runs at `npm publish` time (package.json
+# prepublishOnly), where only the git-tracked repo exists (CI has no access to a contributor's
+# local home directory, and different operators have different paths). Incident (a) is the
+# MOTIVATING PRECEDENT for the general pattern, not a case this specific scope closes. Closing it
+# for real needs a separate, local-only check over the memory store — a different surface with
+# different constraints, not a widening of this one.
+#
 # Advisory (like the CHANGELOG check above), same reasoning: a stale self-count is a documentation
 # defect, not a broken package, and turning publish red on prose trains the override this repo has
 # already measured people reaching for.


### PR DESCRIPTION
## Summary
- Corrects an A-grade finding from codex/gpt-5.5's genuinely independent review of the reship campaign PR #374 — the review completed *after* #374 had already merged, and its finding is real.
- The "Self-restatement" header comment in `scripts/version_lockstep_check.sh` cited a memory-file incident as motivating evidence, worded so it read as though this scan's candidate glob (`CLAUDE.md`/`AGENTS.md`/`SKILL.md` under repo root) reaches that incident. It structurally cannot: the memory store lives under the operator's home directory, outside this repo entirely, and this script runs at `npm publish` time where only the git-tracked repo exists.
- Fixed the comment to state plainly that the memory incident is the *motivating precedent* for the general self-restatement pattern, not a case this specific arm closes.
- Comment-only change — no behavior change. 23/23 lanes in `test_version_lockstep_lanes.sh` unchanged before/after.

## Context — provenance correction riding alongside this fix
This PR also carries a self-caught correction: PR #374's marker/commit/PR text claimed `crossfamily: panel(codex/gpt-5.5)` for the findings it fixed. That claim was **false provenance** — those findings actually came from a same-family Sonnet challenger (`fh-commons:quench-challenger`, Read/Grep/Glob only, no Bash) whose completion was misattributed to codex in real-time narration while codex was still running in the background. This was caught by re-reading codex's full output after the fact and cross-checking timestamps. A separate correction comment is being posted on #374 itself; the underlying code fixes in #374 remain correct and independently verified — only the provenance label was wrong.

## Test plan
- [x] `bash -n scripts/version_lockstep_check.sh` — syntax OK
- [x] `bash scripts/test_version_lockstep_lanes.sh` — 23/23 PASS (unchanged)
- [x] `bash scripts/version_lockstep_check.sh .` on live repo — still PASS
- [x] FH 4-axis pre-commit gate — all axes PASS (sonnet-floor, comment-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017stQ8xPouvNoHqtFa1PNSL