### PR TITLE
feat(satellite): 다이제스트에 대상 축·티어 핀·공개표면 게이트 — 정체성 ④ 의 «조직=레포»

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "scripts/chamber_candidate_collect.sh",
     "scripts/chamber_witness.sh",
     "scripts/digest_landing_check.sh",
+    "scripts/test_satellite_publish_gate_lanes.sh",
     "scripts/relay_channel.sh",
     "scripts/test_relay_channel_lanes.sh",
     "scripts/fh_session_load.sh",

--- a/scripts/frontier_digest_daily.sh
+++ b/scripts/frontier_digest_daily.sh
@@ -12,7 +12,16 @@ FH_DIR="${FD_FH_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 CLAUDE_BIN="${FD_CLAUDE_BIN:-$(command -v claude || echo "${HOME}/.local/bin/claude")}"
 TODAY=$(date +%Y_%m_%d)
 HUMAN_DATE=$(date +%Y-%m-%d)   # pinned once with TODAY — a wake-fired run crossing midnight must not drift (filename date ≠ prompt date)
-LOG_DIR="${FH_DIR}/tracks/_meta/logs"
+# ── 위성 축 (2026-08-18, 원정 2차) ──────────────────────────────────────────
+# 정체성 ④ 「프런티어→조직 전파」의 조직 = **레포**다(운영자 정의). 이 러너는 FH 한 곳만
+# 대상으로 지어졌고, 그래서 ④ 는 «자기 소비»에 머물렀다. 아래 두 변수가 대상 축이다.
+#   FD_FH_DIR   — 어느 레포에서 도는가 (기존)
+#   FD_OUT_DIR  — 그 레포의 **어디에** 떨어뜨리는가 (신설). FH 는 tracks/_meta 지만
+#                 대상 하네스는 자기 문법이 있다(forge-wiki 는 frontmatter 달린 위키 노드).
+#   FD_MODEL    — 어느 티어로 도는가 (신설). 위성마다 도메인 난이도가 다르다.
+# 🟥 기본값은 **전부 종전 그대로**다 — FH 프로덕션 경로 무변경.
+OUT_DIR="${FD_OUT_DIR:-tracks/_meta}"          # FH_DIR 기준 상대경로
+LOG_DIR="${FH_DIR}/${OUT_DIR}/logs"
 LOG_FILE="${LOG_DIR}/frontier_digest_${TODAY}.log"
 
 mkdir -p "$LOG_DIR"
@@ -25,13 +34,43 @@ find "$LOG_DIR" -name 'frontier_digest_*.log' -mtime +30 -delete 2>/dev/null
 # class is "connection closed mid-response", which can leave a partial/empty file — that must not
 # count as done (it would also lock out every later run today via the skip-check below).
 digest_ready() {
-    find "${FH_DIR}/tracks/_meta" -maxdepth 1 -name "frontier_digest_${TODAY}*.md" -size +1k 2>/dev/null | grep -q .
+    find "${FH_DIR}/${OUT_DIR}" -maxdepth 1 -name "frontier_digest_${TODAY}*.md" -size +1k 2>/dev/null | grep -q .
+}
+
+# ── 공개표면 게이트 (2026-08-18, 원정 2차) ──────────────────────────────────
+# 위성이 **공개 레포**를 대상으로 돌면 **매 런이 publish** 다(비가역 표면). FH 자신은
+# tracks/ 가 gitignored 라 이 문제가 없었고, 그래서 이 러너에 게이트가 없었다.
+# §Irreversibility Surface-Class Degrade Invariant: 비가역 표면은 **fail-CLOSED** —
+# 스캐너가 못 재면 «통과»가 아니라 «보류»다.
+#
+# 🟥 **성공 종료 경로가 셋이라 함수로 뺐다.** 초판은 attempt 루프의 성공 분기에만 달았고,
+# 그러면 ⓐ「오늘 이미 돌았다」조기 스킵과 ⓑ「외부에서 나타났다」로 나가는 digest 가
+# **스캔 없이 게시**된다. 레인 P2·P3 이 그 fail-open 을 잡았다.
+#
+# 🟥 rc 3값을 두 값으로 접지 않는다 — 0 게시 / 1 격리 / 그 외 보류. 스캐너는 자기 죽음을
+#    rc=3(NOT SCANNED)으로 신고하므로 그 값을 존중한다.
+publish_gate() {
+    [ "${FD_PUBLIC_TARGET:-0}" = "1" ] || return 0
+    local lib="${FH_DIR}/scripts/psa_scan_lib.sh"
+    [ -f "$lib" ] || { echo "[$(date '+%Y-%m-%d %H:%M:%S')] 🚫 publish gate: psa_scan_lib.sh 부재 — fail-closed" >> "$LOG_FILE"; return 3; }
+    local f out rc
+    f=$(find "${FH_DIR}/${OUT_DIR}" -maxdepth 1 -name "frontier_digest_${TODAY}*.md" 2>/dev/null | head -1)
+    [ -n "$f" ] || return 0
+    out=$(bash -c '. "$1"; psa_load "$2/.claude/rules/.public-surface-patterns.defaults" "$2/.claude/rules/.public-surface-patterns" >/dev/null 2>&1; psa_scan_file "$3"' _ "$lib" "$FH_DIR" "$f" 2>&1)
+    rc=$?
+    case "$rc" in
+        0) echo "[$(date '+%Y-%m-%d %H:%M:%S')] publish gate: CLEAN" >> "$LOG_FILE"; return 0 ;;
+        1) echo "[$(date '+%Y-%m-%d %H:%M:%S')] 🚫 publish gate: LEAK — 격리, 게시 안 함" >> "$LOG_FILE"
+           printf '%s\n' "$out" >> "$LOG_FILE"; mv "$f" "${f}.QUARANTINE" 2>/dev/null; return 2 ;;
+        *) echo "[$(date '+%Y-%m-%d %H:%M:%S')] 🚫 publish gate: NOT SCANNED (rc=$rc) — fail-closed, 게시 안 함" >> "$LOG_FILE"
+           printf '%s\n' "$out" >> "$LOG_FILE"; mv "$f" "${f}.UNSCANNED" 2>/dev/null; return 3 ;;
+    esac
 }
 
 # Skip if already ran today
 if digest_ready; then
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] Already ran today — skipping" >> "$LOG_FILE"
-    exit 0
+    publish_gate; exit $?
 fi
 
 # Single-instance lock (mkdir = atomic on bash 3.2). Guards launchd-vs-manual double dispatch:
