### PR TITLE
feat(node-check): consent-gated auto fast-forward, envelope-enforced

### DIFF
--- a/scripts/fh_node_check.sh
+++ b/scripts/fh_node_check.sh
@@ -199,7 +199,46 @@ if git -C "$FH" rev-parse --git-dir >/dev/null 2>&1 && git -C "$FH" remote get-u
       case "$_BEHIND" in
         ''|*[!0-9]*) : ;;   # not measurable — silent, not a claim
         0) : ;;
-        *) GIT_BEHIND_NOTE="local $_DEFAULT_BRANCH is ${_BEHIND} commit(s) behind origin/$_DEFAULT_BRANCH — run: git checkout $_DEFAULT_BRANCH && git pull --ff-only (or: git merge --ff-only origin/$_DEFAULT_BRANCH)" ;;
+        *)
+          # ── auto-apply, consent-gated, inside a deliberately narrow envelope ───────────────
+          # Operator request 2026-08-15, verbatim: "사람이 일일이 수동으로 깃풀해서 최신화해야하는지를
+          # 판단하지않고 … 세션 시작 시 레포체크를 클로드가 알아서 하고 최신화 제안하는 기능이 있으면
+          # 좋을것같아. 그리고 앞으로도 자동으로 이렇게 동기화할지 물어보는 것도."
+          #
+          # 🟥 IT NEVER SWITCHES BRANCHES, and that is the whole safety envelope — not a nicety.
+          # The recommendation this line used to print told the reader to `git checkout
+          # $_DEFAULT_BRANCH && git pull`. In a SHARED CHECKOUT a checkout yanks the ground out from
+          # under a peer session: measured on this repo 2026-08-09 (two sessions, one worktree, one
+          # committed onto the other's branch), which is why scripts/branch_claim.sh exists at all.
+          # As prose advice a human weighed that; automated, nobody would. So the apply arm fires
+          # ONLY when the default branch is ALREADY checked out, and `--ff-only` means it can
+          # neither rewrite history nor absorb a divergence — it refuses instead.
+          #
+          # Consent is a LEASE, joined mechanically, never inferred: the class must be registered
+          # promotion_eligible in tracks/_meta/consent_classes.yaml AND granted unexpired in the
+          # UAP frontmatter. scripts/consent_registry_check.sh is the single decider (exit 0 = a
+          # real grant was joined; 3 = nothing granted; 1 = broken). Absent, expired, unreadable, or
+          # unknown all take the same branch as "no": surface, do not apply. absent ≠ granted.
+          _AUTOPULL=""
+          if [ -x "$FH/scripts/consent_registry_check.sh" ] \
+             && bash "$FH/scripts/consent_registry_check.sh" >/dev/null 2>&1 \
+             && grep -q '^\s*repo-freshness-autopull:' "$FH/tracks/_meta/user_adaptation_profile.md" 2>/dev/null; then
+            _AUTOPULL=1
+          fi
+          _ON_DEFAULT=""
+          [ "$(git -C "$FH" symbolic-ref --short -q HEAD 2>/dev/null)" = "$_DEFAULT_BRANCH" ] && _ON_DEFAULT=1
+          if [ -n "$_AUTOPULL" ] && [ -n "$_ON_DEFAULT" ] \
+             && git -C "$FH" merge --ff-only "refs/remotes/origin/$_DEFAULT_BRANCH" >/dev/null 2>&1; then
+            # Announce every unprompted run — §Operational Adaptation Loop requires it of a standing
+            # grant, and a sync the reader never saw is indistinguishable from one that never ran.
+            GIT_BEHIND_NOTE="local $_DEFAULT_BRANCH was ${_BEHIND} commit(s) behind — fast-forwarded automatically (standing consent: repo-freshness-autopull). Nothing else was touched; your gitignored state is out of git's reach by construction."
+          else
+            # Every not-applied path lands here and says the same thing: what to run. It does NOT
+            # say why it did not apply, on purpose — "no grant" and "wrong branch" and "ff refused"
+            # would each need their own true sentence, and a wrong reason printed confidently is
+            # worse than none (this file's own §absent-subject rule).
+            GIT_BEHIND_NOTE="local $_DEFAULT_BRANCH is ${_BEHIND} commit(s) behind origin/$_DEFAULT_BRANCH — while ON that branch run: git merge --ff-only origin/$_DEFAULT_BRANCH"
+          fi ;;
       esac
     fi
     # no local branch named $_DEFAULT_BRANCH at all (e.g. a fork never checked it out) → silent,

