### PR TITLE
fix(effect-probe): 「안 쟀다」가 「깨끗하다」로 렌더되던 관측면 구멍 둘 — 빈 디렉토리와 비정규 노드

### DIFF
--- a/.claude/capabilities/adapters/qasp-new-code-anchor.cap
+++ b/.claude/capabilities/adapters/qasp-new-code-anchor.cap
@@ -95,8 +95,11 @@ judge: mechanical
 verdict_binding: VIOLATION ARGS HARNESS_ERROR OUT_OF_SCOPE PEER_ABSENT
 #
 # known-pair — **합성 레포**에서 실행시점에 세운다. peer 히스토리를 안 쓰는 이유 셋:
-#   ① peer 의 이 진입점은 **수리 중**이다(qasp PR #174, 브랜치
-#      `fix/anchor-scan-out-of-scope-repairs` — 이 쌍을 고른 시점의 체크아웃 상태다).
+#   ① peer 의 이 진입점은 **움직인다**. 2026-08-16 이 줄을 쓸 때는 qasp PR #174 가 열려
+#      있었고(브랜치 `fix/anchor-scan-out-of-scope-repairs`), 그 PR 은 **2026-08-17 머지됐다**
+#      (qasp-dev main `cfd0e77`, 브랜치 삭제). 즉 이유는 살아 있고 사례만 닫혔다 —
+#      그 브랜치를 고정 SHA 로 박았으면 squash 로 커밋이 orphan 이 되어 쌍이 지금 죽어 있다.
+#      ★머지 후 known-pair 재실행으로 확인: `--known-positive` rc=1 · `--known-negative` rc=0.
 #      고정 SHA 를 박으면 그 브랜치가 squash 머지되는 순간 커밋이 orphan 이 되어 쌍이 죽는다.
 #   ② 상대 ref(`HEAD~N`)는 커밋이 쌓이면 가리키는 구간이 조용히 움직인다 — 같은 선언이
 #      다른 것을 재게 된다.

--- a/scripts/capability_effect_probe.sh
+++ b/scripts/capability_effect_probe.sh
@@ -105,6 +105,33 @@ _snapshot() {  # $1=dir → "sha  path" 목록 (정렬)
     | tr '\n' '\0' \
     | xargs -0 -n 400 shasum -a 256 2>/dev/null \
     | LC_ALL=C sort
+  # 🟥 **디렉토리 존재 축** (2026-08-17). 위 블록은 `-type f` 라 **파일만** 센다 — 빈
+  #   디렉토리는 관측면에 아예 없었고, `mkdir -p uploads outputs tmp` 만 하는 capability 가
+  #   `writes: read-only` 선언으로 **✅ VERIFIED** 를 받았다(known-pair 3-arm 실측).
+  #   git 은 빈 디렉토리를 추적하지 않으므로 격리 클론 샌드박스에도 없다 — 즉 이건 warm
+  #   cache 가 아니라 **관측면의 구멍**이다(원정 §2 의 진단을 이 실측이 정정했다).
+  #   ★존재만 센다, mtime 은 안 센다 — 안쪽 파일이 바뀔 때마다 디렉토리 mtime 이 움직여
+  #    읽기전용 capability 가 거짓 VIOLATION 을 받는다.
+  #   ★`.git` 제외 경계는 위 파일 축과 **같다**. 갈라지면 한쪽만 고쳐지는 구조가 된다.
+  find "$1" -type d -not -path '*/.git/*' -not -path '*/.git' 2>/dev/null \
+    | LC_ALL=C sort | sed 's/^/dir  /'
+  # 🟥 **비정규 노드 축** (2026-08-17, cross-family codex/gpt-5.5 지목 → 실측 확인).
+  #   `-type f` 도 `-type d` 도 symlink·fifo·소켓·디바이스 노드를 안 센다. 실측:
+  #     entry `ln -sf /etc/passwd leaked_link` + writes: read-only  → ✅ VERIFIED
+  #     entry `mkfifo backdoor_pipe`          + writes: read-only  → ✅ VERIFIED
+  #   위 디렉토리 축을 더한 **뒤에도** 둘 다 통과했다 — 같은 결함 클래스가 남아 있었다.
+  #   ★symlink 는 **대상까지** 잰다. 존재만 세면 같은 경로를 다른 곳으로 다시 거는
+  #    `ln -sf other link` 가 무변화로 보인다 — 그게 이 축에서 가장 위험한 형태다.
+  #   ★`stat -f`/`-printf` 를 안 쓴다 — 전자는 BSD 전용, 후자는 GNU 전용이라 한쪽 CI 에서
+  #    조용히 죽는다([[feedback_wiring_surfaces_hidden_failures]] 의 실측 클래스).
+  #    `-type` 술어와 `readlink` 만 쓰면 양쪽에서 돈다.
+  find "$1" -type l -not -path '*/.git/*' 2>/dev/null | LC_ALL=C sort \
+    | while IFS= read -r _l; do
+        printf 'link  %s -> %s\n' "$_l" "$(readlink "$_l" 2>/dev/null)"
+      done
+  find "$1" -not -path '*/.git/*' -not -path '*/.git' \
+       ! -type f ! -type d ! -type l 2>/dev/null \
+    | LC_ALL=C sort | sed 's/^/node  /'
   # ⚠️ 명명된 한계: 개행이 든 파일명은 `find` 출력에서 쪼개진다. 이 프로브가 도입될 때부터
   #    있던 성질이고 이번에 안 고쳤다 — 고치려면 `find -print0` 로 전 구간을 널 구분해야 한다.
 }
