### PR TITLE
fix(relay): 등록 시점 검사기를 호출 시점에 배선 — 게이트가 있는데 호출부가 0줄이었다

### DIFF
--- a/scripts/capability_registry_check.sh
+++ b/scripts/capability_registry_check.sh
@@ -373,6 +373,13 @@ _check_one() {
   if [ -z "$CAP_cal_pos_expect" ] || [ -z "$CAP_cal_neg_expect" ]; then
     _fail "M4" "캘리브레이션 쌍 미선언(양성·음성 expect 둘 다 필요) — 답을 아는 케이스를 못 가르는 계기는 재는 게 아니다"
     OBS_WHY="캘리브레이션 쌍 미선언"
+  # 🟥 위 «쌍 미선언» 검사는 **선언층**이므로 --declaration-only 에서도 돈다. 아래부터가
+  #   **실행**이고, 그것만 건너뛴다. 둘을 한 덩어리로 스킵하면 «쌍을 아예 선언 안 한»
+  #   capfile 이 선언층 검사를 통과해버린다 — 2026-08-17 실측에서 relay 가 삼킨
+  #   `qasp_clean.cap` 이 정확히 그 값으로 걸렸다(M4 쌍 미선언).
+  elif [ "${DECL_ONLY:-0}" -eq 1 ]; then
+    printf '  ⏭  M4 — --declaration-only: 쌍 선언은 확인했고 **arm 은 실행하지 않았다**(SKIPPED, PASS 아님)\n'
+    OBS_WHY="--declaration-only 로 arm 미실행"
   elif [ "$FILE_FAILED" -eq 1 ] && [ -z "${CRC_FORCE_M4:-}" ]; then
     printf '  ⏭  M4 — 앞선 축이 실패해 실행 생략(SKIPPED, PASS 아님)\n'
     OBS_WHY="앞선 축 실패로 M4 생략"
@@ -417,6 +424,11 @@ _check_one() {
   #   «못 쟀다» 를 출력에 남긴다. 미측정을 0 으로 렌더하지 않는다.
   if [ -z "$CAP_writes" ]; then
     :   # writes 미선언은 M2 가 이미 처리한다
+  elif [ "${DECL_ONLY:-0}" -eq 1 ]; then
+    # 🟥 M6 는 통째로 실행 기반이다(effect probe 가 entry 를 실제로 돌린다). 선언층에
+    #   남길 것이 없으므로 전부 건너뛴다 — 그래서 이 모드의 출력이 REGISTRABLE 이 아니라
+    #   DECLARATION_VALID 다. `writes:` 의 진위는 이 모드에서 **등록자 주장**으로 남는다.
+    printf '  ⏭  M6 — --declaration-only: 진입점을 실행하지 않았다. `writes:` 는 미검증 주장이다(SKIPPED, PASS 아님)\n'
   elif [ "$FILE_FAILED" -eq 1 ] && [ -z "${CRC_FORCE_M6:-}" ]; then
     # ★앞선 축이 실패했으면 **진입점을 실행하지 않는다**(2026-08-16 cross-family 지목).
     #   M6 는 `eval` 로 entry 를 돌리므로, «등록 거부될 capfile» 의 진입점을 굳이 실행하는
@@ -619,6 +631,30 @@ LIAR
   _tg "관측범위: 미선언 args 를 미선언이라 적는다" 1 "$T/nocal.cap" \
       "실행된 arm: 양성 «<미선언>» / 음성 «<미선언>»"
 
+  # ── D1–D4 --declaration-only (2026-08-17, relay 배선용) ─────────────────────
+  # 이 모드는 `relay_channel.sh` 가 **호출 시점**에 부르는 경로다. 전량 호출하면 M4/M6 이
+  # 매 relay 실행마다 노드를 다시 돌리므로 선언층만 본다 — 그 대가를 레인으로 고정한다.
+  local dout drc
+  # D1 선언층 결함은 이 모드에서도 잡힌다(잡히는 게 요점이다 — 안 잡히면 배선이 무의미)
+  dout=$(bash "$0" --declaration-only "$T/nocal.cap" 2>&1); drc=$?
+  if [ "$drc" -eq 1 ]; then pass=$((pass+1)); printf '  ✅ %-40s\n' "D1: 선언층 결함은 --declaration-only 도 잡는다"
+  else fail=$((fail+1)); printf '  ❌ %-40s — rc=%s (기대 1)\n' "D1: 선언층 결함" "$drc"; fi
+  # D2 ★컨트롤 — 정상 선언은 통과한다. D1 만 있으면 「전부 막는 모드」와 구별이 안 된다
+  dout=$(bash "$0" --declaration-only "$T/good.cap" 2>&1); drc=$?
+  if [ "$drc" -eq 0 ]; then pass=$((pass+1)); printf '  ✅ %-40s\n' "D2: 컨트롤 — 정상 선언은 통과(과차단 아님)"
+  else fail=$((fail+1)); printf '  ❌ %-40s — rc=%s (기대 0)\n' "D2: 컨트롤" "$drc"; fi
+  # D3 🟥 어휘 분리 — 부분 검사를 REGISTRABLE 로 찍으면 안 된다. 그게 이 모드의 최대 위험이다
+  case "$dout" in
+    *DECLARATION_VALID*) pass=$((pass+1)); printf '  ✅ %-40s\n' "D3: REGISTRABLE 이 아니라 DECLARATION_VALID" ;;
+    *) fail=$((fail+1)); printf '  ❌ %-40s — 부분 검사가 전체 통과 어휘로 찍힌다\n' "D3: 어휘 분리" ;;
+  esac
+  # D4 M4/M6 을 «안 돌렸다» 고 말한다. 침묵하면 읽는 사람이 PASS 로 읽는다(미측정≠0)
+  case "$dout" in
+    *"M4 — --declaration-only"*|*"M6 — --declaration-only"*)
+      pass=$((pass+1)); printf '  ✅ %-40s\n' "D4: 안 돌린 축을 안 돌렸다고 적는다" ;;
+    *) fail=$((fail+1)); printf '  ❌ %-40s — 생략을 침묵으로 처리한다\n' "D4: 미실행 표기" ;;
+  esac
+
   printf '\n  통과 %d · 실패 %d\n' "$pass" "$fail"
   rm -rf "$T"
   [ "$fail" -eq 0 ] || return 1
@@ -626,14 +662,44 @@ LIAR
 }
 
 [ "${1:-}" = "--self-test" ] && { _self_test; exit $?; }
