### PR TITLE
log(dispatch): 원정 디스패치 원장 16건 — 브랜치에 갇혀 있던 기록을 main 으로

### DIFF
--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -2206,3 +2206,50 @@
   outcome: accepted
   evidence: "**6건 · codex 와 겹친 지적 0.** 최상위는 `GIT_DIR`/`GIT_WORK_TREE` 가 `git -C` 를 이긴다 — **엉뚱한 레포를 재고도 «동결했다» 고 보고**한다(계기가 대상을 틀리는 형태). 그 외 untracked **실행 비트** 미검출(이 레포가 이미 데인 축) · TOCTOU «유령 지문» · 미초기화 서브모듈은 `foreach` 가 건너뜀 · `---` 구분자 경계 · `foreach` 의 `;` rc 소실. 전부 수리, 레인 11→28. ⇒ **계열 분리가 값을 냈다** — 이 6건은 codex 를 한 번 더 돌려서는 안 나온다"
   cost: ~35k tokens
+  agent: general-purpose (isolated) ×3 — 원정 1차 정찰 (qasp rule 세트 · FH 등록 바 · clawd 후보 A)
+  purpose: "원정 착수 전 3면 동시 정찰. 노드 선언 성립성 / 등록 바가 기계로 강제하는 것 / 외부 기여 후보 실태"
+  outcome: accepted
+  evidence: "3팔 전부 근거명령 동반. ⓐ qasp: 진입점 실재(python -m 게이트 CLI 3종)·exit 이미 typed(0/1/2/3, 3=스캔0개 fail-closed)·known-pair 가 peer 테스트에 대조군 형태로 존재·FH grep 0히트 net-new. ⓑ FH 등록 바: .cap 파서 «네 벌» 헤더 주장을 실측 확인(6파일 언급 중 실제 파싱 4) · M1~M6 각 검사 내용 · test_adapter_lanes.sh 는 **하드코딩**(자동발견 없음) · cluster_capability_scan 은 재귀 find 라 자동. 🟥 여기서 부수로 «.cap 이 pre-commit HEAVY/CARVEOUT/LIGHT 어디에도 없다»가 나왔고 그게 이 세션 최대 FH 발견의 실마리였다. ⓒ clawd 후보 A: **반증** — 이미 호출부 12곳 + 전용 테스트 766줄, 「앵커 갭」 아님. 카드 등재 후보가 미조사였음이 드러남"
+  cost: 405k tokens (3팔 합)
+- date: 2026-08-17
+  agent: general-purpose (isolated) ×3 — clawd 기여 후보 평가 → 레인 구축 → 리베이스/재측정
+  purpose: "후보 A 기각 후 대체 후보(fix/validate-theme-*) 를 #888 바에 맞추기. 로컬 완주·되돌림 프로브·upstream 기준선 재측정"
+  outcome: accepted
+  evidence: "평가팔: 컨트롤 붙여 «main 도 동일 실패» 확인 → 이 diff 가 깬 것 0. 되돌림으로 «앵커가 장식이 아니라 **부재**» 확정(test/ 에 validate-theme 0건). 판정 «지금은 못 보낸다». 구축팔: spawnSync 실 CLI 기동 레인 5케이스 + 픽스처 근거 in-comment, 되돌림 3단 통과. 재측정팔: 🟥 **리베이스 전 수치가 PR 트리의 수치가 아니었다** — fork main(7커밋 뒤처짐) 59건 → upstream/main 30건. 운영자 지적(«리베이스부터 하고 재봐야») 이 없었으면 틀린 숫자가 PR 본문에 박힐 뻔했다. 리베이스 충돌 0, 차집합 양방향 공집합, upstream 파일 md5 일치로 선행수정 없음 확인"
+  cost: 420k tokens (3팔 합)
+- date: 2026-08-17
+  agent: general-purpose (isolated) ×2 — 입장 리뷰 정적 + 동적 (upstream 유지관리자 시점)
+  purpose: "운영자 지시 «입장리뷰는 정적 동적 모두». 정적=관례·호출부·문서·기존 테스트 관용구 / 동적=소비자 경로 실행·CI 로컬 재현·5입력 대조·재현성"
+  outcome: accepted
+  evidence: "🟥 **둘의 발견이 거의 안 겹쳤다** — 같은 축인데 정적/동적으로 갈리자 다른 것을 잡았다. 정적: exit 2 가 이 레포 다른 스크립트와 충돌 안 함을 grep 으로 확인 · 호출부 실측 · **문서 갭**(계약이 스크립트 헤더에만, README/가이드 없음) · 임시디렉토리 미정리. 판정 «수정 요청». 동적: 프로그램적 소비자 **0건** 실증 · 5입력 기준선 vs 브랜치 rc 대조표 · 3회반복/다른 cwd/TZ·LANG arm 전부 통과 · **누수 수치 실측 63→66(런당 +3)**. 정적이 «정리 안 함»을 지적하고 동적이 그 수치를 냈다"
+  cost: 250k tokens (2팔 합)
+- date: 2026-08-17
+  agent: general-purpose (isolated) — 3자대면 (스펙 ↔ 구현 ↔ TC)
+  purpose: "우리가 TC 를 새로 썼으므로 출제자=응시자. 구현의 process.exit 전수 열거로 «TC 가 안 덮는 종료 경로»를 강제 탐색"
+  outcome: accepted
+  evidence: "🟥 **이 세션 최대 발견 — 다른 세 축이 전부 놓쳤다.** theme.json 이 파싱되지만 객체가 아닌 값(null/숫자/문자열/불리언)이면 130줄에서 uncaught TypeError → **Node 기본 종료 exit 1**. 1 은 이 PR 이 방금 「검증했고 오류 있음」이라 정의한 값인데 검증을 한 줄도 못 돌렸다 — **PR 이 자기 목적을 무효화한다**. 경계까지 실측: `[]` 는 객체라 크래시 안 하고 정상 exit 1(→ 가드는 isPlainObject 여야지 truthy 가 아니다). 추가로 catch 가 읽기실패를 「파싱 실패」로 오라벨(EISDIR 실측). 판정 «구조적 불일치», 수리는 3면 동시여야 한다고 지정"
+  cost: 125k tokens
+- date: 2026-08-17
+  agent: codex/gpt-5.5 (cross-family, headless) — clawd exit enum 변경 적대 리뷰
+  purpose: "exit code 계약 변경 = Load-Bearing 트리거. 「반증하라」로 발주 — exit 2 안전성·파괴성·테스트 트리비얼 만족 가능성·미재분류 경로·픽스처 취약성"
+  outcome: accepted
+  evidence: "다른 셋이 못 잡은 것 2건: 인자 파서가 값 없는 `--assets` 를 조용히 무시 → **exit 0 가능**(헤더의 「bad usage=2」와 정면 충돌) · `--assets /오타` 가 exit 1 로 렌더(검증이 의도한 애셋에 안 돌았는데). 그리고 유일하게 **위험을 해소**한 축 — exit 2 안전성을 1차 출처 3개(nodejs.org process exit codes · docs.npmjs.com scripts exiting · GH Actions exit codes)로 확인. 내가 「아마 괜찮겠지」로 넘어간 자리였다"
+  cost: 68k tokens
+- date: 2026-08-17
+  agent: general-purpose (isolated) — clawd 통합 수리 (결함 5종 3면 동시)
+  purpose: "네 리뷰의 findings 를 한 번에 수리. 결함별로 구현+스펙헤더+TC 를 같은 커밋에"
+  outcome: accepted
+  evidence: "6커밋. 되돌림 프로브 4개 전부 «정확히 그것만» 확인 — 객체 가드 되돌리자 null/숫자/문자열/불리언 4케이스만 적색이고 **`[]` 컨트롤은 초록 유지**(가드가 과하게 안 넓다는 증거). 기존 관용구 준수(isPlainObject 재사용·install.test.js 의 afterEach 정리 패턴). 누수 재측정 96→96(순증 0, 이전 +3/런). 🟡 팔의 차집합 보고가 33 이었는데 거버너 재측정은 37 — **또 숫자가 갈렸다**. 판정에 쓰는 건 차집합(양방향 공집합)이라 영향 없었고, 그래서 PR 본문에 건수를 안 썼다"
+  cost: 216k tokens
+- date: 2026-08-17
+  agent: general-purpose (isolated) — 축 선언 원장 부착점 3후보 known-pair 측정
+  purpose: "이 세션 자신의 축 누락(ⓐⓑⓓ 미실행)에 대한 처방의 **전제 측정**. 짓지 않는 것이 명시 지시"
+  outcome: accepted
+  evidence: "🟥 **결론이 «셋 다 이 사건 모양을 못 잡는다»** — 그리고 그게 이 측정의 값이다(안 재고 지었으면 못 막는 게이트를 얹고 닫았다고 적었을 것). ⓐ close-check: `gh pr list --author @me` 가 **cwd remote 스코프**라 외부 레포 미조회 · ⓑ gh 래퍼: known-pair 는 갈리나(BLOCK exit1 / 통과 exit0) 미설치 + **절대경로 호출로 무음 우회** 실측 · ⓒ pre-commit: **구조적 불가** — clawd-on-desk 는 core.hooksPath 미설정·.git/hooks/pre-commit 부재라 FH 훅이 볼 수 없다. 부수 발견: **CLAUDE.md ①-b 가 `gh search prs` cross-repo 를 배선된 것처럼 서술하는데 스크립트엔 0히트**(문서-코드 드리프트)"
+  cost: 131k tokens
+- date: 2026-08-17
+  agent: general-purpose (isolated) — qasp 노드 M6 `writes:` 실행 관측
+  purpose: "소스 grep 이 write 0히트였으나 거버너 실행에서 import 부작용(기동 시 경고 출력)이 드러남. 선언이 아니라 실측으로 정해야 함"
+  outcome: accepted
+  evidence: "🟥 **warm-cache 아티팩트를 잡았다.** peer 실제 트리 5축 diff 는 전부 공집합 → 이 머신에서 M6 돌렸으면 거짓 `read-only` 가 통과했을 것. cold checkout 격리 클론에서: arm A `바이트코드 캐시 0→5 디렉토리 · 0→18 파일 · 런타임 디렉토리 3개 생성` / arm B(PYTHONDONTWRITEBYTECODE=1) `바이트코드는 0→0 이지만 런타임 디렉토리 3개는 여전히 생성`. 기전 = peer 의 설정 모듈이 import 시점에 «필요 디렉토리 보장» 루틴을 무조건 실행(감사 모듈 import 체인 경유). known-positive 컨트롤로 계기 생존 확인. 문제의 기동 경고는 소스 직독으로 in-memory 전용 확인(grep 부재 아님). ⇒ 정직한 선언은 `write-local`(닫힌 enum: read-only|write-local|write-remote — 팔이 제안한 산문은 HARNESS_ERROR 로 떨어졌을 것, 거버너가 확인)"
+  cost: 144k tokens

