### PR TITLE
docs: Homebrew tap discoverability (README x4 + CHEATSHEET) + pillars.svg fix

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -197,7 +197,7 @@ claude plugin list
 
 ## 9.5. npx / CLI — zero-install governance gate (any repo, no Claude Code session)
 
-The npm package `@chrono-meta/fh-gate` runs FH's governance gate as a plain CLI — no clone, no plugin, no `claude` session. Use it in CI or any repo. It shells out to a backend (`claude --print` or `codex exec`) and returns a machine-parseable verdict + exit code.
+The npm package `@chrono-meta/fh-gate` runs FH's governance gate as a plain CLI — no clone, no plugin, no `claude` session. Use it in CI or any repo. It shells out to a backend (`claude --print` or `codex exec`) and returns a machine-parseable verdict + exit code. A Homebrew tap ships the exact same content (100% parity — same npm tarball, just a different install path); prefer it if you'd rather not type `npx --package` every time.
 
 ```bash
 # Governance gate — wraps any coding agent's output as a post-generation check
@@ -211,6 +211,14 @@ FH_BACKEND=codex npx --package @chrono-meta/fh-gate fh-gate   # Codex backend (d
 npx --package @chrono-meta/fh-gate fh-run --skill <name>
 npx --package @chrono-meta/fh-gate fh-goal "<goal text>"      # goal runner
 npx --package @chrono-meta/fh-gate fh-codex-doctor --strict  # Codex adapter drift check
+
+# Homebrew alternative (community tap, not yet in Homebrew Core — `brew search` won't
+# find it without tapping first): install once, then call the binaries directly
+brew tap chrono-meta/forge-harness && brew install forge-harness
+fh-gate                     # same as `npx --package @chrono-meta/fh-gate fh-gate`
+fh-run --skill <name>
+fh-goal "<goal text>"
+fh-codex-doctor --strict
 ```
 
 | Knob | Values | Effect |

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,6 +8,7 @@
   <img src="https://img.shields.io/badge/Claude_Code-compatible-a855f7.svg" alt="Claude Code">
   <a href="https://github.com/chrono-meta/forge-harness/issues/72"><img src="https://img.shields.io/badge/Codex-beta_·_help_validate-f59e0b.svg" alt="Codex-compatible beta — help validate (issue #72)"></a>
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
+  <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>
 </p>
 
 <p align="center">
@@ -196,6 +197,10 @@ npx --package @chrono-meta/fh-gate fh-gate                    # 既定: Claude �
 FH_BACKEND=codex npx --package @chrono-meta/fh-gate fh-gate   # Codex バックエンド
 FH_BACKEND=auto npx --package @chrono-meta/fh-gate fh-gate "src/foo.ts" full
 # → FH_GATE_VERDICT: PASS | PENDING | BLOCKED | ESCALATE
