### PR TITLE
fix(publish): fh_hub_identity.sh was misclassified as shipped

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "scripts/branch_claim.sh",
     "scripts/test_branch_claim_lanes.sh",
     "scripts/hook_source_lib.sh",
-    "scripts/fh_hub_identity.sh",
     "scripts/test_hook_source_gate_lanes.sh",
     "templates/.claude/rules/mcp_tool_gating.md",
     ".claude/rules/fh_4axis_gate.md",

--- a/scripts/package_coverage_check.sh
+++ b/scripts/package_coverage_check.sh
@@ -63,6 +63,17 @@ ACCEPTED_ABSENT=(
   # sibling directly above: it exercises scripts/sync-to-be.sh, itself ACCEPTED_ABSENT — a lane
   # suite for a script that never ships has nothing to verify on a consumer's machine either.
   "scripts/sync_to_be_lanes.sh"
+  # Shared identity resolver for the two transports directly above (added to files[] by #368,
+  # REMOVED from it 2026-08-15). It was the odd one out: its own callers — sync-to-be.sh and
+  # sync-from-be.sh — are ACCEPTED_ABSENT here for a reason that applies to it verbatim (the
+  # namespacing it computes only means anything on a machine that HAS the operator's companion
+  # store), yet it alone was listed for shipping. The pre-publish confidentiality scan is what
+  # surfaced the misclassification: it carries the companion store's own directory vocabulary,
+  # which would have reached the registry for the first time in 1.4.98. The one shipped caller,
+  # fh_session_load.sh, sources it behind `[ -f ]` and documents its own degrade ("an unresolved
+  # identity degrades to the historical unsuffixed tracks-meta rather than erroring — that is the
+  # pre-fix behavior, not a new failure mode"), so a consumer loses nothing that consumer ever had.
+  "scripts/fh_hub_identity.sh"
   # ── The three lane suites selfcheck.sh's DEBT-12 pair-loop names but does not ship ────────────
   # Added 2026-08-13, and the way they got here is the point: this check CAUGHT them. Before that
   # loop existed, these names lived in lane_runner_check.sh's DEBT array as bare basenames


### PR DESCRIPTION
## What the gate caught

The **pre-publish confidentiality scan blocked v1.4.98**. `scripts/fh_hub_identity.sh` carries the operator's companion-store directory vocabulary, and it was listed in `package.json` `files[]`.

A known-pair check against the live registry confirmed this would be a **first exposure**, not a pre-existing one:

```
1.4.97 tarball : fh_hub_identity        → 0 hits   (never shipped)
control        : package/scripts/selfcheck.sh → 1 hit  (the instrument sees real files)
```

Scrub-before-publish worked exactly as the doctrine intends.

## Why removal, not an override or a token rewrite

This is a **classification correction**. The file's own two callers — `sync-to-be.sh` and `sync-from-be.sh` — are already `ACCEPTED_ABSENT`, for a reason that applies to it verbatim: the namespacing it computes only means anything on a machine that *has* the companion store. It alone was added to `files[]` (in #368).

The one shipped caller, `fh_session_load.sh`, sources it behind `[ -f ]` and documents its own degrade (*"an unresolved identity degrades to the historical unsuffixed tracks-meta rather than erroring — that is the pre-fix behavior, not a new failure mode"*). A consumer loses nothing it ever had.

`PUBLIC_SURFACE_OK=1` was considered and rejected: residency is an absolute rule here, and there is no reason to make a first-ever gate bypass the precedent.

## Verification

- `public_surface_scan_files.sh`: **blocked → PASS** after the change.
- `package_coverage_check.sh`: PASS, no orphaned reference introduced.
- Reference census: of 5 files referencing it, only `fh_session_load.sh` ships (the other two are `not-ship`; `package_coverage_check.sh` is this PR's own new entry; CHANGELOG is prose).
- **Known-pair with the file physically removed**: `fh_session_load.sh` → rc=0 on 3/3 reps, both under consumer conditions (no companion store) and sibling-harness conditions (companion store present). Control arm with the file present: rc=0 on 2/2.

### Recorded self-correction

The first draw of that known-pair returned rc=124 (timeout) on the file-absent arm and rc=0 on the control, and that was written up as *"the arms differ — my change may be the cause."* **That conclusion was wrong.** Re-running gave rc=0 on both, and reps 3+2 confirmed it: the 124 was a one-off timing flake — a companion-store fetch exceeding the 60s deadline. The measurement is network-timing sensitive and was judged from single draws, which this repo's own rule (`비결정 borderline → reps=3`) exists to prevent. Recorded rather than quietly fixed, because the conclusion *and* its stated grounds both had to be retracted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)