--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -2206,6 +2206,7 @@
   outcome: accepted
   evidence: "**6건 · codex 와 겹친 지적 0.** 최상위는 `GIT_DIR`/`GIT_WORK_TREE` 가 `git -C` 를 이긴다 — **엉뚱한 레포를 재고도 «동결했다» 고 보고**한다(계기가 대상을 틀리는 형태). 그 외 untracked **실행 비트** 미검출(이 레포가 이미 데인 축) · TOCTOU «유령 지문» · 미초기화 서브모듈은 `foreach` 가 건너뜀 · `---` 구분자 경계 · `foreach` 의 `;` rc 소실. 전부 수리, 레인 11→28. ⇒ **계열 분리가 값을 냈다** — 이 6건은 codex 를 한 번 더 돌려서는 안 나온다"
   cost: ~35k tokens
+- date: 2026-08-17
   agent: general-purpose (isolated) ×3 — 원정 1차 정찰 (qasp rule 세트 · FH 등록 바 · clawd 후보 A)
   purpose: "원정 착수 전 3면 동시 정찰. 노드 선언 성립성 / 등록 바가 기계로 강제하는 것 / 외부 기여 후보 실태"
   outcome: accepted
@@ -2253,3 +2254,21 @@
   outcome: accepted
   evidence: "🟥 **warm-cache 아티팩트를 잡았다.** peer 실제 트리 5축 diff 는 전부 공집합 → 이 머신에서 M6 돌렸으면 거짓 `read-only` 가 통과했을 것. cold checkout 격리 클론에서: arm A `바이트코드 캐시 0→5 디렉토리 · 0→18 파일 · 런타임 디렉토리 3개 생성` / arm B(PYTHONDONTWRITEBYTECODE=1) `바이트코드는 0→0 이지만 런타임 디렉토리 3개는 여전히 생성`. 기전 = peer 의 설정 모듈이 import 시점에 «필요 디렉토리 보장» 루틴을 무조건 실행(감사 모듈 import 체인 경유). known-positive 컨트롤로 계기 생존 확인. 문제의 기동 경고는 소스 직독으로 in-memory 전용 확인(grep 부재 아님). ⇒ 정직한 선언은 `write-local`(닫힌 enum: read-only|write-local|write-remote — 팔이 제안한 산문은 HARNESS_ERROR 로 떨어졌을 것, 거버너가 확인)"
   cost: 144k tokens
