### PR TITLE
fix(ci): Axis 1 회귀 게이트가 한 번도 돈 적이 없다 — 계기 오류가 초록으로 렌더되고 있었다

### DIFF
--- a/.github/workflows/regression-guard.yml
+++ b/.github/workflows/regression-guard.yml
@@ -22,21 +22,76 @@ jobs:
       - name: Run regression_guard (--pr mode)
         id: guard
         run: |
+          # Pass UNAMBIGUOUS refs, never branch names. `github.head_ref` is a bare branch name and
+          # is not owner-qualified, so a fork PR whose branch is called `main` would have the guard
+          # resolve the PR side to THIS repo's main and compare it to itself (empty diff -> skip ->
+          # green). The head SHA cannot collide; the base is explicitly remote-qualified.
+          export REGRESSION_GUARD_RESULT_FILE="$RUNNER_TEMP/rg_result"
           set +e
-          bash templates/regression_guard.sh --pr "${{ github.head_ref }}"
+          bash templates/regression_guard.sh --pr \
+            "${{ github.event.pull_request.head.sha }}" \
+            "origin/${{ github.base_ref }}"
           EXIT=$?
-          echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
           set -e
-          exit 0  # capture exit code; handle below
+          echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
+          # Read the verdict from the script's TYPED channel, not by grepping its prose. The file
+          # already existed and this step was grepping stdout anyway — the exact grep-collision
+          # treadmill this repo has a memory about. A missing file is UNKNOWN, never "scanned".
+          if [ -f "$REGRESSION_GUARD_RESULT_FILE" ] \
+             && grep -qx 'result=skip' "$REGRESSION_GUARD_RESULT_FILE"; then
+            echo "scanned=no" >> "$GITHUB_OUTPUT"
+          elif [ -f "$REGRESSION_GUARD_RESULT_FILE" ]; then
+            echo "scanned=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "scanned=unknown" >> "$GITHUB_OUTPUT"
+          fi
+          exit 0  # verdict travels on the outputs above; handled in the next step
 
       - name: Evaluate result
         run: |
           EXIT="${{ steps.guard.outputs.exit_code }}"
-          if [ "$EXIT" = "2" ]; then
-            echo "::error::Regression Guard BLOCK — M-tier issues found. Fix before merge."
-            exit 2
-          elif [ "$EXIT" = "1" ]; then
-            echo "::warning::Regression Guard S-tier warnings present. Review intent before merge."
-          else
-            echo "Regression Guard PASS"
-          fi
+          # 🟥 FAIL-CLOSED ON ANYTHING UNRECOGNISED. The previous form was
+          #   2 -> block · 1 -> warn · else -> "PASS"
+          # and that `else` swallowed EVERY other exit code, including 3 = "the guard could not
+          # run at all". Measured 2026-08-17: 5 of 5 sampled runs exited 3 (unresolvable refs) and
+          # this step printed a green PASS. A gate that renders "could not measure" as "clean" is
+          # not a gate. Enumerate the passing codes; treat the rest as failure.
+          # Anchor: scripts/test_regression_guard_ci_lanes.sh (includes a revert probe).
+          case "$EXIT" in
+            0)
+              if [ "${{ steps.guard.outputs.scanned }}" = "unknown" ]; then
+                echo "::error::Regression Guard exited 0 but wrote no typed result — cannot tell scanned from skipped. Not a pass."
+                exit 1
+              elif [ "${{ steps.guard.outputs.scanned }}" = "no" ]; then
+                # NOT a pass, and deliberately NOT a failure either.
+                #
+                # 🟥 The first draft of this comment justified the branch with a FALSE claim —
+                # that `templates/regression_guard.sh` triggers this workflow without being in
+                # GUARD_PATHSPEC. It IS in it (`templates/*.sh`). The error came from reading
+                # only the first 12 lines of that array; the truncation, not the repo, produced
+                # the finding. Recorded rather than quietly deleted, because the same
+                # read-truncation produced a second wrong claim the same session.
+                #
+                # The real relation, measured: this workflow's `paths:` is a SUBSET of
+                # GUARD_PATHSPEC (the script also gates knowledge/**, AGENTS.md, docs/*.md,
+                # scripts/*.sh, templates/.git-hooks/*, agent definitions — none of which
+                # trigger this workflow at all; that direction is a separate, already-recorded
+                # gap in CLAUDE.md). So a SKIP here should be RARE: if the workflow triggered,
+                # a gated file changed. That is exactly why it must not print "PASS" — a skip
+                # in CI means the run compared nothing, and the honest reading of "compared
+                # nothing" is not "clean". Surfaced rather than blocked: the state is unproven
+                # in the field (0 observed CI skips so far), and blocking on an unproven state
+                # trains the override that would disarm the rest of this gate.
+                echo "::notice::Regression Guard SKIPPED — no changed file matched GUARD_PATHSPEC. This is NOT a pass; nothing was compared."
+              else
+                echo "Regression Guard PASS — scanned, no regression."
+              fi ;;
+            1)
+              echo "::warning::Regression Guard S-tier warnings present. Review intent before merge." ;;
+            2)
+              echo "::error::Regression Guard BLOCK — M-tier issues found. Fix before merge."
+              exit 2 ;;
+            *)
+              echo "::error::Regression Guard could NOT RUN (exit '$EXIT'). An instrument error is not a pass — see the step log above."
+              exit 1 ;;
+          esac

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "templates/degrade_direction_scan.sh",
     "templates/.git-hooks",
     "templates/regression_guard.sh",
