### PR TITLE
chore(release): v1.4.98 — ship 36 files stranded since v1.4.97

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,13 @@
   "plugins": [
     {
       "name": "fh-meta",
-      "version": "1.4.97",
+      "version": "1.4.98",
       "description": "Hub meta-operations toolkit — 35 skills + 7 agents. New in 1.4.53: `fh-codex-doctor` (npm bin) — Codex adapter drift scanner; reads the documented M1/M2/M3 skill tier map + skill/agent source and reports codex-native/adapter-required/claude-native/unclassified per unit, wired into `npm test`/`prepublishOnly` (fail-closed on unclassified Claude-native primitives). New in 1.4.49: steel-quench gains Step 0.6 Verdict-Invariance Probe (groundedness axis — a load-bearing judged gate's verdict must track behavior, not rubric phrasing; measured flip-count over cross-family paraphrases; arXiv:2605.06161 Policy Invariance anchor); multi_model_sidecar_strategy §Vendor-native harness (a model is strongest in its own vendor CLI — Claude/CC, GPT/codex, Gemini/Antigravity; a universal router degrades all of them, so it stays an autocomplete/QA sidecar, never orchestration); predelete_check.sh fail-closed rewrite; memory-hygiene A-TMA anchor. New in 1.4.48: phantom-quench + steel-quench gain external frontier anchors (arXiv:2607.02052 package-hallucination; arXiv:2607.02057 prompt-coverage-adequacy); README model-flat claim reframed from a per-release point-curve to structural invariants (operation flattens across tiers; depth tier-order fixed within a generation). New in 1.4.47: onboarding step ① surfaces the Mode D companion-store session-start load in the auto-read salience anchor (previously only in the local binding + rules, so a greeting could skip the load). New in 1.4.46: context-doctor command-output axis (route to rtk/proxy for verbose CLI stdout, complementing .claudeignore; risk-gated to token-scarce envs). New in 1.4.41: context-doctor 2026 trigger vocab (context engineering/rot/collapse) + phantom-citation hardening; hub measurement-integrity-checklist (cross-model measurement pre-flight: display-name pin/reps≥3/discriminating probe). New in 1.4.40: install-wizard queryable-wiki scaffold (INDEX + session-start read + R/W/C ingest). New in 1.4.39: auto-decorrelation (cross-family verifier sidecar recruitment) + video-ingest (capability-routed video ingestion). New in 1.4.x: verify-axis check-class taxonomy (mandatory-pass/measured/judged), no-reinvention Tier-0 inventory, 7-class failure taxonomy, Destructive-Op Gate, Wave-T (Temper), tier-floor governance, Mode D Model Notice, FC consent lane, default-Sonnet guidance. New in 1.3.0: public-surface-audit, field-harvest Mode B auto-trigger, 4-axis gate scope ext. Validated cross-CLI: Claude Code, Codex, Gemini.",
       "source": "./plugins/fh-meta"
     },
     {
       "name": "fh-commons",
-      "version": "1.4.97",
+      "version": "1.4.98",
       "description": "Project-agnostic utility skills — 5 skills (convergence-loop · deliberation · mcp-circuit-breaker · token-budget-gate · ko-tech-writer) + 1 agent (quench-challenger). Domain-independent utilities transplantable into any project.",
       "source": "./plugins/fh-commons"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrono-meta/fh-gate",
-  "version": "1.4.97",
+  "version": "1.4.98",
   "description": "FH runtime adapters — run FH governance, skills, and agents via Claude or Codex with machine-parseable gates.",
   "license": "MIT",
   "keywords": [

--- a/plugins/fh-commons/.claude-plugin/plugin.json
+++ b/plugins/fh-commons/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-commons",
-  "version": "1.4.97",
+  "version": "1.4.98",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/.claude-plugin/plugin.json
+++ b/plugins/fh-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-meta",
-  "version": "1.4.97",
+  "version": "1.4.98",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/CHANGELOG.md
+++ b/plugins/fh-meta/CHANGELOG.md
@@ -10,6 +10,47 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## Plugin Level
 
+### [1.4.98] — 2026-08-15
+
+**fix: 1.4.97 이후 쌓인 출하면 36파일을 실제로 배포한다 — 특히 «있는데 실행에 도달 못 하던» 검증 축 하나**
+
+- 🔴 **이 릴리스의 존재 이유 자체가 결함 하나다.** `auto-decorrelation` 에 **Step 6.5 — Standpoint
+  axis**(2026-08-14 신설, `crossfamily` 와 직교하는 두 번째 탈상관 축)를 커밋했는데 **버전을 안
+  올렸다.** 플러그인 캐시는 `plugin.json` 버전으로 키잉되므로(`~/.claude/plugins/cache/<mk>/<plugin>/<version>/`),
+  버전이 그대로면 캐시가 무효화되지 않는다 — 즉 **레포에는 있고 어떤 런타임에도 없는 규칙**이 하루
+  넘게 존재했다. 실측(2026-08-15): 설치본 `auto-decorrelation/SKILL.md` 에 `standpoint` **0회** ·
+  `Step 6.5` **0회**, 레포본에는 263~291행에 전문. 나머지 34개 스킬은 드리프트 0 — 정확히 이 한
+  파일만 도달 실패했고, 하필 그게 그날 실제로 안 걸린 기능이었다.
+  **일반형: 스킬을 고치고 버전을 안 올리면 저자 머신을 포함한 모든 런타임에서 그 수정은 존재하지
+  않는다.** `built_but_not_wired` 의 배포채널 판본이고, 게이트가 «행위자가 읽는 곳»에 있어야 한다는
+  gate-locality 원칙이 *배포 지연*이라는 다른 메커니즘으로 재발한 것이다.
+  **기존 검사기는 정상 작동했다** — `session_close_check.sh` ④-b 가 「마지막 태그 이후 출하자산
+  변경 → 재출하 제안」을 정확히 발화하고 있었다. 놓친 지점은 검사기가 아니라 **그 출력을 표시필터로
+  잘라 읽은 것**(`| tail -15`)이었다. 새 기계장치를 짓지 않고 기존 절차를 실행하는 것이 이 릴리스다.
+
+- **Standpoint 축 신설** (PR #370 · #371 · #378) — 계열(family) 다양성은 *리뷰어의 오류분포*를
+  탈상관시키지만 *리뷰가 대조되는 ground truth* 는 탈상관시키지 않는다. 공유 본체(shared-body)
+  변경에서 «누구의 레포를 기준으로 검증했는가」를 폐쇄 enum 으로 기록한다
+  (`tier1` · `tier2(<대상>)` · `tier2b(<대상>)` · `tier3(<대상>)` · `not-applicable` +
+  could-not/did-not/did-not-look 3분 degrade). 실행 시점은 **첫 push 이전, 위험판정 분기 없이**.
+  정본 = `knowledge/shared/harness-core/field_verdict_crossfamily_gate.md §7`.
+  ⚠️ 정직한 현 상태: 이 필드는 **산문 전용**이다 — pre-commit 훅에 `standpoint` 매치 0건,
+  픽스처 스위트 없음(`crossfamily` 는 21건 + 픽스처로 하드 차단). 첫 거짓값이 기록되면 기계화한다.
+
+- **컴패니언 스토어 노드↔노드 스코핑** (PR #368 · #372) — 같은 머신에서 두 하네스가 컴패니언
+  스토어를 공유할 때 서로의 manifest/memory-index 를 되읽던 결함. `fh_hub_identity.sh` 신설로
+  세 호출부의 네임스페이스 판단을 단일 소스로 통일.
+- **레인 배선** (PR #369 · #374) — `test_field_canon` · `test_stale_clone_guard` 재배선(DEBT 2→0),
+  자기-재진술 렌즈 + 임베디드 `--self-test` 디스패처 탐지 신설.
+- **SessionStart 노드 플로어에 origin-behind 탐지** (PR #376) · **frontier-digest 무인
+  파이프라인** (PR #377) · **positioning roadmap 문서** (PR #379).
+- **Homebrew tap 출하** (PR #380 · #383) — `brew install forge-harness`(npm 패키지와 100% parity).
+  Homebrew Core 제출은 채택 기준(star 75 / fork 30 / watcher 30, 자기제출 ×3) 미달로 **보류**,
+  재개조건 ~50+ star 로 명시 기록.
+- **ko-tech-writer 수리** (PR #373) — render-artifact 스코프 · 전칭단정 스캔 · 한글 `\b` 정규식 트랩.
+
+---
+
 ### [1.4.97] — 2026-08-13
 
 **fix: 죽어 있던 게이트 캘리브레이션 배선 · 참조를 「선언」이 아니라 「실제 tarball」과 대조**


### PR DESCRIPTION
## Why this release exists

It fixes the defect that produced it. **Step 6.5 (standpoint axis)** was committed to `auto-decorrelation/SKILL.md` on 2026-08-14 **without a version bump**. Plugin caches are keyed by `plugin.json` version (`.../cache/<marketplace>/<plugin>/<version>/`), so nothing invalidated — the rule existed in the repo and in **no runtime at all**, including the authoring machine's.

**Measured 2026-08-15:**

| | |
|---|---|
| repo `auto-decorrelation/SKILL.md` | Step 6.5 present (full closed enum + Done When) |
| installed copy (`1.4.97`) | `standpoint` **0 matches**, `Step 6.5` **0 matches** |
| other 34 skills | zero drift — exactly one file stranded |

The stranded file was the one whose rule failed to fire that day. That is not a coincidence worth smoothing over: it is the mechanism.

**General form**: a skill edited without a version bump does not exist in any runtime. `built_but_not_wired` applied to the distribution channel — gate-locality recurring through *distribution lag* rather than through file location.

## The existing detector was not at fault

`session_close_check.sh` **④-b** emits `npm-shipped assets changed since v1.4.97 — propose lockstep republish (never auto)` and fired on today's push. It was missed because the push output was read through `| tail -15` — a display filter over a verdict stream, which is a failure class this repo already has on record. **No new machinery is added here**; this runs the procedure that already existed.

## What ships

36 npm-shipped files changed since `v1.4.97` (20 commits). Headline items:

- **Standpoint axis** (#370 · #371 · #378) — second decorrelation axis, orthogonal to `crossfamily:`. Family diversity decorrelates the *reviewer's error distribution*; standpoint decorrelates *which ground truth the review is checked against*. Closed enum, runs **before the first push**, no risk-branch. ⚠️ Honest status: prose-only — 0 hook matches vs 21 for `crossfamily:`, no fixture suite. Mechanize on the first recorded false value, not before.
- **Companion-store node↔node scoping** (#368 · #372) — two harnesses sharing one store read each other's manifest/memory-index.
- **Lane wiring** (#369 · #374) — DEBT 2→0; self-restatement lens; embedded `--self-test` dispatcher detection.
- **SessionStart origin-behind detection** (#376) · **frontier-digest unattended pipeline** (#377) · **positioning roadmap** (#379).
- **Homebrew tap** (#380 · #383) — `brew install forge-harness`. Homebrew Core submission held (acceptance bar: 75 stars / 30 forks / 30 watchers, ×3 self-submitted; actual: 7/0/0) with a documented reopen condition.
- **ko-tech-writer fixes** (#373).

## Verification

- `version_lockstep_check.sh`: PASS — 4 shipped version strings all at 1.4.98 (package.json + 2 plugin.json + marketplace.json ×2 entries + CHANGELOG newest entry).
- `count_check.sh`: PASS (no skill added/removed).
- Pre-commit gate: PASS (lightweight — version strings + CHANGELOG, no behavioral code).
- **How this was found**: the operator asked whether a `standpoint-review` skill should be built. The no-reinvention scan (isolated agent) returned DUPLICATE — the role already lives in `auto-decorrelation` Step 6.5. Source-grounding that claim rather than accepting it is what surfaced the repo↔cache drift. **The skill was not built** — it would have forked existing content and left the reachability defect untouched.

## Residual

Cache invalidation is not verified in this session — it requires a reinstall/restart. First check next session: does `.../cache/forge-harness/fh-meta/1.4.98/skills/auto-decorrelation/SKILL.md` actually contain `standpoint`?

🤖 Generated with [Claude Code](https://claude.com/claude-code)