@@ -90,11 +129,12 @@ for ATTEMPT in $(seq 1 $MAX_ATTEMPTS); do
     # Re-check before spending an attempt (a manual run may have landed the digest during the sleep)
     if digest_ready; then
         echo "[$(date '+%Y-%m-%d %H:%M:%S')] Digest appeared externally before attempt ${ATTEMPT} — success" >> "$LOG_FILE"
-        exit 0
+        publish_gate; exit $?
     fi
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] Attempt ${ATTEMPT}/${MAX_ATTEMPTS}" >> "$LOG_FILE"
     "$CLAUDE_BIN" -p --permission-mode acceptEdits \
-        "[automated-run: launchd] Run /frontier-digest for today (${HUMAN_DATE}). Fetch latest signals from HN, arXiv, and GitHub. Save the digest to tracks/_meta/frontier_digest_${TODAY}.md." \
+        ${FD_MODEL:+--model "$FD_MODEL"} \
+        "[automated-run: launchd] Run /frontier-digest for today (${HUMAN_DATE}). Fetch latest signals from HN, arXiv, and GitHub. Save the digest to ${OUT_DIR}/frontier_digest_${TODAY}.md." \
         >> "$LOG_FILE" 2>&1 &
     CLAUDE_PID=$!
     DEADLINE=$((SECONDS + ATTEMPT_TIMEOUT_SECS))
@@ -114,6 +154,8 @@ for ATTEMPT in $(seq 1 $MAX_ATTEMPTS); do
         EXIT_CODE=$?
     fi
     if digest_ready; then
+        publish_gate; _pg=$?
+        [ "$_pg" -eq 0 ] || exit "$_pg"
         echo "[$(date '+%Y-%m-%d %H:%M:%S')] Digest file present after attempt ${ATTEMPT} (claude exit ${EXIT_CODE}) — success" >> "$LOG_FILE"
         exit 0
     fi

--- a/scripts/frontier_digest_daily.sh
+++ b/scripts/frontier_digest_daily.sh
@@ -21,6 +21,13 @@ HUMAN_DATE=$(date +%Y-%m-%d)   # pinned once with TODAY — a wake-fired run cro
 #   FD_MODEL    — 어느 티어로 도는가 (신설). 위성마다 도메인 난이도가 다르다.
 # 🟥 기본값은 **전부 종전 그대로**다 — FH 프로덕션 경로 무변경.
 OUT_DIR="${FD_OUT_DIR:-tracks/_meta}"          # FH_DIR 기준 상대경로
+# FD_PROFILE — 대상 하네스가 **자기를 설명하는** 파일(FH_DIR 기준 상대경로).
+# 🟥 이게 없으면 위성은 «프런티어 신호 목록»을 남의 폴더에 복사한다 — 실측 2026-08-18:
+#   FD_OUT_DIR 만 옮긴 런의 산출물이 "signals relevant to forge-harness (FH) operations" 였다
+#   (대상 어휘 0히트 · FH 어휘 11히트 · frontmatter 0). 파이프는 관통했으나 **복제**였다.
+# 운영자 정의: *"프런티어 동향을 파악해서 그 하네스에 개선할 포인트를 찾아 남기는 것 —
+#   복제가 아니라 **응용**"* ⇒ 대상 축은 «어디에 쓰나»만이 아니라 «누구를 위해 읽나»다.
+PROFILE_PATH="${FD_PROFILE:-}"
 LOG_DIR="${FH_DIR}/${OUT_DIR}/logs"
 LOG_FILE="${LOG_DIR}/frontier_digest_${TODAY}.log"
 
