### PR TITLE
감사 대상 동결 게이트 — 산문 규율이 세 번 다 못 잡은 자리를 스크립트로

### DIFF
--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -2182,3 +2182,27 @@
   outcome: accepted
   evidence: "tool_uses 25(계기 생존 — 카드가 경고한 `tool_uses: 0` 아님). **4/4 앵커 생존**, 매번 대응 레인만 적색(S1→2건·S2→1건·S3→2건·B1→known-pair 2건), 무관 25~28개는 통과 → 과결합 0. 복원 후 29 passed 재확인, 트리 clean. 🟥 substring 8행은 **전부 ✅ 로 판정했는데 코덱스와 갈렸고 이쪽이 졌다** — 「뚫리는 입력을 제시 못 함」을 판별력 있음으로 읽었으나, 그 단언이 *주장*하는 것(«범위 밖 보고가 났다»)은 파일명만으로 증명되지 않는다. **없음을 증명 못 함 ≠ 판별력 있음**"
   cost: 135k tokens
+- date: 2026-08-18
+  agent: Explore ×4 (isolated) — AX-레디 착수 전 정찰(FH 대상동결 선행자산 · qasp 해석기 어휘 · D2 스캐너 배선 · D3ⓑ 용어 채널 · B5 상태 어휘 · 호출부 0 좌표)
+  purpose: "재발명 방지 + 좌표 확정. 착수 전 «이미 있나» 를 기계로 먼저 묻는다(오늘 이 레포에서 재발명이 한 번 났었다)"
+  outcome: partial
+  evidence: "6축 정찰을 4발주로 묶음(각 대상 지문 `target_freeze.sh verify` 로 시작). **정확했던 것**: 대상동결 선행자산 스캔이 «기계 없음 + 실패 2종 문서화» 를 짚어 3번째 시도의 설계를 결정 · D2 가 `bug_report.py` 호출부 0을 컨트롤 동반으로 확정 · B5 가 `rer_from_act2` 를 «어휘 매핑 어댑터 레퍼런스» 로 지목(재발명 회피) · 근거표 A3 의 팬텀 인용 `PEER_ABSENT` 발견. 🟥 **틀린 것 2건, 둘 다 내가 직접 재현해서 걸렀다**: ⓐ 「`_CAUSE_PLAIN` 커버리지 게이트가 FAIL 레인 4종을 놓친다」 → 그 4종은 `StepEvidence.triage` 가 아니라 이슈-후보 dict 로 가고 소스 주석이 이미 그렇게 갈라놨다(오탐) ⓑ 「`env_cols_source` 가 존재하지 않는다」 → 7히트 실재(주석이 말한 건 *다른 모듈*). ⇒ 정찰 산출은 소스로 닫히기 전엔 좌표가 아니다"
+  cost: ~309k tokens (4건 합)
+- date: 2026-08-18
+  agent: general-purpose (isolated) — qasp 호출부 0/불일치 스캐너 제작
+  purpose: "«완성된 층 + 호출자 없음» 이 하루 4회 났다 — stdlib ast 기반 계기를 known-pair 로 세우고 전수 1회"
+  outcome: accepted
+  evidence: "**known-pair 양성 2/2 · 음성 5/5**(음성은 호출자 *경로까지* 대조). 전수 1024심볼 · ⓐ162(엄격 32)·ⓑ207·UNDECIDABLE 73. 🟥 **자기 오탐 2계열을 스스로 잡아 고쳤다**: `same_module_refs` 가 import 링크를 요구해 구조적으로 항상 0(→엄격 ⓐ 162→32) · `DeviceAdapter` 덕타이핑 미검출. 진양성 손검증 1건(`RuleAutoExpansionGate` — 외부 참조가 주석 2줄, 그 이름은 **존재하지 않는 철자**). ★ **`target_freeze.sh` 의 첫 실사용이 여기서 났다** — 회수 시 `WRONG-TARGET`(발주 중 내가 커밋 3건 투입), 위임분이 stale 판정을 안 들고 오고 현재 트리에서 전량 재실행. 미해결 자백: 손검증 1건뿐 · 미검출 미측정 · CI 미배선"
+  cost: 167k tokens
+- date: 2026-08-18
+  agent: codex/gpt-5.5 (cross-family sidecar) — FH `target_freeze.sh` 게이트 적대검증
+  purpose: "감사 대상 동결 게이트의 fail-open / 오탐 / 셸 이식성 — 재현 명령 필수"
+  outcome: accepted
+  evidence: "**6건, 전부 재현 명령 동반, 내가 직접 재현해 6/6 확인.** S급 3건이 **fail-open**(`_sha` 가 `|awk` 로 rc 소실 · `ls-files -o` 실패가 파이프에 먹힘 · 라벨 문자치환 충돌로 **핀한 적 없는 라벨이 MATCH**) + A급 2(서브모듈·심볼릭링크 미검출) + 과탐 1(빈 커밋). 🟥 **레인 11/11 초록인 상태에서 전부 뚫렸다** — 컨트롤 있음 ≠ 판별력 있음. 전부 수리 + 레인 고정"
+  cost: ~40k tokens
+- date: 2026-08-18
+  agent: agy/gemini (cross-family sidecar, 2번째 계열) — 같은 게이트, **다른 축** 요구
+  purpose: "codex 지적 목록을 먼저 주고 «그 밖의 축»(동시성·env·거짓 안심·인코딩)을 요구 — 한 계열에 몰면 같은 사각이 남는다"
+  outcome: accepted
+  evidence: "**6건 · codex 와 겹친 지적 0.** 최상위는 `GIT_DIR`/`GIT_WORK_TREE` 가 `git -C` 를 이긴다 — **엉뚱한 레포를 재고도 «동결했다» 고 보고**한다(계기가 대상을 틀리는 형태). 그 외 untracked **실행 비트** 미검출(이 레포가 이미 데인 축) · TOCTOU «유령 지문» · 미초기화 서브모듈은 `foreach` 가 건너뜀 · `---` 구분자 경계 · `foreach` 의 `;` rc 소실. 전부 수리, 레인 11→28. ⇒ **계열 분리가 값을 냈다** — 이 6건은 codex 를 한 번 더 돌려서는 안 나온다"
+  cost: ~35k tokens

--- a/package.json
+++ b/package.json
@@ -132,6 +132,8 @@
     "scripts/test_relay_channel_lanes.sh",
     "scripts/fh_session_load.sh",
     "scripts/branch_claim.sh",
+    "scripts/target_freeze.sh",
+    "scripts/test_target_freeze_lanes.sh",
     "scripts/test_branch_claim_lanes.sh",
     "scripts/hook_source_lib.sh",
     "scripts/test_hook_source_gate_lanes.sh",

--- a/plugins/fh-meta/skills/auto-decorrelation/SKILL.md
+++ b/plugins/fh-meta/skills/auto-decorrelation/SKILL.md
@@ -202,6 +202,26 @@ re-checks** it against the artifact (phantom-quench back-trace) before accepting
 source-grounded is **dropped, not judged**. No sidecar-only verdict (no weak-local-judge regression).
 Local 4090 = **canary tier** (evidence-of, never terminal verdict).
 