--- a/scripts/test_node_check_lanes.sh
+++ b/scripts/test_node_check_lanes.sh
@@ -174,6 +174,106 @@ for h in "$FH_REPO"/templates/.git-hooks/pre-commit "$FH_REPO"/templates/.git-ho
   else bad "lane9 sentinel does NOT match shipped $(basename "$h") — every FH machine would report 'not FH gate'" "$(head -3 "$h")"; fi
 done
 
+# ── lane10 — consent-gated auto-pull: the APPLY arm and every REFUSE arm ─────────────────────
+# Added 2026-08-15 with the feature. These lanes exist because the feature's whole safety claim is
+# about what it does NOT do, and "does not" is exactly what a green run cannot demonstrate by
+# itself — every refuse arm below is paired against an apply arm in the same fixture, so a lane
+# that goes silently inert fails the CONTROL rather than passing everything.
+# 🟥 The load-bearing one is lane10-b: in a shared checkout a branch switch yanks the ground out
+# from under a peer session (measured 2026-08-09, two sessions/one worktree). If this feature ever
+# switches branches, that lane is what says so.
+_ap_root="$(mktemp -d)"
+(
+  cd "$_ap_root" || exit 1
+  git init -q up && cd up
+  git config user.email t@t; git config user.name t; git config commit.gpgsign false
+  mkdir -p scripts tracks/_meta
+  cp "$FH_REPO/scripts/fh_node_check.sh" "$FH_REPO/scripts/consent_registry_check.sh" scripts/
+  cp "$FH_REPO/tracks/_meta/consent_classes.yaml" "$FH_REPO/tracks/_meta/user_adaptation_profile.md" tracks/_meta/ 2>/dev/null
+  echo base > f.txt; git add -A >/dev/null; git commit -qm base
+  cd ..; git clone -q up dn; cd up; echo newer > f.txt; git commit -qam ahead
+) >/dev/null 2>&1
+_dn="$_ap_root/dn"
+if [ ! -d "$_dn/.git" ] || [ ! -f "$_dn/tracks/_meta/consent_classes.yaml" ]; then
+  bad "lane10 fixture: could not build the consent fixture (registry/UAP absent — lanes not run)" "$_ap_root"
+else
+  git -C "$_dn" config user.email t@t >/dev/null 2>&1; git -C "$_dn" config user.name t >/dev/null 2>&1
+  git -C "$_dn" fetch -q origin >/dev/null 2>&1
+  _h0="$(git -C "$_dn" rev-parse HEAD)"
+  run "$_dn" "$_ap_root/s_a" >/dev/null 2>&1
+  if [ "$(git -C "$_dn" rev-parse HEAD)" != "$_h0" ]; then
+    ok "lane10-a APPLY: consented + on default branch → fast-forwarded"
+  else
+    bad "lane10-a APPLY: consented + on default branch did NOT fast-forward (feature inert — every refuse lane below is then vacuous)" "$_h0"
+  fi
+
+  # b — the envelope. Never applies off the default branch, and NEVER switches branches.
+  (cd "$_ap_root/up" && echo newer2 > f.txt && git commit -qam ahead2) >/dev/null 2>&1
+  git -C "$_dn" fetch -q origin >/dev/null 2>&1
+  git -C "$_dn" switch -c feat-x -q >/dev/null 2>&1
+  _m0="$(git -C "$_dn" rev-parse main)"
+  # ⚠️ CHECKING main AND THE BRANCH NAME IS NOT ENOUGH — measured by a revert probe 2026-08-15.
+  # With the envelope deliberately broken, `merge --ff-only origin/main` fast-forwards THE BRANCH
+  # YOU ARE ON, so feat-x moved while `main` sat still and the branch name never changed. The first
+  # version of this lane asserted only those two and stayed green against a defeated envelope —
+  # decorative. The tip that must not move is the CURRENT branch's own.
+  _f0="$(git -C "$_dn" rev-parse feat-x)"
+  run "$_dn" "$_ap_root/s_b" >/dev/null 2>&1
+  if [ "$(git -C "$_dn" rev-parse main)" = "$_m0" ] \
+     && [ "$(git -C "$_dn" rev-parse feat-x)" = "$_f0" ] \
+     && [ "$(git -C "$_dn" branch --show-current)" = "feat-x" ]; then
+    ok "lane10-b ENVELOPE: off default branch → no apply on EITHER branch, no switch"
+  else
+    bad "lane10-b ENVELOPE: a branch tip moved off the default branch — the shared-checkout hazard" "main=$_m0->$(git -C "$_dn" rev-parse main) feat-x=$_f0->$(git -C "$_dn" rev-parse feat-x) branch=$(git -C "$_dn" branch --show-current)"
+  fi
+  git -C "$_dn" switch -q main >/dev/null 2>&1
+
+  # c — no grant. absent ≠ granted.
+  cp "$_dn/tracks/_meta/user_adaptation_profile.md" "$_ap_root/uap.bak"
+  python3 - "$_dn/tracks/_meta/user_adaptation_profile.md" <<'PYX'
+import re,sys
+p=sys.argv[1]; s=open(p,encoding='utf-8').read()
+open(p,'w',encoding='utf-8').write(re.sub(r'\nstanding_consent:\n(?:  .*\n|    .*\n)*', '\n', s, count=1))
+PYX
+  _h1="$(git -C "$_dn" rev-parse HEAD)"
+  run "$_dn" "$_ap_root/s_c" >/dev/null 2>&1
+  [ "$(git -C "$_dn" rev-parse HEAD)" = "$_h1" ] \
+    && ok "lane10-c NO-GRANT: absent standing_consent → no apply" \
+    || bad "lane10-c NO-GRANT: applied without a grant" "$_h1"
+
+  # d — expired lease. A lease nobody enforces is not a lease.
+  cp "$_ap_root/uap.bak" "$_dn/tracks/_meta/user_adaptation_profile.md"
+  sed -i.bak2 's/expires: [0-9-]*/expires: 2020-01-01/' "$_dn/tracks/_meta/user_adaptation_profile.md"
+  _h2="$(git -C "$_dn" rev-parse HEAD)"
+  run "$_dn" "$_ap_root/s_d" >/dev/null 2>&1
+  [ "$(git -C "$_dn" rev-parse HEAD)" = "$_h2" ] \
+    && ok "lane10-d EXPIRED: past-dated lease → no apply" \
+    || bad "lane10-d EXPIRED: applied under an expired lease" "$_h2"
+  cp "$_ap_root/uap.bak" "$_dn/tracks/_meta/user_adaptation_profile.md"
+
+  # e — divergence. --ff-only must refuse rather than absorb, and local work must survive.
+  (cd "$_dn" && echo local-only > mine.txt && git add -A && git commit -qm diverge) >/dev/null 2>&1
+  _h3="$(git -C "$_dn" rev-parse HEAD)"
+  run "$_dn" "$_ap_root/s_e" >/dev/null 2>&1
+  if [ "$(git -C "$_dn" rev-parse HEAD)" = "$_h3" ] && [ -f "$_dn/mine.txt" ]; then
+    ok "lane10-e DIVERGED: ff refused, local commit survives"
+  else
+    bad "lane10-e DIVERGED: local history was moved or lost" "$_h3 -> $(git -C "$_dn" rev-parse HEAD)"
+  fi
+
+  # CONTROL — after all the refuse arms, prove the apply arm still fires. Without this, a lane
+  # suite where the feature has gone inert reports 4 clean refusals and looks perfect.
+  git -C "$_dn" reset -q --hard origin/main >/dev/null 2>&1   # noqa: destructive-op (throwaway fixture)
+  (cd "$_ap_root/up" && echo newer3 > f.txt && git commit -qam ahead3) >/dev/null 2>&1
+  git -C "$_dn" fetch -q origin >/dev/null 2>&1
+  _h4="$(git -C "$_dn" rev-parse HEAD)"
+  run "$_dn" "$_ap_root/s_f" >/dev/null 2>&1
+  [ "$(git -C "$_dn" rev-parse HEAD)" != "$_h4" ] \
+    && ok "lane10-CONTROL: apply arm still fires after the refuse arms (instrument alive)" \
+    || bad "lane10-CONTROL: apply arm went inert — the refuse lanes above prove nothing" "$_h4"
+fi
+rm -rf "$_ap_root"
+
 printf '\nnode-check lanes: %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1
 exit 0