@@ -681,6 +708,83 @@ EOF
     pass=$((pass+1)); echo "✅ L15b 컨트롤 — 선언된 enum 안의 비영은 정상 관측(과차단 아님)"
   else
     fails=$((fails+1)); echo "❌ L15b rc=$rc (0 기대) — 정당한 비영 verdict 를 막는다"
+  fi
+
+  # ── L16/L16b 빈 디렉토리 생성은 «쓰기» 다 ────────────────────────────────────
+  #   2026-08-17 known-pair 3-arm 실측: `_snapshot` 이 `-type f` 라 **파일만** 셌고,
+  #   `mkdir -p uploads outputs tmp` 만 하는 capability 가 `writes: read-only` 선언으로
+  #   ✅ VERIFIED 를 받았다. git 이 빈 디렉토리를 추적하지 않으니 격리 클론에도 없어서
+  #   before/after 어느 쪽에도 안 나타난다 — warm cache 가 아니라 관측면의 구멍이다.
+  #   과녁이 실물인 이유: qasp 의 static-review 진입점이 정확히 이 모양이다
+  #   (`settings.py` 가 import 시점에 `ensure_dirs()` 를 무조건 실행).
+  cat > "$d/emptydirs.cap" <<EOF
+id: t:emptydirs
+entry: bash -c 'mkdir -p uploads outputs tmp'
+requires_cwd: $_rs
+writes: read-only
+EOF
+  out=$(probe_one "$d/emptydirs.cap" 2>&1); rc=$?
+  if [ "$rc" = "1" ]; then
+    pass=$((pass+1)); echo "✅ L16 빈 디렉토리 생성은 read-only 선언을 위반한다"
+  else
+    fails=$((fails+1)); echo "❌ L16 rc=$rc (1 기대) — 빈 디렉토리 생성이 «no-write» 로 렌더된다"
+  fi
+  # L16b 컨트롤(과차단 방지): 재는 것은 **상태**지 활동이 아니다. 만들었다가 지워
+  #      순증이 0 이면 위반이 아니다 — 여기서 빨개지면 mkdir 자체를 벌하는 것이고,
+  #      그러면 임시 작업공간을 쓰는 정당한 read-only capability 가 전부 막힌다.
+  cat > "$d/dir_net_zero.cap" <<EOF
+id: t:dirnetzero
+entry: bash -c 'mkdir -p scratch_tmp && rmdir scratch_tmp'
+requires_cwd: $_rs
+writes: read-only
+EOF
+  out=$(probe_one "$d/dir_net_zero.cap" 2>&1); rc=$?
+  if [ "$rc" = "0" ]; then
+    pass=$((pass+1)); echo "✅ L16b 컨트롤 — 순증 0 인 디렉토리 왕복은 위반이 아니다(상태를 잰다)"
+  else
+    fails=$((fails+1)); echo "❌ L16b rc=$rc (0 기대) — 활동을 벌한다(상태가 아니라)"
+  fi
+
+  # ── L17/L17b/L18 비정규 노드도 «쓰기» 다 ────────────────────────────────────
+  #   L16 을 넣은 **뒤에도** 통과하던 형태다(실측): `-type f`·`-type d` 어느 쪽도 안 센다.
+  cat > "$d/symlink.cap" <<EOF
+id: t:symlink
+entry: bash -c 'ln -sf /etc/passwd leaked_link'
+requires_cwd: $_rs
+writes: read-only
+EOF
+  out=$(probe_one "$d/symlink.cap" 2>&1); rc=$?
+  if [ "$rc" = "1" ]; then
+    pass=$((pass+1)); echo "✅ L17 symlink 생성은 read-only 선언을 위반한다"
+  else
+    fails=$((fails+1)); echo "❌ L17 rc=$rc (1 기대) — symlink 가 «no-write» 로 렌더된다"
+  fi
+  # L17b — **대상 재지정**. 존재만 세면 이게 무변화로 보인다: 경로도 타입도 그대로다.
+  #        이 축에서 가장 조용한 형태라 별도 레인으로 둔다.
+  mkdir -p "$_rs" 2>/dev/null; ln -sf /dev/null "$_rs/preexisting_link" 2>/dev/null
+  cat > "$d/relink.cap" <<EOF
+id: t:relink
+entry: bash -c 'ln -sf /etc/passwd preexisting_link'
+requires_cwd: $_rs
+writes: read-only
+EOF
+  out=$(probe_one "$d/relink.cap" 2>&1); rc=$?
+  if [ "$rc" = "1" ]; then
+    pass=$((pass+1)); echo "✅ L17b 기존 symlink 의 **대상 재지정**도 위반이다(존재만 세지 않는다)"
+  else
+    fails=$((fails+1)); echo "❌ L17b rc=$rc (1 기대) — 대상을 안 재고 존재만 센다"
+  fi
+  cat > "$d/fifo.cap" <<EOF
+id: t:fifo
+entry: bash -c 'mkfifo backdoor_pipe'
+requires_cwd: $_rs
+writes: read-only
+EOF
+  out=$(probe_one "$d/fifo.cap" 2>&1); rc=$?
+  if [ "$rc" = "1" ]; then
+    pass=$((pass+1)); echo "✅ L18 fifo/비정규 노드 생성도 위반이다"
+  else
+    fails=$((fails+1)); echo "❌ L18 rc=$rc (1 기대) — 비정규 노드가 감시면 밖이다"
   fi
 
   rm -rf "$d"