+**Target freeze — a prior drop reason, checked before any of the above (2026-08-17).** Grounding a
+finding against *today's* tree proves nothing if the sidecar reviewed *yesterday's*. Pin before
+dispatch and verify on return:
+
+```bash
+bash scripts/target_freeze.sh pin    "$REPO" "$ROUND_LABEL"   # 발주 직전
+bash scripts/target_freeze.sh verify "$REPO" "$ROUND_LABEL"   # 회수 직후
+```
+
+`rc 1` = **WRONG-TARGET → drop the whole round's findings**, not individual ones — the round read a
+tree that moved under it, so which findings survive is not decidable from the output. `rc 10` =
+UNKNOWN (could not measure) — that is **not** a pass; re-pin and re-dispatch. Measured trigger: three
+occurrences in one day, one of which was sending a sidecar a **pre-repair diff** and then grounding
+its findings against the repaired tree — every finding "failed to ground", and the instrument, not
+the reviewer, was wrong.
+
+🟥 **What this does NOT cover**: §L191's inlined-file pattern. When the prompt carries file contents
+on stdin (the robust form for sidecars that have no file tools), the tree freeze says nothing about
+**what bytes you actually sent**. That binding is still owed and is not claimed here.
+
 ## Step 6 — Degrade ladder (the intelligent scale-down)
 
 **Consent branch first — declined ≠ degraded** (`[[capability_escalation_consent]]`): if the UAP has

--- a/plugins/fh-meta/skills/steel-quench/SKILL.md
+++ b/plugins/fh-meta/skills/steel-quench/SKILL.md
@@ -425,7 +425,8 @@ over **unchanged** code:
    `WRONG-TARGET` and stop on mismatch:
 
    ```bash
-   git rev-parse --short HEAD; git diff HEAD | wc -l; git status --porcelain | grep -c '^??'
+   bash scripts/target_freeze.sh pin    "$REPO" "$WAVE_LABEL"   # 발주 직전 — 토큰을 프롬프트에 박는다
+   bash scripts/target_freeze.sh verify "$REPO" "$WAVE_LABEL"   # 회수 직후 — rc 1 이면 WRONG-TARGET
    ```
 
    An audit that did not pin its target **cannot be counted as a terminating round** — it may have
@@ -435,7 +436,29 @@ over **unchanged** code:
    active — gate-locality on the very fix that was closing a gate-locality gap, caught by the round
    that audited it.
 