--- a/scripts/test_node_check_lanes.sh
+++ b/scripts/test_node_check_lanes.sh
@@ -185,7 +185,11 @@ done
 _ap_root="$(mktemp -d)"
 (
   cd "$_ap_root" || exit 1
-  git init -q up && cd up
+  # Pin the branch name: `git init` uses init.defaultBranch, which is main on this
+  # operator's machine and master on a stock Ubuntu (CI). Hardcoding "main" in the
+  # assertions below made lane10-b pass VACUOUSLY there (`rev-parse "$_DEF"` returned
+  # empty, and empty==empty compared true) while CONTROL's reset silently no-op'd.
+  git -c init.defaultBranch=main init -q up && cd up
   git config user.email t@t; git config user.name t; git config commit.gpgsign false
   mkdir -p scripts tracks/_meta
   cp "$FH_REPO/scripts/fh_node_check.sh" "$FH_REPO/scripts/consent_registry_check.sh" scripts/
@@ -233,6 +237,13 @@ if [ ! -d "$_dn/.git" ] || [ ! -f "$_dn/tracks/_meta/consent_classes.yaml" ]; th
   bad "lane10 fixture: could not build the consent fixture (registry/UAP absent — lanes not run)" "$_ap_root"
 else
   git -C "$_dn" config user.email t@t >/dev/null 2>&1; git -C "$_dn" config user.name t >/dev/null 2>&1
+  # Derive rather than assume — belt-and-braces over the pin above, so a future git
+  # whose init behaviour changes again cannot make these lanes vacuous a second time.
+  _DEF="$(git -C "$_dn" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+  [ -n "$_DEF" ] || _DEF=main
+  if ! git -C "$_dn" show-ref --verify --quiet "refs/heads/$_DEF"; then
+    bad "lane10 fixture: default branch '$_DEF' has no local ref — assertions below would be vacuous" "$(git -C "$_dn" branch -a)"
+  fi
   git -C "$_dn" fetch -q origin >/dev/null 2>&1
   _h0="$(git -C "$_dn" rev-parse HEAD)"
   run "$_dn" "$_ap_root/s_a" >/dev/null 2>&1
@@ -246,7 +257,7 @@ else
   (cd "$_ap_root/up" && echo newer2 > f.txt && git commit -qam ahead2) >/dev/null 2>&1
   git -C "$_dn" fetch -q origin >/dev/null 2>&1
   git -C "$_dn" switch -c feat-x -q >/dev/null 2>&1
-  _m0="$(git -C "$_dn" rev-parse main)"
+  _m0="$(git -C "$_dn" rev-parse "$_DEF")"
   # ⚠️ CHECKING main AND THE BRANCH NAME IS NOT ENOUGH — measured by a revert probe 2026-08-15.
   # With the envelope deliberately broken, `merge --ff-only origin/main` fast-forwards THE BRANCH
   # YOU ARE ON, so feat-x moved while `main` sat still and the branch name never changed. The first
@@ -254,14 +265,14 @@ else
   # decorative. The tip that must not move is the CURRENT branch's own.
   _f0="$(git -C "$_dn" rev-parse feat-x)"
   run "$_dn" "$_ap_root/s_b" >/dev/null 2>&1
-  if [ "$(git -C "$_dn" rev-parse main)" = "$_m0" ] \
+  if [ "$(git -C "$_dn" rev-parse "$_DEF")" = "$_m0" ] \
      && [ "$(git -C "$_dn" rev-parse feat-x)" = "$_f0" ] \
      && [ "$(git -C "$_dn" branch --show-current)" = "feat-x" ]; then
     ok "lane10-b ENVELOPE: off default branch → no apply on EITHER branch, no switch"
   else
-    bad "lane10-b ENVELOPE: a branch tip moved off the default branch — the shared-checkout hazard" "main=$_m0->$(git -C "$_dn" rev-parse main) feat-x=$_f0->$(git -C "$_dn" rev-parse feat-x) branch=$(git -C "$_dn" branch --show-current)"
+    bad "lane10-b ENVELOPE: a branch tip moved off the default branch — the shared-checkout hazard" "main=$_m0->$(git -C "$_dn" rev-parse "$_DEF") feat-x=$_f0->$(git -C "$_dn" rev-parse feat-x) branch=$(git -C "$_dn" branch --show-current)"
   fi
-  git -C "$_dn" switch -q main >/dev/null 2>&1
+  git -C "$_dn" switch -q "$_DEF" >/dev/null 2>&1
 
   # c — no grant. absent ≠ granted.
   cp "$_dn/tracks/_meta/user_adaptation_profile.md" "$_ap_root/uap.bak"
@@ -298,7 +309,7 @@ PYX
 
   # CONTROL — after all the refuse arms, prove the apply arm still fires. Without this, a lane
   # suite where the feature has gone inert reports 4 clean refusals and looks perfect.
-  git -C "$_dn" reset -q --hard origin/main >/dev/null 2>&1   # noqa: destructive-op (throwaway fixture)
+  git -C "$_dn" reset -q --hard "origin/$_DEF" >/dev/null 2>&1   # noqa: destructive-op (throwaway fixture)
   (cd "$_ap_root/up" && echo newer3 > f.txt && git commit -qam ahead3) >/dev/null 2>&1
   git -C "$_dn" fetch -q origin >/dev/null 2>&1
   _h4="$(git -C "$_dn" rev-parse HEAD)"

--- a/scripts/test_node_check_lanes.sh
+++ b/scripts/test_node_check_lanes.sh
@@ -189,7 +189,42 @@ _ap_root="$(mktemp -d)"
   git config user.email t@t; git config user.name t; git config commit.gpgsign false
   mkdir -p scripts tracks/_meta
   cp "$FH_REPO/scripts/fh_node_check.sh" "$FH_REPO/scripts/consent_registry_check.sh" scripts/
-  cp "$FH_REPO/tracks/_meta/consent_classes.yaml" "$FH_REPO/tracks/_meta/user_adaptation_profile.md" tracks/_meta/ 2>/dev/null
+  # Build the consent fixture from the SHIPPED TEMPLATE, never from the operator's local
+  # tracks/_meta/ — those are gitignored, so on CI (and on any fresh clone) they do not exist and
+  # the lanes would report a red FAIL for a file whose absence is correct by design. Measured on
+  # CI 2026-08-15: exactly that, "registry/UAP absent — lanes not run". Sourcing the template
+  # instead is strictly better than degrading to SKIP: the lanes then actually run everywhere, and
+  # they validate the very block a consumer is told to copy.
+  cp "$FH_REPO/templates/consent_classes.yaml.example" tracks/_meta/consent_classes.yaml
+  # The grant side has no shipped template (a UAP is per-operator by nature), so synthesize the
+  # minimum the registry check requires: the full R6 fingerprint, far-future expiry so the fixture
+  # never rots into a false refusal, joined to the template's own class name.
+  # Dates are computed at fixture-build time, not hardcoded, for two reasons that pull opposite
+  # ways: a fixed past date rots into a false REFUSE, and a far-future one is refused outright —
+  # R5 caps a lease at 365 days ("an unbounded expiry is a transfer, not a lease"), and the first
+  # version of this fixture used 2099-01-01 and was correctly rejected by the very floor the
+  # feature depends on. GNU-first with validation, same discipline as every _mtime helper here:
+  # `date -d` is GNU, `date -v` is BSD, and neither failing silently is acceptable.
+  _g="$(date +%Y-%m-%d)"
+  _e="$(date -d '+300 days' +%Y-%m-%d 2>/dev/null || date -v+300d +%Y-%m-%d 2>/dev/null || echo '')"
+  case "$_e" in
+    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) : ;;
+    *) bad "lane10 fixture: could not compute a lease expiry (neither GNU nor BSD date worked)" "$_e"; _e="$_g" ;;
+  esac
+  cat > tracks/_meta/user_adaptation_profile.md <<UAPEOF
+---
+standing_consent:
+  repo-freshness-autopull:
+    granted: $_g
+    expires: $_e
+    owner: scripts/fh_node_check.sh
+    mode: ff-only-merge-on-default-branch
+    target: this repo's own default branch, in the local clone, when it is already checked out
+    effects: [network, repo-mutation]
+    sinks: []
+---
+lane fixture — not a real profile
+UAPEOF
   echo base > f.txt; git add -A >/dev/null; git commit -qm base
   cd ..; git clone -q up dn; cd up; echo newer > f.txt; git commit -qam ahead
 ) >/dev/null 2>&1