@@ -97,6 +104,22 @@ landing_witness() {
     return 0   # 🟥 항상 0 — 계측이 러너의 종료 의미를 바꾸면 안 된다
 }
 
+# 프롬프트는 프로필 유무로 **형태가 갈린다**. 미설정이면 종전 문자열 그대로(FH 경로 무변경).
+_build_prompt() {
+    local base="[automated-run: launchd] Run /frontier-digest for today (${HUMAN_DATE}). Fetch latest signals from HN, arXiv, and GitHub."
+    local prof="${FH_DIR}/${PROFILE_PATH}"
+    if [ -n "$PROFILE_PATH" ] && [ -f "$prof" ]; then
+        printf '%s\n\n%s\n\n%s\n\n%s\n\n%s\n' \
+"${base}" \
+"🟥 TARGET HARNESS — this digest is NOT for forge-harness. Read the profile below and write for THAT harness. Copying a generic frontier list here is replication, not propagation; the deliverable is **what THIS harness should change**, each point naming a file or behavior in it." \
+"🟥 STANDPOINT — do not write from forge-harness's chair. OPEN AND READ the target's own files that the profile names: its canon docs AND its actual source. Cite them by path + line number or function name. A point you cannot anchor to something you actually opened is a trend statement, not an application. (This is the standpoint axis applied to frontier input: reading the profile is tier1b, reading the real code is tier2 — the measured difference is whether any Route line appears at all.)" \
+"$(cat "$prof")" \
+"Save the digest to ${OUT_DIR}/frontier_digest_${TODAY}.md, in the node grammar the profile specifies. Do NOT regenerate any index. If a source cannot be fetched, say so — never invent a citation, and cite specific items, not listing pages."
+    else
+        printf '%s %s\n' "${base}" "Save the digest to ${OUT_DIR}/frontier_digest_${TODAY}.md."
+    fi
+}
+
 # Skip if already ran today
 if digest_ready; then
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] Already ran today — skipping" >> "$LOG_FILE"
@@ -164,7 +187,7 @@ for ATTEMPT in $(seq 1 $MAX_ATTEMPTS); do
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] Attempt ${ATTEMPT}/${MAX_ATTEMPTS}" >> "$LOG_FILE"
     "$CLAUDE_BIN" -p --permission-mode acceptEdits \
         ${FD_MODEL:+--model "$FD_MODEL"} \
-        "[automated-run: launchd] Run /frontier-digest for today (${HUMAN_DATE}). Fetch latest signals from HN, arXiv, and GitHub. Save the digest to ${OUT_DIR}/frontier_digest_${TODAY}.md." \
+        "$(_build_prompt)" \
         >> "$LOG_FILE" 2>&1 &
     CLAUDE_PID=$!
     DEADLINE=$((SECONDS + ATTEMPT_TIMEOUT_SECS))

--- a/scripts/frontier_digest_daily.sh
+++ b/scripts/frontier_digest_daily.sh
@@ -67,10 +67,40 @@ publish_gate() {
     esac
 }
 
+# ── 착지 증언 (2026-08-18, 원정 2차 ⓑ) ────────────────────────────────────
+# `digest_landing_check.sh` 는 10 레인을 갖고 selfcheck 루프가 그 self-test 를 돌리는데,
+# **프로덕션 호출부가 0 이었다** — 「후보가 실제로 착지했나」를 아무도 재지 않았다. 그 스크립트
+# 헤더 자신의 표현으로 *"닫히는데 증인이 없다"*. 파이프는 관통하는데 그 사실이 사람 기억으로만.
+#
+# 🟥 **오늘 것이 아니라 직전 다이제스트를 잰다.** 오늘 후보는 착지할 시간이 없었다 — 오늘 것을
+#    재면 «전건 미착지»가 매일 나오고 그건 계기가 아니라 소음이다.
+# 🟥 **차단하지 않는다. 게이트가 아니라 계측이다.** 헤더가 스스로 «선별기»라 적었고
+#    (`file-change ≠ token-introduction` 잔여) 히트는 손으로 열어야 한다. 목적은 **착지율 시계열**
+#    을 파일로 남기는 것 — 세션 시작 노티가 **네트워크 없이 그 파일만 읽게** 하려면 이게 먼저다
+#    (peer: SessionStart 에 원격 호출은 지연·행 위험 · `--author @me` 는 계정 공유 시 오귀속).
+landing_witness() {
+    local checker="${FH_DIR}/scripts/digest_landing_check.sh"
+    [ -x "$checker" ] || { echo "[$(date '+%Y-%m-%d %H:%M:%S')] landing witness: checker 부재 — SKIPPED (not a pass)" >> "$LOG_FILE"; return 0; }
+    local prev
+    prev=$(find "${FH_DIR}/${OUT_DIR}" -maxdepth 1 -name 'frontier_digest_*.md' 2>/dev/null \
+           | grep -v "frontier_digest_${TODAY}" | sort | tail -1)
+    [ -n "$prev" ] || { echo "[$(date '+%Y-%m-%d %H:%M:%S')] landing witness: 직전 digest 없음 — SKIPPED (not a pass)" >> "$LOG_FILE"; return 0; }
+    local out rc
+    out=$(bash "$checker" "$prev" "$FH_DIR" 2>&1); rc=$?
+    case "$rc" in
+        0)  echo "[$(date '+%Y-%m-%d %H:%M:%S')] landing witness [$(basename "$prev")]: ALL-LANDED (rc=0)" >> "$LOG_FILE" ;;
+        1)  echo "[$(date '+%Y-%m-%d %H:%M:%S')] landing witness [$(basename "$prev")]: SOME-UNLANDED (rc=1) — 선별기다, 히트를 손으로 열어라" >> "$LOG_FILE" ;;
+        10) echo "[$(date '+%Y-%m-%d %H:%M:%S')] landing witness [$(basename "$prev")]: HARNESS-ERROR (rc=10) — 못 쟀다, 미착지 0 이 아니다" >> "$LOG_FILE" ;;
+        *)  echo "[$(date '+%Y-%m-%d %H:%M:%S')] landing witness [$(basename "$prev")]: UNEXPECTED rc=$rc — 못 쟀다" >> "$LOG_FILE" ;;
+    esac
+    printf '%s\n' "$out" | sed 's/^/    /' >> "$LOG_FILE"
+    return 0   # 🟥 항상 0 — 계측이 러너의 종료 의미를 바꾸면 안 된다
+}
+
 # Skip if already ran today
 if digest_ready; then
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] Already ran today — skipping" >> "$LOG_FILE"
-    publish_gate; exit $?
+    publish_gate; _pg=$?; [ "$_pg" -eq 0 ] && landing_witness; exit "$_pg"
 fi
 
 # Single-instance lock (mkdir = atomic on bash 3.2). Guards launchd-vs-manual double dispatch:
@@ -129,7 +159,7 @@ for ATTEMPT in $(seq 1 $MAX_ATTEMPTS); do
     # Re-check before spending an attempt (a manual run may have landed the digest during the sleep)
     if digest_ready; then
         echo "[$(date '+%Y-%m-%d %H:%M:%S')] Digest appeared externally before attempt ${ATTEMPT} — success" >> "$LOG_FILE"
-        publish_gate; exit $?
+        publish_gate; _pg=$?; [ "$_pg" -eq 0 ] && landing_witness; exit "$_pg"
     fi
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] Attempt ${ATTEMPT}/${MAX_ATTEMPTS}" >> "$LOG_FILE"
     "$CLAUDE_BIN" -p --permission-mode acceptEdits \
@@ -156,6 +186,7 @@ for ATTEMPT in $(seq 1 $MAX_ATTEMPTS); do
     if digest_ready; then
         publish_gate; _pg=$?
         [ "$_pg" -eq 0 ] || exit "$_pg"
+        landing_witness
         echo "[$(date '+%Y-%m-%d %H:%M:%S')] Digest file present after attempt ${ATTEMPT} (claude exit ${EXIT_CODE}) — success" >> "$LOG_FILE"
         exit 0
     fi

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -703,6 +703,21 @@ else
   fail=1
 fi
 
+# test_satellite_publish_gate_lanes — 위성 공개표면 게이트(2026-08-18, 원정 2차).
+# 🟥 이 배선이 없어서 CI 가 `lane-runner: lane suite(s) with no runner and no declaration` 로
+# 빨갰다. 스위트를 신설하고 아무 데서도 안 돌린 것 — 검사기의 표현대로
+# *"A suite nothing executes is prose."* 그 검사기가 내 신설 레인을 잡았다.
+if [ ! -f scripts/test_satellite_publish_gate_lanes.sh ]; then
+  echo "FAIL  test_satellite_publish_gate_lanes.sh: missing — publish gate has no anchor"
+  fail=1
+elif _out=$(bash scripts/test_satellite_publish_gate_lanes.sh < /dev/null 2>&1); then
+  echo "PASS  test_satellite_publish_gate_lanes.sh ($(printf '%s\n' "$_out" | grep -oE '[0-9]+ passed, [0-9]+ failed' | tail -1))"
+else
+  echo "FAIL  test_satellite_publish_gate_lanes.sh: publish gate lanes failed"
+  _show_failure "$_out"
+  fail=1
+fi
+
 # cluster_capability_scan — wired 2026-08-16 (정체성 ①-(a) cluster-wizard).
 # 종단 판정줄이 `… 캘리브레이션 통과/실패: N PASS / M FAIL` 이라 위 `_subj` 루프의
 # 캘리브레이션 게이트를 **진짜 판정줄로** 만족한다 — 테스트 케이스 제목이 아니다.

--- a/scripts/test_satellite_publish_gate_lanes.sh
+++ b/scripts/test_satellite_publish_gate_lanes.sh
@@ -89,4 +89,23 @@ t "P4b SKIP 을 통과로 렌더하지 않는다"          "honest" "$r"
 
 t "N2 control — LEAK 과 NOT-SCANNED 의 rc 가 다르다" "different" "$([ "${P2RC:-x}" != "${P3RC:-y}" ] && echo different || echo collapsed)"
 
