### PR TITLE
fix(publish): 출하 체인에 넣은 스크립트를 출하물에 안 넣었다

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "scripts/test_version_lockstep_lanes.sh",
     "scripts/package_coverage_check.sh",
     "scripts/publish_freshness_check.sh",
+    "scripts/prepublish_scope_note.sh",
     "scripts/lane_runner_check.sh",
     "scripts/test_package_coverage_lanes.sh",
     "scripts/adapters/peer_resolve.sh",


### PR DESCRIPTION
## 무엇

오전에 `scripts/prepublish_scope_note.sh` 를 `prepublishOnly` 체인에 넣으면서 **`package.json` `files[]` 에는 안 넣었다.** 출하 문서가 **출하물에 없는 파일을 가리키는** 상태였다 — 이 레포가 「만들고 배선 안 함」이라 부르는 클래스다.

```
FAIL  package-coverage: shipped document(s) point at file(s) the package omits:
        scripts/prepublish_scope_note.sh  (named by 1 shipped doc(s), e.g. package.json)
→ 수리 후
PASS  package-coverage: every referenced path is shipped or explicitly accepted (23 accepted, 22 exercised)
```

## 어떻게 잡혔나 — 이게 이 PR 의 요점이다

**실물 `npm publish --dry-run` 이 잡았다.** 오전에 그 스크립트를 만들면서 돌린 것들은 전부 초록이었다:
- `prepublish_scope_note.sh --self-test` 7/7
- `test_marker_axes_run_lanes.sh` 25/25
- PR #413 의 CI `validate` 2잡 + Axis 1

**합성 레인이 구조적으로 못 보는 것을 첫 실사용이 냈다.** 레인들은 스크립트의 *동작*을 검사하고, 이건 *출하 매니페스트 등재 여부*라 어느 레인의 시야에도 없었다.

## 판단 — 예외 등재가 아니라 실제 출하

검사기가 두 선택지를 같이 제시한다: `files[]` 에 넣거나, `ACCEPTED_ABSENT` 로 예외 등재하거나. **앞을 골랐다.**

근거는 취향이 아니라 **형제 일관성**이다 — 같은 체인의 다른 넷이 전부 `files[]` 에 있다:
`publish_freshness_check.sh` · `version_lockstep_check.sh` · `package_coverage_check.sh` · `public_surface_scan_files.sh`

그리고 예외 목록을 늘리는 것은 검사기를 덜 유용하게 만드는 방향이다. 실제로 이 레포엔 **행사되지 않는 stale 예외**가 이미 하나 있고(`.claude/rules/local_fh_context.md`), 검사기가 매 실행마다 *"방치하면 훗날 진짜 누락이 그 예외에 얹혀 침묵한다"* 고 경고한다.

## 영향 — 부풀리지 않는다

**소비자 영향은 0에 가깝다.** `prepublishOnly` 는 발행자만 실행하므로 이 등재가 소비자의 무언가를 고치지 않는다. 값은 ⓐ 2.1.0 출하가 열린다 ⓑ tarball 에서 출하 체인이 자기완결적으로 재구성 가능하다 ⓒ 출하 문서가 없는 파일을 가리키지 않는다 — 셋뿐이다.

## 4축

Axis 1 PASS · Axis 2+3 PASS(마커 6축 형식) · Axis 4 PASS.
`crossfamily: DEGRADED_PANEL_UNUSED` — 한 줄 매니페스트 등재이고 판정 enum·게이트 exit·비가역 경로를 안 건드린다. 이 파일의 *내용*은 #413 에서 codex/gpt-5.5 패널이 이미 8건으로 덮었고, 이번 건은 *등재 여부*다. 안 걸었고 안 걸었다고 적는다.
`standpoint: not-applicable` — 자기 출하 매니페스트.

## 명시 잔여

- **같은 클래스 전수 미조사** — 오늘 추가된 다른 파일이 shipped doc 에서 참조되면서 `files[]` 에 없는 경우를 훑지 않았다(검사기가 tarball 대조로 잡아주긴 한다).
- **stale ACCEPTED_ABSENT 1건 방치**(`.claude/rules/local_fh_context.md`) — 별건.
- 🟥 **이 미스의 일반형**: 이 세션이 오늘 「내가 편집한 파일의 안 본 부분」으로 결함을 **세 번** 냈다(prepublish 정규식이 실물 블록 스칼라 미대응 · 픽스처 헤더가 옛 배열 교육 · 이번 `files[]` 등재). **셋 다 내 편집 범위 안이고 셋 다 자력 적발 0이다.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)