### PR TITLE
feat(npm): star-growth push — postinstall notice + README CTA + badge

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -9,10 +9,15 @@
   <a href="https://github.com/chrono-meta/forge-harness/issues/72"><img src="https://img.shields.io/badge/Codex-beta_·_help_validate-f59e0b.svg" alt="Codex-compatible beta — help validate (issue #72)"></a>
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
   <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>
+  <a href="https://github.com/chrono-meta/forge-harness/stargazers"><img src="https://img.shields.io/github/stars/chrono-meta/forge-harness?style=social" alt="GitHub stars"></a>
 </p>
 
 <p align="center">
   <a href="README.md">English</a> · <a href="README.ko.md">한국어</a> · <a href="README.zh.md">中文</a> · <b>日本語</b>
+</p>
+
+<p align="center">
+  <sub>役に立ったら ⭐ が他の人の発見につながります。</sub>
 </p>
 
 <p align="center">

--- a/README.ko.md
+++ b/README.ko.md
@@ -9,10 +9,15 @@
   <a href="https://github.com/chrono-meta/forge-harness/issues/72"><img src="https://img.shields.io/badge/Codex-beta_·_help_validate-f59e0b.svg" alt="Codex-compatible beta — help validate (issue #72)"></a>
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
   <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>
+  <a href="https://github.com/chrono-meta/forge-harness/stargazers"><img src="https://img.shields.io/github/stars/chrono-meta/forge-harness?style=social" alt="GitHub stars"></a>
 </p>
 
 <p align="center">
   <a href="README.md">English</a> · <b>한국어</b> · <a href="README.zh.md">中文</a> · <a href="README.ja.md">日本語</a>
+</p>
+
+<p align="center">
+  <sub>도움이 됐다면 ⭐ 하나가 다른 사람이 찾는 데 도움이 됩니다.</sub>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -9,10 +9,15 @@
   <a href="https://github.com/chrono-meta/forge-harness/issues/72"><img src="https://img.shields.io/badge/Codex-beta_·_help_validate-f59e0b.svg" alt="Codex-compatible beta — help validate (issue #72)"></a>
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
   <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>
+  <a href="https://github.com/chrono-meta/forge-harness/stargazers"><img src="https://img.shields.io/github/stars/chrono-meta/forge-harness?style=social" alt="GitHub stars"></a>
 </p>
 
 <p align="center">
   <b>English</b> · <a href="README.ko.md">한국어</a> · <a href="README.zh.md">中文</a> · <a href="README.ja.md">日本語</a>
+</p>
+
+<p align="center">
+  <sub>If this is useful, a ⭐ helps others find it.</sub>
 </p>
 
 <p align="center">

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,10 +9,15 @@
   <a href="https://github.com/chrono-meta/forge-harness/issues/72"><img src="https://img.shields.io/badge/Codex-beta_·_help_validate-f59e0b.svg" alt="Codex-compatible beta — help validate (issue #72)"></a>
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
   <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>
+  <a href="https://github.com/chrono-meta/forge-harness/stargazers"><img src="https://img.shields.io/github/stars/chrono-meta/forge-harness?style=social" alt="GitHub stars"></a>
 </p>
 
 <p align="center">
   <a href="README.md">English</a> · <a href="README.ko.md">한국어</a> · <b>中文</b> · <a href="README.ja.md">日本語</a>
+</p>
+
+<p align="center">
+  <sub>如果这对你有用，⭐ 一下能帮助更多人发现它。</sub>
 </p>
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "scripts": {
     "prepare": "chmod +x bin/fh-gate.js bin/fh-run.js bin/fh-goal.js bin/fh-codex-doctor.js scripts/fh-gate.sh scripts/fh-run.sh scripts/fh-goal.sh",
+    "postinstall": "node scripts/postinstall_notice.js",
     "test": "bash scripts/selfcheck.sh",
     "prepublishOnly": "bash scripts/version_lockstep_check.sh && bash scripts/selfcheck.sh && bash scripts/package_coverage_check.sh --vs-tarball && bash scripts/public_surface_scan_files.sh",
     "release": "bash scripts/public_surface_scan_files.sh && npm publish"
@@ -61,6 +62,7 @@
     "docs/pillars.svg",
     "scripts/fh-gate.sh",
     "scripts/frontier_digest_autopilot.sh",
+    "scripts/postinstall_notice.js",
     "scripts/fh-run.sh",
     "scripts/fh-goal.sh",
     "scripts/count_check.sh",

--- a/scripts/postinstall_notice.js
+++ b/scripts/postinstall_notice.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+'use strict';
+// postinstall_notice.js — one-line, stderr-only, CI-silent install notice.
+//
+// WHY: 16k+ npm downloads (measured live, 2026-08-15) vs 7 GitHub stars on the same day —
+// people are using fh-gate and have no reason to ever see the GitHub repo, since `npx
+// @chrono-meta/fh-gate` never surfaces it. This closes that gap at the one moment every
+// installer passes through, without touching fh-gate.js's own stdout (that IS the CI
+// contract per its own header comment — this notice must never risk polluting it).
+//
+// WHY stderr, not stdout: npm's own install-time output already goes to stderr by
+// convention (npm's progress/warnings), and more importantly this keeps it structurally
+// impossible for the notice to ever be mistaken for gate output — a script piping
+// `npx @chrono-meta/fh-gate`'s stdout for FH_GATE_VERDICT: parsing never sees this line,
+// even if this file were somehow invoked in the same process (it isn't — separate
+// lifecycle script, separate process).
+//
+// WHY CI-silent: postinstall banners are a known source of npm-ecosystem noise complaints,
+// and this package explicitly markets itself for CI use (CHEATSHEET.md §9.5). A line that
+// reprints on every CI run install is exactly the annoyance that gets a package reported,
+// not starred. Skip whenever a CI environment is plausible OR the operator opts out.
+if (process.env.CI || process.env.FH_NO_BANNER || process.env.CONTINUOUS_INTEGRATION) {
+  process.exit(0);
+}
+try {
+  process.stderr.write(
+    '\n⭐ forge-harness (fh-gate) — if this is useful, a star helps others find it:\n' +
+    '   https://github.com/chrono-meta/forge-harness\n' +
+    '   (set FH_NO_BANNER=1 to silence this message)\n\n'
+  );
+} catch (_) {
+  // Never fail an install over a courtesy message.
+}
+process.exit(0);


### PR DESCRIPTION
Operator ask: npm has 16,326 downloads vs 7 GitHub stars — usage exists,
awareness of the repo does not.

Added scripts/postinstall_notice.js: a one-line stderr GitHub-star
pointer on install, CI-silent (CI/FH_NO_BANNER env checks), never
touching fh-gate.js's own stdout (the documented CI verdict contract).
Measured limitation found while verifying this locally: npm's default
foreground-scripts=false suppresses postinstall output for a plain `npm
install`/`npx` unless --foreground-scripts is passed — reproduced via a
real pack+install round-trip. Kept anyway (zero cost, CI-silent by
design) but its real reach is lower than hoped; the README channel below
is the actually-reliable one.

Added an explicit "⭐ if useful, star it" line + a live GitHub-stars
badge to all 4 README language variants next to the existing npm/brew
badges — visible on both GitHub and the npm package page (npm renders
README.md directly).

Also fixed a stale reference in the open awesome-claude-code submission
(issue #1961, awaiting maintainer review since 2026-06-07): the demo
prompt used the pre-rename skill name source-grounding-audit instead of
its current name phantom-quench, and added the npm zero-install option
to the Validate-Claims field. Re-triggered bot re-validation, still
validation-passed.