+# ── FD_PROFILE 갈래 (2026-08-18) ──────────────────────────────────────────
+# 🟥 이 배선은 **한 번 소실됐다.** forge-wiki 워킹 사본에만 넣었다가 PR 정리 때 rm 했고,
+# 그 사실을 몰라 다음 대상의 약한 산출을 «입장 티어가 낮다»·«스킬을 못 불렀다»로 오진했다.
+# 산출물은 커밋됐는데 그걸 만든 코드가 없던 상태 — 그래서 레인으로 못 박는다.
+_prompt() { FH_DIR="$1" OUT_DIR=out HUMAN_DATE=2026-08-18 TODAY=2026_08_18 PROFILE_PATH="$2" \
+  bash -c "$(sed -n '/^_build_prompt()/,/^}/p' "$ROOT/scripts/frontier_digest_daily.sh")
+_build_prompt"; }
+pd=$(mktemp -d); printf 'PROFILE_CANARY_BODY
+' > "$pd/p.md"
+case "$(_prompt "$pd" "p.md")" in *"PROFILE_CANARY_BODY"*) r=in ;; *) r=missing ;; esac
+t "P5 프로필이 프롬프트에 실제로 실린다"        "in" "$r"
+case "$(_prompt "$pd" "p.md")" in *"STANDPOINT"*) r=yes ;; *) r=no ;; esac
+t "P5b 입장 지시(대상 소스를 열어라)가 실린다"   "yes" "$r"
+case "$(_prompt "$pd" "")" in *"STANDPOINT"*|*"TARGET HARNESS"*) r=leaked ;; *) r=clean ;; esac
+t "N3 control — 프로필 미설정이면 종전 문자열 그대로(FH 경로 무변경)" "clean" "$r"
+case "$(_prompt "$pd" "nonexistent.md")" in *"STANDPOINT"*) r=leaked ;; *) r=clean ;; esac
+t "N4 control — 프로필 경로가 없으면 조용히 종전 경로(존재하지 않는 파일을 실었다고 안 한다)" "clean" "$r"
+rm -rf "$pd"
+
 echo "----"; echo "satellite publish gate: $pass passed, $fail failed"; [ "$fail" -eq 0 ]

--- a/scripts/test_satellite_publish_gate_lanes.sh
+++ b/scripts/test_satellite_publish_gate_lanes.sh
@@ -17,6 +17,8 @@
 #   P3  NOT-SCAN  → rc=3, 파일이 .UNSCANNED 로 보류 (게시 안 됨) — 스캐너가 죽어도 fail-closed
 #   N1  CONTROL — FD_PUBLIC_TARGET 미설정 → 게이트 자체가 안 돈다 (FH 프로덕션 경로 무변경)
 #   N2  CONTROL — P2 와 P3 의 rc 가 **다르다**(2 vs 3). 같으면 두 실패가 한 값으로 접힌 것이다
+#   P4  착지 증언이 **실제로 로그에 찍힌다** — 직전 digest 가 없으면 «SKIPPED (not a pass)».
+#       배선했다 ≠ 발화한다. 그리고 SKIP 을 통과로 렌더하지 않는 것까지 주장한다
 #
 # Exit 0 = 5/5.
 set -u
@@ -24,7 +26,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 pass=0; fail=0
 t() { if [ "$2" = "$3" ]; then echo "  ✅ $1"; pass=$((pass+1)); else echo "  ❌ $1 — got [$3] want [$2]"; fail=$((fail+1)); fi }
 
