### PR TITLE
fix(claim): 기본 워크플로에 «claim» 을 넣고 이미 있는 branch_claim.sh 를 가리킨다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,7 +355,29 @@ The forge-harness hub has a dual identity: **(a) a seed for others** + **(b) you
 - AI may commit and push automatically (when changes are approved) — **to a feature branch, never to the integration branch**
 - **PR creation requires explicit user request** ("create PR", "PR 올려줘", "pull request")
 - **Reason:** Prevents PR fragmentation — logical units should be grouped into meaningful PRs, not atomized per commit
-- Default workflow: branch → commit → push branch → wait for explicit PR request
+- Default workflow: **claim** → branch → commit → push branch → wait for explicit PR request
+
+🟥 **공유 체크아웃에서는 브랜치를 «잡는» 단계가 별도로 있다 — 그리고 그 기계는 이미 있다**
+(2026-08-18 실측 신설). 세션 여럿이 **한 체크아웃**을 쓰면 HEAD 는 하나뿐이라, 남이 옮기면
+내 발밑이 바뀐다. 순서는 이렇다:
+
+```
+switch 직전   git branch --show-current          ← 실시간 HEAD. claim 파일이 아니다
+자른 직후     git log main..HEAD --oneline       ← 0 줄이 아니면 남의 커밋 위에 앉았다
+잡을 때       bash scripts/branch_claim.sh claim ← 이 줄이 없으면 pre-commit 이 막는다
+확인          bash scripts/branch_claim.sh check
+```
+
+🟥 **`.git/fh-claims/*` 를 읽는 것만으로는 못 막는다** — claim 은 lock 이 아니라 **쓰여진 시점의
+스냅샷**이고, 남이 브랜치를 옮겨도 내 파일은 안 바뀐다. **자기 세션에 대해서도 거짓말한다**(실측:
+claim 이 `main` 인 동안 실제 HEAD 는 peer 브랜치였다 — 두 세션이 독립 재현). 그래서 판별자는
+파일이 아니라 **위 두 줄의 실시간 실행**이고, claim 은 *기록하는* 명령으로만 쓴다.
+
+**남은 잔여 둘, 이름으로 남긴다**: ⓐ 게이트는 **커밋 시점**이라 `switch -c` 사고 자체는 못 막는다
+(그래서 위 두 줄이 여전히 사람 몫이다 — [[feedback_gate_binding_point_not_check_point]])
+ⓑ 반대 방향 — 내가 브랜치를 쥔 동안 남이 되돌리고 커밋하면 **내 staged 파일이 index 에 살아
+있다.** 실측 사례에서 안 섞인 것은 그 세션이 파일 지정 `add` 를 썼기 때문이지 게이트 덕이 아니다.
+⇒ **공유 체크아웃에서 `git add -A` 금지**([[feedback_shared_checkout_ops_touch_others_work]]).
 
 **Integration branch is PR-only** (operator decision 2026-07-20). Never `git push origin main`
 directly. Normal path: `git switch -c <branch>` → push the branch → `gh pr create` → after review


### PR DESCRIPTION
## 한 줄

**신설이 아니라 포인터 수리다** (신규 코드 0 줄). 기계는 이미 다 있었고, **산문이 그 이름을 안 불렀다.**

## 기원 — 내가 낸 팬텀

같은 세션에서 신호에 「claim 갱신 경로가 없다 / pre-commit 후보는 아직 안 지어졌다」고 적었다. **거짓이다.** 실측:

```
scripts/branch_claim.sh              19778B, +x, 실재
templates/.git-hooks/pre-commit      branch-claim 검사 + TOCTOU 재검 둘 다
scripts/test_branch_claim_lanes.sh   레인 실재
branch_claim.sh check                rc=1 — 실제 발화 (HEAD≠claim 상태에서)
컨트롤(있을 수 없는 문자열)          무히트 = 그물이 무차별 아님
```

그리고 **그 훅이 같은 세션에서 내 커밋을 실제로 막았다.** 부재를 주장하면서 컨트롤을 안 돌린 결과이고, peer 세션은 그 위에 «기계화 후보» 를 얹어 한 단계 더 퍼뜨렸다 — 둘 다 정정했다.

원인은 **규칙이 claim 파일을 「읽어라」고만 하고 「갱신해라」를 안 적은 것**이다. 그래서 두 세션이 독립적으로 같은 거짓 결론에 도달했다.

## 무엇을 바꾸나 (`CLAUDE.md`, +23/-1, 산문만)

`Default workflow: branch → …` 에 **claim** 단계를 넣고 명령 4줄을 명시:

| 시점 | 명령 |
|---|---|
| switch 직전 | `git branch --show-current` ← 실시간 HEAD, claim 파일이 아니다 |
| 자른 직후 | `git log main..HEAD --oneline` ← 0 줄이 아니면 남의 커밋 위 |
| 잡을 때 | `bash scripts/branch_claim.sh claim` |
| 확인 | `bash scripts/branch_claim.sh check` |

🟥 **`.git/fh-claims/*` 를 읽는 것만으로는 못 막는다** — claim 은 lock 이 아니라 스냅샷이고 **자기 세션에 대해서도 거짓말한다**(두 세션 독립 재현: claim 이 `main` 인 동안 실제 HEAD 는 peer 브랜치).

## 이름으로 남긴 잔여 둘

- ⓐ 게이트가 **커밋 시점**이라 `switch -c` 사고 자체는 못 막는다 — 그래서 위 두 줄이 여전히 사람 몫이다.
- ⓑ **반대 방향** — 내가 브랜치를 쥔 동안 남이 되돌리고 커밋하면 내 staged 파일이 index 에 산다. 실측 사례에서 **안 섞인 건 그 세션이 파일 지정 `add` 를 썼기 때문이지 게이트 덕이 아니다** ⇒ 공유 체크아웃에서 `git add -A` 금지.

## 정직한 잔여 (검증 쪽)

- `crossfamily: DEGRADED_PANEL_UNUSED` — 사이드카 도달 가능했으나 안 돌렸다. 주장이 «이 스크립트가 존재하고 이렇게 발화한다» 뿐이고 이 머신에서 **rc=1 차단 / claim 후 통과** 2상태로 직접 관측했다. 계열이 더할 해상도가 없다는 **판단 자체는 미검증**이다.
- 🟥 **플로어 티어 sim 미실시** — 살리언스 의존 델타인데 안 돌렸다. 같은 세션의 #442 와 달리 «Skeleton, Not Muscle» 을 여기선 안 지켰고 감추지 않는다.
- **되돌림 프로브 없음** — 산문이라 빨개지는 레인이 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)