### PR TITLE
fix(satellite): 「배선 완료」라고 보고한 계기가 첫날부터 죽어 있었다 — R1~R5 + 타계열 3건

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "scripts/prepublish_scope_note.sh",
     "scripts/lane_runner_check.sh",
     "scripts/test_package_coverage_lanes.sh",
+    "scripts/test_evidence_root_psa_lanes.sh",
     "scripts/adapters/peer_resolve.sh",
     "scripts/adapters/gstack_content_safety.sh",
     "scripts/adapters/mate_agent_boundary.sh",

--- a/scripts/digest_landing_check.sh
+++ b/scripts/digest_landing_check.sh
@@ -85,6 +85,21 @@ FH="${CLAUDE_PROJECT_DIR:-$(cd "$SELF_DIR/.." && pwd)}"
 # ⚠️ 검증기는 **도구**이고 FH 는 **대상**이다 — 두 축을 같은 변수로 묶으면 격리 픽스처에서
 # 도구까지 임시 트리에서 찾다가 죽는다(실측). 도구는 언제나 이 스크립트 옆에 있다.
 CHECKER="$SELF_DIR/utterance_landing_check.sh"
+
+# ── 착지 스코프 (2026-08-18, R1) ────────────────────────────────────────────
+# 기본 스코프는 **FH 자신의 문법**이다(`knowledge` · `CLAUDE.md` · gitignored `tracks/_meta`).
+# 위성이 겨눈 대상 하네스에는 그 셋이 없어서 타깃이 0건 → rc=10 이 매 런 찍힌다. 그건 정직한
+# 값이지만(미측정≠0), 계기가 **구조적으로 죽은 채** 배선된 것과 같다.
+# 🟥 스코프를 «러너가 손으로 목록을 만들어 넘기는» 식으로 풀지 않는다 — 그러면 선후 필터가
+#    두 벌이 되고 관대함이 갈리는 순간 한쪽만 통과하는 입력이 무음 드롭된다
+#    ([[feedback_divergent_leniency_duplicate_normalizers]]). 필터는 여기 한 곳에 두고
+#    **무엇을 볼지만** 밖에서 정한다.
+# 기본값은 종전 그대로 — FH 경로 무변경.
+# ⚠️ **명명된 잔여 (cross-family/codex F4)**: 이 값은 **공백 분리**된 다중 pathspec 이다.
+#    따라서 **경로에 공백이 있으면 갈린다** — `docs public` 은 «한 경로»가 아니라 두 경로가 된다.
+#    다중 경로 지원과의 트레이드오프라 오늘은 **문서화만** 했고 기계 검사는 없다.
+DLC_TRACKED_PATHS="${DLC_TRACKED_PATHS:-knowledge CLAUDE.md}"   # git 추적축 (커밋시각)
+DLC_IGNORED_DIR="${DLC_IGNORED_DIR-tracks/_meta}"               # gitignored 축 (mtime). 빈 값 = 그 축 없음
 SECTION_RE='^## .*Immediate Application Candidates'
 
 # 후보 표에서 (id, 판별토큰 OR 정규식) 을 뽑는다. 토큰 없으면 id 만 내고 정규식은 빈 값.
@@ -193,8 +208,30 @@ do_extract() { # $1 = digest
   [ -f "$d" ] || { echo "❌ digest 없음: $d" >&2; return 10; }
   # 컨트롤 — 이 계기가 살아 있는지 증명한다. 대상 트리에 확실히 존재하는 토큰.
   # 컨트롤이 죽으면 착지 검증기가 rc=10 을 내고 타깃 결과를 인쇄하지 않는다.
-  printf 'CONTROL\tforge-harness\t컨트롤: 레포명\n'
-  printf 'CONTROL\tsession\t컨트롤: 흔한 토큰\n'
+  # 🟥 R1-b (2026-08-18) — 컨트롤이 `forge-harness`/`session` 으로 **하드코딩**이었다.
+  # 위성이 겨눈 레포에는 그 두 토큰이 없으므로 **컨트롤이 매번 죽고** 계기는 rc=10 만 낸다.
+  # R1 의 인자 버그를 고쳐도 이게 남아 있으면 계기는 여전히 구조적으로 죽은 채다 — 그 사실을
+  # 이 레인이 잡았다(수리가 신규 결함의 출처인 것과 같은 얼굴: 반쪽 수리).
+  # 기본값은 **자기 레포 이름**이라 FH 에서는 종전과 동일(`forge-harness`)하다.
+  # 🟥 두 갈래를 갈라야 한다 (cross-family/codex F3 지목, 실측으로 **더 나쁜 형태** 확인):
+  #    초판은 `for _ctl in ${DLC_CONTROLS:-$(basename "$FH") session}` 였는데, 비인용 명령치환은
+  #    단어분리 **와 글로빙**을 둘 다 탄다 — 레포명이 `.*` 인 디렉터리에서 실측하니 컨트롤이
+  #    `.git` 등 **4개로 글로브 확장**됐다. 게다가 컨트롤은 ERE 로 쓰이므로 레포명에 정규식
+  #    메타문자가 있으면 «아무 내용에나 매치»해 **계기 생존이 오탐**이 된다.
+  #  ⇒ 유도 기본값은 **리터럴로 취급**(메타문자 이스케이프) · 사용자 지정값만 정규식으로 둔다.
+  local _ctl _label=1
+  if [ -n "${DLC_CONTROLS:-}" ]; then
+    for _ctl in $DLC_CONTROLS; do            # 명시값은 «정규식» 계약 — 의도적 분리
+      printf 'CONTROL\t%s\t컨트롤%s: %s\n' "$_ctl" "$_label" "$_ctl"
+      _label=$((_label+1))
+    done
+  else
+    local _repo; _repo="$(basename "$FH")"
+    # ERE 메타문자 이스케이프 — 유도값은 «그 문자열이 실제로 있는가» 를 묻는 것이지 패턴이 아니다
+    _repo="$(printf '%s' "$_repo" | sed 's/[][\.^$*+?(){}|]/\\&/g')"
+    printf 'CONTROL\t%s\t컨트롤1: %s\n' "$_repo" "$_repo"
+    printf 'CONTROL\tsession\t컨트롤2: session\n'
+  fi
   while IFS=$'\t' read -r id toks; do
     [ -n "${id:-}" ] || continue
     n=$((n+1))
@@ -226,7 +263,8 @@ do_check() {
     # ⚠️ CLAUDE.md 도 **선후 필터를 거친다.** 초판은 무조건 추가했고, 그래서 이 파일 하나가
     # 필터를 우회해 오탐 원천이 됐다 — 손검증에서 "M1 착지 1파일" 의 그 1파일이 CLAUDE.md
     # 였고, 후보와 무관하게 원래 있던 토큰이었다. 예외 경로 하나가 필터 전체를 무력화한다.
-    [ -f "$FH/CLAUDE.md" ] && [ "$FH/CLAUDE.md" -nt "$d" ] && targets+=("$FH/CLAUDE.md")
+    case " $DLC_TRACKED_PATHS " in *" CLAUDE.md "*)
+      [ -f "$FH/CLAUDE.md" ] && [ "$FH/CLAUDE.md" -nt "$d" ] && targets+=("$FH/CLAUDE.md") ;; esac
     # ★ **digest 보다 나중에 수정된 파일만** 본다. grep 은 "토큰이 있다" 만 재고
     # "이 후보 때문에 생겼다" 는 못 잰다 — 이미 있던 문서가 착지로 잡힌다(실측: 후보 하나가
     # 21파일 히트, 전부 무관한 기존 문서였다). 선후 필터가 인과를 주지는 않지만
@@ -261,11 +299,13 @@ do_check() {
       [ -n "$f" ] || continue
       case "$f" in *.md) ;; *) continue ;; esac
       [ -f "$FH/$f" ] && targets+=("$FH/$f")
-    done < <(git -C "$FH" log --since="@$_dts" --name-only --pretty=format: -- knowledge CLAUDE.md 2>/dev/null | sort -u)
-    while IFS= read -r f; do targets+=("$f"); done < <(
-      find "$FH/tracks/_meta" -name '*.md' -type f -newer "$d" 2>/dev/null | head -400)
+    done < <(git -C "$FH" log --since="@$_dts" --name-only --pretty=format: -- $DLC_TRACKED_PATHS 2>/dev/null | sort -u)
+    if [ -n "$DLC_IGNORED_DIR" ] && [ -d "$FH/$DLC_IGNORED_DIR" ]; then
+      while IFS= read -r f; do targets+=("$f"); done < <(
+        find "$FH/$DLC_IGNORED_DIR" -name '*.md' -type f -newer "$d" 2>/dev/null | head -400)
+    fi
     # dirty tracked — 커밋 안 된 수정본엔 git 시각 증거가 없다. 초록으로 만들지 않고 셈에 남긴다.
