### PR TITLE
feat(marker): ⓓ3자대면에 자기 필드 `thirdparty:` — 「적을 자리가 없다」를 벗는다

### DIFF
--- a/.claude/rules/fh_4axis_gate.md
+++ b/.claude/rules/fh_4axis_gate.md
@@ -194,6 +194,36 @@ controls: n/a — no measurement in this delta (<reason>)
 — zero hook lines, no fixture suite. Recorded here so the gap is visible from the rules side rather
 than only from the hook's absence.
 
+**`thirdparty:` — ⓓ3자 대면의 자기 필드 (2026-08-17 신설).** ⓑ가 `standpoint:` 를 갖는 것과
+같은 형태다: `axes-run` 에는 포인터(`ⓓ=→thirdparty`)만 두고 값은 이 필드가 나른다.
+
+```
+thirdparty: checked(<무엇을 검색했고 무엇을 찾았나>)
+thirdparty: none-found(<무엇을 검색했나>)   ← 찾았는데 선행 없음. «안 봤다»와 다른 명제다
+thirdparty: DEGRADED_NO_ACCESS(<사유>)      ← 못 봤다 (검색 수단 부재)
+thirdparty: DEGRADED_NOT_RUN(<사유>)        ← 안 돌렸다
+thirdparty: UNKNOWN                         ← 안 봤다
+thirdparty: not-applicable(<사유>)
+```
+
+🟥 **왜 `axes-run` 한 칸으로 부족한가.** 그 칸은 **토큰**을 담는데, 이 축이 실제로 내는 것은
+«무엇을 검색해서 무엇을 찾았나» 라 한 토큰에 안 들어간다. **자리가 없으면 안 적히고, 안 적히면
+다음 세션이 «이 축을 돌렸나»를 물을 수도 확인할 수도 없다.**
+실측 근거(2026-08-17): 이 축을 처음 제대로 돌린 세션에서 **발표 주장 6건이 선행자산에 걸렸다**
+(mutation testing · Anthropic skill-creator 블라인드 · Claude Code auto mode · Self-Harness ·
+공식 cross-family 플러그인 · constrained decoding). 그 전까지 이 레포 전체 마크다운에서
+`promptfoo|DeepEval|Inspect|garak|PyRIT|mutation testing` grep 히트는 **1줄**이었다 —
+축은 정본화돼 있었는데 **기록면이 없어서 습관이 안 생겼다.**
+
+**degrade 3값 분리는 `crossfamily:` 를 그대로 상속한다** — 못 봤다 / 안 돌렸다 / 안 봤다는
+서로 다른 명제이고, 자유 산문은 그 셋을 접는다. 접히면 «안 돌린 축»이 «선행 없음»으로 읽힌다.
+
+**검증 범위(오늘 기준)**: 훅은 ⓑ와 동일하게 **포인터가 가리키는 필드의 존재**만 본다.
+enum 값 검증은 안 한다 — `standpoint:` 와 같은 유보이고, 같은 이유다(첫 거짓 값이 기록되면
+그때 기계화한다). ⚠️ ⓑ가 겪은 **화살표 fail-open 도 같이 상속해 미리 막았다**: 화살표를
+필수로 보지 않고 «ⓓ 값이 thirdparty 를 참조하는가»로 본다. 같은 명시 잔여(참조어가 다른
+토큰에 있으면 미검출)도 그대로 남는다.
+
 **Scope, unchanged**: form + non-vacuity + auditability, **never provenance**. A marker claiming
 `ⓐ=codex` when codex never ran passes — deliberately. Catching that is cross-family review *reading*
 the marker, which is not this hook's job.

--- a/scripts/test_marker_axes_run_lanes.sh
+++ b/scripts/test_marker_axes_run_lanes.sh
@@ -168,6 +168,25 @@ controls: n/a — 측정 없음
 standpoint: tier1b(qasp)')
 check "$S7c" PASS "★컨트롤: 포인터에 대상이 붙어도 standpoint: 줄이 있으면 통과 (과차단 방지)"
 
