### PR TITLE
docs(standpoint): 입장 축은 격리의 «하네스 단위» 확장이다 — 운영자 통찰 기록

### DIFF
--- a/knowledge/shared/harness-core/field_verdict_crossfamily_gate.md
+++ b/knowledge/shared/harness-core/field_verdict_crossfamily_gate.md
@@ -159,6 +159,37 @@ changes which ground truth the review is checked against — they are orthogonal
 that maxes out the first while leaving the second at zero has not raised its coverage of
 standpoint-dependent defects at all.*
 
+**Relationship to the isolation axis — standpoint is isolation whose scope moved up to the
+harness (operator, 2026-08-18).** Operator wording: *"요는 이것도 '격리' 프레이밍이 하네스 단위로
+확장되는 거지 … 그 하네스 자체의 입장을 돌리는 거니까 (하네스라는 껍질에 모델이라는 알맹이를
+넣어서 자신이 직접 돌아가게 하니까)."*
+
+The ⓒ isolation axis is normally scoped to a **session**: run the reviewer where the author's
+context cannot reach it — outside the repo, so repo-level instructions are not inherited. `tier2`+
+standpoint makes the same move one scope up: rather than isolating a session from the author's
+context, **boot the target harness itself** — its shell, a model as the filling — and let it run.
+What is isolated is no longer a session but an entire harness's operating context.
+
+This is also the answer to the question the axis reliably draws — *"how is that different from just
+running it in the target repo myself, which I already do before opening a PR?"* Running it yourself
+carries your own assumptions into the run; the harness running itself does not. That is the same
+failure the session-scoped isolation axis already records (a reviewer spawned inside the repo
+inherits that repo's instructions regardless of the prompt), one scope up.
+
+⚠️ **A framing, not an identity — do not collapse the two axes.** Axis membership is decided by
+*what the reviewer receives* (`fh_three_layer_canon.md §1-a`): ⓒ receives the author's sentences
+plus the current tree, ⓑ receives the target's own canon. Raising isolation scope to the harness
+**also swaps the input** — you cannot boot the target harness without it reading its own canon — so
+ⓑ is *isolation-scope expansion accompanied by input replacement*. That accompaniment is why it
+stays a separate axis instead of becoming a tier of ⓒ.
+
+🚫 **Do not describe this as role-play or persona assignment.** *"Act as if you were harness X"* is
+exactly the prompt-level disguise that isolation failures already refuted; booting the shell is its
+opposite. The tier ladder encodes the distinction — `tier2b` (same operator, target's real runtime,
+local wiring visible) sits below `tier3` (a different operator of the target harness runs it)
+precisely because the remaining gap is *whose context is still in the room*, not what the reviewer
+was told to pretend.
+
 **Why the same author cannot close this by working inside the target repo and opening the PR
 there — corrected framing (2026-08-14, after a cross-harness standpoint review of this section
 itself).** The claim is *not* "the author is structurally blind to their own work" — a controlled


### PR DESCRIPTION
## 무엇

`field_verdict_crossfamily_gate.md §7` 에 운영자 통찰(2026-08-18) 한 절 추가. 31줄, 한 파일,
**규칙·enum·게이트 변경 0** — 이미 있는 축이 *왜* 별도 축인지를 적는다.

요지: ⓒ격리 축은 보통 **세션** 스코프다(저자 컨텍스트가 닿지 않는 곳에서 리뷰어를 돌린다).
`tier2`+ 입장 축은 같은 동작을 **한 스코프 위**에서 한다 — 세션을 격리하는 대신 **대상 하네스
자체를 부팅**한다(껍질은 하네스, 알맹이는 모델). 격리되는 것이 세션이 아니라 하네스의 운영
컨텍스트 전체가 된다.

그리고 이게 이 축이 반복해서 부르는 질문 — *"그거 그냥 내가 대상 레포에서 돌려보는 거랑 뭐가
다른가"* — 의 답이다. **내가 돌리면 내 가정이 실려 간다. 하네스가 자기를 돌리면 안 실린다.**

## 두 개의 가드가 본문에 박혀 있다

- ⚠️ **프레이밍이지 동일시가 아니다** — 축 소속은 *리뷰어가 무엇을 받는가*로 갈린다
  (`fh_three_layer_canon.md §1-a`). 격리 스코프를 하네스로 올리면 **입력도 함께 바뀌므로**
  (대상 정본을 안 읽고는 부팅이 안 된다) ⓑ 는 ⓒ 의 티어가 아니라 계속 별도 축이다
- 🚫 **역할극·빙의로 서술 금지** — *"하네스 X 인 것처럼 행동하라"* 는 격리 실패가 이미 반증한
  프롬프트 층 위장이고, 껍질을 부팅하는 건 그 반대다. `tier2b` < `tier3` 의 순서가 그 구분을
  인코딩한다(남은 격차는 «누구의 컨텍스트가 아직 방에 있나»지 «무엇을 연기하라 했나»가 아님)

## 이력 · 귀속

- 원 커밋 `c9bb7e4`(08-18 오전)가 `docs/standpoint-isolation-scope` 에 푸시돼 있었으나 **PR 이 안
  열려 main 에 못 올라왔다.** 오래된 base 위라 force-push 대신 **main 에서 새로 잘라
  cherry-pick** 했다(파기 게이트 회피, 충돌 0)
- 🟥 **세션 카드에는 이 건이 «peer 가 §7 Field-evidence 작업 때 처리 합의» 로 적혀 있다.**
  peer 세션이 1개로 정리되면서 그 합의의 수행자가 사라졌다고 판단해 이 세션이 연다. 그 peer 가
  §7 에 별도 델타를 갖고 있다면 **이 PR 위에 얹는 편이 낫다** — 되돌리는 것보다.

## 검증 잔여 (정직하게)

- 이 PR 은 원 커밋을 **내용 변경 없이** 옮긴 것이라 4축은 원 커밋 시점 판정을 상속한다.
  🟥 **clean cherry-pick 은 pre-commit 을 실행하지 않는다**(충돌 시 `--continue` 만 실행한다) —
  즉 이 브랜치에서 게이트가 다시 돌지는 않았다. 별도 관찰로 기록해 둔다
- crossfamily: not-applicable — 판정 enum·게이트·비가역 경로 무변경
- standpoint: `tier1` — 내용 전용. 🟥 이 절 자체가 입장 축을 서술하지만 그것이 이 델타를
  `tier2` 로 만들지 않는다(무엇을 서술하느냐 ≠ 무엇을 실행했느냐). 아무것도 부팅하지 않았다