-    DIRTY_TRACKED="$(git -C "$FH" diff --name-only -- knowledge CLAUDE.md 2>/dev/null | grep -c '[.]md$')" || true
+    DIRTY_TRACKED="$(git -C "$FH" diff --name-only -- $DLC_TRACKED_PATHS 2>/dev/null | grep -c '[.]md$')" || true
     DIRTY_TRACKED="${DIRTY_TRACKED//[^0-9]/}"; DIRTY_TRACKED="${DIRTY_TRACKED:-0}"
   fi
   # ★ 자기참조 차단 — **이 계기의 첫 실물 실행에서 100% 오탐을 낸 원인**이다.
@@ -294,7 +334,7 @@ do_check() {
   local unchk; unchk="$(grep -c '^# UNCHECKABLE' "$probes" 2>/dev/null)" || true
   unchk="${unchk//[^0-9]/}"; unchk="${unchk:-0}"
   echo "── digest 착지 검증: $(basename "$d") ──"
-  echo "   스코프: 공개 FH 자산 + tracks/ (비공개 companion store 제외 — '조직 전파'가 아니라 '허브 내부 착지')"
+  echo "   스코프: git추적[${DLC_TRACKED_PATHS}] + ignored[${DLC_IGNORED_DIR:-없음}] (비공개 companion store 제외 — '조직 전파'가 아니라 '레포 내부 착지')"
   echo "   타깃 파일 ${#targets[@]}건 (digest 이후 수정분만) · 판별불가 후보 ${unchk}건"
   echo "   축: git추적=커밋시각 · gitignored=mtime · dirty tracked ${DIRTY_TRACKED:-0}건=UNMEASURED"
   echo "   ⚠️ 이 계기는 **선후**를 잰다. 인과가 아니다 — 히트는 열어서 확인하라"
@@ -381,8 +421,47 @@ EOF
     touch knowledge/old.md
     printf 'forge-harness session control\n' > tracks/_meta/card.md
   ) >/dev/null 2>&1
-  out="$( cd "$G" && CLAUDE_PROJECT_DIR="$G" bash "$SELF_DIR/$(basename "${BASH_SOURCE[0]}")" \
+  # 컨트롤은 픽스처가 실제로 담고 있는 토큰으로 고정한다(레포명이 mktemp 난수라서).
+  # 🟥 이 레인의 주장은 **git/mtime 두 축 분리**지 컨트롤 유도가 아니다 — 축을 섞지 않는다.
+  out="$( cd "$G" && CLAUDE_PROJECT_DIR="$G" DLC_CONTROLS="forge-harness session" \
+          bash "$SELF_DIR/$(basename "${BASH_SOURCE[0]}")" \
           "$G/tracks/_meta/frontier_digest_2001_01_02.md" 2>&1 )"
+  # ── ★N-ctl (2026-08-18, R1-b) — 컨트롤이 **레포 이름을 따라간다** ────────────
+  # 초판은 `forge-harness`/`session` 하드코딩이라 **위성이 겨눈 레포에선 매번 컨트롤 사망**
+  # (= rc=10)이었다. R1 의 인자 버그를 고쳐도 계기는 구조적으로 죽은 채였을 것이다.
+  local out_ctl rc_ctl
+  out_ctl="$( cd "$G" && CLAUDE_PROJECT_DIR="$G" bash "$SELF_DIR/$(basename "${BASH_SOURCE[0]}")" \
+          "$G/tracks/_meta/frontier_digest_2001_01_02.md" 2>&1 )"; rc_ctl=$?
+  # 픽스처 레포 이름(mktemp 난수)은 본문에 없다 ⇒ 유도된 컨트롤이 죽어 rc=10 이 정상이다.
+  # 이것이 «유도가 실제로 돈다»의 증거다(하드코딩이면 여기서 rc=1 이 나온다).
+  _t "★N-ctl 컨트롤이 레포명을 따라간다(하드코딩 아님)" 10 "$rc_ctl"
+  # ── ★N-ctl-re (cross-family/codex F3) — 유도 컨트롤은 **리터럴**이지 정규식이 아니다 ──────
+  # 초판은 `for _ctl in ${DLC_CONTROLS:-$(basename "$FH") session}` 였다. 비인용 명령치환이라
+  # ⓐ 레포명이 ERE 메타문자면 «아무 내용에나 매치»해 계기 생존이 **오탐**이 되고
+  # ⓑ 실측하니 글로빙까지 타서 컨트롤이 `.git` 등으로 **확장**되기도 했다.
+  # 🟥 픽스처는 **판별하는 형태**여야 한다. 첫 판본은 레포명을 `.*` 로 잡았는데, 그건 글로빙에
+  #    걸려 죽은 컨트롤이 생기는 바람에 **버그 판본도 rc=10** 을 냈다 — 되돌림 프로브가 그
+  #    장식성을 잡았다([[feedback_fixture_must_use_the_breaking_spelling]]).
+  #    그래서 레포명을 `a.b` 로 쓴다: 글로브로는 아무것도 안 맞아 그대로 남고(확장 없음),
+  #    ERE 로는 `axb` 에 매치된다. 대상에 `axb` 만 두면
+  #      버그 판본 → 컨트롤 **생존(오탐)** → rc≠10
+  #      수리 판본 → 리터럴 `a.b` 없음 → 컨트롤 사망 → rc=10
+  local RG; RG="$(mktemp -d -t 'dlc_re.XXXXXX')" || return 10
+  local RD="$RG/a.b"
+  (
+    mkdir -p "$RD/tracks/_meta" "$RD/knowledge" && cd "$RD" \
+      && git init -q . && git config user.email t@t && git config user.name t
+    printf '# d\n## 📌 FH Immediate Application Candidates\n\n| # | 티어 | 내용 |\n|---|---|---|\n| **A1** | M | `zzz_absent_token` 후보 |\n\n## end\n' \
+      > tracks/_meta/frontier_digest_2001_01_01.md
+    touch -t 200101010000 tracks/_meta/frontier_digest_2001_01_01.md
+    # 리터럴 `a.b` 는 **없다**. `axb`(ERE 로만 매치) 와 `session` 만 있다.
+    printf 'axb 그리고 session\n' > tracks/_meta/card.md
+  ) >/dev/null 2>&1
+  local rc_re
+  ( cd "$RD" && CLAUDE_PROJECT_DIR="$RD" bash "$SELF_DIR/$(basename "${BASH_SOURCE[0]}")" \
+      "$RD/tracks/_meta/frontier_digest_2001_01_01.md" ) >/dev/null 2>&1; rc_re=$?
+  _t "★N-ctl-re 레포명이 정규식 메타문자여도 리터럴로 취급(컨트롤 오탐 없음)" 10 "$rc_re"
+  rm -rf "$RG"
   # ⚠️ **줄 단위로** 본다. `case *"A1"*"미착지"*` 는 마지막 요약줄("N건 중 M건 미착지")까지
   # 삼켜 오매칭한다 — 문자열 위치로 판정하는 prose-grep 함정([[feedback_typed_verdict_channel]]).
   if printf '%s\n' "$out" | grep -qE '후보 A1[[:space:]]+미착지'; then

--- a/scripts/frontier_digest_daily.sh
+++ b/scripts/frontier_digest_daily.sh
@@ -19,6 +19,9 @@ HUMAN_DATE=$(date +%Y-%m-%d)   # pinned once with TODAY — a wake-fired run cro
 #   FD_OUT_DIR  — 그 레포의 **어디에** 떨어뜨리는가 (신설). FH 는 tracks/_meta 지만
 #                 대상 하네스는 자기 문법이 있다(forge-wiki 는 frontmatter 달린 위키 노드).
 #   FD_MODEL    — 어느 티어로 도는가 (신설). 위성마다 도메인 난이도가 다르다.
+#   FD_LOG_DIR  — 로그를 어디에 파는가 (R2). 공개 대상이면 기본값이 **대상 트리 밖**이다.
+#   FD_LANDING_{TRACKED,IGNORED,CONTROLS} — 착지 증언의 스코프·컨트롤 (R1). 미설정이면
+#                 checker 기본값(= FH 문법 + 레포명 컨트롤) 그대로.
 # 🟥 기본값은 **전부 종전 그대로**다 — FH 프로덕션 경로 무변경.
 OUT_DIR="${FD_OUT_DIR:-tracks/_meta}"          # FH_DIR 기준 상대경로
 # FD_PROFILE — 대상 하네스가 **자기를 설명하는** 파일(FH_DIR 기준 상대경로).
