### PR TITLE
fix(publish): effect probe 미출하 + 형제 의존 검사 + publish 신선도 게이트 (BREAKING: 2.0.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,13 @@
   "plugins": [
     {
       "name": "fh-meta",
-      "version": "1.4.99",
+      "version": "1.5.0",
       "description": "Hub meta-operations toolkit — 35 skills + 7 agents. New in 1.4.53: `fh-codex-doctor` (npm bin) — Codex adapter drift scanner; reads the documented M1/M2/M3 skill tier map + skill/agent source and reports codex-native/adapter-required/claude-native/unclassified per unit, wired into `npm test`/`prepublishOnly` (fail-closed on unclassified Claude-native primitives). New in 1.4.49: steel-quench gains Step 0.6 Verdict-Invariance Probe (groundedness axis — a load-bearing judged gate's verdict must track behavior, not rubric phrasing; measured flip-count over cross-family paraphrases; arXiv:2605.06161 Policy Invariance anchor); multi_model_sidecar_strategy §Vendor-native harness (a model is strongest in its own vendor CLI — Claude/CC, GPT/codex, Gemini/Antigravity; a universal router degrades all of them, so it stays an autocomplete/QA sidecar, never orchestration); predelete_check.sh fail-closed rewrite; memory-hygiene A-TMA anchor. New in 1.4.48: phantom-quench + steel-quench gain external frontier anchors (arXiv:2607.02052 package-hallucination; arXiv:2607.02057 prompt-coverage-adequacy); README model-flat claim reframed from a per-release point-curve to structural invariants (operation flattens across tiers; depth tier-order fixed within a generation). New in 1.4.47: onboarding step ① surfaces the Mode D companion-store session-start load in the auto-read salience anchor (previously only in the local binding + rules, so a greeting could skip the load). New in 1.4.46: context-doctor command-output axis (route to rtk/proxy for verbose CLI stdout, complementing .claudeignore; risk-gated to token-scarce envs). New in 1.4.41: context-doctor 2026 trigger vocab (context engineering/rot/collapse) + phantom-citation hardening; hub measurement-integrity-checklist (cross-model measurement pre-flight: display-name pin/reps≥3/discriminating probe). New in 1.4.40: install-wizard queryable-wiki scaffold (INDEX + session-start read + R/W/C ingest). New in 1.4.39: auto-decorrelation (cross-family verifier sidecar recruitment) + video-ingest (capability-routed video ingestion). New in 1.4.x: verify-axis check-class taxonomy (mandatory-pass/measured/judged), no-reinvention Tier-0 inventory, 7-class failure taxonomy, Destructive-Op Gate, Wave-T (Temper), tier-floor governance, Mode D Model Notice, FC consent lane, default-Sonnet guidance. New in 1.3.0: public-surface-audit, field-harvest Mode B auto-trigger, 4-axis gate scope ext. Validated cross-CLI: Claude Code, Codex, Gemini.",
       "source": "./plugins/fh-meta"
     },
     {
       "name": "fh-commons",
-      "version": "1.4.99",
+      "version": "1.5.0",
       "description": "Project-agnostic utility skills — 5 skills (convergence-loop · deliberation · mcp-circuit-breaker · token-budget-gate · ko-tech-writer) + 1 agent (quench-challenger). Domain-independent utilities transplantable into any project.",
       "source": "./plugins/fh-commons"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,13 @@
   "plugins": [
     {
       "name": "fh-meta",
-      "version": "1.5.0",
+      "version": "2.0.0",
       "description": "Hub meta-operations toolkit — 35 skills + 7 agents. New in 1.4.53: `fh-codex-doctor` (npm bin) — Codex adapter drift scanner; reads the documented M1/M2/M3 skill tier map + skill/agent source and reports codex-native/adapter-required/claude-native/unclassified per unit, wired into `npm test`/`prepublishOnly` (fail-closed on unclassified Claude-native primitives). New in 1.4.49: steel-quench gains Step 0.6 Verdict-Invariance Probe (groundedness axis — a load-bearing judged gate's verdict must track behavior, not rubric phrasing; measured flip-count over cross-family paraphrases; arXiv:2605.06161 Policy Invariance anchor); multi_model_sidecar_strategy §Vendor-native harness (a model is strongest in its own vendor CLI — Claude/CC, GPT/codex, Gemini/Antigravity; a universal router degrades all of them, so it stays an autocomplete/QA sidecar, never orchestration); predelete_check.sh fail-closed rewrite; memory-hygiene A-TMA anchor. New in 1.4.48: phantom-quench + steel-quench gain external frontier anchors (arXiv:2607.02052 package-hallucination; arXiv:2607.02057 prompt-coverage-adequacy); README model-flat claim reframed from a per-release point-curve to structural invariants (operation flattens across tiers; depth tier-order fixed within a generation). New in 1.4.47: onboarding step ① surfaces the Mode D companion-store session-start load in the auto-read salience anchor (previously only in the local binding + rules, so a greeting could skip the load). New in 1.4.46: context-doctor command-output axis (route to rtk/proxy for verbose CLI stdout, complementing .claudeignore; risk-gated to token-scarce envs). New in 1.4.41: context-doctor 2026 trigger vocab (context engineering/rot/collapse) + phantom-citation hardening; hub measurement-integrity-checklist (cross-model measurement pre-flight: display-name pin/reps≥3/discriminating probe). New in 1.4.40: install-wizard queryable-wiki scaffold (INDEX + session-start read + R/W/C ingest). New in 1.4.39: auto-decorrelation (cross-family verifier sidecar recruitment) + video-ingest (capability-routed video ingestion). New in 1.4.x: verify-axis check-class taxonomy (mandatory-pass/measured/judged), no-reinvention Tier-0 inventory, 7-class failure taxonomy, Destructive-Op Gate, Wave-T (Temper), tier-floor governance, Mode D Model Notice, FC consent lane, default-Sonnet guidance. New in 1.3.0: public-surface-audit, field-harvest Mode B auto-trigger, 4-axis gate scope ext. Validated cross-CLI: Claude Code, Codex, Gemini.",
       "source": "./plugins/fh-meta"
     },
     {
       "name": "fh-commons",
-      "version": "1.5.0",
+      "version": "2.0.0",
       "description": "Project-agnostic utility skills — 5 skills (convergence-loop · deliberation · mcp-circuit-breaker · token-budget-gate · ko-tech-writer) + 1 agent (quench-challenger). Domain-independent utilities transplantable into any project.",
       "source": "./plugins/fh-commons"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrono-meta/fh-gate",
-  "version": "1.4.99",
+  "version": "1.5.0",
   "description": "FH runtime adapters — run FH governance, skills, and agents via Claude or Codex with machine-parseable gates.",
   "license": "MIT",
   "keywords": [
@@ -92,6 +92,7 @@
     "templates/.claude/rules/session.md",
     "scripts/below_floor_scan.sh",
     "scripts/capability_registry_check.sh",
+    "scripts/capability_effect_probe.sh",
     "scripts/chamber_run.sh",
     "scripts/fh_env_delta_scan.sh",
     "scripts/substrate_jump_detector.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrono-meta/fh-gate",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "FH runtime adapters — run FH governance, skills, and agents via Claude or Codex with machine-parseable gates.",
   "license": "MIT",
   "keywords": [
@@ -27,7 +27,7 @@
     "prepare": "chmod +x bin/fh-gate.js bin/fh-run.js bin/fh-goal.js bin/fh-codex-doctor.js scripts/fh-gate.sh scripts/fh-run.sh scripts/fh-goal.sh",
     "postinstall": "node scripts/postinstall_notice.js",
     "test": "bash scripts/selfcheck.sh",
-    "prepublishOnly": "bash scripts/version_lockstep_check.sh && bash scripts/selfcheck.sh && bash scripts/package_coverage_check.sh --vs-tarball && bash scripts/public_surface_scan_files.sh",
+    "prepublishOnly": "bash scripts/publish_freshness_check.sh && bash scripts/version_lockstep_check.sh && bash scripts/selfcheck.sh && bash scripts/package_coverage_check.sh --vs-tarball && bash scripts/public_surface_scan_files.sh",
     "release": "bash scripts/public_surface_scan_files.sh && npm publish"
   },
   "engines": {
@@ -72,6 +72,7 @@
     "scripts/test_lane_runner_lanes.sh",
     "scripts/test_version_lockstep_lanes.sh",
     "scripts/package_coverage_check.sh",
+    "scripts/publish_freshness_check.sh",
     "scripts/lane_runner_check.sh",
     "scripts/test_package_coverage_lanes.sh",
     "scripts/test_fh_gate_regressions.sh",

--- a/plugins/fh-commons/.claude-plugin/plugin.json
+++ b/plugins/fh-commons/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-commons",
-  "version": "1.4.99",
+  "version": "1.5.0",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-commons/.claude-plugin/plugin.json
+++ b/plugins/fh-commons/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-commons",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/.claude-plugin/plugin.json
+++ b/plugins/fh-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-meta",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/.claude-plugin/plugin.json
+++ b/plugins/fh-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-meta",
-  "version": "1.4.99",
+  "version": "1.5.0",
   "engines": {
     "claudeCode": ">=1.0.0"
   },

--- a/plugins/fh-meta/CHANGELOG.md
+++ b/plugins/fh-meta/CHANGELOG.md
@@ -10,6 +10,34 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## Plugin Level
 
+### [2.0.0] — 2026-08-16
+
+**BREAKING — M6 로 인해 종전 통과하던 capability 등록이 거부될 수 있다. 그리고 그 M6 는 1.4.99 에서 출하되지 않았다.**
+
+- 🔴 **BREAKING: `capability_registry_check.sh` 에 M6(선언 진위 관측)가 실제로 도달한다.**
+  M1–M5 를 전부 통과하던 capfile 이 `writes:` 선언과 실제 부작용이 다르면 이제 **REJECTED** 된다.
+  major 인 이유는 이것 하나다 — 소비자의 초록이 빨강이 될 수 있다. `^1.4.x` 범위가 이 변경을 자동
+  수용하지 않도록 minor 가 아니라 major 로 낸다. 🟥 **M6 를 opt-in 으로 낮추는 선택지는 거부했다**:
+  비가역 표면(등록 → 이후 자동 호출)의 fail-closed 축을 끌 수 있게 만들면 그건 floor 가 아니다.
+- 🔴 **fix: `scripts/capability_effect_probe.sh` 가 `files[]` 에 없어 출하되지 않았다.**
+  M6 를 배선한 커밋(`a48e644`)이 그 M6 가 호출하는 프로브를 출하 목록에 넣지 않았다. 실측 결과
+  1.4.99 tarball 의 `capability_registry_check.sh` 에는 **M6 가 0회** 등장한다 — 소비자는 깨진 M6 가
+  아니라 **M6 자체를 못 받았다**(출하본이 main 보다 뒤처져 있었다). 고치지 않고 재출하했다면 그때
+  프로브 부재 → fail-closed → **모든 등록 거부**가 됐다.
+- **feat: 형제 의존 출하 검사** — `test_capability_entrypoint_shipping.sh` 가 세 번째 방향을 얻었다.
+  출하되는 셸 스크립트가 `${0%/*}/x.sh` 형태로 부르는 **형제 파일**도 `files[]` 에 있어야 한다.
+  기존 두 방향은 `*_capability.sh` **진입점 규약**에만 걸려 있어 이번 결함에 구조적으로 눈이 멀었고,
+  `package_coverage_check.sh` 는 참조 정규식이 `scripts/` 로 **시작하는 리터럴**만 봐서 런타임에
+  조립되는 경로를 볼 수 없다. 이 클래스의 4번째 발생이라 앞단에 기계로 세웠다.
+- **fix: script-dir 해석이 symlink 를 통과한다** — `${0%/*}` 는 심링크 경유 호출에서 링크의
+  디렉토리를 가리켜 M6 가 «프로브 부재» 로 fail-closed 했다(있는데 없다고 말한다). `BASH_SOURCE` +
+  symlink 해소로 교체.
+- **feat: publish 신선도 게이트** — `prepublishOnly` 가 «출하 트리가 커밋된 main 인가» 를 본다.
+  이번 사고와 2026-08-13 의 «남의 미커밋 초안 출하» 가 같은 표면의 두 발생이다.
+- **fix: `sync-to-be.sh` 락 경합 경로가 rc=64 로 죽었다** — `log()` 가 호출부보다 아래에 정의돼
+  macOS `/usr/bin/log` 로 떨어졌고, `set -euo pipefail` 이 의도한 `exit 0` 도착 전에 스크립트를
+  죽였다. 경합 경로는 **경합할 때만** 실행되므로 병렬 세션 둘이 붙기 전까지 출하된 채로 있었다.
+
 ### [1.4.99] — 2026-08-15
 
 **fix: 검출기가 «호출부 0» 을 «10/10 초록» 으로 보고하고 있었다 — 그리고 이 릴리스는 #388 의 첫 출하이기도 하다**

--- a/scripts/capability_registry_check.sh
+++ b/scripts/capability_registry_check.sh
@@ -235,7 +235,22 @@ _check_one() {
     #   것은 그 자체가 위험 노출이다. M4 가 이미 같은 가드를 갖고 있었고 M6 만 없었다.
     printf '  ⏭  M6 — 앞선 축이 실패해 실행 생략(SKIPPED, PASS 아님)\n'
   else
-    local _probe="${0%/*}/capability_effect_probe.sh"
+    # SYMLINK-RESOLVED, not `${0%/*}` (fixed 2026-08-16, reproduced on both sides).
+    # `${0%/*}` yields the directory of the NAME USED TO INVOKE, so a symlink to this script made
+    # the probe lookup land next to the LINK — where nothing lives — and M6 then fail-closed with
+    # "probe 부재" about a probe that exists. A gate that blames a missing file for its own path bug
+    # is worse than one that simply fails: it sends the reader to the wrong repair.
+    # `BASH_SOURCE[0]` is the real file even when invoked through a link; the loop then walks any
+    # remaining links in the path. `readlink -f` is deliberately not used — it is GNU-only and this
+    # ships to macOS (BSD `readlink` has no `-f`).
+    local _src="${BASH_SOURCE[0]:-$0}" _dir
+    while [ -L "$_src" ]; do
+      _dir=$(cd -P "$(dirname "$_src")" >/dev/null 2>&1 && pwd) || break
+      _src=$(readlink "$_src")
+      case "$_src" in /*) ;; *) _src="$_dir/$_src" ;; esac
+    done
+    _dir=$(cd -P "$(dirname "$_src")" >/dev/null 2>&1 && pwd) || _dir="${0%/*}"
+    local _probe="$_dir/capability_effect_probe.sh"
     if [ ! -r "$_probe" ]; then
       # 🟥 **fail-CLOSED.** 등록은 «이후 자동 호출» 로 이어지는 비가역 표면이다
       #   (CLAUDE.md §Irreversibility Surface-Class Degrade Invariant).

--- a/scripts/publish_freshness_check.sh
+++ b/scripts/publish_freshness_check.sh
@@ -114,11 +114,25 @@ self_test() {
   # 상태인가» 에 따라 결과가 바뀌어 레인이 계기가 아니라 날씨가 된다.
   local UP="$T/upstream" WK="$T/work"
   git init -q --bare "$UP"
+  # HEAD 를 명시적으로 main 에 건다. `-b main` 은 git>=2.28 전용이라 안 쓰고 symbolic-ref 로 건다.
+  # 🟥 이 두 줄이 없으면 CI 에서만 깨진다(실측 2026-08-16): 이 머신은 전역
+  # `init.defaultBranch=main` 이라 bare 의 HEAD 가 main 이지만, 러너는 보통 설정이 없어
+  # HEAD 가 `master` 를 가리킨다. 그러면 아래 `git clone` 이 **존재하지 않는 브랜치를 가리키는
+  # HEAD** 를 만나 체크아웃 없이 끝나고, 이어지는 커밋·푸시가 전부 실패하며, origin 이 전진하지
+  # 않아 「뒤처짐」 arm 이 **rc=0 으로 조용히 통과**한다. 계기가 환경에 따라 다른 걸 재고 있었다.
+  git -C "$UP" symbolic-ref HEAD refs/heads/main
   git init -q "$WK"
   ( cd "$WK"
     git config user.email t@t; git config user.name t
     echo one > a.txt; git add a.txt; git commit -qm one
     git branch -M main; git remote add origin "$UP"; git push -q -u origin main ) >/dev/null 2>&1
+  # 셋업이 실제로 섰는지 **단언한다.** 위 블록은 출력을 버리므로 실패해도 조용하고, 그러면
+  # 뒤따르는 모든 arm 이 «검사기가 통과시켰다» 가 아니라 «검사할 게 없었다» 로 초록이 된다
+  # ([[feedback_absence_measurement_needs_control]] — 부재 측정엔 컨트롤을 동반한다).
+  if ! git -C "$UP" rev-parse --verify -q refs/heads/main >/dev/null; then
+    sf=$((sf+1)); echo "  ❌ SETUP 실패 — upstream 에 main 이 서지 않았다. 아래 레인들은 무의미하다"
+    rm -rf "$T"; echo "── publish_freshness 캘리브레이션 실패: $sp PASS / $sf FAIL ──"; return 1
+  fi
 
   # ── known-negative: 깨끗 · main · origin 과 동일 → 통과해야 한다 ──────────
   o=$( cd "$WK" && bash "$SELF" 2>&1 ); rc=$?
@@ -137,7 +151,14 @@ self_test() {
   # 다른 클론에서 커밋을 올려 origin 을 전진시킨 뒤, 원래 워킹트리에서 검사한다.
   ( cd "$T" && git clone -q "$UP" other && cd other
     git config user.email t@t; git config user.name t
+    git checkout -q -B main origin/main
     echo two > c.txt; git add c.txt; git commit -qm two; git push -q origin main ) >/dev/null 2>&1
+  # 같은 이유로 **전진했는지 단언한다**. 이 arm 은 이 파일이 존재하는 이유(08-16 사고 형태)라
+  # 조용히 통과하면 정확히 그 사고를 못 잡는 상태로 돌아간다.
+  if [ "$(git -C "$UP" rev-list --count refs/heads/main)" -lt 2 ]; then
+    sf=$((sf+1)); echo "  ❌ SETUP 실패 — origin 이 전진하지 않았다. 「뒤처짐」 arm 을 실행할 수 없다"
+    rm -rf "$T"; echo "── publish_freshness 캘리브레이션 실패: $sp PASS / $sf FAIL ──"; return 1
+  fi
   o=$( cd "$WK" && git switch -q main && bash "$SELF" 2>&1 ); rc=$?
   _lane "origin 보다 뒤처지면 막는다(08-16 사고형)" 1 "$rc" "behind" "$o"
 

--- a/scripts/publish_freshness_check.sh
+++ b/scripts/publish_freshness_check.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# publish_freshness_check.sh — «지금 팩되는 트리가 커밋된 통합 브랜치인가».
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# 왜 지어졌나 — 같은 표면에서 두 번 터졌고, 둘 다 «출하 후»에 알았다
+# ─────────────────────────────────────────────────────────────────────────────
+# `npm publish` 는 **커밋이 아니라 워킹트리를 팩한다.** 그 한 줄이 두 사고를 만들었다:
+#
+#   2026-08-13  6세션 공유 체크아웃에서 publish → **남의 미커밋 초안이 출하됐다.**
+#   2026-08-16  main 에 머지된 M6 가 tarball 에 없었다 — 출하한 트리가 그 커밋 이전이었다.
+#               소비자가 받은 registry_check 에는 `M6` 가 **0회** 등장한다.
+#
+# 둘 다 «출하물이 main 보다 뒤처지거나 앞서는» 한 클래스다. 기존 publish 게이트
+# (`version_lockstep_check` · `selfcheck` · `package_coverage_check --vs-tarball` ·
+# `public_surface_scan_files`)는 전부 **파일 내용**을 본다 — 그 내용이 **어느 커밋의 것인가**를
+# 묻는 검사는 하나도 없었다. 그래서 이 파일은 기존 검사의 중복이 아니다.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# 무엇을 보증하지 않는가 (과잉주장 금지)
+# ─────────────────────────────────────────────────────────────────────────────
+# · **내용이 옳다는 보증이 아니다.** «커밋됐고 origin 과 같다» 만 본다.
+# · **gitignored 파일은 못 본다.** `git status` 가 안 보므로 dirty 로 안 잡힌다.
+#   다만 gitignored 파일은 `files[]` 로 출하되지 않는 것이 정상이고, 그 축은
+#   `package_coverage_check --vs-tarball` 이 본다.
+# · **원격이 그 사이 움직이는 것은 못 막는다.** fetch 시점의 스냅샷이다.
+#
+# 비가역 표면(publish)이므로 **fail-CLOSED**: 판정할 수 없으면 막는다.
+# 명시적 우회는 `PUBLISH_FRESHNESS_OK=1` — 로그를 남긴다.
+#
+# Usage:  bash scripts/publish_freshness_check.sh [--self-test]
+# Exit:   0 = 출하해도 되는 상태 · 1 = 막힘 · 2 = 판정 불가(역시 막힘)
+set -uo pipefail
+
+INTEGRATION_BRANCH="${FH_INTEGRATION_BRANCH:-main}"
+pass=0; fail=0
+ok()  { printf '  \342\234\205 %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  \342\235\214 %s\n' "$1"; fail=$((fail+1)); }
+
+run_checks() {
+  echo "publish freshness check (branch=$INTEGRATION_BRANCH)"
+
+  git rev-parse --git-dir >/dev/null 2>&1 || {
+    echo "  INSTRUMENT ERROR: not a git repository — freshness cannot be judged. NOT a pass."
+    return 2; }
+
+  # ── ① 워킹트리가 깨끗한가 ────────────────────────────────────────────────
+  # `--porcelain` 은 추적 파일의 수정·스테이징·미추적을 전부 낸다. 미추적까지 세는 것은
+  # 의도적이다 — 2026-08-13 사고는 **남의 미커밋 파일**이 팩된 것이었다.
+  local dirty
+  dirty=$(git status --porcelain 2>/dev/null | grep -vE '^\?\? tracks/' || true)
+  if [ -n "$dirty" ]; then
+    bad "워킹트리가 깨끗하지 않다 — publish 는 커밋이 아니라 이 트리를 팩한다:"
+    printf '%s\n' "$dirty" | head -10 | sed 's/^/      /'
+    local n; n=$(printf '%s\n' "$dirty" | grep -c . || true)
+    [ "${n:-0}" -gt 10 ] && echo "      … 외 $(( n - 10 ))건"
+  else
+    ok "워킹트리 깨끗 (tracks/ 미추적은 gitignored 운영 산출물이라 제외)"
+  fi
+
+  # ── ② 통합 브랜치 위인가 ────────────────────────────────────────────────
+  local head_branch
+  head_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  if [ "$head_branch" = "$INTEGRATION_BRANCH" ]; then
+    ok "HEAD 가 $INTEGRATION_BRANCH"
+  else
+    bad "HEAD 가 '$head_branch' — 통합 브랜치('$INTEGRATION_BRANCH')가 아니다. 피처 브랜치의 트리가 출하된다"
+  fi
+
+  # ── ③ origin 과 같은 커밋인가 ────────────────────────────────────────────
+  # 앞서든 뒤처지든 둘 다 막는다. **뒤처짐**이 2026-08-16 사고(머지된 M6 미출하)이고,
+  # **앞섬**은 «리뷰를 안 거친 로컬 커밋이 출하되는» 반대편 사고다. 방향이 아니라
+  # 불일치 자체가 판정 대상이다.
+  git fetch -q origin "$INTEGRATION_BRANCH" 2>/dev/null || {
+    bad "origin/$INTEGRATION_BRANCH 를 fetch 할 수 없다 — 신선도를 **못 쟀다**. 비가역 표면이므로 막는다"
+    return 1; }
+  local local_sha remote_sha
+  local_sha=$(git rev-parse HEAD 2>/dev/null || echo "")
+  remote_sha=$(git rev-parse "origin/$INTEGRATION_BRANCH" 2>/dev/null || echo "")
+  if [ -z "$local_sha" ] || [ -z "$remote_sha" ]; then
+    bad "커밋 해시를 읽을 수 없다 — 판정 불가"
+  elif [ "$local_sha" = "$remote_sha" ]; then
+    ok "HEAD == origin/$INTEGRATION_BRANCH (${local_sha:0:7})"
+  else
+    local ahead behind
+    ahead=$(git rev-list --count "origin/$INTEGRATION_BRANCH..HEAD" 2>/dev/null || echo "?")
+    behind=$(git rev-list --count "HEAD..origin/$INTEGRATION_BRANCH" 2>/dev/null || echo "?")
+    bad "HEAD(${local_sha:0:7}) != origin/$INTEGRATION_BRANCH(${remote_sha:0:7}) — ahead $ahead · behind $behind. behind 면 머지된 변경이 출하에서 빠진다(2026-08-16 사고 형태)"
+  fi
+
+  echo "----"
+  echo "publish freshness: $pass passed, $fail failed"
+  [ "$fail" -eq 0 ] || return 1
+  return 0
+}
+
+# ── self-test — known-pair. «막는가» 가 아니라 «옳게 막는가» 를 본다 ────────
+self_test() {
+  local T rc sp=0 sf=0
+  T=$(mktemp -d)
+  # $4(선택) = 출력에 반드시 있어야 할 문자열 = **차단 귀속**. rc 만 보는 레인은 «막혔는가» 만
+  # 재고 «옳은 축이 막았는가» 를 못 잰다 — 오늘 이 레포에서 실제로, 사고 재현 픽스처가 엉뚱한
+  # 축(M1)에 걸려 통과한 적이 있다. 기대 축의 문자열까지 확인해야 «막았다» 가 증거가 된다.
+  _lane() { # $1=이름 $2=기대rc $3=실제rc $4=기대문자열(선택) $5=출력
+    local why=""
+    if [ -n "${4:-}" ] && ! printf '%s' "${5:-}" | grep -q -- "$4"; then
+      why=" — rc 는 맞지만 귀속이 틀렸다: '$4' 가 출력에 없다"
+    fi
+    if [ "$3" = "$2" ] && [ -z "$why" ]; then sp=$((sp+1)); printf '  ✅ %-40s rc=%s\n' "$1" "$3"
+    else sf=$((sf+1)); printf '  ❌ %-40s rc=%s (기대 %s)%s\n' "$1" "$3" "$2" "$why"; fi; }
+
+  echo "publish_freshness_check --self-test"
+
+  # 격리된 known-pair 레포를 만든다. 이 레포 자신을 대상으로 삼으면 «오늘 이 트리가 어떤
+  # 상태인가» 에 따라 결과가 바뀌어 레인이 계기가 아니라 날씨가 된다.
+  local UP="$T/upstream" WK="$T/work"
+  git init -q --bare "$UP"
+  git init -q "$WK"
+  ( cd "$WK"
+    git config user.email t@t; git config user.name t
+    echo one > a.txt; git add a.txt; git commit -qm one
+    git branch -M main; git remote add origin "$UP"; git push -q -u origin main ) >/dev/null 2>&1
+
+  # ── known-negative: 깨끗 · main · origin 과 동일 → 통과해야 한다 ──────────
+  o=$( cd "$WK" && bash "$SELF" 2>&1 ); rc=$?
+  _lane "깨끗한 main 은 통과" 0 "$rc" "" "$o"
+
+  # ── known-positive A: 더러운 트리 ────────────────────────────────────────
+  o=$( cd "$WK" && echo dirty > b.txt && bash "$SELF" 2>&1 ); rc=$?
+  _lane "미추적 파일이 있으면 막는다" 1 "$rc" "워킹트리가 깨끗하지 않다" "$o"
+  rm -f "$WK/b.txt"
+
+  # ── known-positive B: 피처 브랜치 ────────────────────────────────────────
+  o=$( cd "$WK" && git switch -q -c feat/x && bash "$SELF" 2>&1 ); rc=$?
+  _lane "피처 브랜치에서는 막는다" 1 "$rc" "통합 브랜치" "$o"
+
+  # ── known-positive C: main 이 origin 보다 뒤처짐 (2026-08-16 사고 형태) ──
+  # 다른 클론에서 커밋을 올려 origin 을 전진시킨 뒤, 원래 워킹트리에서 검사한다.
+  ( cd "$T" && git clone -q "$UP" other && cd other
+    git config user.email t@t; git config user.name t
+    echo two > c.txt; git add c.txt; git commit -qm two; git push -q origin main ) >/dev/null 2>&1
+  o=$( cd "$WK" && git switch -q main && bash "$SELF" 2>&1 ); rc=$?
+  _lane "origin 보다 뒤처지면 막는다(08-16 사고형)" 1 "$rc" "behind" "$o"
+
+  # ── 컨트롤: 따라잡으면 다시 통과해야 한다 (전부 막는 계기가 아님) ────────
+  o=$( cd "$WK" && git pull -q --ff-only origin main && bash "$SELF" 2>&1 ); rc=$?
+  _lane "따라잡으면 다시 통과 (컨트롤)" 0 "$rc" "" "$o"
+
+  rm -rf "$T"
+  # 이 줄은 `selfcheck.sh` 의 embedded --self-test 루프가 «실행이 실제로 일어났다» 를 판정하는
+  # 앵커다(`*캘리브레이션*` 매치). 종단 판정줄이지 테스트 케이스 제목이 아니다 — 그 구분이
+  # 중요한 이유는 `capability_registry_check` 가 정확히 그 이유로 이 루프에서 빠져 있기 때문이다
+  # (그쪽의 캘리브레이션은 한국어 테스트 제목 안에만 있어서, 제목을 바꾸면 진짜 PASS 가
+  # «디스패처 없음» 으로 뒤집힌다).
+  echo "── publish_freshness 캘리브레이션 $([ "$sf" -eq 0 ] && echo 통과 || echo 실패): $sp PASS / $sf FAIL ──"
+  [ "$sf" -eq 0 ]
+}
+
+SELF="$(cd -P "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/$(basename "${BASH_SOURCE[0]:-$0}")"
+
+case "${1:-}" in
+  --self-test) self_test; exit $?;;
+esac
+
+if [ -n "${PUBLISH_FRESHNESS_OK:-}" ]; then
+  echo "⚠️  publish-freshness: PUBLISH_FRESHNESS_OK=1 — 명시적 우회. 무엇을 우회했는지 아래에 남긴다:"
+  run_checks || true
+  echo "⚠️  우회하고 진행한다. 이 줄이 그 기록이다."
+  exit 0
+fi
+
+run_checks
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  cat <<'EOF'
+
+🚫 publish 중단 — 지금 팩되는 트리가 «커밋된 통합 브랜치» 가 아니다.
+   publish 는 커밋이 아니라 워킹트리를 팩한다. 이 상태로 내보내면 출하물과 main 이 갈린다.
+
+   ▸ 정상 경로   : 변경을 커밋 → PR → 머지 → main 에서 pull → 다시 publish
+   ▸ 알고도 강행 : PUBLISH_FRESHNESS_OK=1 npm publish   (무엇을 우회했는지 출력에 남는다)
+EOF
+fi
+exit "$rc"

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -485,7 +485,11 @@ done
 # or trim of that one test name would flip a real PASS into "dispatcher missing?" here (cross-family
 # review caught this, 2026-08-15). chamber_witness/digest_landing_check both print a genuine
 # terminal "캘리브레이션 통과/실패" line, so they stay.
-for _subj in compaction_probe judgment_circuit_lint novelty_claim_check chamber_witness digest_landing_check; do
+# publish_freshness_check joined 2026-08-16. It qualifies for the same reason chamber_witness does
+# and capability_registry_check does not: its terminal line is a genuine VERDICT
+# ("publish_freshness 캘리브레이션 통과/실패"), not a Korean test-case title, so a future rename of
+# any single lane cannot flip a real PASS into a false "dispatcher missing?" here.
+for _subj in compaction_probe judgment_circuit_lint novelty_claim_check chamber_witness digest_landing_check publish_freshness_check; do
   if [ ! -f "scripts/$_subj.sh" ]; then
     _absent_subject_verdict "$_subj --self-test" "scripts/$_subj.sh" || fail=1
   else

--- a/scripts/sync-to-be.sh
+++ b/scripts/sync-to-be.sh
@@ -100,6 +100,18 @@ fi
 # BSD — `mkdir` is atomic on every POSIX filesystem and needs no external binary. Shared (unsuffixed)
 # lock path: both hubs must serialize against EACH OTHER, not just themselves.
 mkdir -p "$BE"
+
+# DEFINED HERE, NOT AT ITS OLD SITE ~50 LINES BELOW (fixed 2026-08-16, reproduced first).
+# The lock loop below calls `log`. Bash resolves an unknown name through PATH, and macOS ships
+# `/usr/bin/log` — so on the CONTENTION path (and only there) `log "companion store busy…"` became
+# a syslog invocation that exits 64, and `set -euo pipefail` then killed the script before the
+# `exit 0` on that same line could run. The close chain saw a hard failure where the code says
+# "next run will retry". Known-positive used to find and confirm it: hold the lock
+# (`mkdir "$BE/.sync.lock.d"`) and run — rc was 64 with `log: Unknown subcommand`, now 0.
+# The contention path only executes under contention, which is why two parallel sessions on one
+# companion store were needed to surface a defect that had been shipping.
+log() { [ "$QUIET" = "--quiet" ] || echo "[sync-to-be] $*"; }
+
 LOCKDIR="$BE/.sync.lock.d"
 LOCK_WAIT=0
 while ! mkdir "$LOCKDIR" 2>/dev/null; do
@@ -152,8 +164,6 @@ resolve_mem_dir() {
   return 0
 }
 MEM="$(resolve_mem_dir "$FH")"
-
-log() { [ "$QUIET" = "--quiet" ] || echo "[sync-to-be] $*"; }
 
 TOTAL=0   # files synced (rsync mode, countable)
 DIRTY=0   # cp-fallback mode can't count cheaply → mark work done, let git-diff gate decide

--- a/scripts/test_capability_entrypoint_shipping.sh
+++ b/scripts/test_capability_entrypoint_shipping.sh
@@ -118,6 +118,66 @@ else
   bad "$dangling declared capability entry point(s) missing from disk — npm would ship a broken files[] and the disk-side check alone stays green"
 fi
 
+# SIBLING DEPENDENCIES (added 2026-08-16 — occurrence #4 of the class this file's header names).
+# The two directions above both key on the ENTRY-POINT convention (`*_capability.sh`). That is
+# structurally blind to the failure that actually happened this time: a shipped script called a
+# NON-entry-point sibling that did not ship. `capability_registry_check.sh` shipped, its new M6 axis
+# ran `${0%/*}/capability_effect_probe.sh`, and that probe was absent from files[] — so on a consumer
+# install M6 would hit its fail-closed branch and reject every registration, blaming a "missing probe"
+# that exists in the repo.
+#
+# WHY `package_coverage_check.sh` IS BLIND TO IT — and why the fix belongs here, not there: that
+# checker's extraction regex requires a reference to START with a shipped top-level directory
+# (`scripts|templates|bin|docs|knowledge|plugins|.claude`). A script naming its own sibling writes
+# `${0%/*}/name.sh` or `$(dirname "$0")/name.sh` — the path is BUILT AT RUNTIME and no literal
+# `scripts/` appears. The reference-follower cannot see a path that does not textually exist.
+#
+# Scope kept narrow on purpose: only SELF-DIRECTORY forms. `$REPO_ROOT/scripts/x.sh` already contains
+# the literal `scripts/x.sh` and is caught upstream; widening past that would duplicate that checker.
+SIB_PAT='(\$\{0%/\*\}|\$\(dirname [^)]*\)|\$\{BASH_SOURCE[^}]*%/\*\})/[A-Za-z0-9_.-]+\.(sh|py|js)'
+SHIPPED_SH=$(node -e '
+  const f=JSON.parse(process.argv[1]);
+  process.stdout.write(f.filter(p=>/^scripts\/.*\.sh$/.test(p)).join("\n"));
+' "$FILES_JSON")
+
+sib_refs=0; sib_missing=0
+if [ -n "$SHIPPED_SH" ]; then
+  while IFS= read -r s; do
+    [ -n "$s" ] && [ -f "$s" ] || continue
+    # `grep -o` yields the whole matched expression; the sibling NAME is its last path segment.
+    # COMMENT LINES ARE STRIPPED FIRST, and that is not cosmetic: the finding's text asserts the
+    # callee is "called at runtime". A file whose PROSE names a sibling (this file's own header does)
+    # would be reported under a claim that is false about it — the right defect attributed to the
+    # wrong caller. Caught during this lane's own known-pair calibration, where the positive arm
+    # named two callers and only one of them actually calls anything.
+    for ref in $(sed 's/^[[:space:]]*#.*//' "$s" | grep -oE "$SIB_PAT" 2>/dev/null | sed 's|.*/||' | sort -u); do
+      sib_refs=$((sib_refs+1))
+      # Only assert on siblings that EXIST in the repo. A reference to a name that is absent from
+      # disk too is a different defect (a dead call), and it belongs to the dangling check above —
+      # claiming it here would report one defect as two.
+      [ -f "scripts/$ref" ] || continue
+      if node -e 'const f=JSON.parse(process.argv[1]);process.exit(f.includes(process.argv[2])?0:1)' \
+           "$FILES_JSON" "scripts/$ref"; then :; else
+        echo "  SIBLING-MISSING scripts/$ref (called by $s at runtime, absent from files[])"
+        sib_missing=$((sib_missing+1))
+      fi
+    done
+  done <<EOF
+$SHIPPED_SH
+EOF
+fi
+
+# Discovery-zero is an instrument failure here for the same reason as above: this repo is KNOWN to
+# contain at least one self-directory sibling call (that is why this block exists). Zero means the
+# pattern stopped matching — a silent scanner, not a clean repo.
+if [ "$sib_refs" -eq 0 ]; then
+  bad "INSTRUMENT DEAD — zero self-directory sibling references found across $(printf '%s\n' "$SHIPPED_SH" | grep -c .) shipped scripts; the pattern is no longer matching anything"
+elif [ "$sib_missing" -eq 0 ]; then
+  ok "all $sib_refs runtime sibling dependenc(ies) of shipped scripts are themselves in files[]"
+else
+  bad "$sib_missing runtime sibling dependenc(ies) absent from files[] — the consumer gets a caller whose callee is missing"
+fi
+
 # CONTROL — the check must be able to say NO. A checker that only ever prints ok is indistinguishable
 # from a checker that is not looking; assert the negative arm on a name that cannot be in files[].
 if node -e 'const f=JSON.parse(process.argv[1]);process.exit(f.includes(process.argv[2])?0:1)' \


### PR DESCRIPTION
## 무엇이 틀렸나

`a48e644` (#394) 가 등록 검사기에 **M6** 를 배선했다. M6 는 `scripts/capability_effect_probe.sh` 를 실행한다.
그 프로브가 **`package.json` `files[]` 에 없었다.**

## 🟥 첫 가설을 손검증이 반증했다

세운 가설: 「소비자가 M6 fail-closed 로 전건 거부당한다」. **틀렸다.**
실물 `npm pack @chrono-meta/fh-gate@1.4.99` 를 받아 대조:

| | 1.4.99 tarball | 레포 main |
|---|---|---|
| `capability_registry_check.sh` | 출하됨 · **`M6` 0회 등장** | `M6` 23회 |
| `capability_effect_probe.sh` | **미출하** | 존재 |
| files[] 대상 중 내용 차이 | **정확히 1건** | — |

**소비자는 깨진 M6 가 아니라 M6 자체를 못 받았다** — 출하본이 main 보다 뒤처져 있었다
(`npm publish` 는 커밋이 아니라 워킹트리를 싼다).

결함은 그래도 실재한다: `files[]` 를 안 고친 채 **지금 재출하하면** 그때 비로소
프로브 부재 → 비가역 표면 fail-closed → **모든 등록 거부**가 된다.

## 계열 축 — 코덱스(gpt-5.5) 4건, 3건 수리 + 1건 처방 거부

코덱스가 스스로 tarball 을 풀고 임시 `node_modules` 를 지어 재현했다.

### [A1] 1.5.0 은 SemVer 상 약하다 → **2.0.0**

M6 는 종전 M1–M5 를 전부 통과하던 capfile 을 `REJECTED` 로 바꾼다. `^1.4.99` 소비자가 자동 수용한다.

🟥 **같은 finding 의 다른 처방(「M6 를 opt-in/경고 단계로」)은 근거를 대고 거부했다.**
등록은 이후 자동 호출로 이어지는 **비가역 표면**이고, 그 위의 fail-closed 축을 끌 수 있게 만들면
그건 floor 가 아니다(`feedback_non_defeasible_floor`). 통과율을 사려고 안전 축을 낮추지 않는다.

### [A2] publish 경계에 git 신선도 검사가 없었다 → `publish_freshness_check.sh`

기존 `prepublishOnly` 넷(`version_lockstep` · `selfcheck` · `package_coverage --vs-tarball` ·
`public_surface_scan`)은 전부 **파일 내용**을 본다. **「그 내용이 어느 커밋의 것인가」를 묻는 검사가
하나도 없었다.** 이번 건과 2026-08-13 「6세션 공유 체크아웃에서 남의 미커밋 초안 출하」가 같은 표면이다.

```
publish_freshness_check --self-test            5 PASS / 0 FAIL
  ✅ 깨끗한 main 은 통과                        (known-negative)
  ✅ 미추적 파일이 있으면 막는다                 (08-13 사고 형태)
  ✅ 피처 브랜치에서는 막는다
  ✅ origin 보다 뒤처지면 막는다                 (08-16 사고 형태)
  ✅ 따라잡으면 다시 통과                        (컨트롤 — 전부 막는 계기가 아니다)
```

각 레인은 **rc 가 아니라 차단 귀속**까지 본다(기대 문자열을 위조하면 rc 가 맞아도 적색 4/1 로 확인).
오늘 이 레포에서 사고 재현 픽스처가 엉뚱한 축에 걸려 통과한 적이 있어서다.

### [B1] `${0%/*}` 가 symlink 를 통과 못 한다

심링크 경유 호출에서 링크의 디렉토리를 가리켜 M6 가 「프로브 부재」로 fail-closed 했다 —
**있는데 없다고 말하니 독자를 틀린 수리로 보낸다.** `BASH_SOURCE` + 심링크 해소 루프로 교체
(`readlink -f` 는 GNU 전용이라 안 씀 — macOS 로 출하된다).

6가지 호출 형태 실측 — 상대 · 절대 · `./` · `sh` · PATH · symlink. **심링크 하나만 갈렸고**,
수리 후 단·이중 심링크 모두 통과, 직접 호출 회귀 없음.

### [B2] CHANGELOG 이 1.4.99 에 멈춰 있었다 → 2.0.0 항목 추가

## 신규 기계층 — 이 클래스 **4번째** 발생

`test_capability_entrypoint_shipping.sh` 에 **형제 의존** 방향을 추가했다.

왜 기존 검사 둘 다 못 잡았는지가 핵심이다:
- 그 파일의 기존 두 방향은 **`*_capability.sh` 진입점 규약**에만 걸린다 → 진입점이 아닌 형제에 눈이 멀었다
- `package_coverage_check.sh` 는 참조 정규식이 `scripts/` 로 **시작하는 리터럴**을 요구한다 →
  `${0%/*}/x.sh` 는 **런타임에 조립되는 경로**라 텍스트로 존재하지 않는다. 참조 추적기는 없는 문자열을 못 본다

```
known-pair:  프로브를 files[] 에서 제거 → rc=1 + SIBLING-MISSING 이 그 파일명을 지목
             되돌리면                    → rc=0
귀속 정밀도: 주석을 정규식 앞에서 제거 — 초판은 자기 헤더의 산문을 「런타임 호출」로
             오귀속했다(옳은 결함 · 틀린 호출자). 보정 중에 자기 known-pair 가 잡았다
```

## 부수 — `sync-to-be.sh` 락 경합이 rc=64 로 죽었다

peer 세션이 이월한 건. `log()` 가 호출부보다 **아래**에 정의돼 macOS `/usr/bin/log` 로 떨어졌고,
`set -euo pipefail` 이 의도한 `exit 0` 도착 전에 스크립트를 죽였다.
**경합 경로는 경합할 때만 실행된다** — 병렬 세션 둘이 같은 동반저장소에 붙기 전까지 출하된 채였다.

락을 인위적으로 잡아 재현(rc=64) → 정의를 루프 위로 → rc=0 + 의도한 안내문 → **되돌리면 다시 64**.

## 되돌림 앵커 3종 (전부 「정확히 그 레인만」 적색)

1. 프로브를 `files[]` 에서 제거 → 형제 레인만 적색, 그 파일명 지목
2. 귀속 기대 문자열 위조 → rc 가 맞는데도 4 PASS / 1 FAIL
3. `publish_freshness_check` 디스패처 제거 → `selfcheck rc=1` 이 **그 subject 를 이름으로** 지목

## 잔여 (명시)

- `version_lockstep_check` 의 CHANGELOG 렌즈는 **경고-only** — 항목을 채웠을 뿐 fail-open 방향은
  안 고쳤다. 막는 쪽으로 돌리면 CHANGELOG 없는 패치가 전부 막힌다(과차단 ↔ fail-open 트레이드).
  측정 재발 1회로 이 레포의 N≥3 임계 미만이라 **안 지었다**
- `publish_freshness_check` 는 **fetch 시점 스냅샷** — 검사 후 publish 전 창은 못 막는다.
  확정점이 아니라 검사점에 붙어 있다
- 형제 검출은 **self-directory 형태만** 본다. `$SCRIPT_DIR/x.sh` 처럼 변수를 한 단계 더 타면
  안 잡힌다 — 지금 넓히면 오탐이 는다
- **Axis 1 은 SKIP(미검, PASS 아님)** — 게이트 pathspec 이 `scripts/**` 와 `package.json` 을 안 본다.
  이 PR 이 고치는 결함이 정확히 그 사각지대에서 났다

## 4축

Axes 2–3 마커 · Axis 4 매니페스트 기록 완료(`tracks/` 는 gitignored 라 CI 가 구조적으로 못 본다).
pre-commit 전축 PASS.