+
+- date: 2026-08-18
+  agent: codex/gpt-5.5 + agy/gemini-3.1-pro-high (cross-family sidecars, 2 families)
+  model: opus (orchestrator)
+  purpose: "Adversarial review of an outbound PR to a third-party repo (clawd-on-desk #892) before force-push — CLI arg-parser hardening + exit-code contract removal, reshaped at maintainer request"
+  prompt_summary: "Arm 1 (codex): given the diff + the maintainer's written request, find scope creep, parser regressions, and vacuous tests. Arm 2 (agy): given codex's findings first, explicitly required to find a DIFFERENT axis."
+  outcome: accepted
+  finding: "Both arms BLOCK. codex: strict parsing made a path beginning with '-' unreachable (2 forms) — a real regression vs upstream main, plus silent last-wins on a repeated flag and a flattened stat-error message. agy on a different axis: switching the guard to `=== null` let an EMPTY-STRING path through, so `path.resolve('')` sent the validator at the caller's cwd. All 4 reproduced by hand against upstream main before acting; all fixed with tests."
+  note: "🟥 Orchestrator self-detection was ZERO on all of them — the author wrote every one of these lines. BUT the run does NOT test family diversity: arm 2 was handed arm 1's findings plus a steer, so the manipulated variable was WHAT IT RECEIVED, not its family. No same-family control was run either, so even codex's catch cannot be attributed to family rather than to a second pair of eyes. Cite as evidence for the receives-different-input axis, never as evidence that mixing families works."
+
+- date: 2026-08-18
+  agent: fh-meta:beginner (4 rounds, same agent resumed)
+  model: inherited
+  purpose: "Cold-read the outbound PR follow-up comment as the maintainer, before posting — natural-voice check plus does-it-answer-the-ask"
+  prompt_summary: "Read the drafted comment cold as the maintainer who wrote the request; quote before judging; report findings only, no rewriting. Rounds 2-4 re-read the repaired text with the changelog of what was edited."
+  outcome: accepted
+  finding: "R1 caught a whole missing item — the maintainer had explicitly asked to KEEP the malformed-top-level-JSON fix and the draft never confirmed it — plus unprompted flattery and a matched rhetorical headline pair. R2/R3 each found NEW defects introduced by the previous round's repair (a contradiction seam between two sections; a dangling 'same way as last time' reference with no antecedent for the reader). R4 clean, so the loop closed on new-findings-0 AND text-unchanged."
+  note: "Two data points for repair-is-a-defect-source inside one hour, both self-detection ZERO. Honest limit: an in-repo subagent inherits project instructions, so this is WEAK isolation by this hub's own standard — a repo-external headless run would be the strong form."