@@ -28,7 +31,20 @@ OUT_DIR="${FD_OUT_DIR:-tracks/_meta}"          # FH_DIR 기준 상대경로
 # 운영자 정의: *"프런티어 동향을 파악해서 그 하네스에 개선할 포인트를 찾아 남기는 것 —
 #   복제가 아니라 **응용**"* ⇒ 대상 축은 «어디에 쓰나»만이 아니라 «누구를 위해 읽나»다.
 PROFILE_PATH="${FD_PROFILE:-}"
-LOG_DIR="${FH_DIR}/${OUT_DIR}/logs"
+# ── R2 (2026-08-18) · 로그는 **공개 대상 트리 밖**에 판다 ───────────────────
+# `FD_PUBLIC_TARGET=1` 은 «이 OUT_DIR 이 공개표면»이라는 선언인데 초판은 그 밑에 로그를 팠다.
+# 스캐너 findings 는 **매치된 토큰 원문**을 찍고(`psa_scan_lib.sh`: `❌ $sev leak — path: 'tok'`)
+# `publish_gate` 는 `-maxdepth 1 -name '*.md'` 만 보므로 그 로그는 **구조적으로 스캔 밖**이다.
+# ⇒ 유출을 격리하면서 그 유출을 같은 공개 트리에 적는 형태였다. 내 위성 2대는 `logs/` 를
+#   gitignore 해뒀지만 **코드가 그걸 보장하지 않는다** — 소비자가 당한다.
+# 🟥 기본값은 종전 그대로(FH 는 tracks/ 가 gitignored 라 무변경). 공개 대상일 때만 밖으로.
+if [ -n "${FD_LOG_DIR:-}" ]; then
+    LOG_DIR="$FD_LOG_DIR"
+elif [ "${FD_PUBLIC_TARGET:-0}" = "1" ]; then
+    LOG_DIR="${HOME}/.cache/fh/frontier_digest/$(basename "$FH_DIR")"
+else
+    LOG_DIR="${FH_DIR}/${OUT_DIR}/logs"
+fi
 LOG_FILE="${LOG_DIR}/frontier_digest_${TODAY}.log"
 
 mkdir -p "$LOG_DIR"
@@ -40,8 +56,16 @@ find "$LOG_DIR" -name 'frontier_digest_*.log' -mtime +30 -delete 2>/dev/null
 # Success = a non-trivial digest file exists. Mere existence is not enough: the dominant failure
 # class is "connection closed mid-response", which can leave a partial/empty file — that must not
 # count as done (it would also lock out every later run today via the skip-check below).
+# 🟥 선택자는 **한 함수**다 (R3, 2026-08-18). 초판은 `digest_ready` 가 `-size +1k`,
+# `publish_gate` 가 필터 없이 `head -1` 이었다 — 같은 날짜 파일이 둘이면 부산물이 CLEAN 을
+# 내고 **진짜 다이제스트는 미스캔으로 게시**된다(두 계열 독립 수렴).
+# 두 벌의 관대함이 갈리는 그 형태다([[feedback_divergent_leniency_duplicate_normalizers]]).
+digest_files() {
+    find "${FH_DIR}/${OUT_DIR}" -maxdepth 1 -name "frontier_digest_${TODAY}*.md" -size +1k 2>/dev/null
+}
+
 digest_ready() {
-    find "${FH_DIR}/${OUT_DIR}" -maxdepth 1 -name "frontier_digest_${TODAY}*.md" -size +1k 2>/dev/null | grep -q .
+    digest_files | grep -q .
 }
 
 # ── 공개표면 게이트 (2026-08-18, 원정 2차) ──────────────────────────────────
@@ -56,22 +80,77 @@ digest_ready() {
 #
 # 🟥 rc 3값을 두 값으로 접지 않는다 — 0 게시 / 1 격리 / 그 외 보류. 스캐너는 자기 죽음을
 #    rc=3(NOT SCANNED)으로 신고하므로 그 값을 존중한다.
+# 🟥 findings 를 **원문 그대로 로그에 적지 않는다** (R2). 스캐너는 매치된 토큰을 인용부호로
+# 찍는데, 그걸 그대로 남기면 «유출을 격리하면서 같은 자리에 유출을 복사»하는 꼴이다.
+# 심각도·경로·패턴 히트 사실은 남기고 **토큰 본문만** 가린다 — 진단은 격리된 파일을 열어서.
+# 🟥 초판은 `s/: '.*'$/…/` 로 **줄 끝의 인용부호만** 잡았다. 스캐너의 allowlist 줄은
+#    `⚪ allowlisted — path: 'tok' (row: … :: …)` 이라 `)` 로 끝나서 **안 가려졌다** — 같은
+#    함수가 잡아야 할 두 형태 중 하나만 잡는 상태였다(자체 격리 대조로 발견, 레인 R2c).
+#    그래서 **줄 안의 모든 인용 스팬**을 가린다. 판정(심각도·경로)은 남고 페이로드만 사라진다.
+# 🟥 두 번째 정정: 인용 스팬만 가려도 allowlist 줄의 `(row: f.md :: <토큰>)` 꼬리는 **인용
+#    없이** 토큰을 또 적는다. 레인 R2c 가 그걸 잡았다(내 첫 수리는 절반이었다).
+# 🟥 세 번째 정정 (cross-family/codex F2): 인용 스팬과 row 꼬리를 가려도 **경로 쪽**이 남는다.
+#    스캐너 출력은 `❌ HIGH leak — <path>: '<tok>'` 이고, 모델이 저장한 **파일명 자체에** 토큰이
+#    들어가면 그 왼쪽은 그대로 로그에 적힌다. 파일명은 우리가 프롬프트로 정하지만 **강제하지는
+#    않는다** — 강제 안 되는 것을 안전 근거로 쓰지 않는다.
+#  ⇒ 경로는 **정규 이름일 때만** 그대로 적고, 아니면 통째로 가린다. 진단 가치(어느 파일인지)는
+#    정규 이름 케이스에서 유지되고, 비정규 이름은 «그 사실 자체»가 진단 정보가 된다.
+_safe_name() {
+    case "$(basename "$1")" in
+        # 🟥 `[0-9_]*` 는 **너무 헐겁다** — 첫 글자만 검사하고 나머지는 `*` 가 다 삼킨다.
+        #    `frontier_digest_2026_08_18-<토큰>.md` 가 정규 이름으로 통과했다(레인 R2d 가 잡음).
+        #    날짜 자릿수를 **전부** 고정한다.
+        frontier_digest_[0-9][0-9][0-9][0-9]_[0-9][0-9]_[0-9][0-9].md) basename "$1" ;;
+        frontier_digest_[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].md) basename "$1" ;;
+        *) echo "[FILENAME REDACTED — 비정규 이름]" ;;
+    esac
+}
+# 🟥 마지막 sed 는 **벨트 앤 브레이스**다: $2 없이 불리거나 치환이 빗나가면 절대경로가 남는데,
+#    그 경로에는 운영자 실명(홈 디렉터리)이 들어 있다(타계열 실측이 `/Users/<이름>/…` 노출을
+#    재현했다). 지금 호출부는 전부 2인자지만, **호출부가 옳다는 것을 안전 근거로 쓰지 않는다.**
+_redact() { # $1 = 출력 · $2 = (선택) 그 출력이 가리키는 실제 경로
+    local body="$1" path="${2:-}"
+    if [ -n "$path" ]; then
+        body="${body//$path/$(_safe_name "$path")}"
+        body="${body//$(basename "$path")/$(_safe_name "$path")}"
+    fi
+    printf '%s\n' "$body" \
+      | sed -e "s/'[^']*'/'[REDACTED — 격리 파일을 열어라]'/g" \
+            -e "s/(row:[^)]*)/(row: [REDACTED])/g" \
+            -e "s#— /[^ :]*:#— [PATH REDACTED]:#g"
+}
+
 publish_gate() {
     [ "${FD_PUBLIC_TARGET:-0}" = "1" ] || return 0
     local lib="${FH_DIR}/scripts/psa_scan_lib.sh"
     [ -f "$lib" ] || { echo "[$(date '+%Y-%m-%d %H:%M:%S')] 🚫 publish gate: psa_scan_lib.sh 부재 — fail-closed" >> "$LOG_FILE"; return 3; }
-    local f out rc
-    f=$(find "${FH_DIR}/${OUT_DIR}" -maxdepth 1 -name "frontier_digest_${TODAY}*.md" 2>/dev/null | head -1)
-    [ -n "$f" ] || return 0
-    out=$(bash -c '. "$1"; psa_load "$2/.claude/rules/.public-surface-patterns.defaults" "$2/.claude/rules/.public-surface-patterns" >/dev/null 2>&1; psa_scan_file "$3"' _ "$lib" "$FH_DIR" "$f" 2>&1)
-    rc=$?
-    case "$rc" in
-        0) echo "[$(date '+%Y-%m-%d %H:%M:%S')] publish gate: CLEAN" >> "$LOG_FILE"; return 0 ;;
-        1) echo "[$(date '+%Y-%m-%d %H:%M:%S')] 🚫 publish gate: LEAK — 격리, 게시 안 함" >> "$LOG_FILE"
-           printf '%s\n' "$out" >> "$LOG_FILE"; mv "$f" "${f}.QUARANTINE" 2>/dev/null; return 2 ;;
-        *) echo "[$(date '+%Y-%m-%d %H:%M:%S')] 🚫 publish gate: NOT SCANNED (rc=$rc) — fail-closed, 게시 안 함" >> "$LOG_FILE"
-           printf '%s\n' "$out" >> "$LOG_FILE"; mv "$f" "${f}.UNSCANNED" 2>/dev/null; return 3 ;;
-    esac
+    local f out rc worst=0 n=0
+    # 🟥 글롭 전 파일을 **순회**한다. 하나라도 비-0 이면 그 값을 물고 나간다(최악 우선:
+    #    3 NOT-SCANNED > 2 LEAK > 0). 한 파일만 보고 나머지를 게시하면 fail-open 이다.
+    while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        n=$((n+1))
+        out=$(bash -c '. "$1"; psa_load "$2/.claude/rules/.public-surface-patterns.defaults" "$2/.claude/rules/.public-surface-patterns" >/dev/null 2>&1; psa_scan_file "$3"' _ "$lib" "$FH_DIR" "$f" 2>&1)
+        rc=$?
+        case "$rc" in
+            0) echo "[$(date '+%Y-%m-%d %H:%M:%S')] publish gate: CLEAN [$(_safe_name "$f")]" >> "$LOG_FILE" ;;
+            1) echo "[$(date '+%Y-%m-%d %H:%M:%S')] 🚫 publish gate: LEAK [$(_safe_name "$f")] — 격리, 게시 안 함" >> "$LOG_FILE"
+               _redact "$out" "$f" >> "$LOG_FILE"; mv "$f" "${f}.QUARANTINE" 2>/dev/null
+               [ "$worst" -lt 2 ] && worst=2 ;;
+            *) echo "[$(date '+%Y-%m-%d %H:%M:%S')] 🚫 publish gate: NOT SCANNED (rc=$rc) [$(_safe_name "$f")] — fail-closed, 게시 안 함" >> "$LOG_FILE"
+               _redact "$out" "$f" >> "$LOG_FILE"; mv "$f" "${f}.UNSCANNED" 2>/dev/null
+               worst=3 ;;
+        esac
+    done < <(digest_files)
+    # 🟥 n==0 은 **자기모순**이다 — 이 함수는 `digest_ready` 가 참인 뒤에만 불린다. 파일이
+    #    사라졌거나 선택자가 서로 어긋난 것이고, 둘 다 «게시해도 좋다»의 근거가 아니다.
+    #    초판은 여기서 0(게시)을 냈다(종전 `[ -n "$f" ] || return 0` 를 그대로 옮긴 것).
+    #    degrade-scan 이 S2 로 지목했고, 비가역 표면이므로 **보류(3)** 로 닫는다.
+    if [ "$n" -eq 0 ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] 🚫 publish gate: 대상 파일 0건인데 digest_ready 는 참이었다 — 보류(fail-closed)" >> "$LOG_FILE"
+        return 3
+    fi
+    return "$worst"
 }
 
 # ── 착지 증언 (2026-08-18, 원정 2차 ⓑ) ────────────────────────────────────