-run() { # $1 = digest body · $2 = psa_lib override ("dead" to break the scanner) → echoes "rc|state"
+run() { # $1 = digest body · $2 = psa_lib override ("dead") · $3 = arm 이름 → echoes "rc|state"
   local td; td=$(mktemp -d)
   mkdir -p "$td/scripts" "$td/out" "$td/.claude/rules"
   cp "$ROOT/scripts/frontier_digest_daily.sh" "$td/scripts/"
@@ -49,6 +51,11 @@ run() { # $1 = digest body · $2 = psa_lib override ("dead" to break the scanner
   ls "$td/out/"*.QUARANTINE >/dev/null 2>&1 && state=quarantine
   ls "$td/out/"*.UNSCANNED  >/dev/null 2>&1 && state=unscanned
   ls "$td/out/"*.md         >/dev/null 2>&1 && [ "$state" = none ] && state=published
+  # 착지 증언이 로그에 남았는지 (P4 가 읽는다)
+  # 🟥 arm 마다 따로 남긴다. 초판은 단일 파일에 덮어써서 **마지막 arm(P3, 스캐너 사망)** 것을
+  # 잡았는데, 거기선 게이트가 실패해 증언이 안 도는 게 정상이다 — 레인이 정상 동작을 실패로
+  # 렌더할 뻔했다. 판정 대상 arm 을 이름으로 고른다.
+  grep -h "landing witness" "$td/out/logs/"*.log 2>/dev/null | head -1 > "/tmp/.lw_$3" || : 
   echo "$rc|$state"
   rm -rf "$td"
 }
@@ -58,9 +65,9 @@ A clean digest with no operator-private tokens. $(head -c 1200 /dev/zero | tr '\
 LEAK_BODY="# digest
 this line carries ZZ_SYNTHETIC_LEAK_TOKEN_ZZ which the fixture pattern file flags HIGH. $(head -c 1200 /dev/zero | tr '\0' 'x')"
 
-r=$(run "$CLEAN_BODY" live); t "P1 CLEAN → 게시"            "0|published"  "$r"
-r=$(run "$LEAK_BODY"  live); t "P2 LEAK → 격리(.QUARANTINE)" "2|quarantine" "$r"; P2RC=${r%%|*}
-r=$(run "$CLEAN_BODY" dead); t "P3 스캐너 사망 → 보류(.UNSCANNED)" "3|unscanned" "$r"; P3RC=${r%%|*}
+r=$(run "$CLEAN_BODY" live clean); t "P1 CLEAN → 게시"            "0|published"  "$r"
+r=$(run "$LEAK_BODY"  live leak);  t "P2 LEAK → 격리(.QUARANTINE)" "2|quarantine" "$r"; P2RC=${r%%|*}
+r=$(run "$CLEAN_BODY" dead dead);  t "P3 스캐너 사망 → 보류(.UNSCANNED)" "3|unscanned" "$r"; P3RC=${r%%|*}
 
 # N1 — 게이트 미활성(FD_PUBLIC_TARGET 없음)이면 LEAK 본문이어도 게시된다 = FH 경로 무변경
 td=$(mktemp -d); mkdir -p "$td/scripts" "$td/out" "$td/.claude/rules"
@@ -73,6 +80,12 @@ out=$(cd "$td" && FD_FH_DIR="$td" FD_OUT_DIR="out" FD_CLAUDE_BIN="$td/scripts/st
 n1state=published; ls "$td/out/"*.QUARANTINE >/dev/null 2>&1 && n1state=quarantine
 t "N1 control — 게이트 미활성이면 안 돈다(FH 경로 무변경)" "0|published" "$n1rc|$n1state"
 rm -rf "$td"
+
+lw=$(cat /tmp/.lw_clean 2>/dev/null)   # 게이트가 CLEAN 인 arm 에서만 증언이 돈다
+case "$lw" in *"landing witness"*) r=logged ;; *) r=absent ;; esac
+t "P4 착지 증언이 로그에 찍힌다(배선했다≠발화한다)" "logged" "$r"
+case "$lw" in *"SKIPPED (not a pass)"*) r=honest ;; *"ALL-LANDED"*) r=honest ;; *"SOME-UNLANDED"*) r=honest ;; *"HARNESS-ERROR"*) r=honest ;; *) r=other ;; esac
+t "P4b SKIP 을 통과로 렌더하지 않는다"          "honest" "$r"
 
 t "N2 control — LEAK 과 NOT-SCANNED 의 rc 가 다르다" "different" "$([ "${P2RC:-x}" != "${P3RC:-y}" ] && echo different || echo collapsed)"
 