+    "scripts/test_regression_guard_ci_lanes.sh",
     "templates/predelete_check.sh",
     "templates/PRE-PUBLISH-CHECKLIST.md",
     "scripts/degrade_direction_scan.sh",

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -527,6 +527,7 @@ for _pair in \
   "scripts/knowledge_seam_check.sh|scripts/test_knowledge_seam_lanes.sh" \
   "templates/.git-hooks/pre-commit|scripts/test_marker_crossfamily_lanes.sh" \
   "templates/.git-hooks/pre-commit|scripts/test_marker_floor_lanes.sh" \
+  ".github/workflows/regression-guard.yml|scripts/test_regression_guard_ci_lanes.sh" \
   "scripts/residency_closure_scan.py|scripts/test_residency_closure_lanes.sh" \
   "scripts/reviewer_capability_corpus.tsv|scripts/test_reviewer_capability_conformance.sh" \
   "scripts/field_canon_preload.sh|scripts/test_field_canon_lanes.sh" \

--- a/scripts/test_regression_guard_ci_lanes.sh
+++ b/scripts/test_regression_guard_ci_lanes.sh
@@ -122,7 +122,14 @@ if git -C "$REPO_ROOT" clone -q --no-local "$REPO_ROOT" "$CL" 2>/dev/null; then
   # This file's own header warns that asserting only BLOCK cannot tell "blocked" from "blocked for
   # the wrong reason". Holding exactly one variable is the fix: base is always a resolvable SHA,
   # so any refusal is attributable to the head, and the assertion checks the head half by name.
-  BASE_SHA=$(git -C "$CL" rev-parse HEAD~1 2>/dev/null || git -C "$CL" rev-parse HEAD)
+  # 🟥 `git rev-parse HEAD~1` prints the literal string "HEAD~1" ON STDOUT when it fails, so
+  # `$(... || fallback)` captures that string alongside the fallback. Measured in CI: the clone of
+  # a detached, branchless checkout has a single reachable commit, HEAD~1 does not exist, and
+  # BASE_SHA became the literal "HEAD~1" — which then failed to resolve and turned this lane red
+  # for a reason unrelated to what it tests. Same family as `|| echo 0` emitting "0\n0".
+  # Use --verify --quiet (silent on failure) and branch on emptiness.
+  BASE_SHA=$(git -C "$CL" rev-parse --verify --quiet 'HEAD~1^{commit}') || BASE_SHA=""
+  [ -n "$BASE_SHA" ] || BASE_SHA=$(git -C "$CL" rev-parse HEAD)
 
   # L8a — a bare NAME must be REFUSED. Name-guessing is what let a fork PR branch called `main`
   # resolve to this repo's main and compare it to itself.