@@ -89,11 +168,29 @@ landing_witness() {
     local checker="${FH_DIR}/scripts/digest_landing_check.sh"
     [ -x "$checker" ] || { echo "[$(date '+%Y-%m-%d %H:%M:%S')] landing witness: checker 부재 — SKIPPED (not a pass)" >> "$LOG_FILE"; return 0; }
     local prev
+    # 🟥 R5 (2026-08-18, **첫 실사용에서 발견**) — `sort` 가 로케일 의존이라 «직전»을 틀리게
+    #    고른다. 실측: 기본 로케일에서 `frontier_digest_2026-06-02.md`(대시 표기 옛 파일)가
+    #    `frontier_digest_2026_08_17.md` 보다 뒤에 정렬돼, **두 달 전 파일**이 직전으로 뽑혔고
+    #    그 파일엔 후보 절이 없어 매 런 HARNESS-ERROR 였다. `LC_ALL=C` 로 바이트 순서를 고정한다.
+    #    (레인 21개가 전부 초록인 채로 이게 살아 있었다 — 픽스처가 한 가지 표기만 썼기 때문이다.)
     prev=$(find "${FH_DIR}/${OUT_DIR}" -maxdepth 1 -name 'frontier_digest_*.md' 2>/dev/null \
-           | grep -v "frontier_digest_${TODAY}" | sort | tail -1)
+           | grep -v "frontier_digest_${TODAY}" | LC_ALL=C sort | tail -1)
     [ -n "$prev" ] || { echo "[$(date '+%Y-%m-%d %H:%M:%S')] landing witness: 직전 digest 없음 — SKIPPED (not a pass)" >> "$LOG_FILE"; return 0; }
     local out rc
-    out=$(bash "$checker" "$prev" "$FH_DIR" 2>&1); rc=$?
+    # 🟥 R1 (2026-08-18) — 초판은 `bash "$checker" "$prev" "$FH_DIR"` 였다. 두 번째 인자는
+    # **«타깃 파일 목록»** 이지 루트가 아니어서, 디렉터리가 타깃으로 들어가 **매 런 rc=10** 이
+    # 찍혔다(실측: 2인자 rc=10 컨트롤 사망 / 1인자 rc=1 컨트롤 2/2). 「배선 완료」라고 보고한
+    # 계기가 배선 첫날부터 죽어 있었다 — 손으로 부른 형태와 러너가 부르는 형태가 달랐다.
+    # 루트는 `CLAUDE_PROJECT_DIR` 로 넘기고, **무엇을 볼지**는 스코프 변수로 넘긴다.
+    # ⚠️ env 접두 할당으로 넘기면 **값의 공백에서 단어분리**된다(기본 스코프가
+    #    `knowledge CLAUDE.md` — 공백이 들어 있다). export 를 서브셸에 가둔다.
+    out=$( export CLAUDE_PROJECT_DIR="$FH_DIR"
+           [ -n "${FD_LANDING_TRACKED:-}" ] && export DLC_TRACKED_PATHS="$FD_LANDING_TRACKED"
+           [ -n "${FD_LANDING_IGNORED+x}" ] && export DLC_IGNORED_DIR="$FD_LANDING_IGNORED"
+           # 🟥 컨트롤 토큰도 대상축이다 — 기본값은 레포 이름이라 FH 는 무변경이지만,
+           #    대상 레포에 확실히 있는 토큰을 위성이 지정할 수 있어야 계기가 산다.
+           [ -n "${FD_LANDING_CONTROLS:-}" ] && export DLC_CONTROLS="$FD_LANDING_CONTROLS"
+           bash "$checker" "$prev" 2>&1 ); rc=$?
     case "$rc" in
         0)  echo "[$(date '+%Y-%m-%d %H:%M:%S')] landing witness [$(basename "$prev")]: ALL-LANDED (rc=0)" >> "$LOG_FILE" ;;
         1)  echo "[$(date '+%Y-%m-%d %H:%M:%S')] landing witness [$(basename "$prev")]: SOME-UNLANDED (rc=1) — 선별기다, 히트를 손으로 열어라" >> "$LOG_FILE" ;;

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -718,6 +718,20 @@ else
   fail=1
 fi
 
+# test_evidence_root_psa_lanes — 워크트리에서 기밀성 오버라이드를 찾는가 (R4, 2026-08-18).
+# 🟥 `EVIDENCE_ROOT` 에는 레인이 **하나도 없었다** — 그래서 `tracks/` 만 옮기고 gitignored
+# 패턴 파일은 안 옮긴 반쪽-픽스가 그대로 출하됐다. 되돌림 프로브로 E1 만 적색 확인.
+if [ ! -f scripts/test_evidence_root_psa_lanes.sh ]; then
+  echo "FAIL  test_evidence_root_psa_lanes.sh: missing — EVIDENCE_ROOT 기밀성 경로에 앵커 없음"
+  fail=1
+elif _out=$(bash scripts/test_evidence_root_psa_lanes.sh < /dev/null 2>&1); then
+  echo "PASS  test_evidence_root_psa_lanes.sh ($(printf '%s\n' "$_out" | grep -oE '[0-9]+ passed, [0-9]+ failed' | tail -1))"
+else
+  echo "FAIL  test_evidence_root_psa_lanes.sh: evidence-root psa lanes failed"
+  _show_failure "$_out"
+  fail=1
+fi
+
 # cluster_capability_scan — wired 2026-08-16 (정체성 ①-(a) cluster-wizard).
 # 종단 판정줄이 `… 캘리브레이션 통과/실패: N PASS / M FAIL` 이라 위 `_subj` 루프의
 # 캘리브레이션 게이트를 **진짜 판정줄로** 만족한다 — 테스트 케이스 제목이 아니다.