### PR DESCRIPTION
## 왜 지금

푸시 때 마감검사기 ④-e 가 **「오늘 디스패치 57건 · 원장 엔트리 0건」**으로 빨갛다. 조사해 보니
엔트리가 **없는 게 아니라 브랜치 둘에 갇혀 있었다** — 원정 1차(08-17)와 원정 후속(08-18) 기록이
각각 푸시만 되고 PR 이 안 났다. 이 PR 이 그 둘을 main 으로 올린다.

```
d5a6b0f  원정 1차   서브에이전트 12건 + 사이드카 1건 → 엔트리 8개(×N 통합분 포함)
2b54889  원정 후속  디스패치 3건                    → 엔트리 2개
```

⚠️ **57 을 다 덮지 못한다.** 이 둘의 합은 16 dispatch 이고 57 은 이 체크아웃의 **오늘 전 세션
합계**다. 나머지는 다른 세션 소관이라 대신 쓰지 않았다 — 지어낸 `outcome`/`evidence` 는 60/40
승급 게이트를 누락보다 더 나쁘게 오염시킨다(`CLAUDE.md §Invocation log obligation` 이 훅이
기록을 대신 쓰지 않는 이유로 명시한 바로 그것).

## 병합 방식 — union, 그리고 그 과정에서 낸 결함 1건