--- a/scripts/test_satellite_publish_gate_lanes.sh
+++ b/scripts/test_satellite_publish_gate_lanes.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# test_satellite_publish_gate_lanes.sh — known-pair anchor for the satellite's publish gate.
+#
+# WHY (2026-08-18, 원정 2차)
+#   frontier_digest_daily.sh 는 FH 자신만 대상으로 지어졌고, FH 의 digest 는 gitignored
+#   `tracks/` 에 떨어진다 — 그래서 **공개 노출 문제가 없었다**. 위성이 **공개 레포**를 대상으로
+#   돌면 **매 런이 publish** 다(비가역 표면). §Irreversibility Surface-Class Degrade Invariant:
+#   비가역 표면은 fail-CLOSED — 스캐너가 못 재면 «통과»가 아니라 «보류»다.
+#
+#   🟥 이 스위트의 진짜 주장은 «스캔한다»가 아니라 **«세 값을 두 값으로 접지 않는다»** 다.
+#   CLEAN(0) · LEAK(1) · NOT-SCANNED(3) 은 처방이 각각 다르다: 각각 게시 / 격리 / 보류.
+#   접으면 «못 쟀다»가 «깨끗하다»로 렌더된다 — [[feedback_not_found_is_not_zero_family]].
+#
+# Lanes
+#   P1  CLEAN     → rc=0, 파일 그대로 (게시)
+#   P2  LEAK      → rc=2, 파일이 .QUARANTINE 로 격리 (게시 안 됨)
+#   P3  NOT-SCAN  → rc=3, 파일이 .UNSCANNED 로 보류 (게시 안 됨) — 스캐너가 죽어도 fail-closed
+#   N1  CONTROL — FD_PUBLIC_TARGET 미설정 → 게이트 자체가 안 돈다 (FH 프로덕션 경로 무변경)
+#   N2  CONTROL — P2 와 P3 의 rc 가 **다르다**(2 vs 3). 같으면 두 실패가 한 값으로 접힌 것이다
+#
+# Exit 0 = 5/5.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+t() { if [ "$2" = "$3" ]; then echo "  ✅ $1"; pass=$((pass+1)); else echo "  ❌ $1 — got [$3] want [$2]"; fail=$((fail+1)); fi }
+
+run() { # $1 = digest body · $2 = psa_lib override ("dead" to break the scanner) → echoes "rc|state"
+  local td; td=$(mktemp -d)
+  mkdir -p "$td/scripts" "$td/out" "$td/.claude/rules"
+  cp "$ROOT/scripts/frontier_digest_daily.sh" "$td/scripts/"
+  cp "$ROOT/.claude/rules/.public-surface-patterns.defaults" "$td/.claude/rules/" 2>/dev/null
+  # 🟥 오버라이드 파일이 없으면 스캐너는 `override_absent(HIGH operator literals unscanned)` 로
+  # **NOT SCANNED** 를 낸다 — MED 히트를 찾고도 «부분 커버리지는 판정이 아니다»라며 거부한다.
+  # 엄격하게 옳은 동작이고, 그래서 이 픽스처는 **합성 리터럴**로 자립시킨다: 운영자의 실제
+  # 리터럴에 의존하면 이 스위트가 그 파일의 존재 여부에 따라 갈린다.
+  printf 'HIGH\tZZ_SYNTHETIC_LEAK_TOKEN_ZZ\n' > "$td/.claude/rules/.public-surface-patterns"
+  if [ "$2" = "dead" ]; then printf '#!/usr/bin/env bash\npsa_load(){ :; }\npsa_scan_file(){ return 3; }\n' > "$td/scripts/psa_scan_lib.sh"
+  else cp "$ROOT/scripts/psa_scan_lib.sh" "$td/scripts/"; fi
+  printf '%s\n' "$1" > "$td/out/frontier_digest_$(date +%Y_%m_%d).md"
+  # 러너가 digest_ready 로 이미 있는 파일을 보고 조기 종료하지 않도록, 게이트 경로를 직접 태운다:
+  # attempt 루프 진입 전에 skip 하므로 여기서는 러너 본체 대신 게이트 분기만 재현할 수 없다.
+  # → 러너를 그대로 돌리되 CLAUDE_BIN 을 no-op 스텁으로 줘서 attempt 를 태운다.
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$td/scripts/stub-claude"; chmod +x "$td/scripts/stub-claude"
+  local out rc
+  out=$(cd "$td" && FD_FH_DIR="$td" FD_OUT_DIR="out" FD_PUBLIC_TARGET=1 \
+        FD_CLAUDE_BIN="$td/scripts/stub-claude" FD_MAX_ATTEMPTS=1 FD_ATTEMPT_TIMEOUT_SECS=20 \
+        FD_POLL_SECS=1 bash scripts/frontier_digest_daily.sh 2>&1); rc=$?
+  local state=none
+  ls "$td/out/"*.QUARANTINE >/dev/null 2>&1 && state=quarantine
+  ls "$td/out/"*.UNSCANNED  >/dev/null 2>&1 && state=unscanned
+  ls "$td/out/"*.md         >/dev/null 2>&1 && [ "$state" = none ] && state=published
+  echo "$rc|$state"
+  rm -rf "$td"
+}
+
+CLEAN_BODY="# digest
+A clean digest with no operator-private tokens. $(head -c 1200 /dev/zero | tr '\0' 'x')"
+LEAK_BODY="# digest
+this line carries ZZ_SYNTHETIC_LEAK_TOKEN_ZZ which the fixture pattern file flags HIGH. $(head -c 1200 /dev/zero | tr '\0' 'x')"
+
+r=$(run "$CLEAN_BODY" live); t "P1 CLEAN → 게시"            "0|published"  "$r"
+r=$(run "$LEAK_BODY"  live); t "P2 LEAK → 격리(.QUARANTINE)" "2|quarantine" "$r"; P2RC=${r%%|*}
+r=$(run "$CLEAN_BODY" dead); t "P3 스캐너 사망 → 보류(.UNSCANNED)" "3|unscanned" "$r"; P3RC=${r%%|*}
+
+# N1 — 게이트 미활성(FD_PUBLIC_TARGET 없음)이면 LEAK 본문이어도 게시된다 = FH 경로 무변경
+td=$(mktemp -d); mkdir -p "$td/scripts" "$td/out" "$td/.claude/rules"
+cp "$ROOT/scripts/frontier_digest_daily.sh" "$ROOT/scripts/psa_scan_lib.sh" "$td/scripts/"
+cp "$ROOT/.claude/rules/.public-surface-patterns.defaults" "$td/.claude/rules/" 2>/dev/null
+printf '%s\n' "$LEAK_BODY" > "$td/out/frontier_digest_$(date +%Y_%m_%d).md"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$td/scripts/stub-claude"; chmod +x "$td/scripts/stub-claude"
+out=$(cd "$td" && FD_FH_DIR="$td" FD_OUT_DIR="out" FD_CLAUDE_BIN="$td/scripts/stub-claude" \
+      FD_MAX_ATTEMPTS=1 FD_POLL_SECS=1 bash scripts/frontier_digest_daily.sh 2>&1); n1rc=$?
+n1state=published; ls "$td/out/"*.QUARANTINE >/dev/null 2>&1 && n1state=quarantine
+t "N1 control — 게이트 미활성이면 안 돈다(FH 경로 무변경)" "0|published" "$n1rc|$n1state"
+rm -rf "$td"
+
+t "N2 control — LEAK 과 NOT-SCANNED 의 rc 가 다르다" "different" "$([ "${P2RC:-x}" != "${P3RC:-y}" ] && echo different || echo collapsed)"
+
+echo "----"; echo "satellite publish gate: $pass passed, $fail failed"; [ "$fail" -eq 0 ]