--- a/scripts/test_evidence_root_psa_lanes.sh
+++ b/scripts/test_evidence_root_psa_lanes.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# test_evidence_root_psa_lanes.sh — pre-commit 의 기밀성 스캐너가 **워크트리에서도 오버라이드를
+# 찾는가** (R4, 2026-08-18).
+#
+# WHY
+#   `tracks/` 는 `--git-common-dir` 기준 `EVIDENCE_ROOT` 로 옮겼는데, **똑같이 gitignored 인**
+#   `.claude/rules/.public-surface-patterns` 는 `$REPO_ROOT` 에 남아 있었다. 그래서 워크트리
+#   커밋이 매번 **defaults-only** 로 돌았다 — 회사명·실명 토큰 클래스가 통째로 UNSCANNED 고,
+#   그 상태는 **비차단 경고**라 조용히 지나간다. 반쪽-픽스의 전형
+#   ([[feedback_half_fix_propagation_boundary]]) 이고, EVIDENCE_ROOT 에는 **레인이 하나도
+#   없었다** — 그래서 반쪽인 채로 출하됐다.
+#
+# Lanes
+#   E1  워크트리에서 커밋해도 오버라이드를 찾는다 (경고 배너 없음)
+#   E1n CONTROL — 오버라이드를 지우면 같은 실행에서 배너가 **뜬다**(계기가 살아 있다는 증거)
+#   E2  CONTROL — 메인 트리는 종전 그대로 동작한다 (회귀 없음)
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+t() { if [ "$2" = "$3" ]; then echo "  ✅ $1"; pass=$((pass+1)); else echo "  ❌ $1 — got [$3] want [$2]"; fail=$((fail+1)); fi }
+
+BANNER='CONFIDENTIALITY COVERAGE REDUCED'
+
+setup() { # $1 = base dir
+  local b="$1"
+  mkdir -p "$b/main"
+  ( cd "$b/main" && git init -q . && git config user.email t@t && git config user.name t
+    mkdir -p .claude/rules scripts templates/.git-hooks tracks/_meta
+    cp "$ROOT/scripts/psa_scan_lib.sh" scripts/
+    cp "$ROOT/.claude/rules/.public-surface-patterns.defaults" .claude/rules/ 2>/dev/null
+    cp "$ROOT/templates/.git-hooks/pre-commit" templates/.git-hooks/
+    printf 'tracks/\n.claude/rules/.public-surface-patterns\n' > .gitignore
+    printf 'x\n' > seed.md
+    git add -A && git commit -qm base ) >/dev/null 2>&1
+  # gitignored 오버라이드 — **메인 트리에만** 둔다 (실제 배치가 그렇다)
+  printf 'HIGH\tZZ_R4_OVERRIDE_TOKEN_ZZ\n' > "$b/main/.claude/rules/.public-surface-patterns"
+}
+
+run_hook() { # $1 = 실행 디렉터리 → echoes banner|clean
+  local out
+  ( cd "$1" && printf 'hello\n' > probe.md && git add probe.md \
+    && bash templates/.git-hooks/pre-commit ) >/tmp/.r4out 2>&1
+  if grep -q "$BANNER" /tmp/.r4out; then echo banner; else echo clean; fi
+}
+
+B=$(mktemp -d); setup "$B"
+( cd "$B/main" && git worktree add -q "$B/wt" -b wtbranch ) >/dev/null 2>&1
+# 워크트리에는 templates/ 가 체크아웃돼 있다(tracked). 오버라이드는 없다(gitignored).
+t "E1 워크트리에서도 오버라이드를 찾는다"          "clean"  "$(run_hook "$B/wt")"
+t "E2 control — 메인 트리 회귀 없음"               "clean"  "$(run_hook "$B/main")"
+mv "$B/main/.claude/rules/.public-surface-patterns" "$B/main/.claude/rules/.psa.bak"
+t "E1n control — 오버라이드가 진짜 없으면 배너가 뜬다" "banner" "$(run_hook "$B/wt")"
+
+# ── E3 · «있지만 무효» (cross-family/codex 지적, 2026-08-18) ─────────────────
+# 🟥 지적: E1/E1n 은 **파일 없음**만 재고, EVIDENCE_ROOT 쪽 파일이 «있지만 비었거나 손상»인
+#    경로를 안 잰다. 실측해 보니 기존 기계가 이미 **소리내며** 처리한다 —
+#      빈 파일  → PSA_OVERRIDE_PRESENT=0 → 커버리지 축소 배너
+#      손상 행  → PSA_BAD_ROWS>0        → «gate INACTIVE/INCOMPLETE»
+#    🟥 그리고 **폴백하지 않는 것이 옳은 방향**이다: 워크트리에 있는 다른 파일로 조용히
+#    갈아타면 «어느 패턴셋으로 쟀는지»가 로그에서 사라진다. 시끄럽게 알리는 쪽을 고정한다.
+printf 'HIGH\tZZ_WT_LOCAL_ZZ\n' > "$B/wt/.claude/rules/.public-surface-patterns"   # 워크트리 로컬본
+: > "$B/main/.claude/rules/.public-surface-patterns"                                  # EVIDENCE_ROOT = 빈 파일
+t "E3 EVIDENCE_ROOT 가 비었으면 조용히 폴백하지 않고 알린다" "banner" "$(run_hook "$B/wt")"
+printf 'no-tab-garbage-row\n' > "$B/main/.claude/rules/.public-surface-patterns"
+out3=$( ( cd "$B/wt" && printf 'z\n' > p2.md && git add p2.md && bash templates/.git-hooks/pre-commit ) 2>&1 )
+case "$out3" in *"INACTIVE/INCOMPLETE"*) r=announced ;; *) r=silent ;; esac
+t "E3b 손상 행은 «게이트 무효»로 알린다(조용한 통과 아님)" "announced" "$r"
+rm -rf "$B" /tmp/.r4out
+
+echo "----"; echo "evidence-root psa: $pass passed, $fail failed"; [ "$fail" -eq 0 ]

--- a/scripts/test_satellite_publish_gate_lanes.sh
+++ b/scripts/test_satellite_publish_gate_lanes.sh
@@ -20,7 +20,13 @@
 #   P4  착지 증언이 **실제로 로그에 찍힌다** — 직전 digest 가 없으면 «SKIPPED (not a pass)».
 #       배선했다 ≠ 발화한다. 그리고 SKIP 을 통과로 렌더하지 않는 것까지 주장한다
 #
-# Exit 0 = 5/5.
+#   R1  착지 증언이 **살아 있다** — 러너가 부르는 형태로 rc=10(계기 사망)이 아니어야 한다
+#   R1n CONTROL — 옛 형태(디렉터리를 타깃으로)는 지금도 rc=10 이다. 고친 게 이거라는 증명
+#   R2  공개 대상이면 로그가 **OUT_DIR 밖**이다 / R2n CONTROL — 비공개면 종전 자리 그대로
+#   R2b LEAK 로그에 **토큰 원문이 없다**(리댁션) — 유출을 격리하며 같은 자리에 복사하지 않는다
+#   R3  같은 날 파일이 둘이고 **뒤엣것이 LEAK** 이면 rc=2 — head -1 이면 CLEAN 이 나온다
+#
+# Exit 0 = 전 레인.
 set -u
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 pass=0; fail=0
@@ -44,7 +50,9 @@ run() { # $1 = digest body · $2 = psa_lib override ("dead") · $3 = arm 이름 
   # → 러너를 그대로 돌리되 CLAUDE_BIN 을 no-op 스텁으로 줘서 attempt 를 태운다.
   printf '#!/usr/bin/env bash\nexit 0\n' > "$td/scripts/stub-claude"; chmod +x "$td/scripts/stub-claude"
   local out rc
+  # R2 이후 공개 대상의 로그는 OUT_DIR 밖이다 — arm 은 자기 위치를 명시한다(레인이 로그를 읽어야 하므로)
   out=$(cd "$td" && FD_FH_DIR="$td" FD_OUT_DIR="out" FD_PUBLIC_TARGET=1 \
+        FD_LOG_DIR="$td/logs" \
         FD_CLAUDE_BIN="$td/scripts/stub-claude" FD_MAX_ATTEMPTS=1 FD_ATTEMPT_TIMEOUT_SECS=20 \
         FD_POLL_SECS=1 bash scripts/frontier_digest_daily.sh 2>&1); rc=$?
   local state=none
@@ -55,7 +63,9 @@ run() { # $1 = digest body · $2 = psa_lib override ("dead") · $3 = arm 이름 
   # 🟥 arm 마다 따로 남긴다. 초판은 단일 파일에 덮어써서 **마지막 arm(P3, 스캐너 사망)** 것을
   # 잡았는데, 거기선 게이트가 실패해 증언이 안 도는 게 정상이다 — 레인이 정상 동작을 실패로
   # 렌더할 뻔했다. 판정 대상 arm 을 이름으로 고른다.
-  grep -h "landing witness" "$td/out/logs/"*.log 2>/dev/null | head -1 > "/tmp/.lw_$3" || : 
+  grep -h "landing witness" "$td/logs/"*.log 2>/dev/null | head -1 > "/tmp/.lw_$3" || : 
+  # R2 레인이 읽는다: LEAK arm 의 로그에 토큰 원문이 남았나
+  cp "$td/logs/"*.log "/tmp/.lg_$3" 2>/dev/null || : 
   echo "$rc|$state"
   rm -rf "$td"
 }
@@ -107,5 +117,172 @@ t "N3 control — 프로필 미설정이면 종전 문자열 그대로(FH 경로
 case "$(_prompt "$pd" "nonexistent.md")" in *"STANDPOINT"*) r=leaked ;; *) r=clean ;; esac
 t "N4 control — 프로필 경로가 없으면 조용히 종전 경로(존재하지 않는 파일을 실었다고 안 한다)" "clean" "$r"
 rm -rf "$pd"