--- a/scripts/test_regression_guard_ci_lanes.sh
+++ b/scripts/test_regression_guard_ci_lanes.sh
@@ -99,25 +99,48 @@ if git -C "$REPO_ROOT" clone -q --no-local "$REPO_ROOT" "$CL" 2>/dev/null; then
   done
   _left=$(git -C "$CL" for-each-ref --format='%(refname:short)' refs/heads | wc -l | tr -d ' ')
   cp "$GUARD" "$CL/templates/regression_guard.sh"
-  BR=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)
-  SHA=$(git -C "$REPO_ROOT" rev-parse HEAD)
+  # The head fixture is the VULNERABILITY ITSELF, not an arbitrary name: `main`. In this clone
+  # `origin/main` exists and local `main` does not — exactly a fork PR whose branch is called
+  # `main`. The old resolver guessed `main -> origin/main` and compared the base repo to itself.
+  # (An earlier fixture used `rev-parse --abbrev-ref HEAD`, which returns the literal string
+  # "HEAD" on a detached checkout — a ref that DOES resolve, so the lane asserted nothing. Caught
+  # by reproducing the CI shape locally rather than trusting the developer-machine green.)
+  BR=main
+  # Take every SHA from INSIDE the clone. A SHA read from the source repo is not guaranteed to
+  # exist in the clone: when the source is a detached checkout with no local branches (which is
+  # exactly what actions/checkout leaves), `git clone` has few refs to transfer from, so an
+  # arbitrary source SHA may simply be absent. Reading from the clone removes that assumption
+  # instead of hoping it holds — the previous version of this lane hoped, and CI disagreed.
+  SHA=$(git -C "$CL" rev-parse HEAD)
+  # 🟥 The BASE side must be a SHA too, and this cost a red CI to learn.
+  # The first version passed `origin/main` as the base. That resolves on a developer machine and
+  # NOT in CI: a GitHub Actions checkout is detached with no local `main`, so a clone of it has no
+  # `origin/main` either. Consequences, both measured on the same run:
+  #   L8b failed  — base unresolvable, so the SHA lane could never reach its assertion
+  #   L8a "passed" FOR THE WRONG REASON — it expects exit 3, and got exit 3 from the BASE failing,
+  #                 not from the head NAME being refused. A green lane measuring something else.
+  # This file's own header warns that asserting only BLOCK cannot tell "blocked" from "blocked for
+  # the wrong reason". Holding exactly one variable is the fix: base is always a resolvable SHA,
+  # so any refusal is attributable to the head, and the assertion checks the head half by name.
+  BASE_SHA=$(git -C "$CL" rev-parse HEAD~1 2>/dev/null || git -C "$CL" rev-parse HEAD)
 
-  # L8a — a bare NAME must now be REFUSED. Name-guessing is what let a fork PR branch called
-  # `main` resolve to this repo's main and compare it to itself.
-  out=$(cd "$CL" && bash templates/regression_guard.sh --pr "$BR" "origin/main" 2>&1); rc=$?
-  if [ "$rc" -eq 3 ] && printf '%s' "$out" | grep -q 'does not resolve'; then
-    printf '  ✅ %-30s bare name refused (local refs left: %s)\n' "L8a-name-refused" "$_left"
+  # L8a — a bare NAME must be REFUSED. Name-guessing is what let a fork PR branch called `main`
+  # resolve to this repo's main and compare it to itself.
+  out=$(cd "$CL" && bash templates/regression_guard.sh --pr "$BR" "$BASE_SHA" 2>&1); rc=$?
+  if [ "$rc" -eq 3 ] && printf '%s' "$out" | grep -q "head='$BR'->'<none>'"; then
+    printf '  ✅ %-30s fork-collision name '"'"'%s'"'"' refused, attributed to HEAD (local refs: %s)\n' "L8a-name-refused" "$BR" "$_left"
   else
-    printf '  ❌ %-30s expected exit 3 refusal, got rc=%s: %s\n' "L8a-name-refused" "$rc" "$(printf '%s' "$out" | head -1)"; FAIL=1
+    printf '  ❌ %-30s expected exit 3 naming head=%s, got rc=%s: %s\n' "L8a-name-refused" "$BR" "$rc" "$(printf '%s' "$out" | head -1)"; FAIL=1
   fi
 