### PR DESCRIPTION
원정 2차(과녁 = **④ 프런티어→조직 전파**, 🔵 RC). 운영자 정의: **조직 = 레포**이고, 프런티어 수준을 답습해 **그 하네스에 뿌려주는 것**이 이 정체성이다.

## 왜 ④ 가 RC 에 머물렀나 (실측)

```
frontier_digest_daily.sh:9   FH_DIR="${FD_FH_DIR:-<자기 레포 루트>}"
                             LOG_DIR·digest_ready·프롬프트가 전부 tracks/_meta 고정
「대상 하네스」 개념           체인에 grep 0건 (컨트롤: standpoint 는 잡힘)
```
**`FH_DIR` 하나가 실행 주체와 대상을 겸했다.** 그래서 「FH 만 대상」은 설정이 아니라 **구조**였고, ④ 는 «전파»가 아니라 «자기 소비»였다.

## 변경 3종 — 전부 기본값 종전 그대로

| | |
|---|---|
| `FD_OUT_DIR` | 대상 레포의 **어디에** 떨어뜨리나. FH 는 `tracks/_meta`, 대상 하네스는 자기 문법이 있다(forge-wiki 는 frontmatter 달린 위키 노드) |
| `FD_MODEL` | 티어 핀. 위성마다 도메인 난이도가 다르다 |
| `publish_gate()` | 공개 레포 대상이면 **매 런이 publish** 다(비가역 표면). `0 게시 · 1 격리 · 그 외 보류` |

🟥 **핵심 주장은 «스캔한다»가 아니라 «세 값을 두 값으로 접지 않는다»** 다. CLEAN·LEAK·NOT-SCANNED 는 처방이 각각 다르다(게시/격리/보류). 접으면 «못 쟀다»가 «깨끗하다»로 렌더된다.

## 🟥 레인이 내 fail-open 을 잡았다

초판은 게이트를 attempt 루프 성공분기에만 달았다. 그런데 러너의 **성공 종료 경로는 셋**이다 — ⓐ「오늘 이미 돌았다」조기 스킵 ⓑ「외부에서 나타났다」 ⓒ attempt 후. **ⓐⓑ 로 나가는 digest 는 스캔 없이 게시된다.** P2·P3 이 적발 → 함수로 빼서 셋 다 배선. **자력 적발 0.**

## 앵커 — `test_satellite_publish_gate_lanes.sh` 5/5

P1 CLEAN→게시 · P2 LEAK→격리 · P3 **스캐너 사망→보류** · **N1** 게이트 미활성이면 안 돈다(FH 경로 무변경) · **N2** LEAK(2) ≠ NOT-SCANNED(3)

**되돌림 2 arm**: A(NOT-SCANNED→CLEAN 접기) → **P3 만** 적색 · B(조기스킵 게이트 제거) → P2·P3·N2 적색. **레인이 서로 다른 구멍을 지킨다.**

## 정직한 잔여

- 🟥 **실행 반쪽 미실시** — `FD_OUT_DIR` 를 forge-wiki 로 겨눈 **실런은 안 돌렸다**. `standpoint: tier1b` 로 기록한 이유다(그 레포 파일을 읽고 `fw init`/`fw sync` 는 실행했으나 **이 델타**를 거기서 돌린 적은 없다).
- 🟥 **위성 운영 요건이 하나 늘었다**: 대상 레포에 `.public-surface-patterns` 오버라이드가 없으면 스캐너가 `override_absent(HIGH operator literals unscanned)` 로 NOT SCANNED 를 내므로 위성이 **영원히 fail-closed** 된다. 부분 커버리지는 판정이 아니라는 그 규율이 옳고, 배포 요건이 그만큼 늘어난다.
- `crossfamily: DEGRADED_PANEL_UNUSED` — 되돌림 A arm 이 핵심 주장을 직접 반증 가능하게 만들었다고 판단해 사이드카 미투입. **그 판단 자체는 미검증.**
- 픽스처는 **합성 리터럴**로 자립. 초판이 운영자 실제 리터럴에 의존해 스캐너가 NOT SCANNED 를 냈다 — 스캐너가 옳고 픽스처가 부실했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)