+# ── ⓓ3자대면 자기 필드 `thirdparty:` (2026-08-17 신설) ─────────────────────────
+# ⓑ 와 같은 형태이므로 **ⓑ가 실측으로 겪은 fail-open 을 미리 막았는지**를 같이 고정한다.
+S7d=$(mk "$D_SIX" 'axes-run: ⓐ=none ⓑ=none ⓒ=none ⓓ=→thirdparty ⓔ=none ⓕ=none
+controls: n/a — 측정 없음')
+check "$S7d" BLOCK "★ⓓ=→thirdparty 인데 thirdparty: 줄이 없음 → 차단 (죽은 포인터)"
+
+S7e=$(mk "$D_SIX" 'axes-run: ⓐ=none ⓑ=none ⓒ=none ⓓ=thirdparty ⓔ=none ⓕ=none
+controls: n/a — 측정 없음')
+check "$S7e" BLOCK "★화살표 없는 ⓓ=thirdparty 도 차단 (ⓑ가 뚫렸던 그 표기 fail-open)"
+
+S7f=$(mk "$D_SIX" 'axes-run: ⓐ=none ⓑ=none ⓒ=none ⓓ=→thirdparty(promptfoo·DeepEval) ⓔ=none ⓕ=none
+controls: n/a — 측정 없음
+thirdparty: none-found(promptfoo·DeepEval·mutation testing 훑음)')
+check "$S7f" PASS "★컨트롤: 포인터에 대상이 붙어도 thirdparty: 줄이 있으면 통과 (과차단 방지)"
+
+S7g=$(mk "$D_SIX" 'axes-run: ⓐ=none ⓑ=none ⓒ=none ⓓ=none ⓔ=none ⓕ=none
+controls: n/a — 측정 없음')
+check "$S7g" PASS "★컨트롤: ⓓ=none 이면 thirdparty: 줄이 없어도 통과 (포인터를 안 쓴 경우)"
+
 S8=$(mk "$D_SIX" 'axes-run: ⓐ=codex ⓑ=→standpoint ⓒ=none ⓓ=none ⓔ=실사용 ⓕ=되돌림
 axes-run: ⓐ=거짓말 ⓑ=x ⓒ=x ⓓ=x ⓔ=x ⓕ=x
 controls: alive — ok

--- a/templates/.git-hooks/pre-commit
+++ b/templates/.git-hooks/pre-commit
@@ -866,6 +866,26 @@ validate_marker_axes_run() { # $1 = marker path
       echo "       standpoint: not-applicable"
       return 1
     fi
+
+    # ⓓ3자대면도 같은 형태 — 값은 `thirdparty:` 자기 필드가 나른다 (2026-08-17 신설).
+    # 🟥 왜 자기 필드가 필요한가: `axes-run` 한 칸은 **토큰**만 담는다. ⓓ가 실제로 내는 것은
+    #    «무엇을 검색해서 무엇을 찾았나» 라 한 토큰에 안 들어간다. 자리가 없으면 안 적히고,
+    #    안 적히면 다음 세션이 «이 축을 돌렸나»를 물을 수도 확인할 수도 없다.
+    #    실측(2026-08-17): 이 축을 처음 제대로 돌린 세션에서 발표 주장 **6건**이 선행자산에
+    #    걸렸는데, 그 결과를 기록할 필드가 없었다.
+    # ⚠️ ⓑ 와 **똑같은 fail-open 을 반복하지 않는다** — 화살표를 필수로 보지 않고
+    #    «ⓓ 값이 thirdparty 를 참조하는가» 로 넓힌다(ⓑ가 그렇게 뚫렸던 실측이 바로 위에 있다).
+    #    같은 명시 잔여도 그대로 상속한다: 참조어가 다른 토큰에 있으면 안 잡힌다.
+    if echo "$line" | grep -qE "(^|[[:space:]])ⓓ=[^[:space:]]*thirdparty" \
+       && ! grep -qE '^[[:space:]]*thirdparty:[[:space:]]*[^[:space:]]' "$m" 2>/dev/null; then
+      echo "  ❌ MARKER — 'ⓓ=→thirdparty' 라고 적었는데 'thirdparty:' 줄이 없다"
+      echo "     포인터가 가리키는 곳이 비어 있으면 그건 기록이 아니라 죽은 포인터다."
+      echo "       thirdparty: checked(promptfoo·DeepEval 훑음 — 겹침 없음)"
+      echo "       thirdparty: none-found(<무엇을 검색했나>)   ← 찾았는데 없음. «안 봤다»와 다르다"
+      echo "       thirdparty: UNKNOWN                        ← 안 봤다"
+      echo "       thirdparty: not-applicable"
+      return 1
+    fi
   fi
 
   line=$(grep -m1 -E '^[[:space:]]*controls:' "$m" 2>/dev/null \


### PR DESCRIPTION
## 왜

운영자 지시(2026-08-17): *"적을 자리조차 아직 없는 것만큼은 벗어나고 싶어."*

🟥 **먼저 전제 정정.** 같은 날 아침 「ⓓ는 적을 자리조차 없다」고 보고했는데, 그날 6축 확장이 착지하며 `axes-run:` 에 ⓓ 키가 생겼다(훅이 여섯 키를 전부 요구한다). 그 진술은 더 이상 참이 아니다.

**남아 있던 진짜 결손은 «전용 필드»** 다:

| 축 | 기록 형태 |
|---|---|
| ⓑ입장 | 포인터(`ⓑ=→standpoint`) + **자기 필드 `standpoint:` 에 값** |
| ⓓ3자대면 | `axes-run` 한 칸에 **토큰만** |

이 축이 실제로 내는 것은 «무엇을 검색해서 무엇을 찾았나» 라 **한 토큰에 안 들어간다.** 자리가 없으면 안 적히고, 안 적히면 다음 세션이 「이 축을 돌렸나」를 물을 수도 확인할 수도 없다.

**실측 근거**: 이 축을 처음 제대로 돌린 세션(2026-08-17)에서 **발표 주장 6건이 선행자산에 걸렸다**(mutation testing · Anthropic skill-creator 블라인드 · Claude Code auto mode · Self-Harness · 공식 cross-family 플러그인 · constrained decoding). 그 전까지 이 레포 전체 마크다운에서 `promptfoo|DeepEval|Inspect|garak|PyRIT|mutation testing` grep 히트는 **1줄**이었다 — 축은 정본화돼 있었는데 **기록면이 없어서 습관이 안 생겼다.**

## 무엇을

```
thirdparty: checked(<무엇을 검색했고 무엇을 찾았나>)
          | none-found(<무엇을 검색했나>)   ← 찾았는데 선행 없음. «안 봤다»와 다른 명제
          | DEGRADED_NO_ACCESS(<사유>)      ← 못 봤다
          | DEGRADED_NOT_RUN(<사유>)        ← 안 돌렸다
          | UNKNOWN                         ← 안 봤다
          | not-applicable(<사유>)
```

- degrade 3값 분리는 `crossfamily:` 를 그대로 상속 — 자유 산문은 셋을 접고, 접히면 «안 돌린 축»이 «선행 없음»으로 읽힌다
- 훅은 ⓑ와 동일하게 **포인터가 가리키는 필드의 존재**만 검사. enum 값 검증은 유보(`standpoint:` 와 같은 사유)
- 🟥 **ⓑ가 실측으로 겪은 fail-open 을 미리 막았다** — 화살표를 필수로 보지 않고 «ⓓ 값이 thirdparty 를 참조하는가»로 본다. ⓑ는 `ⓑ=standpoint`(화살표 없음)가 검사를 통째로 비껴가는 걸 겪었다. 같은 명시 잔여(참조어가 다른 토큰에 있으면 미검출)도 상속
- **규칙 정본에도 적었다** — 훅에만 있고 규칙에 없으면 이 파일 자신이 «gate-locality 결함」이라 부른 그 형태가 된다

## 검증

픽스처 4레인 신설(BLOCK 2 · PASS 컨트롤 2), 스위트 **rc=0**.

**되돌림 프로브** — 분기를 죽이니:
```
BLOCK 레인 2건   → 정확히 적색
PASS 컨트롤 2건  → 초록 유지   (과차단 방지 컨트롤이 안 죽었다)
복원             → rc=0
```
레인이 장식이 아니고 컨트롤에 판별력이 있다.

## 마커 — 이 필드를 자기 자신에게 썼다

```
thirdparty: DEGRADED_NOT_RUN(외부 선행 미조사) — 이 형태의 외부 선행을 안 찾아봤다.
            설계는 내부 선례(crossfamily · standpoint)를 상속했을 뿐이다.
```

**안 돌렸다는 사실이 이제 기록면에 남는다.** 그 전에는 남길 자리가 없어서, 안 돌린 것과 돌렸는데 없는 것이 똑같이 침묵으로 보였다.

## 🟥 명시 잔여

- `standpoint: DEGRADED_NOT_RUN(qasp-dev · pmh-dev)` — 이 훅은 형제 하네스로 가는 **전파 자산**이라 그쪽 게이트 판정을 바꾸는데, 이 세션은 대상 레포에서 **아무것도 실행하지 않았다**. 정적으로 읽지도 않았으므로 tier1b 도 아니다. **전파 전에 갚아야 할 빚**
- `crossfamily: DEGRADED_PANEL_UNUSED` — 패널은 가용(같은 날 실측: agy + ollama×5 REACHABLE·PIN-OK, codex 는 UNTRUSTED-PIN 제외). 안 돌린 사유: 기존 enum 을 안 건드리는 필드 추가이고 검사 형태가 이미 검증된 ⓑ 패턴의 복제
- enum 값 검증 미기계화(존재만 검사) — `standpoint:` 와 동일 유보

🤖 Generated with [Claude Code](https://claude.com/claude-code)