-   > **Named residual — the freeze claim is currently SELF-ATTESTED, and deliberately not
+   > ✅ **MECHANIZED 2026-08-17 — the residual below is the history, not the current state.**
+   > The recurrence condition this paragraph set ("mechanize on the first recurrence") fired **three
+   > times in one day**: a cross-family review was sent a **pre-repair** diff · a review's output was
+   > truncated with `tail`, losing findings and the pin itself · a scan was followed by an edit that
+   > shifted every line number. All three were "did I send / read the tree that is there now?", and
+   > the prose rule above was already in place and caught **none** of them (operator-approved as the
+   > next session's 1순위, 2026-08-17).
+   >
+   > `scripts/target_freeze.sh` (lanes: `scripts/test_target_freeze_lanes.sh`, **28/28**) takes the
+   > third attempt deliberately **through** the two failures recorded below: it content-addresses
+   > `git diff HEAD` (the **patch**, not its line count — so a same-line-count in-place edit is
+   > caught, lane A) and hashes untracked files separately (lane B), and it is **not a hook** —
+   > two explicit commands the dispatcher runs, so it cannot become the 100%-firing background noise
+   > of attempt ①. It refuses to answer at all when `assume-unchanged`/`skip-worktree` is set
+   > (exit 10 UNKNOWN, never MATCH), and a **restore-to-original lane returns MATCH** — that arm is
+   > the point: without it, "always reports WRONG" would pass every other lane.
+   > 🟥 **Scope, stated narrowly**: it freezes the *target tree*, **not the bytes you inlined into a
+   > sidecar prompt**. Where files are pasted into the prompt (`auto-decorrelation` §L191 — sidecars
+   > often cannot read a tree at all), the inlined content needs its own binding; this script does
+   > not provide it.
+   >
+   > **Named residual (HISTORICAL — superseded by the block above) — the freeze claim was
+   > SELF-ATTESTED, and deliberately not
    > mechanized.** Criterion 1 turns on "unmodified since the previous audit", and nothing checks
    > that. Two attempts to mechanize it on the day the rule was written were both wrong: a hook
    > advisory that fired on 100% of markers (noise, and its convergence detector could not match the

--- a/scripts/adapters/mate_agent_boundary.sh
+++ b/scripts/adapters/mate_agent_boundary.sh
@@ -100,14 +100,34 @@ if [ -n "$TARGET" ]; then
   [ -r "$TARGET" ] || _harness_error "대상 경로를 읽을 수 없다: $TARGET"
 fi
 
-# peer 트리를 **변이하지 않는다** — cwd 만 peer 로 두고 읽기만 한다.
-# (기본 대상이 peer 레포 상대경로라 cwd 가 peer 여야 한다.)
+# peer 트리를 **변이하지 않는다** — cwd 만 두고 읽기만 한다.
 # 판정은 파이프를 통과시키지 않는다(PIPE-VERDICT).
-if [ -n "$TARGET" ]; then
-  out=$(cd "$PEER_ROOT" && bash "$ENTRY" "$TARGET" 2>&1); rc=$?
-else
-  out=$(cd "$PEER_ROOT" && bash "$ENTRY" 2>&1); rc=$?
-fi
+#
+# 🟥 **초판은 대상을 인자로 넘겼고, peer 는 그 인자를 안 읽는다** (2026-08-18 실측).
+#    peer 진입점은 `TARGET=".claude/agents/mate-failure-patcher.md"` 를 **하드코딩**하고
+#    `$1` 은 `pass()`/`fail()` 헬퍼 안에서만 쓴다. 그래서 `--known-positive` / `--known-negative`
+#    두 arm 이 **같은 파일**(peer 실물 명세서)을 재고 있었다 ⇒ **캘리브레이션 쌍이 죽어 있었다.**
+#    음성 arm 이 초록이던 것은 판별력이 아니라 **실물이 마침 실패 상태**여서다.
+#    이 픽스처 파일의 헤더가 스스로 경고한 그 상태다 — *"실물을 양성 arm 으로 쓰면 계기의
+#    판정이 남의 편집에 따라 조용히 뒤집힌다"*.
+# ⇒ 대상이 명시되면 **peer 가 기대하는 모양의 임시 트리**를 만들어 거기서 돌린다.
+#   peer 코드를 고치지 않고(남의 레포다) peer 의 하드코딩된 상대경로를 만족시키는 방법이다.
+_run_peer() {
+  if [ -z "$TARGET" ]; then
+    ( cd "$PEER_ROOT" && bash "$ENTRY" ) 2>&1
+    return $?
+  fi
+  local stage
+  stage=$(mktemp -d) || return 10
+  mkdir -p "$stage/.claude/agents" || { rm -rf "$stage"; return 10; }
+  cp "$TARGET" "$stage/.claude/agents/mate-failure-patcher.md" || { rm -rf "$stage"; return 10; }
+  local o r
+  o=$( cd "$stage" && bash "$ENTRY" 2>&1 ); r=$?
+  rm -rf "$stage"
+  printf '%s\n' "$o"
+  return $r
+}
+out=$(_run_peer); rc=$?
 printf '%s\n' "$out"
 
 # ── 명시 재매핑 (같은 숫자, 다른 사건 — 전파가 아니다) ───────────────────────

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -961,6 +961,21 @@ else
   fail=1
 fi
 
+# target_freeze — 같은 형태(shipped subject + 자기 앵커). 🟥 이 블록이 없어서 `lane-runner`
+# 검사가 «돌리는 게 없는 스위트는 산문이다» 로 정확히 걸었다. 지은 사람이 자기 레인을 안
+# 배선한 것이고, 오늘 이 세션이 남의 코드에서 네 번 잡은 그 얼굴이다.
+if [ ! -f scripts/target_freeze.sh ]; then
+  echo "FAIL  scripts/target_freeze.sh is in package.json files[] but absent — a deleted subject, not a skip"
+  fail=1
+elif [ -f scripts/test_target_freeze_lanes.sh ]; then
+  if ! bash scripts/test_target_freeze_lanes.sh; then
+    fail=1
+  fi
+else
+  echo "FAIL  test_target_freeze_lanes.sh: target_freeze.sh present but its anchor is missing"
+  fail=1
+fi
+
 # And the ablation calibrator, for the third instance of the same reason. Its whole job is telling
 # apart states that look identical from outside — "the arm could not answer" vs "the runner is dead"
 # vs "the runner read the answer off disk" — and round 2 of its own adversarial review found that

--- a/scripts/target_freeze.sh
+++ b/scripts/target_freeze.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# target_freeze.sh — 발주한 감사의 **대상을 동결**하고, 회수 시 그게 같은 대상인지 대조한다.
+#
+# ## 왜 (N=3, 2026-08-17 운영자 승인)
+#
+# 같은 결함이 하루에 세 번 났다: ① cross-family 리뷰에 **수리 이전** diff 발송 ② 리뷰 출력을
+# `tail` 로 잘라 지적·핀 유실 ③ 스캔 후 파일 편집으로 라인 번호 밀림. 셋 다 「보낸 것/읽은
+# 것이 지금 트리가 맞나」를 안 찍어서 생겼고, **산문 규율은 이미 있었는데 세 번 다 안 걸렸다**
+# (`steel-quench/SKILL.md §PIN THE TARGET`). 그래서 산문이 아니라 스크립트다.
+#
+# ## 🟥 선행 실패 2종을 피한다 — 이건 3번째 시도다
+#
+# 같은 SKILL.md 가 두 번의 기계화 실패를 이미 기록해 뒀다:
+#   ① 훅 advisory  → 마커 100% 에서 발화 = 배경 소음, 수렴 탐지기가 어휘를 못 맞춤 → 제거
+#   ② `base-SHA + diff 줄 수` 지문 → **in-place 편집에 불변**(산문 수리의 기본 형태!)이고
+#      untracked 에 구조적으로 맹목 → 제거
+# ⇒ 그래서 여기서는 **줄 수가 아니라 내용을 해시**하고(①의 반대), untracked 를 **따로**
+#   센다(②의 반대). 훅에 안 건다 — 발주자가 명시적으로 부르는 두 커맨드다.
+#
+# ## 설계 제약 (전부 이 레포의 기존 실패에서 나왔다)
+#   ⓐ tracked 변경 + untracked 를 **content-address** (steel-quench L450)
+#   ⓑ `assume-unchanged`/`skip-worktree` 은폐 검사 필수 (publish_freshness_check.sh:61)
+#   ⓒ git 실패 = **UNKNOWN**, 절대 clean 아님 (session_close_check.sh:38-48)
+#   ⓓ `.git` 전체를 지문에 넣지 않는다 — `index` 가 정당하게 갱신돼 거짓 불일치
+#      (capability_effect_probe.sh:253)
+#   ⓔ 판정 키는 트리가 아니라 **세션** (branch_claim.sh:13-20)
+#   ⓕ 사이드카는 트리를 못 읽는 경우가 많다 → **발주자 측 대조**여야 한다
+#      (auto-decorrelation/SKILL.md:191)
+#
+# ## 사용
+#   bash scripts/target_freeze.sh pin    <repo> <label>   # 발주 직전. 지문 토큰을 stdout 에
+#   bash scripts/target_freeze.sh verify <repo> <label>   # 회수 직후. 불일치면 WRONG-TARGET
+#   bash scripts/target_freeze.sh show   <repo> <label>
+#
+# ## 종료 코드
+#   0   MATCH        — 대상이 그대로다
+#   1   WRONG-TARGET — 대상이 움직였다. **그 라운드의 판정을 무효화하라**
+#   10  UNKNOWN      — 잴 수 없었다(git 실패·해시 도구 부재·핀 없음). 미측정이지 통과 아님
+#
+# 🟥 **이 스크립트는 «내가 보낸 내용»이 아니라 «대상 트리»를 잰다.** 사이드카에 파일을
+#    인라인해 보냈다면 그 인라인 내용의 해시도 따로 결박해야 한다(ⓕ) — 여기서는 안 한다.
+#    범위를 넓게 주장하지 않으려고 명시한다.
+
+set -u
+
+_die_unknown() { printf 'UNKNOWN — %s\n' "$1" >&2; exit 10; }
+
+# 🟥 **`git -C` 는 `GIT_DIR`/`GIT_WORK_TREE` 를 못 이긴다** (cross-family agy, 2026-08-18).
+#    호출자 환경에 그 변수가 남아 있으면 이 스크립트는 **엉뚱한 레포**를 재고도 «정상 경로를
+#    동결했다» 고 보고한다. 지문 계기가 대상을 틀리는 형태라 다른 모든 지적보다 상위다.
+_git() { env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE git "$@"; }
+
+_sha() {
+  # chamber_witness.sh:84 와 같은 형태(macOS/linux 폴백). 도구 없으면 fail-closed.
+  #
+  # 🟥 **`| awk` 로 잘라내지 않는다** (cross-family codex, 2026-08-18, 재현 확인).
+  #    `shasum | awk` 는 shasum 의 rc 를 잃는다 — 해시 도구가 특정 입력에서 실패해도
+  #    awk 는 rc 0 을 내고 stdout 이 비어, 서로 다른 내용이 **같은 빈 지문**을 받아 MATCH 가
+  #    된다. 게이트 안에서 이 형태가 fail-open 이다.
+  local out rc
+  if command -v shasum >/dev/null 2>&1; then out=$(shasum -a 256); rc=$?
+  elif command -v sha256sum >/dev/null 2>&1; then out=$(sha256sum); rc=$?
+  else return 3; fi
+  [ "$rc" -eq 0 ] || return 3
+  out=${out%% *}
+  [ -n "$out" ] || return 3
+  printf '%s\n' "$out"
+}
+
+_label_key() {
+  # 🟥 문자 치환으로 파일명을 만들지 않는다 — `a/b` 와 `a_b` 가 **같은 핀 파일**이 되어,
+  #    핀한 적 없는 라벨을 verify 하면 MATCH 가 나온다(cross-family codex, 재현 확인).
+  #    해시는 충돌하지 않으므로 라벨 공간이 파일명 공간에 안전하게 들어간다.
+  printf '%s' "$1" | _sha
+}
+
+_fingerprint() {
+  # stdout: <64자 해시>  ·  실패 시 비영 종료 + stdout 은 **빈다**
+  # 🟥 명령이 실패하면서 stdout 에 무언가를 뱉는 형태를 만들지 않는다 — 그러면 폴백 없이도
+  #    쓰레기 값이 지문이 되고, 대조가 «항상 일치» 로 조용히 무너진다.
+  local repo="$1" head diff_patch untracked hidden combined subs files rc
+
+  # 🟥 `HEAD` 가 아니라 **트리 해시**를 쓴다 (cross-family codex, 재현 확인). 이 지문의
+  #    주장은 «감사한 내용이 그대로인가» 이고, 빈 커밋(`--allow-empty`)은 내용을 안 바꾸는데
+  #    HEAD 만 움직여 **정상 조작이 WRONG-TARGET** 이 됐다. 오탐이 잦으면 이 게이트는
+  #    override 를 습관화시키고 그건 폐기 경로다.
+  head=$(_git -C "$repo" rev-parse "HEAD^{tree}" 2>&1) || { printf '%s\n' "$head" >&2; return 1; }
+
+  # ⓑ 은폐 비트 — 이게 켜져 있으면 tracked 변경이 diff 에 안 나온다. 지문이 거짓말을 하므로
+  #    「일치」를 낼 자격이 없다.
+  hidden=$(_git -C "$repo" ls-files -v 2>&1) || { printf '%s\n' "$hidden" >&2; return 1; }
+  if printf '%s\n' "$hidden" | grep -qE '^[hS]'; then
+    printf 'assume-unchanged/skip-worktree 비트가 켜져 있다 — 지문이 변경을 못 본다\n' >&2
+    return 2
+  fi
+
+  # ⓐ-1 tracked 변경: **줄 수가 아니라 패치 내용**. staged 포함(HEAD 기준).
+  diff_patch=$(_git -C "$repo" diff HEAD 2>&1) || { printf '%s\n' "$diff_patch" >&2; return 1; }
+
+  # ⓐ-2 서브모듈: `git diff HEAD` 는 서브모듈 포인터만 보고 **그 안의 dirty 내용은 못 본다**
+  #      (cross-family codex, 재현 확인 — 서브모듈 파일을 고쳐도 MATCH 였다).
+  #      `--recursive` 상태 문자열이 dirty 표식(`+`)과 SHA 를 함께 낸다.
+  #      🟥 `submodule status` **만으로는 부족하다**: 그 줄은 서브모듈의 HEAD 를 말하므로,
+  #      서브모듈 워킹트리를 고치기만 하면(커밋 없이) SHA 가 안 바뀌어 여전히 MATCH 였다
+  #      (수리 1차본이 그랬고, 재현으로 잡았다). 각 서브모듈 **안으로 내려가** 상태와
+  #      패치 내용을 함께 해시에 넣는다.
+  subs=$(_git -C "$repo" submodule status --recursive 2>&1) || { printf '%s\n' "$subs" >&2; return 1; }
+  if [ -n "$subs" ]; then
+    # 🟥 미초기화 서브모듈(`-<sha> path`)은 `foreach` 가 **건너뛴다**(agy 지적). 그 안의
+    #    내용은 지문에 한 글자도 안 들어가므로 «같다» 를 낼 자격이 없다.
+    if printf '%s\n' "$subs" | grep -q '^-'; then
+      printf '미초기화 서브모듈이 있다 — 그 안을 못 잰다(git submodule update --init 후 재시도)\n' >&2
+      return 2
+    fi
+    local subdetail
+    subdetail=$(_git -C "$repo" submodule foreach --recursive --quiet \
+                  'git status --porcelain --untracked-files=all && git diff HEAD' 2>&1) \
+      || { printf '%s\n' "$subdetail" >&2; return 1; }
+    subs="${subs}"$'\n'"${subdetail}"
+  fi
+
+  # ⓐ-3 untracked(무시되지 않은 것): 경로 + 내용 해시.
+  # 🟥 **파이프 안에서 목록을 만들지 않는다** — `git ls-files -o | while … | sort` 는 git 의
+  #    rc 를 마지막 `sort` 의 rc 로 덮는다. 목록 취득이 실패해도 «untracked 없음» 으로 접혀
+  #    MATCH 가 나왔다(재현 확인). 목록을 먼저 변수로 받고 rc 를 본다.
+  # ★NUL 구분자는 `$( )` 가 삼킨다 — 목록은 **임시 파일**로 받아야 rc 도 보고 구분자도 산다.
+  files=$(mktemp) || return 3
+  _git -C "$repo" ls-files -o --exclude-standard -z >"$files" 2>/dev/null; rc=$?
+  if [ "$rc" -ne 0 ]; then
+    rm -f "$files"
+    printf 'ls-files -o 실패(rc=%s) — untracked 를 못 쟀다\n' "$rc" >&2
+    return 1
+  fi
+
+  untracked=""
+  while IFS= read -r -d '' f; do
+    local entry
+    if [ -L "$repo/$f" ]; then
+      # 🟥 심볼릭 링크는 **가리키는 문자열**이 내용이다. `-f` 로만 보면 깨진 링크의
+      #    재지정(retarget)을 통째로 놓친다(재현 확인).
+      entry="LINK $(readlink "$repo/$f" 2>/dev/null || printf 'UNREADABLE')"
+    elif [ -d "$repo/$f" ]; then
+      # 🟥 untracked **디렉토리**는 `ls-files -o` 가 한 항목으로 접는다(중첩 git repo 가
+      #    대표 사례). 그 안의 내용 변경을 이 지문은 못 본다 ⇒ «놓쳤다» 를 «같다» 로
+      #    렌더하지 않고 **잴 수 없음(UNKNOWN)으로 fail-closed** 한다.
+      printf 'untracked 디렉토리를 만났다(%s) — 내용까지 못 잰다\n' "$f" >&2
+      rm -f "$files"; return 2
+    elif [ -f "$repo/$f" ]; then
+      # 🟥 **모드도 내용이다** (agy 지적). tracked 파일은 `git diff` 가 `old mode/new mode`
+      #    를 내지만 untracked 는 스트림만 해시해서, `chmod +x` 가 지문에 안 잡혔다.
+      #    이 레포는 실행 비트 소실로 훅이 조용히 무장해제된 이력이 있다
+      #    ([[feedback_exec_bit_loss_disarms_hooks_silently]]).
+      local mode; if [ -x "$repo/$f" ]; then mode=x; else mode=-; fi
+      entry="$mode $(_sha <"$repo/$f")" || { rm -f "$files"; return 3; }
+      case "$entry" in "$mode ") rm -f "$files"; return 3 ;; esac
+    else
+      entry="NOTAFILE"
+    fi
+    untracked="${untracked}${f} ${entry}"$'\n'
+  done <"$files"
+  rm -f "$files"
+  untracked=$(printf '%s' "$untracked" | LC_ALL=C sort)
+
+  # 🟥 **필드를 이어붙이고 한 번 해시하지 않는다** (agy 지적): `---` 는 diff 패치의 표준
+  #    헤더(`--- a/file`)라 필드 경계가 내용에 나타날 수 있고, 그러면 서로 다른 상태가 같은
+  #    결합 문자열을 만들 여지가 생긴다. 각 필드를 **먼저 해시**해 길이를 고정한 뒤 잇는다.
+  local h_head h_diff h_subs h_untracked
+  h_head=$(printf '%s' "$head" | _sha) || return 3
+  h_diff=$(printf '%s' "$diff_patch" | _sha) || return 3
+  h_subs=$(printf '%s' "$subs" | _sha) || return 3
+  h_untracked=$(printf '%s' "$untracked" | _sha) || return 3
+
+  # 🟥 **TOCTOU** (agy 지적): 위 단계들은 원자적 스냅샷이 아니다. 1단계 뒤에 누가
+  #    `git commit -a` 를 하면 «옛 트리 + 빈 diff» 라는 **한 순간도 존재한 적 없는 상태**가
+  #    핀으로 저장되고, 그 뒤 아무 변경이 없어도 verify 가 WRONG-TARGET 을 낸다.
+  #    ⇒ 끝에서 트리를 다시 읽어 **읽는 동안 움직였으면 지문을 내지 않는다**(fail-closed).
+  local head2
+  head2=$(_git -C "$repo" rev-parse "HEAD^{tree}" 2>/dev/null) || return 1
+  if [ "$head2" != "$head" ]; then
+    printf '지문 계산 도중 트리가 움직였다 — 스냅샷이 일관되지 않는다\n' >&2
+    return 2
+  fi
+
+  combined=$(printf '%s %s %s %s\n' "$h_head" "$h_diff" "$h_subs" "$h_untracked" | _sha) || return 3
+  [ -n "$combined" ] || return 3
+  printf '%s\n' "$combined"
+}
+
+_pin_path() {
+  local repo="$1" label="$2" gitdir sid
+  gitdir=$(_git -C "$repo" rev-parse --git-common-dir 2>/dev/null) || return 1
+  case "$gitdir" in /*) : ;; *) gitdir="$repo/$gitdir" ;; esac
+  # ⓔ 세션 키 — branch_claim.sh:86-91 과 같은 상속 경로.
+  sid="${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-local}}"
+  printf '%s/fh-targets/%s\n' "$gitdir" "$sid"
+}
+
+main() {
+  local cmd="${1:-}" repo="${2:-}" label="${3:-}"
+  [ -n "$cmd" ] && [ -n "$repo" ] && [ -n "$label" ] || {
+    printf 'usage: target_freeze.sh {pin|verify|show} <repo> <label>\n' >&2; exit 10; }
+  [ -d "$repo" ] || _die_unknown "레포 경로가 없다: $repo"
+  _git -C "$repo" rev-parse --git-dir >/dev/null 2>&1 || _die_unknown "git 레포가 아니다: $repo"
+
+  local dir fp rc
+  dir=$(_pin_path "$repo" "$label") || _die_unknown "git-common-dir 를 못 읽었다"
+  local lkey; lkey=$(_label_key "$label") || _die_unknown "라벨 키를 못 만들었다(해시 도구 부재)"
+  local file="$dir/${lkey}.fp"
+
+  case "$cmd" in
+    pin)
+      fp=$(_fingerprint "$repo"); rc=$?
+      [ "$rc" -eq 0 ] && [ -n "$fp" ] || _die_unknown "지문을 못 냈다 (rc=$rc)"
+      mkdir -p "$dir" || _die_unknown "핀 저장 디렉토리를 못 만들었다"
+      printf '%s\n' "$fp" >"$file" || _die_unknown "핀을 못 썼다"
+      # 발주 프롬프트에 그대로 박을 한 줄.
+      printf 'TARGET-FINGERPRINT %s %s\n' "$label" "${fp:0:16}"
+      ;;
+    verify)
+      [ -f "$file" ] || _die_unknown "핀이 없다 — 발주 전에 pin 을 안 했다 ($label)"
+      local pinned; pinned=$(cat "$file") || _die_unknown "핀을 못 읽었다"
+      fp=$(_fingerprint "$repo"); rc=$?
+      [ "$rc" -eq 0 ] && [ -n "$fp" ] || _die_unknown "지문을 못 냈다 (rc=$rc)"
+      if [ "$fp" = "$pinned" ]; then
+        printf 'MATCH %s %s\n' "$label" "${fp:0:16}"; exit 0
+      fi
+      printf 'WRONG-TARGET %s — 핀 %s / 현재 %s\n' "$label" "${pinned:0:16}" "${fp:0:16}" >&2
+      printf '🟥 이 라운드의 판정을 **무효화**하라. 대상이 발주 이후 움직였다.\n' >&2
+      exit 1
+      ;;
+    show)
+      [ -f "$file" ] || _die_unknown "핀이 없다 ($label)"
+      printf 'PINNED %s %s\n' "$label" "$(cat "$file")"
+      ;;
+    *) _die_unknown "알 수 없는 커맨드: $cmd" ;;
+  esac
+}
+
+main "$@"

--- a/scripts/test_adapter_lanes.sh
+++ b/scripts/test_adapter_lanes.sh
@@ -145,6 +145,23 @@ if [ -n "$MT_ROOT" ]; then
 else
   echo "  ⏭  M4    [resolve-alias ] mate 실물 루트 없음 — SKIP (통과 아님)"
 fi
+# 🟥 M2b/M2c — **대상 인자가 실제로 먹히는가** (2026-08-18 신설).
+#    초판은 대상을 peer 진입점에 `$1` 로 넘겼는데 **peer 는 그 인자를 안 읽는다**
+#    (`TARGET` 하드코딩). 그래서 양성·음성 두 arm 이 **같은 파일**(peer 실물)을 재고 있었고,
+#    음성의 초록은 판별력이 아니라 **실물이 마침 실패 상태**여서였다 — 캘리브레이션 쌍이
+#    죽어 있었다. M2/M3 만으로는 그 상태를 못 가른다(둘 다 «기대대로» 나올 수 있다).
+#    ⇒ **픽스처를 변형해 판정이 따라오는지**를 본다. peer 실물 상태와 무관하게 성립한다.
+if [ -n "$MT_ROOT" ]; then
+  _MUT="$T/mutated_positive.md"
+  # 양성 픽스처에서 T11(finding_id 어휘 제약) 한 줄만 뺀다.
+  grep -v '\^\[a-f0-9\]{6,64}\$' "$(dirname "$M")/fixtures/mate_agent_boundary_known_positive.md" >"$_MUT"
+  _lane M2b target-honored "양성에서 한 조항만 빼면 → FAIL (대상 인자가 실제로 먹힌다)" 1 \
+    "$(_rc bash "$M" --target "$_MUT")"
+  _lane M2c target-honored "원본 양성은 그대로 PASS (변형 레인의 컨트롤)" 0 \
+    "$(_rc bash "$M" --known-positive)"
+else
+  echo "  ⏭  M2b/M2c [target-honored] mate 실물 루트 없음 — SKIP (통과 아님)"
+fi
 _lane_peer "$MT_ROOT" M5 enum "없는 대상 → HARNESS_ERROR(10). peer 헤더가 «위반 0 이 아니다» 라고 못 박은 값" 10 \
   "$(_rc bash "$M" --target "$T/does_not_exist.md")"
 _lane_peer "$MT_ROOT" M6 enum "알 수 없는 모드 → HARNESS_ERROR(10)" 10 "$(_rc bash "$M" --bogus-mode)"

--- a/scripts/test_target_freeze_lanes.sh
+++ b/scripts/test_target_freeze_lanes.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# test_target_freeze_lanes.sh — known pairs for scripts/target_freeze.sh
+#
+# 🟥 이 레인이 실제로 재는 것: 「대상이 움직였음을 **가르는가**」. 양성만 재면 «항상 다르다고
+#    하는 계기» 와 구분되지 않고, 그 계기는 매 라운드 판정을 무효화해 아무도 안 쓰게 된다
+#    (= 선행 실패 ①의 배경-소음 경로). 그래서 **복원 후 MATCH** 레인이 이 파일의 핵심이다.
+#
+# 🟥 그리고 이 스크립트가 존재하는 이유인 **선행 실패 2종**을 각각 한 레인으로 고정한다:
+#    A  줄 수가 같은 in-place 편집  — `base-SHA + diff 줄 수` 지문이 못 잡던 것
+#    B  untracked 파일 추가         — 같은 지문이 구조적으로 맹목이던 것
+#    이 둘이 빠지면 3번째 시도도 같은 자리에서 무너진다.
+
+set -u
+T="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/target_freeze.sh"
+pass=0; fail=0
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+R="$WORK/repo"
+
+# run <label> <expect MATCH|WRONG|UNKNOWN> <cmd...>
+run() {
+  local label="$1" want="$2"; shift 2
+  local out rc got
+  out=$("$@" 2>&1); rc=$?
+  case "$rc" in
+    0)  got=MATCH ;;
+    1)  got=WRONG ;;
+    10) got=UNKNOWN ;;
+    *)  got="rc$rc" ;;
+  esac
+  if [ "$got" = "$want" ]; then
+    printf '  ✅ %-52s %s (expected %s)\n' "$label" "$got" "$want"; pass=$((pass+1))
+  else
+    printf '  ❌ %-52s %s (expected %s)\n     out: %s\n' "$label" "$got" "$want" "$out"; fail=$((fail+1))
+  fi
+}
+
+echo "[target-freeze] fixture build"
+mkdir -p "$R" && git init -q "$R"
+git -C "$R" config user.email t@t; git -C "$R" config user.name t
+printf 'a\n' >"$R/a.txt"
+git -C "$R" add -A && git -C "$R" commit -qm init
+
+echo "[target-freeze] lanes"
+run "pin (최초)"                        MATCH   bash "$T" pin "$R" demo
+
+# ── A. 선행 실패 ②-1: 줄 수 불변 in-place 편집 ─────────────────────────────
+printf 'b\n' >"$R/a.txt"
+run "A 줄 수 같은 in-place 편집 → WRONG"  WRONG   bash "$T" verify "$R" demo
+printf 'a\n' >"$R/a.txt"
+
+# ── C. 판별력 컨트롤 — 되돌리면 다시 MATCH («항상 다르다» 계기가 아님) ────────
+run "C 복원 후 → MATCH (판별력 컨트롤)"   MATCH   bash "$T" verify "$R" demo
+
+# ── B. 선행 실패 ②-2: untracked 추가 ────────────────────────────────────────
+printf 'new\n' >"$R/untracked.txt"
+run "B untracked 추가 → WRONG"          WRONG   bash "$T" verify "$R" demo
+rm -f "$R/untracked.txt"
+run "B 제거 후 → MATCH"                 MATCH   bash "$T" verify "$R" demo
+
+# ── gitignore 된 파일은 대상이 아니다 (오탐 경로 — 산출물 디렉토리가 매 런 바뀐다) ──
+printf 'out/\n' >"$R/.gitignore"
+git -C "$R" add .gitignore && git -C "$R" commit -qm ignore
+run "pin (ignore 커밋 후 재핀)"          MATCH   bash "$T" pin "$R" demo
+mkdir -p "$R/out" && printf 'noise\n' >"$R/out/run.log"
+run "ignored 산출물 생성 → MATCH (오탐 없음)" MATCH bash "$T" verify "$R" demo
+
+# ── ⓑ 은폐 비트: 잴 수 없으면 «일치» 를 낼 자격이 없다 ──────────────────────
+git -C "$R" update-index --assume-unchanged a.txt
+printf 'HIDDEN\n' >"$R/a.txt"
+run "assume-unchanged → UNKNOWN (통과 아님)" UNKNOWN bash "$T" verify "$R" demo
+git -C "$R" update-index --no-assume-unchanged a.txt
+printf 'a\n' >"$R/a.txt"
+
+# ── ⓒ 미측정을 통과로 접지 않는다 ───────────────────────────────────────────
+run "핀 없는 라벨 → UNKNOWN"             UNKNOWN bash "$T" verify "$R" nolabel
+run "git 레포 아님 → UNKNOWN"            UNKNOWN bash "$T" verify "$WORK" demo
+
+# ── 스테이징만 해도 대상은 움직인 것이다 ────────────────────────────────────
+printf 'staged\n' >"$R/a.txt"; git -C "$R" add a.txt
+run "staged 변경 → WRONG"                WRONG   bash "$T" verify "$R" demo
+
+# ══════════════════════════════════════════════════════════════════════════════
+# cross-family(codex, 2026-08-18)가 **뚫은** 경로들 — 전부 재현 확인 후 여기 고정한다.
+# 🟥 위 11 레인이 초록인 채로 아래가 전부 통과했다: 컨트롤이 있다는 것과 판별력이 있다는
+#    것은 다르다. 이 블록이 없으면 다음 수리가 같은 자리를 조용히 다시 연다.
+# ══════════════════════════════════════════════════════════════════════════════
+echo
+echo "[target-freeze] cross-family 가 뚫은 경로 (fail-open 3 · 오탐 1)"
+
+# ── S: 라벨 별칭 — `a/b` 와 `a_b` 가 같은 핀 파일이면 «핀한 적 없는 라벨» 이 MATCH ──
+bash "$T" pin "$R" a_b >/dev/null 2>&1
+run "S 라벨 별칭 a/b (핀 없음) → UNKNOWN"  UNKNOWN bash "$T" verify "$R" a/b
+
+# ── S: `ls-files -o` 실패가 파이프에 먹혀 «untracked 없음» 으로 접히던 것 ──────────
+FAKEBIN="$WORK/fakebin"; mkdir -p "$FAKEBIN"
+REALGIT=$(command -v git)
+printf '#!/usr/bin/env bash
+if [ "$1" = "-C" ] && [ "$3" = "ls-files" ] && [ "$4" = "-o" ]; then exit 42; fi
+exec %q "$@"
+' "$REALGIT" >"$FAKEBIN/git"
+chmod +x "$FAKEBIN/git"
+bash "$T" pin "$R" lsfail >/dev/null
+printf 'new
+' >"$R/u2.txt"
+run "S ls-files -o 고장 → UNKNOWN (MATCH 아님)" UNKNOWN env PATH="$FAKEBIN:$PATH" bash "$T" verify "$R" lsfail
+rm -f "$R/u2.txt"
+
+# ── S: untracked 중첩 git repo — 안의 내용 변경을 못 보므로 **fail-closed** ────────
+mkdir -p "$R/nested" && git init -q "$R/nested"
+git -C "$R/nested" config user.email t@t; git -C "$R/nested" config user.name t
+printf 'one
+' >"$R/nested/x.txt"
+run "S untracked 디렉토리 → UNKNOWN (못 잰다고 말한다)" UNKNOWN bash "$T" pin "$R" nested
+rm -rf "$R/nested"
+
+# ── A: 깨진 심볼릭 링크 재지정 — 링크가 가리키는 문자열이 내용이다 ─────────────────
+ln -s missing-one "$R/link"
+run "A 심볼릭 링크 pin"                     MATCH   bash "$T" pin "$R" symlink
+ln -sfn missing-two "$R/link"
+run "A 링크 재지정 → WRONG"                 WRONG   bash "$T" verify "$R" symlink
+ln -sfn missing-one "$R/link"
+run "A 링크 복원 → MATCH (판별력 컨트롤)"    MATCH   bash "$T" verify "$R" symlink
+rm -f "$R/link"
+
+# ── S: 서브모듈 **워킹트리** 내용 변경 (커밋 없이) ────────────────────────────────
+#    🟥 `submodule status` 만으로는 못 잡는다 — 그 줄은 서브모듈의 HEAD 를 말하므로,
+#    커밋 없이 파일만 고치면 SHA 가 그대로다. 수리 1차본이 정확히 여기서 뚫렸다.
+SUB="$WORK/sub"; mkdir -p "$SUB" && git init -q "$SUB"
+git -C "$SUB" config user.email t@t; git -C "$SUB" config user.name t
+printf 'v1\n' >"$SUB/s.txt"; git -C "$SUB" add -A; git -C "$SUB" commit -qm sub
+SR="$WORK/subhost"; mkdir -p "$SR" && git init -q "$SR"
+git -C "$SR" config user.email t@t; git -C "$SR" config user.name t
+printf 'a\n' >"$SR/a.txt"; git -C "$SR" add -A; git -C "$SR" commit -qm init
+if git -C "$SR" -c protocol.file.allow=always submodule add -q "$SUB" sub 2>/dev/null; then
+  git -C "$SR" commit -qm addsub
+  printf 'v2\n' >"$SR/sub/s.txt"
+  run "S 서브모듈 pin"                        MATCH   bash "$T" pin "$SR" sm
+  printf 'v3\n' >"$SR/sub/s.txt"
+  run "S 서브모듈 워킹트리 변경 → WRONG"       WRONG   bash "$T" verify "$SR" sm
+  printf 'v2\n' >"$SR/sub/s.txt"
+  run "S 서브모듈 복원 → MATCH (판별력 컨트롤)" MATCH   bash "$T" verify "$SR" sm
+else
+  printf '  ⚠️  서브모듈 레인 skip — 이 git 이 file:// 서브모듈을 거부한다(미측정, 통과 아님)\n'
+fi
+
+# ── A: 오탐 — 빈 커밋은 **내용을 안 바꾼다**. 트리 해시를 쓰므로 MATCH 여야 한다 ────
+# ★앞 레인이 스테이징을 남겨 뒀다. 그대로 `--allow-empty` 하면 **그 스테이징이 커밋되어**
+#   트리가 실제로 바뀐다 — 초판에서 이 레인이 빨갰던 이유는 스크립트가 아니라 픽스처였다.
+git -C "$R" reset -q --hard HEAD
+bash "$T" pin "$R" emptycommit >/dev/null
+git -C "$R" commit --allow-empty -qm noop
+run "A 빈 커밋(같은 tree) → MATCH (오탐 아님)" MATCH  bash "$T" verify "$R" emptycommit
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 2번째 계열(agy, 2026-08-18)이 **다른 축**에서 뚫은 것 — codex 지적 목록을 주고 «그 밖»을
+# 요구했다. 계열을 나눈 것이 값을 냈다(같은 계열 둘이면 같은 사각이 남는다).
+# ══════════════════════════════════════════════════════════════════════════════
+echo
+echo "[target-freeze] 2번째 계열이 뚫은 축"
+
+# ── S: `GIT_DIR` 이 `git -C` 를 이긴다 — 엉뚱한 레포를 재고 «동결했다» 고 보고하던 것 ──
+OTHER="$WORK/other"; mkdir -p "$OTHER" && git init -q "$OTHER"
+git -C "$OTHER" config user.email t@t; git -C "$OTHER" config user.name t
+printf 'other\n' >"$OTHER/o.txt"; git -C "$OTHER" add -A; git -C "$OTHER" commit -qm other
+git -C "$R" reset -q --hard HEAD
+bash "$T" pin "$R" gitdir >/dev/null
+printf 'moved\n' >"$R/a.txt"
+# 환경변수가 살아 있으면 $R 이 아니라 $OTHER 를 재서 «변화 없음»(MATCH)이 나왔다.
+run "S GIT_DIR 오염 상태에서도 대상은 R → WRONG" WRONG \
+    env GIT_DIR="$OTHER/.git" GIT_WORK_TREE="$OTHER" bash "$T" verify "$R" gitdir
+git -C "$R" checkout -q -- a.txt
+run "S 오염 제거 후 복원 → MATCH (판별력 컨트롤)" MATCH bash "$T" verify "$R" gitdir
+
+# ── S: `_sha` 가 `| awk` 로 rc 를 잃던 것 — 해시 실패가 «빈 지문» 으로 접히면 MATCH ──────
+#    🟥 이 레인은 **되돌림 프로브가 만들었다**: `_sha` 의 rc 검사를 되돌렸는데 26 레인이
+#    전부 초록이었다 = 그 수리를 덮는 앵커가 하나도 없었다(장식 앵커). 계기가 스스로를
+#    못 재는 자리를 되돌림이 짚어낸 것이다.
+SHABIN="$WORK/shabin"; mkdir -p "$SHABIN"
+REALSHA=$(command -v shasum || true)
+if [ -n "$REALSHA" ]; then
+  printf '#!/usr/bin/env bash\ninput=$(cat)\ncase "$input" in boom*) exit 7 ;; esac\nprintf %%s "$input" | %q "$@"\n' "$REALSHA" >"$SHABIN/shasum"
+  chmod +x "$SHABIN/shasum"
+  git -C "$R" reset -q --hard HEAD
+  printf 'boom1\n' >"$R/u4.txt"
+  run "S 해시 도구 실패 → UNKNOWN (pin)"      UNKNOWN env PATH="$SHABIN:$PATH" bash "$T" pin "$R" shafail
+  rm -f "$R/u4.txt"
+  run "S 정상 도구로는 pin 됨 (판별력 컨트롤)" MATCH   bash "$T" pin "$R" shafail
+else
+  printf '  ⚠️  _sha 레인 skip — shasum 부재(미측정, 통과 아님)\n'
+fi
+
+# ── B: untracked 파일의 실행 비트 — 이 레포가 이미 데인 축 ────────────────────────
+printf '#!/bin/sh\necho hi\n' >"$R/u3.sh"; chmod 644 "$R/u3.sh"
+run "B 실행비트 pin"                        MATCH   bash "$T" pin "$R" execbit
+chmod +x "$R/u3.sh"
+run "B chmod +x → WRONG (내용은 그대로다)"   WRONG   bash "$T" verify "$R" execbit
+chmod 644 "$R/u3.sh"
+run "B 비트 복원 → MATCH (판별력 컨트롤)"    MATCH   bash "$T" verify "$R" execbit
+rm -f "$R/u3.sh"
+
+printf '\n[target-freeze] pass=%d fail=%d\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## 왜 (N=3, 운영자 승인 2026-08-17)

같은 결함이 하루에 세 번 났다: ① cross-family 리뷰에 **수리 이전** diff 발송 ② 리뷰 출력을 `tail` 로 잘라 지적·핀 유실 ③ 스캔 후 편집으로 라인 번호 밀림. 셋 다 「보낸 것/읽은 것이 지금 트리가 맞나」를 안 찍어서 생겼고, **산문 규율(`steel-quench §PIN THE TARGET`)은 이미 있었는데 세 번 다 안 걸렸다.**

## 🟥 이건 3번째 기계화 시도다 — 앞의 둘을 피해서 지었다

같은 SKILL.md 가 실패 2종을 기록해 뒀다:
- 훅 advisory → 마커 **100%에서 발화** = 배경 소음 → 제거
- `base-SHA + diff 줄 수` 지문 → **in-place 편집에 불변**(산문 수리의 기본 형태)이고 untracked 에 맹목 → 제거

⇒ 줄 수가 아니라 **패치 내용**을 해시하고, untracked 를 따로 세고, **훅에 안 건다**(발주자가 명시적으로 부르는 두 커맨드).

## 🟥 cross-family 2계열이 12건을 냈고, 그중 S급 3건이 fail-open 이었다

레인 **11/11 초록인 상태에서 뚫렸다** — 컨트롤 있음 ≠ 판별력 있음.

**codex(gpt-5.5)** — `_sha` 가 `| awk` 로 rc 소실 · `ls-files -o` 실패가 파이프에 먹혀 «untracked 없음»으로 접힘 · **라벨 문자치환 충돌(`a/b`≡`a_b`)로 핀한 적 없는 라벨이 MATCH** · 서브모듈 미검출 · 심볼릭 링크 재지정 미검출 · 빈 커밋 과탐

**agy(gemini)** — **`GIT_DIR`/`GIT_WORK_TREE` 가 `git -C` 를 이긴다**(엉뚱한 레포를 재고도 «동결했다» 고 보고) · untracked **실행 비트** 미검출 · TOCTOU «유령 지문» · 미초기화 서브모듈은 `foreach` 가 건너뜀 · `---` 구분자 경계 · `foreach` 의 `;` rc 소실

★ **겹친 지적 0.** agy 에는 codex 지적 목록을 주고 «그 밖의 축» 을 요구했다 — 계열을 나눈 것이 값을 냈다.
★ 전부 **직접 재현 확인 후** 수리(사이드카 산출은 미신뢰 입력).

## 🟥 되돌림 프로브가 장식 앵커를 하나 잡았다 — 그리고 그 판정이 세 갈래였다

`_sha` rc 수리를 되돌렸는데 **26 레인 전부 초록** = 앵커 0개. 레인을 신설하고 다시 걸었는데 **여전히 초록** — 방어가 **두 겹**이었기 때문이고, 둘을 다 걷었을 때 **정확히 그 레인 하나만** 적색이 됐다.

⇒ 되돌림 「초록」의 값은 셋이다: `ⓐ 장식` / `ⓑ 레인이 딴 걸 잼` / `ⓒ 방어 중복`. **한 겹씩 늘려가며** 걸어야 갈린다.

## 배선

- `steel-quench §PIN THE TARGET` — 3-command 산문 → 두 커맨드. SELF-ATTESTED 잔여 블록은 지우지 않고 «HISTORICAL» 로 표시하고 위에 실측을 얹었다
- `auto-decorrelation Step 5` — 드롭 사유 확장. `rc 1` = **그 라운드 전체 무효화**(개별 finding 이 아니다: 트리가 움직였으면 어느 것이 살아남는지가 출력에서 결정 불가)
- `package.json files[]` — 출하 문서가 지시하는데 패키지에 없던 스크립트 2개(`package_coverage_check.sh` 가 잡았다)

## 첫 실사용에서 실제로 발화했다

caller-zero 스캐너 제작을 격리 위임하면서 핀을 걸었는데, 회수 시 **`WRONG-TARGET`** 이 떴다(발주 중 커밋 3건이 들어갔다). 위임분이 stale 판정을 들고 오지 않고 현재 트리에서 전량 재실행했다.

## 검증

레인 **28/28** · 판별력 컨트롤 10건(복원 후 MATCH: in-place·untracked·심볼릭링크·서브모듈·GIT_DIR·실행비트·해시도구)

## 명시된 잔여

- **인라인 바이트는 안 잰다** — 사이드카에 파일을 stdin 으로 붙여 보내는 경로에서 «내가 실제로 보낸 것» 의 결박은 여전히 없다
- **소비자 install 실행 반쪽 없음** — 팩된 산출물을 깨끗한 install 에 풀어 돌리는 레인이 없다(마커 `standpoint: DEGRADED_NOT_RUN`)
- **하네스 단위 peer-review(ⓓ②) 미실시** — 선행자산 스캔(①)만 했다