+
+
+# ── R1~R3 (2026-08-18) · 압축 후 수리분 앵커 ───────────────────────────────
+# 🟥 세 결함 다 **내가 같은 날 만들었고**, 셋 다 레인이 없어서 「배선 완료」로 보고됐다.
+
+# R2 · 공개 대상이면 로그가 OUT_DIR **밖**이다
+_logloc() { # $1 = FD_PUBLIC_TARGET 값 → echoes inside|outside
+  local td; td=$(mktemp -d); mkdir -p "$td/scripts" "$td/out" "$td/.claude/rules"
+  cp "$ROOT/scripts/frontier_digest_daily.sh" "$td/scripts/"
+  cp "$ROOT/scripts/psa_scan_lib.sh" "$td/scripts/"
+  cp "$ROOT/.claude/rules/.public-surface-patterns.defaults" "$td/.claude/rules/" 2>/dev/null
+  printf 'HIGH\tZZ_SYNTHETIC_LEAK_TOKEN_ZZ\n' > "$td/.claude/rules/.public-surface-patterns"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$td/scripts/stub-claude"; chmod +x "$td/scripts/stub-claude"
+  printf 'clean body — 아무 토큰도 없다\n%s\n' "$(head -c 1200 /dev/zero | tr '\0' 'x')" \
+    > "$td/out/frontier_digest_$(date +%Y_%m_%d).md"
+  ( cd "$td" && FD_FH_DIR="$td" FD_OUT_DIR="out" FD_PUBLIC_TARGET="$1" \
+    FD_CLAUDE_BIN="$td/scripts/stub-claude" FD_MAX_ATTEMPTS=1 FD_POLL_SECS=1 \
+    bash scripts/frontier_digest_daily.sh ) >/dev/null 2>&1
+  local r=outside
+  [ -d "$td/out/logs" ] && r=inside
+  echo "$r"; rm -rf "$td"
+}
+t "R2 공개 대상이면 로그가 OUT_DIR 밖에 앉는다"  "outside" "$(_logloc 1)"
+t "R2n control — 비공개면 종전 자리 그대로(FH 경로 무변경)" "inside"  "$(_logloc 0)"
+
+# R2b · LEAK 로그에 토큰 원문이 남지 않는다 (run() 이 /tmp/.lg_leak 에 복사해 둔다)
+if [ -f /tmp/.lg_leak ]; then
+  if grep -q 'ZZ_SYNTHETIC_LEAK_TOKEN_ZZ' /tmp/.lg_leak; then r=raw
+  elif grep -q 'REDACTED' /tmp/.lg_leak; then r=redacted
+  else r=nofinding; fi
+else r=nolog; fi
+t "R2b LEAK 로그가 토큰 원문을 안 적는다(리댁션)" "redacted" "$r"
+# R2c · 리댁션이 **allowlist 줄 형태**(끝이 `)`)도 가린다 — 초판은 줄 끝 앵커라 놓쳤다
+_red() { bash -c "$(sed -n '/^_redact()/,/^}/p' "$ROOT/scripts/frontier_digest_daily.sh")
+_redact \"\$1\"" _ "$1"; }
+case "$(_red "  ⚪ allowlisted — f.md: 'ZZ_TOK_ZZ' (row: f.md :: ZZ_TOK_ZZ)")" in
+  *ZZ_TOK_ZZ*) r=raw ;; *REDACTED*) r=redacted ;; *) r=other ;;
+esac
+t "R2c 리댁션이 allowlist 줄 형태도 가린다"      "redacted" "$r"
+case "$(_red "  ❌ HIGH leak — f.md: 'ZZ_TOK_ZZ'")" in
+  *ZZ_TOK_ZZ*) r=raw ;; *REDACTED*) r=redacted ;; *) r=other ;;
+esac
+t "R2c-n control — 종전 형태(줄 끝 인용)도 여전히 가린다" "redacted" "$r"
+
+# R2d · **경로 쪽** 토큰 (cross-family/codex F2) — 파일명에 토큰이 들어가면 왼쪽이 남았다
+_leaky_name() {
+  local td; td=$(mktemp -d); mkdir -p "$td/scripts" "$td/out" "$td/.claude/rules"
+  cp "$ROOT/scripts/frontier_digest_daily.sh" "$ROOT/scripts/psa_scan_lib.sh" "$td/scripts/"
+  cp "$ROOT/.claude/rules/.public-surface-patterns.defaults" "$td/.claude/rules/" 2>/dev/null
+  printf 'HIGH\tZZ_SYNTHETIC_LEAK_TOKEN_ZZ\n' > "$td/.claude/rules/.public-surface-patterns"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$td/scripts/stub-claude"; chmod +x "$td/scripts/stub-claude"
+  local d; d=$(date +%Y_%m_%d)
+  # 🟥 파일명 자체에 토큰이 들어간 케이스. 본문에도 넣어야 스캐너가 히트를 낸다.
+  printf 'ZZ_SYNTHETIC_LEAK_TOKEN_ZZ\n%s\n' "$(head -c 1200 /dev/zero | tr '\0' 'x')" \
+    > "$td/out/frontier_digest_${d}-ZZ_SYNTHETIC_LEAK_TOKEN_ZZ.md"
+  ( cd "$td" && FD_FH_DIR="$td" FD_OUT_DIR="out" FD_PUBLIC_TARGET=1 FD_LOG_DIR="$td/logs" \
+    FD_CLAUDE_BIN="$td/scripts/stub-claude" FD_MAX_ATTEMPTS=1 FD_POLL_SECS=1 \
+    bash scripts/frontier_digest_daily.sh ) >/dev/null 2>&1
+  if grep -q 'ZZ_SYNTHETIC_LEAK_TOKEN_ZZ' "$td/logs/"*.log 2>/dev/null; then echo raw
+  elif grep -q 'FILENAME REDACTED' "$td/logs/"*.log 2>/dev/null; then echo redacted
+  else echo other; fi
+  rm -rf "$td"
+}
+t "R2d 파일명에 든 토큰도 로그에 안 남는다"       "redacted" "$(_leaky_name)"
+
+# R3 · 같은 날 파일이 둘이면 **전부** 스캔한다 (head -1 이면 앞엣것만 보고 CLEAN 을 낸다)
+_two_files() {
+  local td; td=$(mktemp -d); mkdir -p "$td/scripts" "$td/out" "$td/.claude/rules"
+  cp "$ROOT/scripts/frontier_digest_daily.sh" "$td/scripts/"
+  cp "$ROOT/scripts/psa_scan_lib.sh" "$td/scripts/"
+  cp "$ROOT/.claude/rules/.public-surface-patterns.defaults" "$td/.claude/rules/" 2>/dev/null
+  printf 'HIGH\tZZ_SYNTHETIC_LEAK_TOKEN_ZZ\n' > "$td/.claude/rules/.public-surface-patterns"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$td/scripts/stub-claude"; chmod +x "$td/scripts/stub-claude"
+  local d; d=$(date +%Y_%m_%d)
+  # 🟥 «먼저 걸리는» 쪽을 깨끗하게 둔다 — 초판(head -1)이면 이쪽만 보고 CLEAN 을 냈다.
+  printf 'aaa clean\n%s\n' "$(head -c 1200 /dev/zero | tr '\0' 'x')" > "$td/out/frontier_digest_${d}.md"
+  printf 'zzz ZZ_SYNTHETIC_LEAK_TOKEN_ZZ\n%s\n' "$(head -c 1200 /dev/zero | tr '\0' 'x')" \
+    > "$td/out/frontier_digest_${d}_b.md"
+  local rc
+  ( cd "$td" && FD_FH_DIR="$td" FD_OUT_DIR="out" FD_PUBLIC_TARGET=1 FD_LOG_DIR="$td/logs" \
+    FD_CLAUDE_BIN="$td/scripts/stub-claude" FD_MAX_ATTEMPTS=1 FD_POLL_SECS=1 \
+    bash scripts/frontier_digest_daily.sh ) >/dev/null 2>&1; rc=$?
+  local q=no; ls "$td/out/"*_b.md.QUARANTINE >/dev/null 2>&1 && q=yes
+  echo "$rc|$q"; rm -rf "$td"
+}
+r=$(_two_files)
+t "R3 둘째 파일의 LEAK 을 놓치지 않는다(rc)"      "2"   "${r%%|*}"
+t "R3b 둘째 파일이 실제로 격리된다"               "yes" "${r##*|}"
+
+# R3c · 선택자 자기모순(digest_ready 참인데 게이트가 볼 파일 0건) → **보류**, 게시 아님
+_selector_race() {
+  local td; td=$(mktemp -d); mkdir -p "$td/scripts" "$td/out" "$td/.claude/rules"
+  cp "$ROOT/scripts/frontier_digest_daily.sh" "$ROOT/scripts/psa_scan_lib.sh" "$td/scripts/"
+  cp "$ROOT/.claude/rules/.public-surface-patterns.defaults" "$td/.claude/rules/" 2>/dev/null
+  printf 'HIGH\tZZ_SYNTHETIC_LEAK_TOKEN_ZZ\n' > "$td/.claude/rules/.public-surface-patterns"
+  # digest_files 를 «참이라 말하고 목록은 비게» 만든다 — 레이스의 최소 재현
+  cat > "$td/drv.sh" <<'EOD'
+FD_FH_DIR="$PWD"; export FD_FH_DIR
+eval "$(sed -n '/^publish_gate()/,/^}/p' scripts/frontier_digest_daily.sh)"
+eval "$(sed -n '/^_redact()/,/^}/p' scripts/frontier_digest_daily.sh)"
+digest_files() { :; }               # 0건
+FH_DIR="$PWD"; OUT_DIR=out; LOG_FILE=/dev/null; FD_PUBLIC_TARGET=1
+publish_gate; echo "rc=$?"
+EOD
+  local o; o=$(cd "$td" && bash drv.sh 2>&1); rm -rf "$td"; echo "${o##*rc=}"
+}
+t "R3c 선택자 자기모순은 게시가 아니라 보류(3)" "3" "$(_selector_race)"
+
+# R1 · 착지 증언이 **러너를 통해** 살아 있다
+# 🟥 초판 레인은 checker 를 **직접** 불러서, R1 을 원복해도 초록이었다 — 호출부를 우회한
+#    장식 앵커다([[feedback_anchor_can_be_decorative]]). 되돌림 프로브가 그걸 잡았다.
+#    지금은 **러너를 돌리고 그 로그**를 읽는다. 러너가 어떻게 부르는지가 판정 대상이다.
+_runner_witness() { # echoes verdict-word from the log
+  local td; td=$(mktemp -d)
+  ( cd "$td" && git init -q . && git config user.email t@t && git config user.name t ) >/dev/null 2>&1
+  mkdir -p "$td/scripts" "$td/out" "$td/knowledge"
+  cp "$ROOT/scripts/frontier_digest_daily.sh" "$ROOT/scripts/digest_landing_check.sh" \
+     "$ROOT/scripts/utterance_landing_check.sh" "$td/scripts/"
+  chmod +x "$td/scripts/digest_landing_check.sh"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$td/scripts/stub-claude"; chmod +x "$td/scripts/stub-claude"
+  local d; d=$(date +%Y_%m_%d)
+  cat > "$td/out/frontier_digest_2001_01_01.md" <<'EOF'
+# prev digest
+## 📌 FH Immediate Application Candidates
+
+| # | 티어 | 내용 |
+|---|---|---|
+| **M1** | **M** | `ZZ_LANDED_TOKEN_ZZ` 를 배선한다 |
+EOF
+  sleep 1
+  printf 'ZZ_LANDED_TOKEN_ZZ 배선함 · ZZ_CTL_ZZ\n' > "$td/out/landed.md"
+  printf 'today body\n%s\n' "$(head -c 1200 /dev/zero | tr '\0' 'x')" > "$td/out/frontier_digest_${d}.md"
+  ( cd "$td" && FD_FH_DIR="$td" FD_OUT_DIR="out" FD_LOG_DIR="$td/logs" \
+    FD_LANDING_TRACKED="knowledge" FD_LANDING_IGNORED="out" FD_LANDING_CONTROLS="ZZ_CTL_ZZ" \
+    FD_CLAUDE_BIN="$td/scripts/stub-claude" FD_MAX_ATTEMPTS=1 FD_POLL_SECS=1 \
+    bash scripts/frontier_digest_daily.sh ) >/dev/null 2>&1
+  local lw; lw=$(grep -h "landing witness" "$td/logs/"*.log 2>/dev/null | tail -1)
+  case "$lw" in
+    *HARNESS-ERROR*) echo dead ;;
+    *ALL-LANDED*)    echo landed ;;
+    *SOME-UNLANDED*) echo measured ;;
+    *SKIPPED*)       echo skipped ;;
+    *)               echo none ;;
+  esac
+  rm -rf "$td"
+}
+t "R1 러너가 부르는 형태에서 계기가 살아 있다(HARNESS-ERROR 아님)" "landed" "$(_runner_witness)"
+
+# R5 · «직전 다이제스트» 선택이 **표기 혼재**에서도 옳은가 (첫 실사용 발견)
+# 🟥 실물 코퍼스에는 `2026-06-02`(대시)와 `2026_08_17`(언더바)가 **섞여 있다.** 로케일 정렬은
+#    대시본을 뒤로 보내 **두 달 전 파일**을 직전으로 골랐고, 그 파일엔 후보 절이 없어 매 런
+#    HARNESS-ERROR 였다. 픽스처가 한 표기만 쓰면 레인 21개가 다 초록인 채로 이게 산다.
+_prev_pick() {
+  local td; td=$(mktemp -d); mkdir -p "$td/out"
+  # 🟥 **같은 연도**여야 재현된다. 첫 픽스처는 `2020-06-02` 를 썼는데 그건 로케일 정렬에서도
+  #    올바르게 뒤로 가서 **버그 판본도 초록**이었다(되돌림 프로브가 잡은 세 번째 장식 앵커).
+  #    실물 코퍼스의 표기를 그대로 쓴다: `2026-06-02` vs `2026_08_17`.
+  : > "$td/out/frontier_digest_2026-06-02.md"     # 옛 대시 표기, 날짜상 더 과거
+  : > "$td/out/frontier_digest_2026_08_17.md"     # 언더바 표기, 더 최근
+  local d; d=$(date +%Y_%m_%d)
+  : > "$td/out/frontier_digest_${d}.md"           # 오늘 것 (제외 대상)
+  # 러너의 선택 표현을 그대로 떼어 쓴다 — 우회하면 앵커가 장식이 된다
+  local expr; expr=$(sed -n '/prev=\$(find/,/tail -1)/p' "$ROOT/scripts/frontier_digest_daily.sh")
+  local got; got=$( cd "$td" && FH_DIR="$td" OUT_DIR=out TODAY="$d" bash -c "$expr; basename \"\$prev\"" )
+  rm -rf "$td"; echo "$got"
+}
+t "R5 표기가 섞여도 «직전»은 날짜상 최신이다" "frontier_digest_2026_08_17.md" "$(_prev_pick)"
 
 echo "----"; echo "satellite publish gate: $pass passed, $fail failed"; [ "$fail" -eq 0 ]