### PR DESCRIPTION
## 한 줄

**「안 쟀다」가 「깨끗하다」로 렌더되던 관측면 구멍 둘을 닫는다.** `capability_effect_probe.sh`
(M6 — `.cap` 의 `writes:` 선언이 실제 관측과 맞는지 검증하는 게이트)가 **파일만** 세고 있었다.

## 왜 지금 — 원정 1차 답습 갈래 ②의 선행조건

qasp 노드를 `writes: write-local` 로 **정직하게** 선언해도 계기가 그 값을 검증도 반증도 못 하는
상태였다. 그 값의 기전이 정확히 `ensure_dirs()` 의 **빈 디렉토리 생성**이기 때문이다.
즉 이 PR 은 어댑터를 짓는 게 아니라, **어댑터를 정직하게 등록할 수 있는 전제**를 세운다.

## 실측 — known-pair, 컨트롤 동반

| arm | base | fixed |
|---|---|---|
| 없던 경로에 파일 쓰기 (컨트롤) | 1 | 1 |
| 기존 디렉토리에 파일 쓰기 (컨트롤) | 1 | 1 |
| **빈 디렉토리만 생성** | **0** 🟥 | 1 |
| **`ln -sf /etc/passwd link`** | **0** 🟥 | 1 |
| **`mkfifo pipe`** | **0** 🟥 | 1 |
| 실물 read-only capability 3종 (과차단 대조군) | 0 | 0 |