+
+# または Homebrew 経由（内容は同じ、インストール後は npx 接頭辞不要）:
+brew tap chrono-meta/forge-harness && brew install forge-harness
+fh-gate
 ```
 
 `fh-gate` は両ランタイムに同じ FH ガバナンスプロンプトを使います。`FH_BACKEND=claude` は `claude --print` を、`FH_BACKEND=codex` は `codex exec` を実行し、`FH_BACKEND=auto` は両 CLI が揃っていれば Codex を優先します — ただし `auto` はフォールバック*選択*であり、レグは 1 つだけ走ります。`FH_BACKEND=cross` は両ファミリーを走らせて findings を union します(一方だけが見つけた指摘も指摘なので、投票ではなく union)。判定はレグ中で最も重いものです。コストは約 2 倍なので既定ではなく、判定・ゲート・不可逆な面の変更に使います。出力は実際に走ったレグを常に明示します(`FH_GATE_LEGS:`、`FH_GATE_DECORRELATED:`) — 片方のファミリーしかない環境では単一レグに縮退し、その事実を明記します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -8,6 +8,7 @@
   <img src="https://img.shields.io/badge/Claude_Code-compatible-a855f7.svg" alt="Claude Code">
   <a href="https://github.com/chrono-meta/forge-harness/issues/72"><img src="https://img.shields.io/badge/Codex-beta_·_help_validate-f59e0b.svg" alt="Codex-compatible beta — help validate (issue #72)"></a>
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
+  <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>
 </p>
 
 <p align="center">
@@ -195,6 +196,10 @@ npx --package @chrono-meta/fh-gate fh-gate                    # 기본: Claude �
 FH_BACKEND=codex npx --package @chrono-meta/fh-gate fh-gate   # Codex 백엔드
 FH_BACKEND=auto npx --package @chrono-meta/fh-gate fh-gate "src/foo.ts" full
 # → FH_GATE_VERDICT: PASS | PENDING | BLOCKED | ESCALATE
+
+# 또는 Homebrew로 (같은 내용, 설치 후엔 npx 접두어 불필요):
+brew tap chrono-meta/forge-harness && brew install forge-harness
+fh-gate
 ```
 
 `fh-gate`는 두 런타임에 동일한 FH 거버넌스 프롬프트를 씁니다. `FH_BACKEND=claude`는 `claude --print`를, `FH_BACKEND=codex`는 `codex exec`를 실행하며, `FH_BACKEND=auto`는 두 CLI가 모두 있으면 Codex를 우선합니다 — 다만 `auto`는 폴백 *선택*이라 레그를 하나만 돌립니다. `FH_BACKEND=cross`는 두 패밀리를 모두 돌려 findings를 union 합니다(한쪽만 본 지적도 지적이므로 투표가 아니라 union). 판정은 레그 중 가장 무거운 것입니다. 비용이 약 2배라 기본값이 아니며, 판정·게이트·비가역 표면 변경에 씁니다. 출력은 실제로 돈 레그를 항상 밝힙니다(`FH_GATE_LEGS:`, `FH_GATE_DECORRELATED:`) — 한 패밀리만 설치된 머신에서는 단일 레그로 내려가되 그 사실을 명시합니다. 단일 패밀리 결과가 교차검증된 것처럼 읽히는 편이 더 나쁘기 때문입니다.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <img src="https://img.shields.io/badge/Claude_Code-compatible-a855f7.svg" alt="Claude Code">
   <a href="https://github.com/chrono-meta/forge-harness/issues/72"><img src="https://img.shields.io/badge/Codex-beta_·_help_validate-f59e0b.svg" alt="Codex-compatible beta — help validate (issue #72)"></a>
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
+  <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>
 </p>
 
 <p align="center">
@@ -128,6 +129,7 @@ cd ~/projects/{your-project} && claude
 | Solo dev, one project, just trying it | [`templates/starter_profile.md`](templates/starter_profile.md) — one command, curated first-five skills |
 | Multiple projects, want the compounding hub | Clone the hub (quickstart above) |
 | CI / non-Claude runtime, gates only | `npx @chrono-meta/fh-gate` (zero-install governance gate) |