--- a/templates/.git-hooks/pre-commit
+++ b/templates/.git-hooks/pre-commit
@@ -39,7 +39,12 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 #    종전엔 ⓐ 가 **사실상의 장벽**이라 ⓑ 가 도달 불가였다. ⓐ 를 없애면 ⓑ 가 **처음으로 실재**한다.
 #    ⇒ 워크트리를 쓸 거면 `core.hooksPath` 를 **절대 경로**로 설정해라:
 #         git config core.hooksPath "$(git rev-parse --show-toplevel)/templates/.git-hooks"
-#       그러면 모든 워크트리가 **메인 트리의 훅 한 벌**을 돌아 자기무력화가 구조적으로 막힌다.
+#       그러면 모든 워크트리가 **메인 트리의 훅 한 벌**을 돈다.
+#    🟥 정정 (2026-08-18) — 초판은 여기에 «그러면 자기무력화가 **구조적으로 막힌다**» 라고
+#       적었고 그건 **과대주장**이다. 절대 경로가 막는 것은 **훅 파일 자체의 교체**뿐이다:
+#       이 훅은 `$REPO_ROOT/scripts/*` 를 10곳 넘게 **source** 하므로(psa_scan_lib ·
+#       branch_claim · regression_guard …), 워크트리에서 그 헬퍼 하나를 고치면 게이트는
+#       그대로 초록으로 통과한다. 「막힌다」가 아니라 **「한 겹 좁아진다」**가 정확하다.
 #    🟥 이 훅은 그것을 **강제하지 않는다** — 자기 자신의 설치 형태를 자기가 검사하는 것은
 #       이미 무력화된 뒤엔 안 돌기 때문이다(검사기가 검사 대상). 문서·설치 안내가 그 층이다.
 _gcd=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