-  # L8b — an unambiguous SHA must resolve and actually compute a merge-base.
-  out=$(cd "$CL" && bash templates/regression_guard.sh --pr "$SHA" "origin/main" 2>&1); rc=$?
+  # L8b — unambiguous SHAs on both sides must resolve and compute a merge-base.
+  out=$(cd "$CL" && bash templates/regression_guard.sh --pr "$SHA" "$BASE_SHA" 2>&1); rc=$?
   if printf '%s' "$out" | grep -q 'PR MODE: merge-base='; then
     printf '  ✅ %-30s %s\n' "L8b-sha-resolves" "$(printf '%s' "$out" | grep -o 'merge-base=[^ ]*')"
   else
     printf '  ❌ %-30s SHA did not resolve (rc=%s): %s\n' "L8b-sha-resolves" "$rc" "$(printf '%s' "$out" | head -1)"; FAIL=1
   fi
+
 else
   printf '  ⚠️  %-30s clone unavailable — lanes SKIPPED (not passed)\n' "L8-ci-shape"
 fi

--- a/scripts/test_regression_guard_ci_lanes.sh
+++ b/scripts/test_regression_guard_ci_lanes.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# test_regression_guard_ci_lanes.sh — regression fixtures for Axis 1's CI path.
+#
+# WHY (measured 2026-08-17, and this is a production fail-open that ran silently):
+# `Axis 1 — Backward Regression Check` reported a GREEN check on every PR it triggered on, while
+# never once comparing anything. Two independent faults, both required:
+#   ① templates/regression_guard.sh --pr took a bare BRANCH NAME and ran `git merge-base main
+#      <branch>`. In a GitHub Actions PR checkout neither name resolves — actions/checkout lands
+#      on a DETACHED HEAD and creates refs/remotes/origin/*, not local branches. `fetch-depth: 0`
+#      was already set and is NOT the cause: the history was there, the NAMES were not. → exit 3.
+#   ② the workflow's Evaluate step was `2 -> block · 1 -> warn · else -> "PASS"`, so exit 3
+#      ("could not run") fell into `else` and printed a green PASS.
+# Sample: 5 of 5 runs inspected (4 historical + the one that surfaced it) hit ① and rendered ②.
+# Scope stated honestly: 5/5 SAMPLED, not an exhaustive audit of every run ever.
+#
+# ② is the load-bearing half. Fixing ① alone leaves the next instrument error just as green,
+# because `else` swallows every code nobody enumerated.
+#
+# These lanes assert BOTH directions, and include a REVERT PROBE: the fail-closed branch is
+# neutralized and the suite must go red at exactly that lane — an anchor nobody has watched fail
+# is an anchor nobody knows is alive.
+#
+# Usage: bash scripts/test_regression_guard_ci_lanes.sh   Exit: 0 = all behave; 1 = regression.
+
+set -uo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WF="$REPO_ROOT/.github/workflows/regression-guard.yml"
+GUARD="$REPO_ROOT/templates/regression_guard.sh"
+T=$(mktemp -d); trap 'rm -rf "$T"' EXIT
+FAIL=0
+
+# ── instrument calibration ───────────────────────────────────────────────────
+# Extract the workflow's verdict logic and PROVE it arrived. An empty extraction would let every
+# lane "pass" against nothing — the exact class this suite exists to close.
+# Extracted with stdlib only. PyYAML is NOT a declared dependency of this repo, and this suite
+# runs inside selfcheck.sh — a missing module here would block unrelated legitimate commits with
+# an error about the wrong thing (cross-family finding, 2026-08-17).
+python3 - "$WF" > "$T/eval.sh" <<'PYX'
+import sys, re
+lines = open(sys.argv[1], encoding="utf-8").read().split("\n")
+try:
+    i = next(k for k, l in enumerate(lines) if l.strip() == "- name: Evaluate result")
+except StopIteration:
+    sys.exit(0)                      # emit nothing -> the calibration check below aborts loudly
+j = next(k for k in range(i, len(lines)) if lines[k].strip().startswith("run:"))
+indent = len(lines[j + 1]) - len(lines[j + 1].lstrip())
+body = []
+for l in lines[j + 1:]:
+    if l.strip() and (len(l) - len(l.lstrip())) < indent:
+        break
+    body.append(l[indent:])
+run = "\n".join(body)
+run = run.replace("${{ steps.guard.outputs.exit_code }}", "$EXIT_IN")
+run = run.replace("${{ steps.guard.outputs.scanned }}", "$SCANNED_IN")
+sys.stdout.write('EXIT="$EXIT_IN"\n' + re.sub(r"^EXIT=.*\n", "", run, count=1, flags=re.M))
+PYX
+if ! grep -q 'could NOT RUN' "$T/eval.sh"; then
+  echo "❌ HARNESS-ERROR — the workflow's Evaluate logic did not extract from $WF."
+  echo "   Lanes below would measure an empty script. Aborting rather than reporting green."
+  exit 1
+fi
+
+verdict() { # $1=exit_code $2=scanned ; echoes rc + first line
+  local out rc
+  out=$(EXIT_IN="$1" SCANNED_IN="$2" bash "$T/eval.sh" 2>&1); rc=$?
+  printf '%s|%s' "$rc" "$(printf '%s' "$out" | head -1)"
+}
+lane() { # $1=id $2=exit $3=scanned $4=expect(ok|fail) $5=substring
+  local r; r=$(verdict "$2" "$3"); local rc="${r%%|*}" msg="${r#*|}"
+  local got=ok; [ "$rc" -ne 0 ] && got=fail
+  if [ "$got" = "$4" ] && printf '%s' "$msg" | grep -q "$5"; then
+    printf '  ✅ %-30s rc=%s  %s\n' "$1" "$rc" "$(printf '%s' "$msg" | cut -c1-58)"
+  else
+    printf '  ❌ %-30s expected %s+/%s/, got rc=%s %s\n' "$1" "$4" "$5" "$rc" "$msg"; FAIL=1
+  fi
+}
+
+echo "== Evaluate-step lanes =="
+lane L1-clean-scanned   0 yes ok   "PASS — scanned"
+lane L2-skip-not-a-pass 0 no  ok   "NOT a pass"
+lane L2b-unknown-typed  0 unknown fail "wrote no typed result"
+lane L3-s-tier-warn     1 yes ok   "warning"
+lane L4-m-tier-block    2 yes fail "BLOCK"
+lane L5-instrument-3    3 yes fail "could NOT RUN"
+lane L6-unknown-99     99 yes fail "could NOT RUN"
+lane L7-empty-output   ""  yes fail "could NOT RUN"
+
+echo "== script lane — ref resolution under a CI-shaped checkout =="
+# Real reproduction: a detached-HEAD clone with no local branch refs, which is what broke ①.
+CL="$T/clone"
+if git -C "$REPO_ROOT" clone -q --no-local "$REPO_ROOT" "$CL" 2>/dev/null; then
+  git -C "$CL" checkout -q --detach HEAD
+  # 🟥 The first version of this lane claimed "no local branch refs" and did NOT create that
+  # state — `git clone` makes one, so the resolver matched the FIRST candidate and the lane never
+  # exercised the CI shape it advertised (cross-family finding, 2026-08-17). Delete every local
+  # branch so only refs/remotes/* remain — what actions/checkout actually leaves behind.
+  for _b in $(git -C "$CL" for-each-ref --format='%(refname:short)' refs/heads); do
+    git -C "$CL" branch -q -D "$_b" >/dev/null 2>&1 || true   # noqa: destructive-op (throwaway clone)
+  done
+  _left=$(git -C "$CL" for-each-ref --format='%(refname:short)' refs/heads | wc -l | tr -d ' ')
+  cp "$GUARD" "$CL/templates/regression_guard.sh"
+  BR=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)
+  SHA=$(git -C "$REPO_ROOT" rev-parse HEAD)
+
+  # L8a — a bare NAME must now be REFUSED. Name-guessing is what let a fork PR branch called
+  # `main` resolve to this repo's main and compare it to itself.
+  out=$(cd "$CL" && bash templates/regression_guard.sh --pr "$BR" "origin/main" 2>&1); rc=$?
+  if [ "$rc" -eq 3 ] && printf '%s' "$out" | grep -q 'does not resolve'; then
+    printf '  ✅ %-30s bare name refused (local refs left: %s)\n' "L8a-name-refused" "$_left"
+  else
+    printf '  ❌ %-30s expected exit 3 refusal, got rc=%s: %s\n' "L8a-name-refused" "$rc" "$(printf '%s' "$out" | head -1)"; FAIL=1
+  fi
+
+  # L8b — an unambiguous SHA must resolve and actually compute a merge-base.
+  out=$(cd "$CL" && bash templates/regression_guard.sh --pr "$SHA" "origin/main" 2>&1); rc=$?
+  if printf '%s' "$out" | grep -q 'PR MODE: merge-base='; then
+    printf '  ✅ %-30s %s\n' "L8b-sha-resolves" "$(printf '%s' "$out" | grep -o 'merge-base=[^ ]*')"
+  else
+    printf '  ❌ %-30s SHA did not resolve (rc=%s): %s\n' "L8b-sha-resolves" "$rc" "$(printf '%s' "$out" | head -1)"; FAIL=1
+  fi
+else
+  printf '  ⚠️  %-30s clone unavailable — lanes SKIPPED (not passed)\n' "L8-ci-shape"
+fi
+
+echo "== revert probe — is the fail-closed branch load-bearing, or decoration? =="
+# Neutralize ONLY the catch-all failure branch; L5/L6/L7 must go red and nothing else may move.
+sed 's/exit 1 ;;/: ;;/' "$T/eval.sh" > "$T/eval_neutered.sh"
+if ! diff -q "$T/eval.sh" "$T/eval_neutered.sh" >/dev/null; then
+  r=$(EXIT_IN=3 SCANNED_IN=yes bash "$T/eval_neutered.sh" >/dev/null 2>&1; echo $?)
+  if [ "$r" -eq 0 ]; then
+    echo "  ✅ revert probe            neutralizing the catch-all makes exit 3 pass again → anchor is alive"
+  else
+    echo "  ❌ revert probe            neutralized branch STILL fails — the lane is not testing what it claims"; FAIL=1
+  fi
+else
+  echo "  ❌ revert probe            neutralization was a no-op — the probe measured nothing"; FAIL=1
+fi
+
+[ $FAIL -eq 0 ] && { echo "✅ all regression-guard CI lanes behave"; exit 0; }
+echo "❌ regression-guard CI lane regression"; exit 1