두 브랜치 모두 같은 append-only 원장의 **같은 지점**에 붙어서 cherry-pick 이 두 번 다 충돌했다.
append-only 원장이므로 **union 으로 해소**했다(어느 쪽도 버리지 않는다).

🟥 **그런데 union 이 엔트리 하나를 조용히 삼켰다.** 충돌 구간의 경계가 엔트리 중간(`- date:` 는
공통 컨텍스트, `agent:` 부터가 분기)이라, 마커를 걷어내자 한 엔트리의 `agent:` 이하가 **앞
엔트리 몸통에 붙어** 버렸다 — YAML 은 정상 파싱되고(중복 키는 마지막이 이긴다) 엔트리 수만 1
줄었다. **조용한 손실**이다.

검출은 **대조군**으로 했다 — 같은 검사기를 `main` 에도 돌렸다:

```
main   엔트리 196   agent키0 57   agent키2+ 0     ← 57 은 옛 스키마(정상)
직후   엔트리 205   agent키0 57   agent키2+ 1     ← 이 1 이 결함
수리후 엔트리 206   agent키0 57   agent키2+ 0     ← 196+8+2 = 206 ✅
```

대조군 없이 「agent 키 없는 엔트리 58개」만 봤으면 **옛 스키마를 결함으로 오판**했을 것이다
(`[[feedback_absence_measurement_needs_control]]`).

## 검증

- `yaml.safe_load` 통과, 엔트리 **206 = 196(main) + 8 + 2** — 산술로 손실 0 확인
- 4축 게이트 통과(두 커밋 모두), Privacy · Confidentiality PASS

axes-run: ⓒ격리 그라운딩(대조군 대비 엔트리 수 검증) · 나머지 미실행 — 기록 추가 전용, 로직 변경 0
crossfamily: not-applicable — 판정 enum·게이트·비가역 경로 무변경
standpoint: not-applicable — 소비자 게이트 수용·세션 지시 무변경(Q0-ⓑ 불성립)