--- a/templates/consent_classes.yaml.example
+++ b/templates/consent_classes.yaml.example
@@ -44,6 +44,36 @@
 #   Re-point the class's `owner` or `mode` after the grant and the join fails: that is the point.
 
 classes:
+  # ---- REAL, ADOPTABLE class (not illustrative) -------------------------------------
+  # Ships with fh_node_check.sh's consent-gated auto-pull. Copy this block verbatim into your
+  # own tracks/_meta/consent_classes.yaml, then grant it in your UAP frontmatter to enable the
+  # apply arm. Without both, the check surfaces "N commits behind" and never touches the repo —
+  # absent is not granted.
+  #
+  # Read the reason before adopting: this class takes a DIFFERENT verdict from the `local-commit`
+  # example further down, on a deliberately narrow ground. If your integration branch is not
+  # PR-only/protected, that ground does not hold for you and you should not adopt it.
+  - name: repo-freshness-autopull
+    owner: scripts/fh_node_check.sh
+    mode: ff-only-merge-on-default-branch
+    target: this repo's own default branch, in the local clone, when it is already checked out
+    capabilities: [network, repo-mutation]
+    sinks: []
+    feeds: []
+    promotion_eligible: true
+    lease_days: 92
+    reason: >
+      A fast-forward pull introduces nothing new: every commit it brings down is already on the
+      integration branch, which is PR-only and server-side protected, so all of it has passed the
+      gates. `local-commit` below is classified feeds:[go-public] because it CREATES ungated
+      content that publish can then ship; this makes the tree MATCH canon instead. Publish packs
+      the working tree, so a tree matching origin is strictly safer to publish from than a stale
+      one. Blast radius also excludes personal state by construction — a pull touches tracked
+      files only, and session/memory/companion state is gitignored or outside the repo.
+      Envelope (enforced in code, not prose): applies ONLY when the default branch is already
+      checked out, never switches branches, and --ff-only refuses a divergence rather than
+      absorbing it. Lanes: scripts/test_node_check_lanes.sh lane10-a..e + CONTROL.
+
   # ---- promotion-eligible example -------------------------------------------------
   - name: dispatch-readonly-sim-local-artifact
     owner: fh-meta:sim-conductor          # the gate/skill that does the asking