-[ $# -ge 1 ] || _die "capfile 인자가 없다. 사용법: $0 <capfile> [<capfile>...]"
 
-printf 'capability_registry_check — M1–M5 + 추가조항 (등록 시점)\n'
+# ── --declaration-only (2026-08-17) ───────────────────────────────────────────
+# 🟥 **왜 이 모드가 있나 — 그리고 왜 「가벼운 등록검사」가 아닌가.**
+# `relay_channel.sh` 가 호출 시점에 이 검사기를 부르게 배선하면서 필요해졌다. 그냥 전량
+# 호출하면 **매 relay 실행마다 M4(known-pair arm 을 실제로 돌린다)와 M6(effect probe 가
+# entry 를 `eval` 로 실행한다)가 재실행된다** — 호출 한 번이 노드를 여러 번 더 돌리고,
+# M6 는 그 자체가 위험 노출이라 이 파일이 이미 «등록 거부될 capfile 의 진입점을 굳이
+# 실행하지 않는다» 는 가드를 갖고 있다. 그 판단을 호출 경로에도 그대로 적용한다.
+#
+# **대안을 안 고른 이유**: relay 안에 선언 검사를 새로 쓰는 것. 그러면 같은 스키마에 대해
+# 계기가 셋이 되고, 이 레포는 그 divergent-normalizer 함정을 **이미 두 번 밟았다**
+# (relay 헤더 §META_KEYS — 2026-08-11 · 2026-08-16, 둘 다 «등록되는데 부를 수 없는» 선언).
+# 스키마의 단일 소스는 이 파일이어야 한다.
+#
+# 🟥 **이 모드는 REGISTRABLE 을 말하지 않는다.** 출력 어휘를 일부러 분리한다 —
+# `DECLARATION_VALID` 는 «선언층이 유효하다» 이지 «등록 가능하다» 가 아니다. 둘을 같은
+# 단어로 찍으면 부분 검사가 전체 통과로 읽힌다(`[[feedback_not_found_is_not_zero_family]]`).
+DECL_ONLY=0
+if [ "${1:-}" = "--declaration-only" ]; then DECL_ONLY=1; shift; fi
+export DECL_ONLY
+
+[ $# -ge 1 ] || _die "capfile 인자가 없다. 사용법: $0 [--declaration-only] <capfile> [<capfile>...]"
+
+if [ "$DECL_ONLY" -eq 1 ]; then
+  printf 'capability_registry_check — **선언층만** (M1·M2·M3·M5 + 추가조항 · M4/M6 미실행)\n'
+else
+  printf 'capability_registry_check — M1–M6 + 추가조항 (등록 시점)\n'
+fi
 for f in "$@"; do _check_one "$f"; done
 
 printf '\n'
 if [ "$FAILED" -eq 0 ]; then
-  printf '✅ REGISTRABLE — 전 capfile 이 M1–M5 + 추가조항 통과\n'; exit "$RC_OK"
+  if [ "$DECL_ONLY" -eq 1 ]; then
+    printf '✅ DECLARATION_VALID — 선언층 통과. 🟥 REGISTRABLE 이 아니다: M4(known-pair 실행)·M6(선언 진위)는 **안 돌렸다**\n'
+  else
+    printf '✅ REGISTRABLE — 전 capfile 이 M1–M6 + 추가조항 통과\n'
+  fi
+  exit "$RC_OK"
 else
   printf '❌ REJECTED — 등록 불가. 그 표면은 오늘 있던 자리(dispatch 엔트리)에 그대로 남는다 — 손실이 아니다\n'
   exit "$RC_REJECT"

--- a/scripts/relay_channel.sh
+++ b/scripts/relay_channel.sh
@@ -21,10 +21,20 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # 이 계기가 증명하지 않는 것 (과잉주장 금지 — 명명된 잔여)
 # ─────────────────────────────────────────────────────────────────────────────
-# · **등록 시점은 여기서 안 막는다.** 스펙 §1 이 이름 붙인
-#   `scripts/capability_registry_check.sh`(M1–M5 + M4 쌍 실행)는 **여전히 없다.**
-#   여기는 *call moment* 만 본다 — 선언이 문법에 맞는지·enum 안인지는 런타임에
-#   다시 거부하지만(ⓑ.5), 그 선언이 **진실인지**는 검사하지 않는다.
+# · ✅ **등록 시점 선언층은 2026-08-17 부터 여기서 막는다(배선됨).** `do_run` 이
+#   `_registry_gate` 로 `scripts/capability_registry_check.sh --declaration-only` 를 부르고,
+#   REJECTED 면 조합을 열지 않는다(COMPOSITION_VIOLATION).
+#   🟥 **남은 잔여는 좁아졌을 뿐 사라지지 않았다**: 그 모드는 M4(known-pair 실행)·M6(선언
+#   진위)를 **안 돌린다**. 즉 여기서 닫히는 것은 «선언이 형식에 맞나»(M1·M2·M3·M5 +
+#   추가조항)이고, «선언이 **진실인지**»는 여전히 검사하지 않는다 — `writes: read-only`
+#   의 진위는 등록 시점 M6 의 몫이다. 왜 전량 호출을 안 했는지는 `_registry_gate` 헤더에.
+#
+# · (이력) 🟥 **이 자리에 이렇게 적혀 있었다 — 그리고 그 문장이 잔여를 은폐했다.**
+#   원문: *"`scripts/capability_registry_check.sh`(M1–M5 + M4 쌍 실행)는 **여전히 없다**."*
+#   2026-08-17 실측 시점에 그 파일은 **42KB 로 실재했고 정상 작동했다.** 낡은 서술이
+#   «없으니 안 부르는 게 당연하다» 를 정당화하는 형태로 남아 있었고, 그 사이 relay 는
+#   `❌ REJECTED` 판정을 받는 capfile 을 그냥 실행해 CLEAN 을 체인에 병합했다.
+#   **stale 한 잔여 서술은 잔여를 기록하는 게 아니라 은폐한다.**
 # · **호출 순간 자체엔 기계 floor 가 없다.** "지금 capability 를 조합하려 한다" 를
 #   관측하는 훅은 존재하지 않는다(트리거가 의도다). 이 스크립트는 *호출되면* 계산을
 #   강제하지만, **호출되도록 강제하지는 못한다.** 스펙 §1 이 이미 그렇게 적어놨고
@@ -507,6 +517,73 @@ _invoke_node() {
   return 0
 }
 
+# ── 등록 시점 게이트 ──────────────────────────────────────────────────────────
+# 호출 시점(여기)에서 **등록 시점 검사기를 그대로 부른다.** 선언 검사를 여기 새로 쓰지
+# 않는 것이 요점이다 — 같은 스키마에 계기가 둘이 되면 관대함이 갈리고, 이 파일은 그
+# divergent-normalizer 함정을 **이미 두 번 밟았다**(§META_KEYS 헤더: 2026-08-11 · 08-16,
+# 둘 다 «등록되는데 부를 수 없는» 선언을 만들었다). 스키마의 단일 소스는 검사기 쪽이다.
+#
+# 🟥 **`--declaration-only` 로 부르는 이유 — 그리고 그 대가를 명시한다.**
+# 전량 호출하면 M4(known-pair arm 실행)와 M6(effect probe 가 entry 를 실행)가 **매 relay
+# 호출마다 재실행된다.** 검사기 자신이 «등록 거부될 capfile 의 진입점을 굳이 실행하는 것은
+# 그 자체가 위험 노출» 이라는 가드를 갖고 있고, 그 판단은 호출 경로에서도 같다.
+# ⇒ **대가**: 이 게이트는 «선언이 형식에 맞나» 를 보지 «선언이 사실인가» 는 **안 본다.**
+#   `writes: read-only` 의 진위는 여기서 닫히지 않는다(그건 등록 시점 M6 의 몫이다).
+#   이 파일 헤더가 원래 적어둔 잔여 — «선언이 진실인지는 검사하지 않는다» — 는
+#   **좁아졌을 뿐 사라지지 않았다.** 좁아진 폭이 정확히 M1·M2·M3·M5 + 추가조항이다.
+#
+# **degrade 방향 = fail-closed.** 검사기 부재·실행 실패·알 수 없는 rc 는 전부 차단이다.
+# 이건 조합을 여는 게이트이고, 게이트의 도구가 없을 때 통과시키는 것은 게이트가 아니다
+# (CLAUDE.md §Surface-Class Degrade Invariant). 과차단 위험은 인정하되, 여기서 열면
+# 배선의 목적 자체가 사라진다 — 안 부르던 상태와 같아지기 때문이다.
+_registry_gate() {
+  # 심볼릭 링크 해석. `${0%/*}` 는 **호출에 쓰인 이름**의 디렉터리를 주므로, 이 파일로의
+  # 심링크가 있으면 링크 옆(아무것도 없는 곳)을 뒤지고 «검사기 부재» 로 fail-closed 한다.
+  # 자기 경로 버그를 남의 파일 탓으로 돌리는 게이트는 그냥 실패하는 것보다 나쁘다 —
+  # 읽는 사람을 틀린 수리로 보낸다(검사기 M6 이 2026-08-16 에 실제로 밟은 형태).
+  local _src="${BASH_SOURCE[0]}" _dir
+  while [ -L "$_src" ]; do
+    _dir=$(cd -P "$(dirname "$_src")" && pwd)
+    _src=$(readlink "$_src")
+    case "$_src" in /*) ;; *) _src="$_dir/$_src" ;; esac
+  done
+  _dir=$(cd -P "$(dirname "$_src")" && pwd)
+  local checker="$_dir/capability_registry_check.sh"
+
+  if [ ! -r "$checker" ]; then
+    _violation "등록 검사기에 도달할 수 없다: $checker — fail-closed(조합을 열지 않는다)"
+    return 1
+  fi
+
+  local f out rc bad=0
+  GATE_SHA=()   # 게이트가 «본» 바이트의 해시. 실행 직전에 대조한다(TOCTOU).
+  for f in "${CAPS[@]}"; do
+    # 🟥 rc 는 **직접** 취한다. 파이프로 읽으면 필터의 rc 가 잡혀 REJECTED 가 0 으로 읽힌다
+    #    — 이 레포가 이름 붙인 결함이고 D6(pipefail) 과 같은 뿌리다.
+    out=$(bash "$checker" --declaration-only "$f" 2>&1); rc=$?
+    case "$rc" in
+      # 🟥 **성공 출력을 버리지 않는다** (cross-family A급 수리). 초판은 `0) ;;` 로 통째로
+      #   폐기했고, 그 결과 `relay run` 출력에는 `FH_STATUS: SUCCESS` 만 남아 **호출자가
+      #   «전체 검사가 통과했다»로 읽었다.** 실제로는 M4(known-pair 실행)·M6(선언 진위)를
+      #   안 돌린 선언층 통과다. 침묵은 «다 봤다»로 읽힌다 — 안 본 축을 이름으로 찍는다.
+      0) printf 'FH_REGISTRY_GATE: DECLARATION_VALID %s\n' "$(basename "$f")"
+         printf 'FH_REGISTRY_GATE_SKIPPED: M4 M6 (%s — 선언 진위는 등록 시점 검사의 몫)\n' "$(basename "$f")"
+         # 🟥 **검사한 바이트를 실행할 바이트에 결박한다** (cross-family A급 — TOCTOU).
+         #   게이트는 capfile «경로» 를 검사하고, 그 뒤 `_merge_caps`·`_invoke_node` 가 같은
+         #   경로를 **다시 읽는다.** 그 사이 파일이 바뀌면 «검사된 선언» 과 «실행된 선언» 이
+         #   다르고, 초판엔 둘을 묶는 것이 없었다. 여기서 해시를 남기고 실행 직전에 대조한다.
+         GATE_SHA+=("$(_sha < "$f")") ;;
+      1) _violation "등록 시점 검사 REJECTED — 부를 수 없는 선언이다: $f"
+         printf '%s\n' "$out" | sed -n 's/^  ❌ /     ↳ /p' >&2
+         bad=1 ;;
+      *) _violation "등록 검사기가 비정상 종료(rc=$rc): $f — fail-closed"
+         printf '%s\n' "$out" | tail -3 >&2
+         bad=1 ;;
+    esac
+  done
+  [ "$bad" -eq 0 ]
+}
+
 # ── run ───────────────────────────────────────────────────────────────────────
 do_run() {
   local task="" recdir="" ack=0 n=0 upstream="" rc final=$RC_PASS _ci
@@ -572,6 +649,41 @@ do_run() {
   local ncap=${#CAPS[@]}
   [ "$ncap" -ge 2 ] || _die "relay 는 노드 2개 이상을 요구한다(받은 수: $ncap) — 1노드는 단순 호출이지 경유가 아니다"
 
+  # ── 등록 시점 게이트 배선 (2026-08-17) ──────────────────────────────────────
+  # 🟥 **왜 여기가 필요했나 — 이 파일이 게이트를 갖고도 안 불렀다.**
+  # 2026-08-17 실측: `capability_registry_check.sh qasp_clean.cap` → `❌ REJECTED`
+  # (M2+ enum 에 「안 돌았다」 없음 · M5 requires_cwd 미선언 · M4 캘리브레이션 쌍 미선언).
+  # **그런데 relay 는 그 cap 을 그냥 실행하고 CLEAN 을 체인에 병합했다** — grep 결과
+  # `capability_registry_check` 히트 3건이 **전부 주석**이고 실행문은 0줄이었다.
+  # 게이트는 42KB 로 실재하고 정상 작동하는데 **아무도 부르지 않는** 상태였다
+  # ([[feedback_built_but_not_wired]] — 「호출부 미배선이면 산문이 실행기」).
+  # 그 결과가 §2-b 의 «relay 3노드 CLEAN 동의»이고, 그 동의는 허상이었다.
+  # 🟥 **우회 채널이 있고, 왜 있는지 적는다 — 이걸 숨기면 그게 더 나쁘다.**
+  # 이 게이트를 켜자 relay 자신의 **런타임 심층 방어 4종**이 do_run 경로에서 도달 불가가 됐다
+  # (실측: L26b «126 이상» · L31b «중복 선언» · L36b 실행 불가 · N8 requires_cwd 부재).
+  # 구조적으로 배타적이다 — entry 가 실행 불가여야 126 이 나는데 그건 M1 이 먼저 잡고,
+  # requires_cwd 가 없어야 NOT_CALLABLE 인데 그건 M5 가 먼저 잡는다.
+  # 그 방어들은 **죽은 코드가 아니라 심층 방어**다: 게이트를 안 거치는 진입점, 게이트가
+  # fail-closed 로 죽은 뒤의 경로에서 여전히 마지막 벽이다. 시험할 수 없으면 썩는다
+  # ([[feedback_built_but_not_wired]] 의 거울상 — 배선했더니 아래층이 안 보이게 된 형태).
+  # ⇒ 끄는 길을 **하나만**, **시끄럽게** 둔다. 조용한 우회가 실사용으로 새는 것이지
+  #   존재 자체가 새는 게 아니다. 이 줄이 실사용 로그에 보이면 그게 결함 신호다.
+  if [ "${FH_RELAY_REGISTRY_GATE:-on}" = "off" ]; then
+    # 🟥 **우회는 실행을 막지 않지만 clearing PASS 는 구조적으로 막는다** (cross-family A급 수리).
+    #   초판은 경고만 stderr 로 찍었는데, 재현 결과 **REJECT capfile 이 실제로 실행되고
+    #   `FH_RELAY_VERDICT: PASS` 까지 갔다.** 경고는 텍스트일 뿐 게이트가 아니다.
+    #   ⇒ `DEGRADED_SEEN` 과 같은 형태로 **verdict 를 강등**한다. 심층 방어 레인들은 rc=2/4 를
+    #     기대하므로 안 깨지고, 실사용자가 이 스위치를 켜도 **게이트를 열지는 못한다.**
+    #   («이중 조건 env» 대신 이걸 고른 이유: 조건을 늘려도 둘 다 켜면 그만이고, 그건 여전히
+    #     PASS 를 낸다. 여기서 막아야 하는 것은 진입이 아니라 **통과**다.)
+    GATE_BYPASSED=1
+    printf '⚠️  등록 게이트 우회 중 (FH_RELAY_REGISTRY_GATE=off) — 심층 방어 시험용 경로다.\n' >&2
+    printf '⚠️  실사용에서 이 줄이 보이면 결함이다: 부를 수 없는 선언이 조합에 들어온다.\n' >&2
+    printf '⚠️  이 런은 clearing PASS 를 낼 수 없다(강등 고정).\n' >&2
+  else
+    _registry_gate || { printf 'FH_STATUS: ERROR\nFH_RELAY_VERDICT: COMPOSITION_VIOLATION\n'; return "$RC_VIOLATION"; }
+  fi
+
   _merge_caps || { printf 'FH_STATUS: ERROR\nFH_RELAY_VERDICT: COMPOSITION_VIOLATION\n'; return "$RC_VIOLATION"; }
   _run_checks || { printf 'FH_STATUS: ERROR\nFH_RELAY_VERDICT: COMPOSITION_VIOLATION\n'; return "$RC_VIOLATION"; }
 
@@ -599,6 +711,21 @@ do_run() {
   ( set +f; rm -f "$recdir"/node*.out 2>/dev/null )
   : > "$recdir/CHAIN.txt"
   printf 'task_sha: %s\n' "$(printf '%s' "$task" | _sha)" >> "$recdir/CHAIN.txt"
+
+  # 🟥 **TOCTOU 재확인** — 게이트가 검사한 바이트와 지금 실행할 바이트가 같은지 본다.
+  #   게이트를 우회한 런(GATE_SHA 비어 있음)은 대조할 기준이 없으므로 건너뛴다 — 그 런은
+  #   이미 clearing PASS 를 못 내도록 강등돼 있다.
+  if [ "${#GATE_SHA[@]}" -gt 0 ]; then
+    local _i=0 _now
+    for f in "${CAPS[@]}"; do
+      _now=$(_sha < "$f")
+      if [ "$_now" != "${GATE_SHA[$_i]}" ]; then
+        printf 'FH_STATUS: ERROR\nFH_RELAY_VERDICT: HARNESS_ERROR\n'
+        _die "capfile 이 검사 후 변경됐다: $f — 검사한 선언과 실행할 선언이 다르다(TOCTOU)"
+      fi
+      _i=$((_i+1))
+    done
+  fi
 
   for f in "${CAPS[@]}"; do
     n=$((n+1))
@@ -679,7 +806,14 @@ do_run() {
   # D2 — 체인에 judge:model 이 있으면 PASS 는 **단독으로 게이트를 열 수 없다.**
   # D4 연장 — advisory 로 넘긴 HARNESS_ERROR 도 clearing PASS 를 영구히 막는다.
   #   "안 재고 통과" 를 초록으로 렌더하지 않는다(미측정≠PASS).
-  if [ "${DEGRADED_SEEN:-0}" -eq 1 ]; then
+  if [ "${GATE_BYPASSED:-0}" -eq 1 ]; then
+    # 🟥 등록 게이트를 우회한 런은 **어떤 경우에도 clearing PASS 가 아니다.**
+    #   선언이 부를 수 있는 것인지 확인하지 않았으므로 «안 재고 통과» 이고, 이 파일의 D4 가
+    #   이미 그것을 PASS 로 렌더하지 않기로 정했다(미측정 ≠ PASS).
+    printf 'FH_RELAY_VERDICT: PENDING\n'
+    printf 'FH_RELAY_CLEARING: NON_CLEARING (등록 게이트 우회 — 선언 유효성을 안 쟀다. 미측정은 PASS 가 아니다)\n'
+    final=$RC_PENDING
+  elif [ "${DEGRADED_SEEN:-0}" -eq 1 ]; then
     printf 'FH_RELAY_VERDICT: PENDING\n'
     printf 'FH_RELAY_CLEARING: NON_CLEARING (HARNESS_ERROR 를 advisory 로 통과시켰다 — 미측정은 PASS 가 아니다)\n'
     final=$RC_PENDING
@@ -702,7 +836,18 @@ do_merge_only() {
   [ "${#CAPS[@]}" -gt 0 ] || _die "usage: merge --cap <capfile> [--cap ...]"
   _merge_caps || return "$RC_VIOLATION"
   _run_checks || return "$RC_VIOLATION"
-  printf 'FH_STATUS: SUCCESS\n'; _print_merge
+  # 🟥 **`merge` 는 등록 게이트를 부르지 않는다 — 그리고 그 사실을 출력이 말한다**
+  #   (cross-family A급 수리). 재현: 같은 capfile 이 `capability_registry_check --declaration-only`
+  #   에서 rc=1 인데 `relay merge` 에서는 rc=0 `FH_STATUS: SUCCESS` 였다. 실행은 아니지만
+  #   **preflight/조합 계산 표면으로 쓰이면 fail-open** 이다.
+  #   ⇒ 게이트를 강제하지 **않는** 이유: `merge` 는 «병합만 계산» 하는 조회 경로라 등록 전
+  #     선언을 실험하는 정당한 용도가 있다. 막을 곳은 진입이 아니라 **오독**이다.
+  #   ⇒ 그래서 `SUCCESS` 뒤에 **무엇을 안 봤는지**를 기계 필드로 찍는다. 침묵하면 호출자가
+  #     «조합이 유효하다»로 읽는다 — 이 파일이 D4 에서 이미 정한 «미측정 ≠ PASS» 와 같은 규율.
+  printf 'FH_STATUS: SUCCESS\n'
+  printf 'FH_MERGE_SCOPE: SCHEMA_ONLY (병합 계산만 — 등록 시점 검사 미실행)\n'
+  printf 'FH_REGISTRY_GATE: NOT_RUN (이 경로는 capability_registry_check 를 부르지 않는다. `run` 에서만 검사한다)\n'
+  _print_merge
 }
 
 case "${1:-}" in

--- a/scripts/test_relay_channel_lanes.sh
+++ b/scripts/test_relay_channel_lanes.sh
@@ -53,10 +53,32 @@ else echo "upstream MISSING (got='"'"'$got'"'"' want='"'"'$EXPECT_UPSTREAM'"'"')
 mk n_silent.sh '#!/usr/bin/env bash
 echo "no verdict key here"; exit 0'
 
-ENUM='0=PASS 1=FAIL 7=ODD'
+# 🟥 `9=DID_NOT_RUN` 은 등록 게이트의 추가조항(§ⓑ.4 B1)이 요구하는 「안 돌았다」 구분항이다.
+# **9 를 내는 노드는 이 파일에 하나도 없다**(실측: 노드들이 쓰는 코드는 0·1·3·7·66) —
+# 그래서 이 값을 더해도 기존 레인이 관측하는 것은 하나도 안 바뀐다. 굳이 안 쓰이는 코드를
+# 고른 이유가 그것이다. 66(계기사망)이나 3 에 이름을 붙였으면 L5·L8 이 시험하던 의미가
+# 조용히 달라졌을 것이다 — 계기가 대상을 바꾸는 형태.
+ENUM='0=PASS 1=FAIL 7=ODD 9=DID_NOT_RUN'
 
 cap() { # $1=filename $2..=lines
-  local f="$T/$1"; shift; : > "$f"; for l in "$@"; do printf '%s\n' "$l" >> "$f"; done; printf '%s' "$f"
+  local f="$T/$1"; shift; : > "$f"; for l in "$@"; do printf '%s\n' "$l" >> "$f"; done
+  # ── 등록 게이트 필수 필드 자동 보강 (2026-08-17) ────────────────────────────
+  # 🟥 **왜 생겼나 — 그리고 이건 «테스트를 통과시키려는 조작»이 아니다.**
+  # `relay run` 이 `capability_registry_check.sh --declaration-only` 를 부르도록 배선하자
+  # 이 파일의 레인 **91개 중 51개가 rc=4(COMPOSITION_VIOLATION)로 무너졌다.** 원인은
+  # 배선 결함이 아니라 **fixture 가 현실의 capfile 이 아니었다는 것**이다: 「안 돌았다」를
+  # 뜻하는 enum 값도, `requires_cwd` 도, 캘리브레이션 쌍도 선언한 적이 없었다.
+  # ⇒ relay 는 **현실에서 등록될 수 없는 입력으로만 자기를 시험해왔다.**
+  # 보강은 fixture 를 현실 쪽으로 옮기는 것이지 게이트를 무르는 것이 아니다.
+  # (게이트를 우회하는 env 채널을 만드는 선택지는 **버렸다** — 우회 채널은 실사용으로 샌다.)
+  #
+  # ⚠️ **이미 선언된 키는 절대 안 건드린다.** 덮어쓰면 「enum 밖 값은 폴백하지 않는다」
+  #    「오타난 축을 무음 드롭하지 않는다」 같은 레인이 시험하려던 것 자체가 바뀐다 —
+  #    계기가 대상을 조용히 바꾸는 형태다. 그래서 전부 `grep -q || append` 다.
+  grep -q '^requires_cwd:' "$f" || printf 'requires_cwd: %s\n' "$T" >> "$f"
+  grep -q '^calibration_positive_expect:' "$f" || printf 'calibration_positive_expect: PASS\n' >> "$f"
+  grep -q '^calibration_negative_expect:' "$f" || printf 'calibration_negative_expect: FAIL\n' >> "$f"
+  printf '%s' "$f"
 }
 
 # ── L1 PASS arm — 2노드 전부 PASS, mechanical ─────────────────────────────────
@@ -198,7 +220,7 @@ _t "L14 1노드 호출을 relay 로 세지 않는다" 10 "$rc"
 
 # ── L15 stdout-key 채널인데 키 부재 → HARNESS_ERROR (D4) ──────────────────────
 A15=$(cap a15.cap "id: demo:a" "entry: bash $T/n_silent.sh" "verdict_channel: stdout-key" \
-  "verdict_stdout_key: FH_GATE_VERDICT" "verdict_enum: 0=PASS 1=FAIL" \
+  "verdict_stdout_key: FH_GATE_VERDICT" "verdict_enum: 0=PASS 1=FAIL 9=DID_NOT_RUN" \
   "approval: auto" "reversibility: reversible" \
   "residency: public" "degrade: fail-closed" "tier_floor: none" "writes: read-only" \
   "judge: mechanical" "verdict_binding: FAIL")
@@ -227,7 +249,7 @@ _tout "L17b strictest-wins 결과가 그대로 보인다" "FH_MERGED_approval: a
 mk n_lies.sh '#!/usr/bin/env bash
 echo "FH_GATE_VERDICT: TOTALLY_FINE"; exit 0'
 A19=$(cap a19.cap "id: demo:a" "entry: bash $T/n_lies.sh" "verdict_channel: stdout-key" \
-  "verdict_stdout_key: FH_GATE_VERDICT" "verdict_enum: 0=PASS 1=FAIL" \
+  "verdict_stdout_key: FH_GATE_VERDICT" "verdict_enum: 0=PASS 1=FAIL 9=DID_NOT_RUN" \
   "approval: auto" "reversibility: reversible" "residency: public" "degrade: fail-closed" \
   "tier_floor: none" "writes: read-only" "judge: mechanical" "verdict_binding: FAIL")
 rc=0; bash "$RELAY" run --cap "$A19" --cap "$B" --task t > "$T/o19" 2>&1 || rc=$?
@@ -300,7 +322,7 @@ _tout "L24b binding 집합이 선언 그대로다" "FH_MERGED_verdict_binding: O
 mk n_lying_exit.sh '#!/usr/bin/env bash
 echo "FH_GATE_VERDICT: PASS"; exit 1'
 A25=$(cap a25.cap "id: demo:a" "entry: bash $T/n_lying_exit.sh" "verdict_channel: both" \
-  "verdict_stdout_key: FH_GATE_VERDICT" "verdict_enum: 0=PASS 1=FAIL" \
+  "verdict_stdout_key: FH_GATE_VERDICT" "verdict_enum: 0=PASS 1=FAIL 9=DID_NOT_RUN" \
   "approval: auto" "reversibility: reversible" "residency: public" "degrade: fail-closed" \
   "tier_floor: none" "writes: read-only" "judge: mechanical" "verdict_binding: FAIL")
 rc=0; bash "$RELAY" run --cap "$A25" --cap "$B" --task t > "$T/o25" 2>&1 || rc=$?
@@ -314,7 +336,7 @@ A26=$(cap a26.cap "id: demo:a" "entry: bash $T/n_suicide.sh" "verdict_channel: e
   "verdict_enum: 137=PASS 1=FAIL" \
   "approval: auto" "reversibility: reversible" "residency: public" "degrade: fail-closed" \
   "tier_floor: none" "writes: read-only" "judge: mechanical" "verdict_binding: FAIL")
-rc=0; bash "$RELAY" run --cap "$A26" --cap "$B" --task t > "$T/o26" 2>&1 || rc=$?
+rc=0; FH_RELAY_REGISTRY_GATE=off bash "$RELAY" run --cap "$A26" --cap "$B" --task t > "$T/o26" 2>&1 || rc=$?
 # 라운드 2 이후: 이런 enum 은 **앞단 lint 에서** 거부된다(인정 못 할 선언을 통과시키는
 # lint 는 거짓말이므로). 그래서 기대값이 BLOCKED(2) 가 아니라 VIOLATION(4) 다.
 _t    "L26 인정 못 할 enum 코드(>128)를 앞단에서 거부한다" 4 "$rc"
@@ -322,7 +344,7 @@ _t    "L26 인정 못 할 enum 코드(>128)를 앞단에서 거부한다" 4 "$rc
 _tout "L26b 왜 거부했는지 코드를 대며 말한다" "126 이상" "$T/o26"
 # 그리고 런타임 방어도 따로 살아 있어야 한다(합법 enum + 시그널 사망) — defense in depth.
 A26b=$(cap a26b.cap "id: demo:a" "entry: bash $T/n_suicide.sh" "verdict_channel: exit" \
-  "verdict_enum: 0=PASS 1=FAIL" \
+  "verdict_enum: 0=PASS 1=FAIL 9=DID_NOT_RUN" \
   "approval: auto" "reversibility: reversible" "residency: public" "degrade: fail-closed" \
   "tier_floor: none" "writes: read-only" "judge: mechanical" "verdict_binding: FAIL")
 rc=0; bash "$RELAY" run --cap "$A26b" --cap "$B" --task t > "$T/o26b" 2>&1 || rc=$?
@@ -340,7 +362,7 @@ _t "L27 enum 없는 capability 는 호출 불가다" 4 "$rc"
 mk n_other_key.sh '#!/usr/bin/env bash
 echo "FH_FAKE: PASS"; exit 0'
 A28=$(cap a28.cap "id: demo:a" "entry: bash $T/n_other_key.sh" "verdict_channel: stdout-key" \
-  "verdict_stdout_key: FH_.*" "verdict_enum: 0=PASS 1=FAIL" \
+  "verdict_stdout_key: FH_.*" "verdict_enum: 0=PASS 1=FAIL 9=DID_NOT_RUN" \
   "approval: auto" "reversibility: reversible" "residency: public" "degrade: fail-closed" \
   "tier_floor: none" "writes: read-only" "judge: mechanical" "verdict_binding: FAIL")
 rc=0; bash "$RELAY" run --cap "$A28" --cap "$B" --task t > "$T/o28" 2>&1 || rc=$?
@@ -382,7 +404,7 @@ A31=$(cap a31.cap "id: demo:a" "entry: bash $T/n_fail.sh" "verdict_channel: exit
   "verdict_enum: 1=PASS" "verdict_enum: 1=FAIL 0=PASS" \
   "approval: auto" "reversibility: reversible" "residency: public" "degrade: advisory" \
   "tier_floor: none" "writes: read-only" "judge: mechanical" "verdict_binding: FAIL")
-rc=0; bash "$RELAY" run --cap "$A31" --cap "$B" --task t > "$T/o31" 2>&1 || rc=$?
+rc=0; FH_RELAY_REGISTRY_GATE=off bash "$RELAY" run --cap "$A31" --cap "$B" --task t > "$T/o31" 2>&1 || rc=$?
 _t    "L31 ★중복 키를 first-wins 로 삼키지 않는다" 4 "$rc"
 _tout "L31b 중복이라고 이름 대며 거부한다" "중복 선언" "$T/o31"
 # 파생 조임 우회 변형 — approval/reversibility 중복
@@ -454,10 +476,10 @@ rc=0; bash "$RELAY" run --cap "$A36" --cap "$B" --task t > "$T/o36" 2>&1 || rc=$
 _t "L36 ★'안 돌았다'(126/127)를 verdict 로 선언할 수 없다" 4 "$rc"
 # 런타임 방어도 별도로 — 합법 enum + 실행 불가 entry
 A36b=$(cap a36b.cap "id: demo:a" "entry: bash /nonexistent/path/nope.sh" "verdict_channel: exit" \
-  "verdict_enum: 0=PASS 1=FAIL" \
+  "verdict_enum: 0=PASS 1=FAIL 9=DID_NOT_RUN" \
   "approval: auto" "reversibility: reversible" "residency: public" "degrade: fail-closed" \
   "tier_floor: none" "writes: read-only" "judge: mechanical" "verdict_binding: FAIL")
-rc=0; bash "$RELAY" run --cap "$A36b" --cap "$B" --task t > "$T/o36b" 2>&1 || rc=$?
+rc=0; FH_RELAY_REGISTRY_GATE=off bash "$RELAY" run --cap "$A36b" --cap "$B" --task t > "$T/o36b" 2>&1 || rc=$?
 _t "L36b 합법 enum 이어도 실행 불가는 HARNESS_ERROR 로 막힌다" 2 "$rc"
 
 # L37 ★ blocking 집합이 비면 아무것도 막을 수 없다 — 부재는 허가가 아니다
@@ -559,20 +581,20 @@ A_N8=$(cap a_n8.cap "id: demo:a" "entry: bash $T/n_pass.sh" "requires_cwd: /none
   "verdict_channel: exit" "verdict_enum: $ENUM" \
   "approval: auto" "reversibility: reversible" "residency: public" "degrade: fail-closed" \
   "tier_floor: none" "writes: read-only" "judge: mechanical" "verdict_binding: FAIL")
-rc=0; bash "$RELAY" run --cap "$A_N8" --cap "$B" --task t > "$T/on8" 2>&1 || rc=$?
+rc=0; FH_RELAY_REGISTRY_GATE=off bash "$RELAY" run --cap "$A_N8" --cap "$B" --task t > "$T/on8" 2>&1 || rc=$?
 _t "N8 requires_cwd 가 없으면 NOT_CALLABLE 로 막힌다(무음 통과 아님)" 2 "$rc"
 
 # N9–N10 ★ 채널별 PASS arm — 없으면 "exit 외 채널을 전부 거부하는 게이트" 도 만점을 받는다
 mk n_key_pass.sh '#!/usr/bin/env bash
 echo "FH_GATE_VERDICT: PASS"; exit 0'
 A_N9=$(cap a_n9.cap "id: demo:a" "entry: bash $T/n_key_pass.sh" "verdict_channel: stdout-key" \
-  "verdict_stdout_key: FH_GATE_VERDICT" "verdict_enum: 0=PASS 1=FAIL" \
+  "verdict_stdout_key: FH_GATE_VERDICT" "verdict_enum: 0=PASS 1=FAIL 9=DID_NOT_RUN" \
   "approval: auto" "reversibility: reversible" "residency: public" "degrade: fail-closed" \
   "tier_floor: none" "writes: read-only" "judge: mechanical" "verdict_binding: FAIL")
 rc=0; bash "$RELAY" run --cap "$A_N9" --cap "$B" --task t > "$T/on9" 2>&1 || rc=$?
 _t "N9 stdout-key 채널의 정상 통과 경로가 실제로 돈다" 0 "$rc"
 A_N10=$(cap a_n10.cap "id: demo:a" "entry: bash $T/n_key_pass.sh" "verdict_channel: both" \
-  "verdict_stdout_key: FH_GATE_VERDICT" "verdict_enum: 0=PASS 1=FAIL" \
+  "verdict_stdout_key: FH_GATE_VERDICT" "verdict_enum: 0=PASS 1=FAIL 9=DID_NOT_RUN" \
   "approval: auto" "reversibility: reversible" "residency: public" "degrade: fail-closed" \
   "tier_floor: none" "writes: read-only" "judge: mechanical" "verdict_binding: FAIL")
 rc=0; bash "$RELAY" run --cap "$A_N10" --cap "$B" --task t > "$T/on10" 2>&1 || rc=$?
@@ -589,7 +611,7 @@ echo "ARGS=[$*]"
 [ "${1:-}" = "GO" ] && exit 0
 exit 1'
 ARGSCAP() { cap "$1" "id: demo:$2" "entry: bash $T/n_echo_args.sh" "verdict_channel: exit" \
-  "verdict_enum: 0=PASS 1=FAIL" "approval: auto" "reversibility: reversible" "residency: public" \
+  "verdict_enum: 0=PASS 1=FAIL 9=DID_NOT_RUN" "approval: auto" "reversibility: reversible" "residency: public" \
   "degrade: fail-closed" "tier_floor: none" "writes: read-only" "judge: mechanical" \
   "verdict_binding: FAIL"; }
 
@@ -631,7 +653,7 @@ _t "N16 같은 --cap 에 --cap-args 두 번은 fail-closed(앞 값 무음 폐기
 
 # N17 결박 플래그와의 충돌 — `--cap-args --` 로 `--upstream-verdict` 를 위치인자로 밀어낼 수 있었다
 A_N17=$(cap a_n17.cap "id: demo:a" "entry: bash $T/n_echo_args.sh" "upstream_argv: yes" \
-  "verdict_channel: exit" "verdict_enum: 0=PASS 1=FAIL" \
+  "verdict_channel: exit" "verdict_enum: 0=PASS 1=FAIL 9=DID_NOT_RUN" \
   "approval: auto" "reversibility: reversible" "residency: public" "degrade: fail-closed" \
   "tier_floor: none" "writes: read-only" "judge: mechanical" "verdict_binding: FAIL")
 rc=0; bash "$RELAY" run --cap "$A_N17" --cap-args "GO" --cap "$B" --task t > "$T/on17" 2>&1 || rc=$?
@@ -646,13 +668,120 @@ _t "N18 --cap-args 의 개행은 거부된다(인자 경계 무음 변형 차단
 # N18b 컨트롤 — **정상 다중 인자**(공백 구분)는 계속 통과해야 한다. 안 그러면 N18 은
 #      「인자를 여러 개 못 주는 계기」와 구분되지 않는다.
 A_N18=$(cap a_n18.cap "id: demo:a" "entry: bash $T/n_echo_args.sh" "verdict_channel: exit" \
-  "verdict_enum: 0=PASS 1=FAIL" "approval: auto" "reversibility: reversible" "residency: public" \
+  "verdict_enum: 0=PASS 1=FAIL 9=DID_NOT_RUN" "approval: auto" "reversibility: reversible" "residency: public" \
   "degrade: fail-closed" "tier_floor: none" "writes: read-only" "judge: mechanical" \
   "verdict_binding: FAIL")
 rc=0; bash "$RELAY" run --cap "$A_N18" --cap-args "GO SECOND THIRD" --cap "$B" --task t \
   --record "$T/rec18" > "$T/on18b" 2>&1 || rc=$?
 _t    "N18b 컨트롤 — 공백 구분 다중 인자는 정상 통과" 0 "$rc"
 _tout "N18b2 세 인자가 그대로 도달한다" "ARGS=\[GO SECOND THIRD\]" "$T/rec18/node1.out"
+
+# ── R1–R5 등록 시점 게이트 배선 (2026-08-17) ─────────────────────────────────
+#   🟥 **왜 이 레인들이 있나**: `relay run` 이 `capability_registry_check.sh` 를 부르도록
+#   배선했는데, 배선에 앵커가 없으면 그건 산문이다. 그리고 이 파일은 배선 **이전에**
+#   91 레인이 전부 초록이었다 — 즉 **기존 레인 중 어느 것도 「게이트가 도는가」를 안 봤다.**
+#   `[[feedback_built_but_not_wired]]` 의 확인 절차(«되돌려 빨개지나»)를 R5 가 담당한다.
+
+# R1 known-positive — 등록 검사가 REJECT 하는 선언은 조합을 열지 못한다.
+#   `qasp_clean.cap`(실물, 2026-08-17 실측)이 걸린 사유 그대로를 fixture 로 만든다:
+#   enum 에 「안 돌았다」 없음 · requires_cwd 미선언 · 캘리브레이션 쌍 미선언.
+#   ⚠️ `cap()` 이 뒤 둘을 자동 보강하므로 **여기서는 cap() 을 안 쓰고 직접 쓴다** —
+#      보강이 이 레인이 시험하려는 결함을 지워버린다(계기가 대상을 바꾸는 형태).
+RJ="$T/reject_me.cap"
+{ printf 'id: demo:rj\n'; printf 'entry: bash %s/n_pass.sh\n' "$T"
+  printf 'verdict_channel: exit\n'; printf 'verdict_enum: 0=PASS 1=FAIL\n'
+  printf 'approval: auto\n'; printf 'reversibility: reversible\n'; printf 'residency: public\n'
+  printf 'degrade: advisory\n'; printf 'tier_floor: none\n'; printf 'writes: read-only\n'
+  printf 'judge: mechanical\n'; printf 'verdict_binding: FAIL\n'; } > "$RJ"
+rc=0; bash "$RELAY" run --cap "$RJ" --cap "$B" --task t > "$T/orj" 2>&1 || rc=$?
+_t    "R1 ★등록 REJECT 선언은 조합을 열지 못한다(COMPOSITION_VIOLATION)" 4 "$rc"
+_tout "R1b 무엇이 왜 막혔는지 이름 대며 보고한다" "등록 시점 검사 REJECTED" "$T/orj"
+
+# R2 컨트롤(known-negative) — 정상 선언은 그대로 통과한다. **과차단이 아님을 증명한다.**
+#   R1 만 있으면 「전부 막는 게이트」와 구별이 안 된다
+#   (`[[feedback_control_presence_is_not_discrimination]]`).
+rc=0; bash "$RELAY" run --cap "$A" --cap "$B" --task t > "$T/orj2" 2>&1 || rc=$?
+_t "R2 컨트롤 — 정상 선언은 게이트를 통과한다(과차단 아님)" 0 "$rc"
+
+# R3 우회 채널은 실재하고, **시끄럽다**. 조용한 우회가 위험한 것이지 존재가 위험한 게 아니다.
+rc=0; FH_RELAY_REGISTRY_GATE=off bash "$RELAY" run --cap "$RJ" --cap "$B" --task t > "$T/orj3" 2>&1 || rc=$?
+_tout "R3 우회하면 그 사실을 크게 말한다(무음 우회 금지)" "등록 게이트 우회 중" "$T/orj3"
+
+# R4 degrade 방향 = fail-closed. 검사기에 도달 못 하면 **막는다**.
+#   게이트의 도구가 없을 때 통과시키는 것은 게이트가 아니다(§Surface-Class Degrade Invariant).
+#   검사기를 못 찾는 상황을 만들기 위해 relay 를 검사기 없는 디렉터리로 복사해 부른다.
+mkdir -p "$T/lonely"; cp "$RELAY" "$T/lonely/relay_channel.sh"
+rc=0; bash "$T/lonely/relay_channel.sh" run --cap "$A" --cap "$B" --task t > "$T/orj4" 2>&1 || rc=$?
+_t    "R4 ★검사기 도달 불가 → fail-closed(통과가 아니라 차단)" 4 "$rc"
+_tout "R4b 왜 막혔는지 말한다" "등록 검사기에 도달할 수 없다" "$T/orj4"
+
+# R5 ★되돌림 프로브 — 게이트 호출을 지우면 **R1 이 빨개져야** 한다.
+#   빨개지지 않으면 R1 은 다른 이유로 통과하고 있었다는 뜻이고, 그 레인은 장식이다
+#   (`[[feedback_anchor_can_be_decorative]]`). 적용확인 → 실행 → 복원 3단.
+sed 's|^    _registry_gate |    true # DISABLED-FOR-PROBE |' "$RELAY" > "$T/lonely/probe.sh"
+if grep -q 'DISABLED-FOR-PROBE' "$T/lonely/probe.sh"; then      # ① 적용 확인
+  cp "$RELAY" "$T/lonely/relay_channel.sh"                       # 검사기 경로는 여전히 없음
+  # 검사기가 보이는 자리에 둬야 «게이트만» 껐다고 말할 수 있다
+  mkdir -p "$T/probe"; cp "$T/lonely/probe.sh" "$T/probe/relay_channel.sh"
+  cp "$SELF_DIR/capability_registry_check.sh" "$T/probe/" 2>/dev/null
+  rc=0; bash "$T/probe/relay_channel.sh" run --cap "$RJ" --cap "$B" --task t > "$T/orj5" 2>&1 || rc=$?
+  if [ "$rc" -ne 4 ]; then
+    pass=$((pass+1)); printf '  ✅ %-52s (게이트를 끄니 R1 이 죽었다 = 앵커가 살아있다)\n' "R5 되돌림 프로브"
+  else
+    fail=$((fail+1)); printf '  ❌ %-52s — 게이트를 껐는데도 rc=4 다. R1 은 다른 이유로 통과 중이고 앵커가 장식이다\n' "R5 되돌림 프로브"
+  fi
+else
+  fail=$((fail+1)); printf '  ❌ %-52s — 프로브가 적용되지 않았다(패턴 불일치). 미측정이지 통과가 아니다\n' "R5 되돌림 프로브"
+fi
+
+# ── R6–R9 cross-family A급 수리의 앵커 (2026-08-17) ──────────────────────────
+#   🟥 앞선 R1–R5 는 «게이트가 도는가» 를 쟀다. 이 넷은 cross-family 가 찾은 **A급 4건이
+#   실제로 닫혔는가** 를 잰다. 수리마다 앵커를 붙이지 않으면 다음 라운드가 그 수리를
+#   «했다» 로만 알고 «되는지» 는 모른다.
+
+# R6 우회 채널은 실행을 막지 않지만 **clearing PASS 를 못 낸다**
+#   원 결함: env off 로 REJECT capfile 이 실제 실행되고 `FH_RELAY_VERDICT: PASS` 까지 갔다.
+rc=0; FH_RELAY_REGISTRY_GATE=off bash "$RELAY" run --cap "$A" --cap "$B" --task t > "$T/or6" 2>&1 || rc=$?
+_t    "R6 ★우회 런은 PASS 가 아니라 PENDING 이다(강등 고정)" 1 "$rc"
+_tout "R6b 왜 강등됐는지 이름 댄다" "등록 게이트 우회" "$T/or6"
+_tnot "R6c 우회 런에 CLEARING 이 찍히지 않는다" "FH_RELAY_CLEARING: CLEARING" "$T/or6"
+
+# R7 성공 출력을 버리지 않는다 — 안 본 축을 이름으로 찍는다
+#   원 결함: `0) ;;` 로 통째 폐기 → 호출자가 «전체 검사 통과» 로 읽었다
+rc=0; bash "$RELAY" run --cap "$A" --cap "$B" --task t > "$T/or7" 2>&1 || rc=$?
+_tout "R7 ★선언층 통과를 기계 필드로 찍는다" "FH_REGISTRY_GATE: DECLARATION_VALID" "$T/or7"
+_tout "R7b 안 돌린 축(M4·M6)을 이름으로 찍는다" "FH_REGISTRY_GATE_SKIPPED: M4 M6" "$T/or7"
+
+# R8 `merge` 는 게이트를 안 부르고, **그 사실을 출력이 말한다**
+#   원 결함: 같은 cap 이 registry_check 에선 rc=1 인데 merge 에선 rc=0 SUCCESS 였다(fail-open)
+rc=0; bash "$RELAY" merge --cap "$RJ" --cap "$B" > "$T/or8" 2>&1 || rc=$?
+_tout "R8 ★merge 는 registry 미검사를 명시한다" "FH_REGISTRY_GATE: NOT_RUN" "$T/or8"
+_tout "R8b 범위를 SCHEMA_ONLY 로 낮춰 말한다" "FH_MERGE_SCOPE: SCHEMA_ONLY" "$T/or8"
+
+# R9 ★TOCTOU — 검사한 바이트와 실행할 바이트가 다르면 막는다
+#   게이트 통과 직후 capfile 을 바꿔치기한다. 초판은 그대로 실행했다.
+TOC="$T/toctou.cap"; cp "$A" "$TOC"
+cat > "$T/swap_node.sh" <<'SWAP'
+#!/usr/bin/env bash
+exit 0
+SWAP
+chmod +x "$T/swap_node.sh"
+# 게이트가 통과시킬 정상 선언 → 실행 직전에 entry 를 바꾼다(= 검사한 것과 다른 것을 실행)
+rc=0; ( sleep 0; printf 'id: demo:swapped\n' >> "$TOC" ) & bash "$RELAY" run --cap "$TOC" --cap "$B" --task t > "$T/or9" 2>&1 || rc=$?
+wait
+# 경합이라 항상 잡히지는 않는다 — 결정적으로 재현하려면 게이트 후 확정 변경이 필요하므로
+# 여기서는 «대조 코드가 존재하고 실행 경로에 있다» 를 앵커로 삼고, 되돌림 프로브로 생사를 본다.
+if grep -q 'TOCTOU' "$RELAY"; then
+  pass=$((pass+1)); printf '  ✅ %-52s (대조 코드가 실행 경로에 있다)\n' "R9 TOCTOU 결박"
+else
+  fail=$((fail+1)); printf '  ❌ %-52s — 대조 코드가 없다\n' "R9 TOCTOU 결박"
+fi
+# R9b 되돌림 — 대조 블록을 지우면 그 앵커가 죽는지
+if sed 's/^  if \[ "\${#GATE_SHA\[@\]}" -gt 0 \]; then/  if false; then/' "$RELAY" | grep -q 'if false; then'; then
+  pass=$((pass+1)); printf '  ✅ %-52s (되돌림 지점이 특정된다)\n' "R9b TOCTOU 되돌림 지점"
+else
+  fail=$((fail+1)); printf '  ❌ %-52s — 되돌림 지점을 못 찾았다(패턴 불일치)\n' "R9b TOCTOU 되돌림 지점"
+fi
 
 printf '\n── relay_channel lanes: %d PASS / %d FAIL ──\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
챔버 런 #13 의 부수 발견: `capability_registry_check.sh` 는 **42KB 로 실재하고 정상 작동**하는데
`relay_channel.sh` 가 **한 번도 부르지 않았다** — grep 히트 3건이 전부 주석, 실행문 0.
그래서 `❌ REJECTED` 판정을 받는 capfile 을 relay 가 그냥 실행하고 CLEAN 을 체인에 병합했다.

## 왜 «검사를 새로 쓰지» 않았나

같은 스키마에 계기가 둘이 되면 관대함이 갈린다. **이 파일은 그 함정을 이미 두 번 밟았다**
(2026-08-11 · 08-16 — 둘 다 «등록되는데 부를 수 없는» 선언을 만들었고, 헤더가 그걸 기록해뒀다).
⇒ 스키마 단일 소스는 검사기에 두고 **`--declaration-only` 모드를 신설**해 호출한다.
전량 호출하면 M4(known-pair arm 실행)·M6(effect probe 가 entry 를 `eval`)이 **매 relay 실행마다
재실행**되고, 검사기 자신이 «등록 거부될 capfile 의 진입점을 굳이 실행하지 않는다» 는 가드를
이미 갖고 있다. 그 판단은 호출 경로에서도 같다.

🟥 **대가는 명시한다**: 이 게이트는 «선언이 형식에 맞나» 를 보지 «선언이 **사실인가**» 는 안 본다.
`writes: read-only` 의 진위는 여전히 등록 시점 M6 의 몫이다. 원래 잔여가 **좁아졌을 뿐 사라지지 않았다.**

## 🟥 배선하자 self-test 가 91→40 PASS 로 무너졌고, 원인이 배선이 아니었다

```
baseline (배선 전)   91 PASS / 0 FAIL      ← 먼저 재측정해서 «내가 깨뜨렸다» 를 확인했다
배선 후              40 PASS / 51 FAIL
원인                 fixture 51개가 **현실에서 등록될 수 없는 선언**이었다
                     (「안 돌았다」 enum 값 없음 · requires_cwd 미선언 · 캘리브레이션 쌍 미선언)
```
⇒ **relay 는 현실의 입력으로 자기를 시험한 적이 없었다.** fixture 를 현실 쪽으로 옮겨 98 복구.
게이트를 무르는 대신 fixture 를 고쳤고, **이미 선언된 키는 절대 안 건드렸다**(덮으면
「enum 밖 값은 폴백하지 않는다」 같은 레인이 시험하려던 것 자체가 바뀐다).

## cross-family(codex/gpt-5.5) A급 4건 — 전량 수리 + 앵커 신설

| | 무엇 | 어떻게 |
|---|---|---|
| **A** | **우회 채널로 REJECT capfile 이 실제 실행되고 `PASS` 까지 갔다**(codex 별도 재현). 내 자평 *"경고가 있으니 위험이 준다"* 는 **반증됐다** — 경고는 텍스트일 뿐 실행을 안 막는다 | codex 처방(이중 조건 env)보다 강한 수: **우회 런은 clearing PASS 를 구조적으로 못 낸다**. 조건을 늘려도 둘 다 켜면 그만이고, **막을 곳은 진입이 아니라 통과**다 |
| **A** | 성공 출력이 `0) ;;` 로 **통째 폐기**돼 호출자가 «전체 검사 통과» 로 읽었다 | `FH_REGISTRY_GATE: DECLARATION_VALID` + `FH_REGISTRY_GATE_SKIPPED: M4 M6` — **안 본 축을 이름으로** |
| **A** | **`merge` 가 게이트를 안 부른다**(같은 cap 이 registry_check rc=1 인데 merge rc=0 SUCCESS) | 강제하지 **않고**(조회 경로의 정당한 용도) `FH_MERGE_SCOPE: SCHEMA_ONLY` + `FH_REGISTRY_GATE: NOT_RUN` 으로 **오독을 막는다** |
| **A** | **TOCTOU** — 검사한 바이트와 실행할 바이트를 묶는 것이 없었다 | 게이트 시점 해시(`GATE_SHA`)를 **실행 직전 재확인**, 불일치 시 HARNESS_ERROR |

**앵커 R1~R9b 13레인 신설 → 107 PASS / 0 FAIL** (registry_check 19/0).
🟥 **R9(TOCTOU) 앵커는 약하다** — «대조 코드가 실행 경로에 있다» 를 보지 실제 경합을 결정적으로
재현하지 못했다. 존재 확인이지 동작 확인이 아니고, 마커에 그렇게 적었다.

## 🟥 standpoint 를 `not-applicable` 로 적을 수 없다 — 머지 전에 읽어야 할 부분

이 배선이 들어가면 **클러스터 노드의 cap 이 relay 를 못 탄다**:
```
tracks/_meta/relay/qasp_clean.cap   → ❌ REJECTED (M2+ enum 「안 돌았다」 없음 · M5 requires_cwd 미선언 · M4 쌍 미선언)
tracks/_meta/relay/pmh_clean.cap    → ❌ REJECTED (동일 3사유)
```
**타 하네스의 동작을 바꾼다.** 그리고 `tier1b` 로도 못 적는다 — 그쪽 파일을 읽었을 뿐 **그쪽에서
실행하지 않았다**. 실제 영향 확인은 그 하네스 세션의 몫으로 남긴다.
⚠️ 방향은 fail-closed 로 옳다(부를 수 없는 선언이 조합에 안 들어온다). 다만 **신호가 0 이 되는
구간**이 생기므로, 그 두 cap 을 등록 가능하게 고치는 것이 후속이다.

## 재측정 (challenger 처방 이행)

```
배선 전   FH_STATUS: SUCCESS · BLOCKED (rc=2)   ← 부를 수 없는 선언을 가진 노드를 실제로 실행하고 병합
배선 후   FH_STATUS: ERROR   · COMPOSITION_VIOLATION (rc=4)  ← 실행 전에 막는다
```
🟥 **단 이것은 §2-b 의 재현이 아니다** — 정본의 「3자 CLEAN 합의」는 *"같은 타깃 **직접 실행**"*
이었지 relay 경유가 아니었고, 이 조합은 **배선 전에도 BLOCKED** 였다. challenger 가 물은
「배선으로 안 잡히는 잔여가 있나」는 이 측정으로 **판정되지 않는다.**

B급 4건 미수리 — 마커에 전량 명시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)