`-type f` 도 `-type d` 도 symlink·fifo·소켓·디바이스를 안 센다. **디렉토리 축만 넣고
끝냈으면 「고쳤다」고 보고하면서 같은 클래스를 남길 뻔했다** — 그걸 cross-family 가 잡았다.

symlink 는 **대상까지** 잰다: 존재만 세면 같은 경로를 다른 곳으로 다시 거는
`ln -sf other link` 가 무변화로 보인다(이 축에서 가장 조용한 형태, L17b 가 앵커).

`stat -f`/`-printf` 는 안 썼다 — 각각 BSD/GNU 전용이라 한쪽 CI 에서 조용히 죽는 클래스다.
`-type` 술어 + `readlink` 만으로 양쪽에서 돈다.

## 🟥 원정 정본의 진단을 반증했다 (같이 정정함)

`expedition_2026-08-17_run1.md §2` 는 원인을 **warm cache** 로 적었다 —
*"디렉토리가 이미 있어서 `mkdir` 이 무음 no-op 이었다"*. **arm 2 가 그걸 반증한다**:
기존 디렉토리에 써도 잡힌다(스냅샷이 내용까지 해싱하므로). 결론은 맞고 기전이 틀렸다.

정정 없이 두면 다음 세션이 「샌드박스를 cold 로 강제」하는 처방을 짓는데, 샌드박스는
**이미 cold 다**(fresh clone) — 없는 문제를 고치고 진짜 구멍은 남는다. 정본에 정정 블록을 넣었다.

## 검증 축

- **ⓐ 계열** — codex/gpt-5.5 8건 지목, grounded 5. 1건 폐쇄(비정규 노드) · 3건 명명 ·
  1건 기각(L16b 를 "fix detector 아님"이라 했는데 **의도된 바**다 — 과차단 방향 컨트롤이라
  되돌림에서 초록으로 남는 게 정상). 오탐 0.
- **ⓔ 첫 실사용** — 실물 위치에서 self-test 23 PASS + known-pair 5arm 재실행
  (격리 사본 통과는 사본 통과일 뿐이라 위치를 옮겨 다시 돌렸다)
- **ⓕ 되돌림** — 두 축 **개별** 되돌림: dir 축 제거 → `L16` **만** 적색 ·
  node 축 제거 → `L17`·`L17b`·`L18` **만** 적색. 과결합 0.
- Axis 1 regression-guard PASS (M 0 · S 0)

레인 **18 → 23** (`L16`/`L16b`/`L17`/`L17b`/`L18`).

## 🟥 안 닫은 것 — 전부 확인했고 이름으로 남긴다

- **메타데이터 전용 쓰기** — `chmod +x` · xattr · 하드링크 토폴로지. `shasum` 은 바이트만 본다 (A급)
- **`.git` 하위 빈 디렉토리** — `.git` 은 의도적 제외이고 `GIT_META_WATCH` 는 파일 축만 덮는다
- **개행이 든 파일명** — 프로브 도입 시점부터의 성질, 새 축이 그대로 물려받았다
- **전수 미확인** — 새 축이 기존 선언을 빨갛게 만드는지는 **등록된 `.cap` 3종까지만** 확인됐다
- 🟥 **어댑터 자체는 안 지었다.** 이 PR 을 「qasp 노드 등록 완료」로 반올림하지 말 것

## 부수

오늘 qasp-dev #174 머지(main `cfd0e77`)로 낡은 `qasp-new-code-anchor.cap` 의 known-pair
사유 서술 갱신 — **이유는 살아 있고 사례만 닫혔다**(그 브랜치를 고정 SHA 로 박았으면 squash 로
지금 쌍이 죽어 있다). 머지 후 known-pair 재실행 확인: `--known-positive` 1 · `--known-negative` 0.