--- a/templates/regression_guard.sh
+++ b/templates/regression_guard.sh
@@ -64,13 +64,41 @@ if [ "${1:-}" = "--pr" ]; then
   fi
   PR_BRANCH="$2"
   BASE_BRANCH="${3:-main}"
-  BASE_REF=$(git merge-base "$BASE_BRANCH" "$PR_BRANCH" 2>/dev/null)
-  if [ -z "$BASE_REF" ]; then
-    echo "ERROR: cannot compute merge-base for $PR_BRANCH vs $BASE_BRANCH" >&2
+  # Resolve each side to a ref that actually EXISTS in this checkout.
+  #
+  # WHY (measured 2026-08-17, 5 of 5 SAMPLED CI runs — not an exhaustive audit): a bare branch
+  # NAME does not resolve in a GitHub Actions PR checkout. actions/checkout lands on a DETACHED
+  # HEAD and creates refs/remotes/origin/*, not local branches — so `git merge-base main <branch>`
+  # found neither side, returned empty, and this block exited 3. `fetch-depth: 0` was already set
+  # and is NOT the cause; the history was present, the NAMES were not. The workflow then rendered
+  # that instrument error as a green PASS (fixed in the same commit).
+  #
+  # 🟥 THE FIRST FIX FOR THIS INTRODUCED A WORSE HOLE, caught by cross-family review before it
+  # shipped. It resolved `ref -> origin/ref -> refs/remotes/origin/ref` and fell back to HEAD.
+  # `github.head_ref` is only a branch NAME, not owner-qualified, so a **fork PR whose branch is
+  # named `main`** resolved the PR side to the BASE repo's `main` — merge-base(main, main) = main,
+  # empty diff, SKIP, green. A guard silently comparing a branch to itself is worse than one that
+  # errors. So: NO name-guessing and NO silent HEAD fallback. Callers pass something
+  # unambiguous (a SHA, or an explicit `origin/<ref>`); anything that does not resolve EXACTLY
+  # is an instrument error, and the workflow now fails closed on that.
+  _rg_resolve_ref() { # $1 = ref-ish; echoes it iff it resolves EXACTLY as given (rc=1 otherwise)
+    git rev-parse --verify --quiet "${1}^{commit}" >/dev/null 2>&1 && printf '%s' "$1"
+  }
+  _BASE_RESOLVED=$(_rg_resolve_ref "$BASE_BRANCH") || _BASE_RESOLVED=""
+  _HEAD_RESOLVED=$(_rg_resolve_ref "$PR_BRANCH")  || _HEAD_RESOLVED=""
+  if [ -z "$_BASE_RESOLVED" ] || [ -z "$_HEAD_RESOLVED" ]; then
+    echo "ERROR: ref does not resolve — base='$BASE_BRANCH'->'${_BASE_RESOLVED:-<none>}' head='$PR_BRANCH'->'${_HEAD_RESOLVED:-<none>}'" >&2
+    echo "       Pass an unambiguous ref (a SHA, or origin/<branch>). Guessing is how a fork PR" >&2
+    echo "       branch named 'main' silently compared the base repo's main to itself." >&2
     exit 3
   fi