@@ -312,8 +317,17 @@ if [ ! -r "$PSA_LIB" ]; then
   FAILED=1
 else
   . "$PSA_LIB"
+  # ── R4 (2026-08-18) · 오버라이드는 **EVIDENCE_ROOT** 에서 찾는다 ──────────────
+  # `tracks/` 는 `--git-common-dir` 로 옮겼는데 **똑같이 gitignored 인** 이 패턴 파일은
+  # `$REPO_ROOT` 에 남아 있었다. 그래서 워크트리 커밋이 매번 **defaults-only** 로 기밀성
+  # 스캔을 돌았다(회사명·실명 클래스가 통째로 UNSCANNED, 게다가 비차단 경고라 조용하다).
+  # 반쪽-픽스의 전형이다([[feedback_half_fix_propagation_boundary]]).
+  # 🟥 `defaults` 는 **tracked** 라 `REPO_ROOT` 가 맞다 — 같이 옮기면 안 된다. 옮기는 것은
+  #    gitignored 인 오버라이드 쪽 하나뿐이고, 없으면 REPO_ROOT 로 폴백한다.
+  PSA_OVR="$EVIDENCE_ROOT/.claude/rules/.public-surface-patterns"
+  [ -r "$PSA_OVR" ] || PSA_OVR="$REPO_ROOT/.claude/rules/.public-surface-patterns"
   psa_load "$REPO_ROOT/.claude/rules/.public-surface-patterns.defaults" \
-           "${PSA_PATTERNS:-$REPO_ROOT/.claude/rules/.public-surface-patterns}"
+           "${PSA_PATTERNS:-$PSA_OVR}"
   if [ "$PSA_OVERRIDE_PRESENT" -eq 0 ]; then
     # 2026-08-16 weekly-audit residual — operator decision: LOUDER WARNING, not fail-closed.
     # A hard block here would fail every fresh clone's / CI's / worktree's first commit (the


### PR DESCRIPTION
어제 위성(정체성 ④)을 배선하며 **내가 만든** 결함 다섯을, 타계열 둘이 찾은 셋과 함께 닫는다.
공통 얼굴 하나 — **레인이 없어서 「배선 완료」로 보고됐다.**

## 무엇이 실제로 깨져 있었나

| # | 결함 | 어떻게 드러났나 |
|---|---|---|
| **R1** | `landing_witness()` 가 checker 에 **디렉터리를 «타깃 파일»로** 넘겨 **매 런 rc=10** | 손으로 부른 형태(1인자, rc=1 컨트롤 2/2)와 러너가 부르는 형태(2인자, rc=10 컨트롤 사망)가 달랐다 |
| **R1-b** | 컨트롤 토큰이 `forge-harness`/`session` **하드코딩** — R1 을 고쳐도 위성에선 죽은 채 | **R1 레인을 쓰다가** 드러났다 (반쪽 수리) |
| **R2** | 공개 대상 트리 «안»에 로그를 파고 findings 가 **토큰 원문**을 찍었다 (HIGH) | 유출을 격리하면서 같은 공개 트리에 그 유출을 적는 형태. `publish_gate` 는 `*.md` 만 봐서 구조적으로 스캔 밖 |
| **R3** | `publish_gate` 가 `head -1` 로 **한 파일만** 스캔 | 선택자가 `digest_ready` 와 갈려 있었다 (두 계열 독립 수렴) |
| **R4** | gitignored 패턴 오버라이드를 `REPO_ROOT` 에서만 찾음 → **워크트리가 defaults-only** | `tracks/` 만 EVIDENCE_ROOT 로 옮긴 반쪽-픽스. 회사명·실명 클래스 UNSCANNED, 게다가 비차단 경고 |
| **R5** | 「직전 다이제스트」를 로케일 `sort` 로 골라 **두 달 전 파일**을 집었다 | 🟥 **레인이 아니라 첫 실사용이 잡았다** — 그 시점 레인 21개는 전부 초록 |

## 타계열 패널 — 자력 적발 0 인 항목이 둘

축을 갈라 보냈다: **codex/gpt-5.5 = diff** · **agy/gemini = 주장 목록(코드 아님)**.

- **F2** (codex) 파일명에 든 토큰이 로그 왼쪽에 남는다 → 비정규 파일명은 통째로 가린다
- **F3** (codex) 유도 컨트롤이 **ERE 로** 쓰여 레포명 메타문자면 «아무거나 매치». 🟥 실측은 더 나빴다 — 비인용 명령치환이라 **글로빙까지** 타서 컨트롤이 4개로 확장
- **C2** (agy) 경로 잔존을 독립 재현 → 벨트앤브레이스 sed
- **F1** (codex) **실측으로 기각** — 빈/손상 오버라이드는 기존 기계가 이미 시끄럽게 막는다(배너 대신 «게이트 INACTIVE»). 레인 E3/E3b 로 그 사실을 고정
- **C3** (agy) `git log --all` 로 **실제 유출 0** 독립 확인 — 로그는 전부 gitignored 였다

## 🟥 되돌림 프로브가 내 **장식 앵커 3건**을 잡았다

```
① R1 초판 레인이 checker 를 직접 불러 러너 호출부를 우회 → 원복해도 초록
② N-ctl-re 픽스처가 `.*` → 버그 판본도 rc=10 (같은 값, 다른 이유)
③ R5 픽스처가 `2020-06-02` → 연도가 달라 로케일 정렬이 올바르게 동작
```
셋 다 **「가능한 경우가 하나」 가정**이다. 「뚫리는 표기」로 다시 짰고 지금은 **8/8 이 정확히 그 레인만** 적색이다.

## 검증

```
레인   위성 22 · EVIDENCE_ROOT 5(신설 — 이 경로엔 앵커가 0개였다) · 착지 self-test 12
되돌림 8/8 각각 그 레인만 적색 · 복원 후 전 레인 초록 재확인
selfcheck rc=0 · FAIL 0
첫실사용 FH 프로덕션 러너 실행 → R5 발견 → 수리 후 재실행하여 실판정(rc=1) 확인
위성    launchd plist 2개 재작성·재적재, 공개 트리 로그 잔여 0
```

## 정정 1건 (내 말이 틀렸다)

훅 주석의 «절대 hooksPath 면 자기무력화가 **구조적으로 막힌다**» 는 **과대주장**이다. 훅이 `$REPO_ROOT/scripts/*` 를 10곳 넘게 **source** 하므로 워크트리에서 헬퍼 하나를 고치면 게이트는 초록으로 통과한다. → 「한 겹 좁아진다」로 정정.

## 명명된 잔여

1. `DLC_TRACKED_PATHS` 는 **공백 분리 계약** — 경로에 공백이 있으면 갈린다 (codex F4, **문서화만**)
2. 🟥 **내일 발화 산출은 못 봤다** — 이 델타는 배선을 고쳤지 산출을 본 게 아니다
3. 프로필 → `acceptEdits` **쓰기 경계 미해결** (운영자 결정 대기)
4. 리댁션은 **현 세 형태만** 잡는다 — 스캐너가 형태를 늘리면 또 샌다
5. **ⓓ 3자대면 미실시** (`thirdparty: UNKNOWN`) — 선행자산 조사도, 다른 하네스 페르소나 리뷰도 안 했다
6. 🟥 감사 diff 를 만들며 **`git add -A` 를 한 번 썼다** — 공유 체크아웃 금지 규율 위반. 남의 파일이 안 섞인 건 peer 가 그때 커밋을 끝냈기 때문이지 내가 지켰기 때문이 아니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)