+| Prefer `brew` over `npx`/`npm` | `brew tap chrono-meta/forge-harness && brew install forge-harness` — same 100%-parity content, different install UX (community tap; not yet in Homebrew Core, so `brew search` won't find it without the tap first) |
 
 ---
 
@@ -230,6 +232,10 @@ npx --package @chrono-meta/fh-gate fh-gate                    # default: Claude 
 FH_BACKEND=codex npx --package @chrono-meta/fh-gate fh-gate   # Codex backend
 FH_BACKEND=auto npx --package @chrono-meta/fh-gate fh-gate "src/foo.ts" full
 # → FH_GATE_VERDICT: PASS | PENDING | BLOCKED | ESCALATE
+
+# or, via Homebrew (same content, no npx prefix needed after install):
+brew tap chrono-meta/forge-harness && brew install forge-harness
+fh-gate
 ```
 
 `fh-gate` uses the same FH governance prompt for both runtimes. `FH_BACKEND=claude` runs `claude --print`; `FH_BACKEND=codex` runs `codex exec`; `FH_BACKEND=auto` prefers Codex when both CLIs are present — note that `auto` is fallback *selection*: it runs ONE leg. `FH_BACKEND=cross` runs BOTH families and unions their findings (a finding only one family saw is still a finding, so it unions rather than votes); the verdict is the most severe across legs. It costs ~2x, so it is for load-bearing verdict/gate/irreversible-surface changes, not a default. The output always declares which legs actually ran (`FH_GATE_LEGS:`, `FH_GATE_DECORRELATED:`) — on a machine with only one family, `cross` degrades to that single leg and says so, because a single-family result that reads as cross-checked is worse than an honest one.

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,6 +8,7 @@
   <img src="https://img.shields.io/badge/Claude_Code-compatible-a855f7.svg" alt="Claude Code">
   <a href="https://github.com/chrono-meta/forge-harness/issues/72"><img src="https://img.shields.io/badge/Codex-beta_·_help_validate-f59e0b.svg" alt="Codex-compatible beta — help validate (issue #72)"></a>
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
+  <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>
 </p>
 
 <p align="center">
@@ -185,6 +186,10 @@ npx --package @chrono-meta/fh-gate fh-gate                    # 默认：Claude 
 FH_BACKEND=codex npx --package @chrono-meta/fh-gate fh-gate   # Codex 后端
 FH_BACKEND=auto npx --package @chrono-meta/fh-gate fh-gate "src/foo.ts" full
 # → FH_GATE_VERDICT: PASS | PENDING | BLOCKED | ESCALATE
+
+# 或通过 Homebrew（内容相同，安装后无需 npx 前缀）：
+brew tap chrono-meta/forge-harness && brew install forge-harness
+fh-gate
 ```
 
 `fh-gate` 对两种运行时使用同一套 FH 治理提示。`FH_BACKEND=claude` 运行 `claude --print`；`FH_BACKEND=codex` 运行 `codex exec`；`FH_BACKEND=auto` 在两个 CLI 都存在时优先选择 Codex —— 但 `auto` 是回退式*选择*，只运行一条腿。`FH_BACKEND=cross` 会运行两个模型家族并对 findings 取并集(只有一方发现的问题仍然是问题，因此是并集而非投票)，判定取各腿中最严重者。成本约为 2 倍，因此并非默认值，适用于判定/门禁/不可逆面的变更。输出始终声明实际运行了哪些腿(`FH_GATE_LEGS:`、`FH_GATE_DECORRELATED:`) —— 在只装了一个家族的机器上，`cross` 会降级为单腿并明确说明，因为让单家族结果读起来像交叉验证过更糟。

--- a/docs/pillars.svg
+++ b/docs/pillars.svg
@@ -17,10 +17,6 @@
   <!-- Background -->
   <rect width="680" height="100" fill="url(#bg)"/>
 
-  <!-- Top hot-metal accent -->
-  <rect width="680" height="3" fill="#e07d2a" filter="url(#glow)"/>
-  <rect y="3" width="680" height="5" fill="#e07d2a" fill-opacity="0.10"/>
-
   <!-- ═══ HARNESS (x=8, cx=88) ═══ -->
   <rect x="8" y="10" width="160" height="84" rx="5" fill="url(#cd)" stroke="#c46820" stroke-width="0.8"/>
   <!-- Chain link icon (harness = link) -->

--- a/docs/pillars.svg
+++ b/docs/pillars.svg
@@ -19,9 +19,9 @@
 
   <!-- ═══ HARNESS (x=8, cx=88) ═══ -->
   <rect x="8" y="10" width="160" height="84" rx="5" fill="url(#cd)" stroke="#c46820" stroke-width="0.8"/>
-  <!-- Chain link icon (harness = link) -->
-  <ellipse cx="81" cy="34" rx="10" ry="6" fill="none" stroke="#e07d2a" stroke-width="2" transform="rotate(-35 81 34)"/>
-  <ellipse cx="95" cy="44" rx="10" ry="6" fill="none" stroke="#e07d2a" stroke-width="2" transform="rotate(-35 95 44)"/>
+  <!-- Chain link icon (harness = link) — opposite tilts so the two loops actually interlock -->
+  <ellipse cx="82" cy="33" rx="9" ry="13" fill="none" stroke="#e07d2a" stroke-width="2" transform="rotate(-30 82 33)"/>
+  <ellipse cx="94" cy="45" rx="9" ry="13" fill="none" stroke="#e07d2a" stroke-width="2" transform="rotate(30 94 45)"/>
   <text x="88" y="63" text-anchor="middle" font-family="Georgia,'Times New Roman',serif" font-size="13" font-weight="bold" fill="#f5943a" letter-spacing="2">HARNESS</text>
   <text x="88" y="76" text-anchor="middle" font-family="Georgia,'Times New Roman',serif" font-size="9.5" fill="#9e7040">Harness-ify a project</text>
   <text x="88" y="88" text-anchor="middle" font-family="Georgia,'Times New Roman',serif" font-size="9.5" fill="#9e7040">— raise its floor</text>


### PR DESCRIPTION
Homebrew badge + brew install alternative added alongside existing npm
instructions in all 4 README language variants and CHEATSHEET.md's
zero-install CLI section — the tap has no discovery path yet (not in
Homebrew Core), so a direct doc link is the only route.

Also drops the thick top accent bar in docs/pillars.svg (an 8px glowing
orange rect + translucent rect above the HARNESS/FORGE/ACCELERATE/COMPOUND
row) per operator request — cosmetic only, verified via local SVG render.
