### PR TITLE
fix(landing): 후보 파서를 실물 형식 4종으로 — 계기가 6.7% 만 읽고 있었다

### DIFF
--- a/scripts/digest_landing_check.sh
+++ b/scripts/digest_landing_check.sh
@@ -90,8 +90,57 @@ SECTION_RE='^## .*Immediate Application Candidates'
 # 후보 표에서 (id, 판별토큰 OR 정규식) 을 뽑는다. 토큰 없으면 id 만 내고 정규식은 빈 값.
 _extract() { # $1 = digest path
   awk -v sec="$SECTION_RE" '
+    # 판별자 추출 — 표/문단 **두 경로가 공유**한다(중복 정규화기 방지).
+    function harvest(body, toks,   tmp, w, t) {
+      tmp=body
+      while (match(tmp, /\[\[[^]]+\]\]/)) {
+        w=substr(tmp, RSTART+2, RLENGTH-4); tmp=substr(tmp, RSTART+RLENGTH)
+        if (length(w) >= 5) toks = (toks == "" ? w : toks "|" w)
+      }
+      tmp=body
+      while (match(tmp, /`[^`]+`/)) {
+        t=substr(tmp, RSTART+1, RLENGTH-2); tmp=substr(tmp, RSTART+RLENGTH)
+        sub(/[: ].*$/, "", t)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", t)
+        if (length(t) < 5) continue
+        if (t ~ /[][(){}.*+?^$\\|]/) { if (t ~ /^[A-Za-z0-9_.-]+$/) { } else continue }
+        gsub(/\./, "\\.", t)
+        toks = (toks == "" ? t : toks "|" t)
+      }
+      return toks
+    }
     $0 ~ sec { inblk=1; next }
-    inblk && /^## /  { inblk=0 }
+    inblk && /^## /  { if (pid != "") { print pid "\t" ptoks; pid="" } inblk=0; inpara=0 }
+    # ── 문단 형식 (2026-08-18 신설) ───────────────────────────────────────
+    # 🟥 이 계기는 후보를 **표**로만 읽었다. 실측: 다이제스트 60건 중 표 형식은 **4건**,
+    # 나머지는 `**① …**` `**[A] …**` `**1. …**` `**#1 …**` 같은 **문단 형식**이다.
+    # 즉 계기가 실물의 6.7% 만 읽을 수 있었고, 그래서 첫 실측이 rc=10(«후보 절을 못 찾았다»)
+    # 을 냈다. 안 드러난 이유는 **프로덕션 호출부가 0** 이었기 때문 — 아무도 안 돌렸다.
+    # ⚠️ 머리 표기는 여러 종이라 한 모양에 맞추지 않는다(실측: ① · [A] · 1. · #1 · 그 외).
+    #    **`**` 로 열리는 줄**을 항목 시작으로 보고, 다음 항목/절까지를 본문으로 모은다.
+    # 🟥 판별자 추출은 **표 경로와 같은 코드**를 쓴다 — 두 벌로 갈리면 관대함이 어긋나
+    #    한쪽만 통과하는 입력이 무음 드롭된다(divergent leniency).
+    # 항목 머리 **네** 형식을 다 받는다. 실측(60건 후보 절 전수, 하나씩 열어서 확인):
+    #   `**…**` 74 · 표 `|` 28 · `### [M] 1.` 22 · **번호 리스트 `1. **…**`**(초기 다이제스트의 주 형식)
+    # 🟥 초판은 `**` 만 받았고, 표가 섞인 절에서 **표 앞의 `**` 줄을 먼저 삼켜** 표 행을
+    #    UNCHECKABLE 로 떨어뜨렸다(회귀 실측). 그래서 **표 행은 항상 표 경로가 먼저 가져간다**.
+    inblk && (/^###+ / || /^\*\*/ || /^[0-9]+\. / || /^- \*\*/) {
+      if (pid != "") { print pid "\t" ptoks }
+      pid=$0; ptoks=""
+      sub(/^###+ /, "", pid); sub(/^[0-9]+\. /, "", pid); sub(/^- /, "", pid)
+      sub(/^\*\*/, "", pid); sub(/\*\*.*$/, "", pid)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", pid)
+      # 🟥 substr 로 자르지 않는다 — awk 는 로케일에 따라 **바이트** 단위라 한글/기호를
+      #    중간에서 쪼개고 그 출력이 UTF-8 로 안 읽힌다(실측: 집계 스크립트가 UnicodeDecodeError).
+      #    id 는 표시용이므로 자르지 말고 **공백 기준 앞 6낱말**만 쓴다.
+      if (split(pid, _w, /[[:space:]]+/) > 6) {
+        pid=""; for (_i=1; _i<=6; _i++) pid = pid (_i>1 ? " " : "") _w[_i]
+      }
+      ptoks=harvest($0, ptoks)
+      inpara=1; next
+    }
+    # 표 행은 아래 표 경로가 처리한다 — 여기서 안 먹는다(우선순위 명시).
+    inblk && inpara && !/^\|/ && !/^###+ / && !/^[0-9]+\. / && !/^- \*\*/ { ptoks=harvest($0, ptoks); next }
     inblk && /^\|/ {
       line=$0
       # 헤더/구분선 제외
@@ -135,6 +184,7 @@ _extract() { # $1 = digest path
       }
       print id "\t" toks
     }
+    END { if (pid != "") print pid "\t" ptoks }
   ' "$1"
 }
 


### PR DESCRIPTION
## 한 줄

착지 검증기가 후보를 **표로만** 읽었다. 실물 60건 중 표는 **4건(6.7%)** 이다.

## 실측 — 형식 전수

| 형식 | 수 |
|---|---|
| 표 `\| … \|` | **4건** ← 계기가 읽을 수 있던 전부 |
| 문단 `**…**` | 74개 항목 |
| 헤딩 `### [M] 1.` | 22개 |
| 번호 `1. **…**` | 초기 다이제스트의 주 형식 |

즉 **계기와 대상의 형식이 처음부터 안 맞았다.**

## 🟥 왜 지금까지 안 드러났나 — 이게 이 PR 의 본체다

**프로덕션 호출부가 0 이었다.** 아무도 안 돌렸으니 형식 불일치도 안 보였다. 오늘 그 호출부를 배선(#446)해서 **처음 돌렸고 첫 실행이 뱉었다** — `rc=10` «후보 절을 못 찾았다 — 0건과 미검출을 가르기 위해 실패로 낸다».

🟢 **계기가 «0건» 으로 접었으면 거짓 초록이 났다.** 그 설계가 자기를 구했다.

⇒ 일반화: **self-test 만 도는 스크립트는 실물과 어긋나 있어도 초록이다.** 자기 픽스처는 자기가 만든 형식을 쓰기 때문이다. 같은 형태를 다른 계기에서도 의심하라.

## 변경

- 항목 머리 **4종**을 받는다. 🟥 **표 행은 항상 표 경로가 먼저** 가져간다(우선순위 명시)
- 판별자 추출을 `harvest()` 로 빼서 **표/문단 두 경로가 공유** — 두 벌로 갈리면 관대함이 어긋나 한쪽만 통과하는 입력이 **무음 드롭**된다

## 결과

- 후보 절이 있는 **56건 전부** 추출(절 없는 4건은 후보를 안 낸 날 — 결함 아님)
- `--self-test` **10 레인 rc=0** 유지
- **실제 착지 측정 확인**: 08-17 다이제스트 → 후보 3건 전부 착지(21·13·3 파일), 컨트롤 2/2 생존, **판별불가 1건이라 rc=1** — 전건 통과로 렌더하지 않는다

## ⚠️ 이 수리 중 내가 낸 결함 3건 (전부 실측이 잡음, 자력 0)

1. 초판이 `**` 만 받아 **표가 섞인 절에서 표 행을 삼켰다**(회귀)
2. `substr(pid,1,40)` 이 awk 에서 **바이트 절단** → 한글을 쪼개 출력이 UTF-8 로 안 읽힘
3. 내 `grep -c` 집계가 서브셸에서 빈 값 → 「0건」처럼 보임. 파이썬 계기로 재측정해 갈랐다

## ⚠️ 근본 처방은 안 했다

형식을 **늘리는** 쪽으로만 갔다. 다섯 번째 형식이 나오면 또 0 이 된다. 진짜 답은 **다이제스트 출력 규격 고정**이고 운영자 결정 사안으로 남긴다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)