### PR DESCRIPTION
## What this adds — and what it deliberately does not

The **detection half already existed** (`fh_node_check.sh`, #376: fetches origin, counts commits behind the *default* branch, prints the remedy). This adds only the **apply** half the operator asked for.

The safety envelope is **enforced in code, not promised in prose**:

| | |
|---|---|
| Applies | only when the default branch is **already checked out** |
| Branch switch | **never** — no `git checkout`, ever |
| Divergence | `--ff-only` refuses rather than absorbing |
| No consent / expired / unknown | surfaces the remedy, touches nothing |

Why the envelope is the whole point: in a shared checkout a branch switch **yanks the ground out from under a peer session** — measured on this repo 2026-08-09 (two sessions, one worktree, one committed onto the other's branch), which is why `branch_claim.sh` exists. The old recommendation string told the reader to `git checkout main && git pull`. As prose a human weighed that; automated, nobody would. That string is fixed here too.

Consent is joined **mechanically**: registered `promotion_eligible` class + unexpired UAP grant + `consent_registry_check.sh` rc=0. Absent is not granted.

## Registry classification — a recorded divergence, not an oversight

`templates/consent_classes.yaml.example` classifies `local-commit` as `feeds: [go-public]` / not promotable, on the taint rule. This class takes the opposite verdict on three grounds:

1. A fast-forward pull **introduces nothing new** — every commit it brings down is already on the integration branch, which is PR-only and server-side protected. `local-commit` *creates* ungated content; this makes the tree *match* canon.
2. **Publish packs the working tree** (measured on this repo: a session publishing from a shared checkout shipped another session's uncommitted draft). A tree matching origin is strictly *safer* to publish from than a stale one.
3. **Blast radius excludes personal state by construction** — verified with a control: `tracks/**` (`.gitignore:45`) and `CLAUDE.local.md` (`:17`) report IGNORED while the control `scripts/selfcheck.sh` reports tracked, so the no-hit is a real no-hit. The unreachable set is exactly the set the companion store syncs.

Named residual, in the file: this holds only while the integration branch stays PR-only and protected.

## Verification — and the probe that changed the outcome

Six lanes added to `scripts/test_node_check_lanes.sh` (**23 passed, 0 failed**), run against a real two-repo git fixture: apply · off-default-branch · no-grant · expired-lease · diverged · **CONTROL** (the apply arm must still fire *after* the refuse arms, or four clean refusals would look perfect over an inert feature).

🟥 **A revert probe caught the first version of lane10-b being decorative.** With the envelope condition deliberately defeated, the lane still passed. Isolating the hypothesis in a separate fixture showed why: `merge --ff-only origin/main` fast-forwards **the branch you are on**, so a broken envelope moved `feat-x` (dcf50bb→39e8018) while `main` sat still and the branch *name* never changed — and those two were the only things the lane asserted. Hardened to assert the current branch's own tip; the probe now reddens exactly that lane (22/1), restore → 23/23.

Without that probe this would have shipped six green lanes over an unguarded feature.

## Residual

`crossfamily: DEGRADED_NOT_RUN` — the panel was reachable and not recruited. The load-bearing question here ("does the envelope hold") is mechanical and was answered by execution, which already falsified my first answer to it. But a cross-family read of the envelope **design** has not been done, and the design is mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)