-  HEAD_REF="$PR_BRANCH"
-  echo "PR MODE: merge-base=$(git rev-parse --short "$BASE_REF") branch=$PR_BRANCH"
+  BASE_REF=$(git merge-base "$_BASE_RESOLVED" "$_HEAD_RESOLVED" 2>/dev/null)
+  if [ -z "$BASE_REF" ]; then
+    echo "ERROR: cannot compute merge-base for $_HEAD_RESOLVED vs $_BASE_RESOLVED" >&2
+    exit 3
+  fi
+  HEAD_REF="$_HEAD_RESOLVED"
+  echo "PR MODE: merge-base=$(git rev-parse --short "$BASE_REF") base=$_BASE_RESOLVED head=$_HEAD_RESOLVED"
 elif [ "${1:-}" = "--staged" ]; then
   # Pre-commit context: evaluate the staged index against HEAD. On a direct-to-main
   # workflow, --pr's merge-base(main,main)=HEAD yields an empty diff, so staged changes


### PR DESCRIPTION
## 무엇이 깨져 있었나

`Axis 1 — Backward Regression Check` 가 **초록을 내면서 아무것도 비교하지 않았다.** 표본 5런(PR #429 + 과거 4) **전부** 같은 자리에서 죽었다.

```
로그    ERROR: cannot compute merge-base for <branch> vs main   →  exit 3
① 스크립트  --pr 이 브랜치 «이름»을 받아 git merge-base main <branch>
           CI 체크아웃엔 그 로컬 ref 가 없다 (detached HEAD + refs/remotes/origin/* 만)
           🟥 fetch-depth: 0 은 **이미 설정돼 있어 원인이 아니다** — 이력은 있었고 «이름»이 없었다
② 워크플로  2→block · 1→warn · **else→"PASS"**  →  exit 3 이 else 로 떨어져 초록
```

**②가 load-bearing 이다.** ①만 고치면 **다음 계기 오류가 또 조용히 초록**이다. `else` 가 아무도 열거하지 않은 모든 코드를 삼킨다.

## 🟥 첫 수리가 더 나쁜 구멍을 만들었고, cross-family 가 출하 전에 잡았다

`_rg_resolve_ref` 가 `ref → origin/ref → refs/remotes/origin/ref` 로 추측하고 HEAD 로 폴백했다. `github.head_ref` 는 **owner 가 안 붙은 브랜치 이름**이라 — **fork PR 의 브랜치 이름이 `main` 이면** PR 쪽이 **base 레포의 `main`** 으로 해석된다. `merge-base(main, main) = main` → 빈 diff → SKIP → 초록. **자기 자신과 비교하는 게이트라 원 결함보다 나쁘다.**

처분: **이름 추측과 HEAD 폴백을 통째로 제거**했다. 해석되지 않으면 그건 계기 오류이고, 워크플로가 이제 거기서 fail-closed 한다. 워크플로는 **head SHA + `origin/<base_ref>`** 를 넘긴다 — SHA 는 충돌할 수 없다.

## 수리

| | |
|---|---|
| ① | 명시 ref 만 수용(SHA/`origin/<ref>`), 추측·폴백 제거 |
| ② | 통과 코드를 `case` 로 **열거**, 나머지 fail-closed |
| ③ | `SKIP` 을 `PASS` 라 부르지 않음 — 차단은 안 함(실측 0건 상태에 차단은 override 를 훈련시킨다) |
| ④ | SKIP 판정을 prose-grep → **typed 채널**(`REGRESSION_GUARD_RESULT_FILE`, 이미 있었는데 안 쓰고 있었다). 채널 없으면 **UNKNOWN → 차단** |

## 앵커 — `scripts/test_regression_guard_ci_lanes.sh` 11레인

- 평가셸을 워크플로 YAML 에서 **stdlib 로** 추출(PyYAML 미의존 — 이 스위트는 `selfcheck.sh` 안에서 돈다) + **추출 실패 시 HARNESS-ERROR 중단**
- 종료코드 known-pair 7값(0-scanned / 0-skip / 0-unknown / 1 / 2 / 3 / 99 / 빈값)
- **CI 형태 재현**: 로컬 브랜치 ref 를 전부 지운 detached 클론에서 «이름 거부(L8a) / SHA 해석(L8b)» 양 arm
- **되돌림 프로브**: fail-closed 분기를 무력화하면 `exit 3` 이 다시 통과하는지 → 앵커가 살아있음을 확인
- `selfcheck.sh` 앵커 루프와 `package.json files[]` 에 배선

## ⚠️ 소급 효과

**이 워크플로의 과거 초록은 Axis 1 이 봤다는 증거가 아니다.** 병렬 세션이 자기가 오늘 머지한 PR 3건(#426·#427·#428)도 같은 상태였다고 확인했다. 「CI 초록이었으니 검증됐다」로 인용된 곳은 재평가 대상이다.

## 이 세션 자신의 결함 (기록 — 숨기지 않는다)

- **첫 검증이 «수리 전» 스크립트를 쟀다** — 클론은 커밋 상태를 가져오는데 수리가 미커밋이었다. 옛 오류 문구가 그대로 나와서 잡혔다
- **`sed +12p` 로 `GUARD_PATHSPEC` 을 12줄만 읽고** 「`templates/regression_guard.sh` 가 pathspec 에 없다」는 **거짓 주장**을 워크플로 주석에 적었다. 전문엔 `templates/*.sh` 로 있다 — 정정문을 그 주석에 남겼다
- **내 L8 레인이 주장한 상태를 안 만들었다**(clone 이 로컬 브랜치를 만든다) — cross-family 지적, 지금은 전부 삭제하고 잔여 수를 출력에 찍는다
- 수리 후 자체 발견 2건: `\u` 이스케이프가 bash 3.2 에서 문자로 찍힘 · **내가 추가한 `scanned=unknown` 차단 경로에 레인이 없었다**(L2b 신설)

## 잔여 (안 고쳤다)

- 워크플로 `paths:` ⊂ `GUARD_PATHSPEC` — `knowledge/**`·`AGENTS.md`·`docs/*.md`·`scripts/*.sh`·에이전트 정의는 이 워크플로를 **트리거하지 않는다**. CLAUDE.md 가 이미 기록한 별건이고, 넓히면 CI 부하와 과차단이 함께 는다 → **운영자 결정**
- SKIP 은 여전히 초록 잡이라 branch protection 은 통과시킨다 — 위 수리로 발생 가능성이 낮아졌으나 0 은 아니다
- **표본 5런은 전수가 아니다** — 「한 번도」는 5/5 에 대한 진술이다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qj4cLMnC5KZQ8ZK1Js1cZy