### PR TITLE
feat(satellite): 프로필이 «금지선·산출자리·sink» 를 선언하게 하고, 선언을 실제 deny 로 물질화

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "scripts/chamber_candidate_collect.sh",
     "scripts/chamber_witness.sh",
     "scripts/digest_landing_check.sh",
+    "scripts/test_satellite_profile_schema_lanes.sh",
     "scripts/test_satellite_publish_gate_lanes.sh",
     "scripts/relay_channel.sh",
     "scripts/test_relay_channel_lanes.sh",

--- a/scripts/frontier_digest_daily.sh
+++ b/scripts/frontier_digest_daily.sh
@@ -32,6 +32,15 @@ HUMAN_DATE=$(date +%Y-%m-%d)   # pinned once with TODAY — a wake-fired run cro
 #                 checker 기본값(= FH 문법 + 레포명 컨트롤) 그대로.
 # 🟥 기본값은 **전부 종전 그대로**다 — FH 프로덕션 경로 무변경.
 OUT_DIR="${FD_OUT_DIR:-tracks/_meta}"          # FH_DIR 기준 상대경로
+# 🟥 처방 2 (2026-08-19) — `FD_OUT_DIR` 가 **레포 밖 절대경로**를 받는다.
+# 종전엔 `${FH_DIR}/${OUT_DIR}` 로만 조립돼 상대경로 전제였다. 그런데 어떤 대상 레포는
+# «`git status` 에 설명되지 않은 것이 뜨면 사건» 으로 취급한다(ⓓ 3자대면, gstack §Compiled
+# binaries) — 거기선 untracked 산출이 **매일 아침 오염**이다. 레포 밖에 떨어뜨릴 수 있어야 한다.
+# 🟥 기본값 무변경: 상대경로면 종전과 **바이트 동일**한 경로가 나온다.
+case "$OUT_DIR" in
+    /*) OUT_ABS="$OUT_DIR" ;;
+    *)  OUT_ABS="${FH_DIR}/${OUT_DIR}" ;;
+esac
 # FD_PROFILE — 대상 하네스가 **자기를 설명하는** 파일(FH_DIR 기준 상대경로).
 # 🟥 이게 없으면 위성은 «프런티어 신호 목록»을 남의 폴더에 복사한다 — 실측 2026-08-18:
 #   FD_OUT_DIR 만 옮긴 런의 산출물이 "signals relevant to forge-harness (FH) operations" 였다
@@ -51,7 +60,7 @@ if [ -n "${FD_LOG_DIR:-}" ]; then
 elif [ "${FD_PUBLIC_TARGET:-0}" = "1" ]; then
     LOG_DIR="${HOME}/.cache/fh/frontier_digest/$(basename "$FH_DIR")"
 else
-    LOG_DIR="${FH_DIR}/${OUT_DIR}/logs"
+    LOG_DIR="${OUT_ABS}/logs"
 fi
 LOG_FILE="${LOG_DIR}/frontier_digest_${TODAY}.log"
 
@@ -69,11 +78,168 @@ find "$LOG_DIR" -name 'frontier_digest_*.log' -mtime +30 -delete 2>/dev/null
 # 내고 **진짜 다이제스트는 미스캔으로 게시**된다(두 계열 독립 수렴).
 # 두 벌의 관대함이 갈리는 그 형태다([[feedback_divergent_leniency_duplicate_normalizers]]).
 digest_files() {
-    find "${FH_DIR}/${OUT_DIR}" -maxdepth 1 -name "frontier_digest_${TODAY}*.md" -size +1k 2>/dev/null
+    find "${OUT_ABS}" -maxdepth 1 -name "frontier_digest_${TODAY}*.md" -size +1k 2>/dev/null
 }
 
 digest_ready() {
     digest_files | grep -q .
+}
+
+# ── 프로필 스키마 게이트 (2026-08-19, 처방 1+3 · C-2 정밀) ────────────────────
+# ⓓ 3자대면이 낸 설계 결함: 프로필이 «금지 파일 / 산출 자리 / 이 레포의 sink» 를 **요구하지
+# 않는다**. the-bible 프로필에 금지선 5개가 있는 건 내가 그 도메인을 알아서 쓴 것이지 스키마가
+# 요구해서가 아니다 — 다음 위성에서 그 자리가 비면 **조용히** 빠진다.
+#
+# 🟥 그리고 대상이 «남의 레포인데 주인이 FH 로 신청한» 경우(운영자 정의 2026-08-19), 이 세 필드는
+#    위생이 아니라 **권한·동의 표면**이다. 주인이 「내 레포에서 뭘 건드리지 마라 / 여기 뭐가
+#    나가면 안 되나」를 선언하는 자리가 이것뿐이다. 비면 FH 는 그걸 **모르는 채로** 돈다.
+#
+# 검사 성격 — §Mechanization Boundary: 이건 **채널 검사**다(필드가 있나 · 타입이 맞나 ·
+# 비공허한가). 값이 **옳은가**는 안 본다. 후자를 코드로 굳히면 오늘의 판단이 내일의 천장이 된다.
+# ⇒ `egress_sinks: [none]` 같은 **명시적 «없음»은 정당한 값**이고, 금지되는 건 **안 적는 것**뿐이다.
+#
+# 🟥 산문은 검증이 안 되므로 프로필 **맨 앞 frontmatter 블록**만 기계가 읽는다. 본문은 종전대로
+#    사람이 쓰는 산문이고 프롬프트에 통째로 실린다(형태 무변경).
+_profile_field() {
+    # $1 = 프로필 경로, $2 = 필드명 → 값을 줄 단위로 stdout. 없으면 무출력.
+    # inline flow(`[a, b]`) 와 block list(`- a`) 둘 다 받는다.
+    awk -v want="$2" '
+        NR==1 { if ($0 != "---") exit; inb=1; next }
+        inb && $0 == "---" { inb=0; exit }
+        !inb { exit }
+        {
+            if (index($0, want ":") == 1) {
+                val = substr($0, length(want) + 2)
+                sub(/^[ \t]+/, "", val); sub(/[ \t]+$/, "", val)
+                if (val ~ /^\[.*\]$/) {
+                    sub(/^\[/, "", val); sub(/\]$/, "", val)
+                    n = split(val, a, ",")
+                    for (i = 1; i <= n; i++) {
+                        sub(/^[ \t]+/, "", a[i]); sub(/[ \t]+$/, "", a[i])
+                        if (a[i] != "") print a[i]
+                    }
+                } else if (val != "") {
+                    print val
+                }
+                cap = 1; next
+            }
+            if (cap) {
+                if ($0 ~ /^[ \t]*-[ \t]+/) {
+                    v = $0; sub(/^[ \t]*-[ \t]+/, "", v)
+                    sub(/^[ \t]+/, "", v); sub(/[ \t]+$/, "", v)
+                    if (v != "") print v
+                } else if ($0 ~ /^[A-Za-z_]/) {
+                    cap = 0
+                }
+            }
+        }
+    ' "$1"
+}
+
+# 프로필이 선언한 금지선을 **런 단위 deny** 로 물질화한다.
+# 🟥 대상 레포 파일을 **한 줄도 안 고친다** — `claude --settings <JSON>` 이 JSON 문자열을 받는다.
+#    ⓑ(남의 레포) 형태에서 결정적이다: 우리가 그쪽 `.claude/` 에 쓸 권한이 없어도 걸린다.
+# 🟥 실측 known-pair 4런(2026-08-19, scratchpad/kp): deny 없음 → 센티넬 유출 1 /
+#    deny 주입 → 0. Bash(`cat`·`python3`) 경로도 같은 쌍으로 갈렸다(컨트롤이 유출했으므로
+#    「headless 라 Bash 가 원래 안 돈다」 가설은 반증). **막은 것은 deny 다.**
+# 🟥 안 잰 칸: 공식 문서가 *"임의 subprocess 에는 Read deny 가 안 걸린다 — OS 레벨은 sandbox"*
+#    라고 명시한다. 내 arm 은 BLOCKED 를 냈지만 «python 이 막혔다»와 «python 을 시도조차
+#    안 했다»를 구분 못 한다(각 arm reps=1). ⇒ **subprocess 우회는 미측정**이지 닫힌 게 아니다.
+# 🟥 **주장 범위 — 이건 «Read tool deny» 이지 egress 방화벽이 아니다** (cross-family A3).
+#    닫히는 것: Claude 의 Read/Grep/Glob + 인식되는 Bash 파일명령(cat·head·tail·sed).
+#    안 닫히는 것: 임의 subprocess(python/node 가 직접 open) · 미선언 경로에 같은 비밀이
+#    또 있는 경우 · **프로필 본문 자체**(프롬프트에 통째로 실려 이미 나간다).
+#    OS 레벨 차단은 sandbox 뿐이고 이 러너는 그걸 안 쓴다.
+# 🟥 파싱 문법도 YAML 전체가 아니다 (cross-family B7): frontmatter 안의
+#    **인용 없는 스칼라 + 단순 리스트**(`[a, b]` 또는 `- a`)만 받는다. 인용 스칼라·값 안의
+#    쉼표·인라인 주석은 오판하며, 방향은 fail-closed(과차단)다.
+PROFILE_SETTINGS_JSON=""
+_json_str() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+
+validate_profile() {
+    local prof="$1" missing="" f v n
+    if ! head -1 "$prof" | grep -q '^---$'; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] 🚫 profile gate: frontmatter 블록 없음 — 스키마 미선언, fail-closed" >> "$LOG_FILE"
+        return 4
+    fi
+    for f in satellite_profile output_location forbidden_paths egress_sinks; do
+        v=$(_profile_field "$prof" "$f")
+        [ -n "$v" ] || missing="${missing}${f} "
+    done
+    if [ -n "$missing" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] 🚫 profile gate: 필수 필드 누락 [${missing% }] — fail-closed" >> "$LOG_FILE"
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')]   («없음»을 뜻하려면 빈 값이 아니라 명시적으로 none 을 적어라)" >> "$LOG_FILE"
+        return 4
+    fi
+    # 🟥 `output_location` 은 **읽어서 대조한다**. 존재만 검사하면 「슬롯은 있고 소비처가 0」인
+    #    반쪽 외부화가 되고, 그동안 선언값과 실제 `FD_OUT_DIR` 이 조용히 갈린다
+    #    ([[feedback_half_externalization_slot_without_consumer]]).
+    #    프로필이 «내 산출은 여기»라고 적었는데 러너가 딴 데 떨어뜨리면 선언과 실제가 갈린 것이다.
+    # ⚠️ **주장 범위**: 이건 «러너가 어디로 지시하는가»의 대조지 «모델이 딴 파일에 못 쓴다»가
+    #    아니다(cross-family A5). 쓰기 억제는 위 forbidden_paths deny 가 하고, 그것도 부분적이다.
+    local declared decl_abs
+    declared=$(_profile_field "$prof" output_location)
+    case "$declared" in
+        /*) decl_abs="$declared" ;;
+        *)  decl_abs="${FH_DIR}/${declared}" ;;
+    esac
+    decl_abs="${decl_abs%/}"
+    if [ "$decl_abs" != "${OUT_ABS%/}" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] 🚫 profile gate: 산출 자리 불일치 — 프로필 선언 '$decl_abs' vs 실제 '${OUT_ABS%/}' — fail-closed" >> "$LOG_FILE"
+        return 4
+    fi
+
+    # deny 물질화. `none` 은 «선언된 없음»이라 규칙을 안 만든다.
+    # 🟥 F6: 절대경로가 오면 `./` 를 안 붙인다. 초판은 무조건 붙여 `.//abs` 를 만들었다.
+    # 🟥 F8: control char 는 JSON 문자열을 깬다 — 인용/역슬래시와 같이 fail-closed.
+    _deny_path() {
+        case "$1" in
+            /*) printf '%s' "$1" ;;
+            *)  printf './%s' "$1" ;;
+        esac
+    }
+    local rules="" item esc fp_any=0
+    while IFS= read -r item; do
+        [ -n "$item" ] || continue; [ "$item" = "none" ] && continue
+        case "$item" in *'"'*|*'\'*|*[[:cntrl:]]*)
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] 🚫 profile gate: forbidden_paths 에 인용/역슬래시/control char — JSON 조립 불가, fail-closed" >> "$LOG_FILE"
+            return 4 ;;
+        esac
+        esc=$(_json_str "$(_deny_path "$item")")
+        rules="${rules}\"Edit(${esc})\",\"Write(${esc})\","
+        fp_any=1
+    done <<EOF
+$(_profile_field "$prof" forbidden_paths)
+EOF
+    while IFS= read -r item; do
+        [ -n "$item" ] || continue; [ "$item" = "none" ] && continue
+        case "$item" in *'"'*|*'\'*|*[[:cntrl:]]*)
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] 🚫 profile gate: egress_sinks 에 인용/역슬래시/control char — JSON 조립 불가, fail-closed" >> "$LOG_FILE"
+            return 4 ;;
+        esac
+        esc=$(_json_str "$(_deny_path "$item")")
+        rules="${rules}\"Read(${esc})\","
+    done <<EOF
+$(_profile_field "$prof" egress_sinks)
+EOF
+    # 🟥 F4 (cross-family A4): `Edit`/`Write` deny 만으로는 파일 변경이 안 닫힌다.
+    #    `--permission-mode acceptEdits` 는 공식 문서상 **mkdir·touch·rm·rmdir·mv·cp·sed 를
+    #    자동 승인**한다 — 즉 `sed -i` 한 줄로 forbidden_paths 의 파일을 고칠 수 있었다.
+    #    무인 런에서 그 변이 명령들은 필요가 없으므로 통째로 닫는다.
+    # ⚠️ 이건 경로별이 아니라 **명령별**이라 coarse 하다. 정밀하게 닫는 유일한 층은 OS sandbox 다.
+    if [ "$fp_any" = "1" ]; then
+        for _c in sed mv cp rm rmdir; do
+            rules="${rules}\"Bash(${_c}:*)\","
+        done
+    fi
+    if [ -n "$rules" ]; then
+        PROFILE_SETTINGS_JSON="{\"permissions\":{\"deny\":[${rules%,}]}}"
+        n=$(printf '%s' "$rules" | tr -cd ',' | wc -c | tr -d ' ')
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] profile gate: OK — deny 규칙 ${n}건 주입" >> "$LOG_FILE"
+    else
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] profile gate: OK — 선언된 금지선 없음(none), deny 규칙 0건" >> "$LOG_FILE"
+    fi
+    return 0
 }
 
 # ── 공개표면 게이트 (2026-08-18, 원정 2차) ──────────────────────────────────
@@ -191,7 +357,7 @@ landing_witness() {
     #    `frontier_digest_2026_08_17.md` 보다 뒤에 정렬돼, **두 달 전 파일**이 직전으로 뽑혔고
     #    그 파일엔 후보 절이 없어 매 런 HARNESS-ERROR 였다. `LC_ALL=C` 로 바이트 순서를 고정한다.
     #    (레인 21개가 전부 초록인 채로 이게 살아 있었다 — 픽스처가 한 가지 표기만 썼기 때문이다.)
-    prev=$(find "${FH_DIR}/${OUT_DIR}" -maxdepth 1 -name 'frontier_digest_*.md' 2>/dev/null \
+    prev=$(find "${OUT_ABS}" -maxdepth 1 -name 'frontier_digest_*.md' 2>/dev/null \
            | grep -v "frontier_digest_${TODAY}" | LC_ALL=C sort | tail -1)
     [ -n "$prev" ] || { echo "[$(date '+%Y-%m-%d %H:%M:%S')] landing witness: 직전 digest 없음 — SKIPPED (not a pass)" >> "$LOG_FILE"; return 0; }
     local out rc
@@ -229,9 +395,9 @@ _build_prompt() {
 "🟥 TARGET HARNESS — this digest is NOT for forge-harness. Read the profile below and write for THAT harness. Copying a generic frontier list here is replication, not propagation; the deliverable is **what THIS harness should change**, each point naming a file or behavior in it." \
 "🟥 STANDPOINT — do not write from forge-harness's chair. OPEN AND READ the target's own files that the profile names: its canon docs AND its actual source. Cite them by path + line number or function name. A point you cannot anchor to something you actually opened is a trend statement, not an application. (This is the standpoint axis applied to frontier input: reading the profile is tier1b, reading the real code is tier2 — the measured difference is whether any Route line appears at all.)" \
 "$(cat "$prof")" \
-"Save the digest to ${OUT_DIR}/frontier_digest_${TODAY}.md, in the node grammar the profile specifies. Do NOT regenerate any index. If a source cannot be fetched, say so — never invent a citation, and cite specific items, not listing pages."
+"Save the digest to ${OUT_ABS}/frontier_digest_${TODAY}.md, in the node grammar the profile specifies. Do NOT regenerate any index. If a source cannot be fetched, say so — never invent a citation, and cite specific items, not listing pages."
     else
-        printf '%s %s\n' "${base}" "Save the digest to ${OUT_DIR}/frontier_digest_${TODAY}.md."
+        printf '%s %s\n' "${base}" "Save the digest to ${OUT_ABS}/frontier_digest_${TODAY}.md."
     fi
 }
 
@@ -292,6 +458,30 @@ trap 'echo "[$(date "+%Y-%m-%d %H:%M:%S")] SIGNAL: runner received INT/HUP" >> "
 # 인터럽터블 sleep — foreground sleep 은 끝나야 trap 이 돌아 신호 수신이 sleep 잔여시간만큼
 # 늦는다(challenger B-1: launchd 의 TERM→~20s→KILL 창에서 backoff 600s 기준 기록 확률 ~3%).
 # `sleep & wait` 는 wait 가 builtin 이라 신호를 즉시 받는다 → trap 즉발.
+# 🟥 프로필 스키마 게이트는 **dispatch 직전**에 선다 — 여기가 비가역 경계다(한 번 나간
+#    바이트는 안 돌아온다). 위쪽 publish_gate 조기-종료 경로들보다 **뒤**에 두는 것은 의도다:
+#    이미 착지한 다이제스트의 게시/증언은 프로필과 무관하고, 거기서 막으면 어제 산출이
+#    스캔도 못 받고 묶인다.
+# 🟥 «위성인가»는 FD_PROFILE 유무로 판정하지 **않는다** (cross-family S1, 2026-08-19).
+#    초판이 그렇게 했고, 그러면 `FD_FH_DIR` 만 남의 레포로 돌린 런이 프로필 없이 **그대로
+#    dispatch 된다** — 게이트를 끄는 방법이 «필드를 안 적는 것»이었다. 더 나쁜 건 내 레인 E2 가
+#    그 우회를 「FH 경로 무변경」이라며 **초록으로 고정**하고 있었다는 것이다
+#    ([[feedback_lane_vocabulary_blind_to_its_own_fix]] — 수리와 같은 어휘로 레인을 쓰면 안 잡힌다).
+# 판정은 **기계적**이다: 엔진이 사는 레포에서 도는가(FH 자기 런), 남의 레포에서 도는가(위성).
+IS_SATELLITE=0
+[ "$(cd "$FH_DIR" 2>/dev/null && pwd -P)" != "$(cd "$ENGINE_DIR" 2>/dev/null && pwd -P)" ] && IS_SATELLITE=1
+if [ "$IS_SATELLITE" = "1" ] && [ -z "$PROFILE_PATH" ]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] 🚫 profile gate: 위성 런(FD_FH_DIR≠엔진 레포)인데 FD_PROFILE 미설정 — fail-closed" >> "$LOG_FILE"
+    rmdir "$LOCK_DIR" 2>/dev/null; exit 4
+fi
+if [ -n "$PROFILE_PATH" ]; then
+    if [ ! -f "${FH_DIR}/${PROFILE_PATH}" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] 🚫 profile gate: FD_PROFILE 지정됐는데 파일 부재 ($PROFILE_PATH) — fail-closed" >> "$LOG_FILE"
+        rmdir "$LOCK_DIR" 2>/dev/null; exit 4
+    fi
+    validate_profile "${FH_DIR}/${PROFILE_PATH}" || { rmdir "$LOCK_DIR" 2>/dev/null; exit 4; }
+fi
+
 _isleep() { sleep "$1" & wait $!; }
 for ATTEMPT in $(seq 1 $MAX_ATTEMPTS); do
     # Re-check before spending an attempt (a manual run may have landed the digest during the sleep)
@@ -302,6 +492,7 @@ for ATTEMPT in $(seq 1 $MAX_ATTEMPTS); do
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] Attempt ${ATTEMPT}/${MAX_ATTEMPTS}" >> "$LOG_FILE"
     "$CLAUDE_BIN" -p --permission-mode acceptEdits \
         ${FD_MODEL:+--model "$FD_MODEL"} \
+        ${PROFILE_SETTINGS_JSON:+--settings "$PROFILE_SETTINGS_JSON"} \
         "$(_build_prompt)" \
         >> "$LOG_FILE" 2>&1 &
     CLAUDE_PID=$!

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -718,6 +718,21 @@ else
   fail=1
 fi
 
+# test_satellite_profile_schema_lanes — 프로필 스키마 게이트(2026-08-19, 처방 1+3 · C-2).
+# 🟥 신설하고 안 배선해서 `lane-runner: A suite nothing executes is prose` 로 CI 가 빨갰다.
+#    바로 윗 블록이 **같은 사고의 기록**인데 그걸 읽고도 같은 실수를 했다 — 산문은 자기
+#    바로 위에 있어도 안 읽힌다는 실측이고, 잡은 것은 검사기다.
+if [ ! -f scripts/test_satellite_profile_schema_lanes.sh ]; then
+  echo "FAIL  test_satellite_profile_schema_lanes.sh: missing — 프로필 스키마 게이트에 앵커 없음"
+  fail=1
+elif _out=$(bash scripts/test_satellite_profile_schema_lanes.sh < /dev/null 2>&1); then
+  echo "PASS  test_satellite_profile_schema_lanes.sh ($(printf '%s\n' "$_out" | grep -oE 'PASS=[0-9]+ FAIL=[0-9]+' | tail -1))"
+else
+  echo "FAIL  test_satellite_profile_schema_lanes.sh: 프로필 스키마 레인 실패"
+  _show_failure "$_out"
+  fail=1
+fi
+
 # test_evidence_root_psa_lanes — 워크트리에서 기밀성 오버라이드를 찾는가 (R4, 2026-08-18).
 # 🟥 `EVIDENCE_ROOT` 에는 레인이 **하나도 없었다** — 그래서 `tracks/` 만 옮기고 gitignored
 # 패턴 파일은 안 옮긴 반쪽-픽스가 그대로 출하됐다. 되돌림 프로브로 E1 만 적색 확인.

--- a/scripts/test_frontier_digest_retry.sh
+++ b/scripts/test_frontier_digest_retry.sh
@@ -21,6 +21,12 @@ TODAY=$(date +%Y_%m_%d)
 mk_sandbox() {  # stdout: sandbox dir
   local T; T=$(mktemp -d)
   mkdir -p "$T/fh/tracks/_meta/logs" "$T/bin"
+  # 🟥 2026-08-19: 러너가 «엔진 레포가 아닌 트리»에서 돌면 프로필 선언을 요구한다
+  #    (FD_PROFILE 미설정으로 게이트를 끌 수 있으면 그게 우회다 — cross-family S1).
+  #    이 샌드박스도 엔진 레포가 아니므로 선언을 준다. 재시도/watchdog 로직을 재는 레인이라
+  #    금지선은 비우되(`none`) **명시적으로** 적는다 — 빈 값은 미선언과 같이 막힌다.
+  printf -- '---\nsatellite_profile: v1\nforbidden_paths: [none]\noutput_location: tracks/_meta\negress_sinks: [none]\n---\n' \
+      > "$T/fh/.satellite-profile.md"
   echo "$T"
 }
 
@@ -31,7 +37,7 @@ run_case() {  # $1=name $2=stub-body $3=expect-grep $4=expect-exit [$5=extra-env
   chmod +x "$T/bin/claude-stub"
   local log="$T/fh/tracks/_meta/logs/frontier_digest_${TODAY}.log"
   set +e
-  env FD_FH_DIR="$T/fh" FD_CLAUDE_BIN="$T/bin/claude-stub" \
+  env FD_FH_DIR="$T/fh" FD_PROFILE=.satellite-profile.md FD_CLAUDE_BIN="$T/bin/claude-stub" \
       FD_ATTEMPT_TIMEOUT_SECS=3 FD_POLL_SECS=1 FD_RETRY_SLEEP_SECS=1 $extra \
       bash "$RUNNER" >/dev/null 2>&1
   local rc=$?
@@ -70,7 +76,7 @@ run_case "③ 1차 실패 → 2차 성공 조기종료" \
 T=$(mk_sandbox)
 printf '#!/usr/bin/env bash\nexit 1\n' > "$T/bin/claude-stub"; chmod +x "$T/bin/claude-stub"
 log="$T/fh/tracks/_meta/logs/frontier_digest_${TODAY}.log"
-env FD_FH_DIR="$T/fh" FD_CLAUDE_BIN="$T/bin/claude-stub" \
+env FD_FH_DIR="$T/fh" FD_PROFILE=.satellite-profile.md FD_CLAUDE_BIN="$T/bin/claude-stub" \
     FD_ATTEMPT_TIMEOUT_SECS=3 FD_POLL_SECS=1 FD_RETRY_SLEEP_SECS=30 \
     bash "$RUNNER" >/dev/null 2>&1 &
 RPID=$!

--- a/scripts/test_satellite_profile_schema_lanes.sh
+++ b/scripts/test_satellite_profile_schema_lanes.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# 위성 프로필 스키마 게이트 레인 (2026-08-19, 처방 1+3 · C-2)
+#
+# 🟥 레인은 **실제 러너를 실행**한다. 함수만 따로 부르면 호출부 우회가 되고, 그건 어제
+#    되돌림이 적발한 장식 앵커 3건과 같은 형태다.
+# 🟥 `--settings` 가 **실제 argv 에 닿았는지**를 스텁이 기록해서 확인한다 —
+#    「만들었다」가 아니라 「전달됐다」를 잰다([[feedback_built_but_not_wired]]).
+set -u
+RUNNER="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/frontier_digest_daily.sh"
+PASS=0; FAIL=0
+# 🟥 스텁은 다이제스트를 안 만든다 → 러너는 정상적으로 «실패»로 끝난다. 프로덕션 백오프
+#    (3회 × 600s)를 그대로 돌면 레인이 30분이 되므로 여기서만 줄인다. **러너 기본값 무변경.**
+export FD_MAX_ATTEMPTS=1 FD_RETRY_SLEEP_SECS=1 FD_POLL_SECS=1 FD_ATTEMPT_TIMEOUT_SECS=30
+TMPROOT=$(mktemp -d); trap 'rm -rf "$TMPROOT"' EXIT
+
+ok(){ PASS=$((PASS+1)); printf '  ✅ %s\n' "$1"; }
+ng(){ FAIL=$((FAIL+1)); printf '  ❌ %s — %s\n' "$1" "$2"; }
+
+# argv 를 기록하는 claude 스텁. 다이제스트는 안 만든다(= 러너는 결국 실패로 끝난다).
+mk_stub(){ cat > "$1" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "${STUB_ARGV_OUT}"
+exit 0
+EOF
+chmod +x "$1"; }
+
+# 대상 레포 하나를 만든다. $1=프로필 내용(없으면 프로필 파일 자체를 안 만든다)
+mk_repo(){
+    local d="$TMPROOT/repo.$RANDOM$RANDOM"; mkdir -p "$d/signals"
+    [ $# -ge 1 ] && printf '%s' "$1" > "$d/.satellite-profile.md"
+    printf '%s' "$d"
+}
+
+run_runner(){  # $1=repo  → rc, 로그는 $LOGD
+    LOGD="$TMPROOT/log.$RANDOM"; mkdir -p "$LOGD"
+    STUB="$TMPROOT/claude.stub"; mk_stub "$STUB"
+    STUB_ARGV_OUT="$TMPROOT/argv.$RANDOM"; export STUB_ARGV_OUT
+    FD_FH_DIR="$1" FD_OUT_DIR=signals FD_PROFILE=.satellite-profile.md \
+    FD_LOG_DIR="$LOGD" FD_CLAUDE_BIN="$STUB" FD_MODEL=sonnet \
+    bash "$RUNNER" >/dev/null 2>&1
+    RC=$?
+}
+
+FM_FULL='---
+satellite_profile: v1
+forbidden_paths: [ETHOS.md, LICENSE]
+output_location: signals
+egress_sinks: [.env, secrets/**]
+---
+
+# 본문 산문
+'
+
+echo "── A. 필수 필드 ──"
+# A1 frontmatter 자체가 없다 (현행 프로필 두 개가 이 상태다)
+r=$(mk_repo '# 위성 프로필
+
+산문만 있다'); run_runner "$r"
+[ "$RC" -eq 4 ] && ok "A1 frontmatter 부재 → rc=4" || ng "A1 frontmatter 부재" "rc=$RC (기대 4)"
+grep -q 'frontmatter 블록 없음' "$LOGD"/*.log && ok "A1b 사유가 로그에 이름으로" || ng "A1b 사유 로그" "미기록"
+
+# A2~A5 필드별 누락
+for miss in satellite_profile forbidden_paths output_location egress_sinks; do
+    fm=$(printf '%s' "$FM_FULL" | grep -v "^${miss}:")
+    r=$(mk_repo "$fm"); run_runner "$r"
+    [ "$RC" -eq 4 ] && ok "A:$miss 누락 → rc=4" || ng "A:$miss 누락" "rc=$RC (기대 4)"
+    grep -q "필수 필드 누락.*$miss" "$LOGD"/*.log && ok "A:$miss 이름이 로그에" || ng "A:$miss 로그" "이름 없음"
+done
+
+# A6 빈 값은 누락과 같다 (명시적 none 을 요구한다)
+r=$(mk_repo '---
+satellite_profile: v1
+forbidden_paths:
+output_location: signals
+egress_sinks: [none]
+---
+'); run_runner "$r"
+[ "$RC" -eq 4 ] && ok "A6 빈 값 → rc=4 (none 을 명시해야)" || ng "A6 빈 값" "rc=$RC (기대 4)"
+
+echo "── B. 통과 + deny 물질화 ──"
+r=$(mk_repo "$FM_FULL"); run_runner "$r"
+[ "$RC" -ne 4 ] && ok "B1 완전한 프로필 → 게이트 통과" || ng "B1 완전 프로필" "rc=4 (과차단)"
+# 🟥 F9 (cross-family A9): 문자열 grep 은 **깨진 JSON 도 초록**으로 만든다. argv 에서
+#    --settings 인자를 꺼내 **JSON 으로 파싱**하고 `.permissions.deny[]` 멤버십을 본다.
+deny_has(){ python3 -c '
+import json,sys
+argv=open(sys.argv[1],encoding="utf-8").read().split("\n")
+try: i=argv.index("--settings")
+except ValueError: sys.exit(2)
+d=json.loads(argv[i+1])["permissions"]["deny"]
+sys.exit(0 if sys.argv[2] in d else 1)' "$STUB_ARGV_OUT" "$1" 2>/dev/null; }
+grep -qx -- '--settings' "$STUB_ARGV_OUT" && ok "B2 --settings 가 실제 argv 에 닿았다" || ng "B2 argv 배선" "--settings 없음"
+deny_has 'Read(./.env)'      && ok "B3 egress_sinks → Read deny (JSON 파싱)" || ng "B3 Read deny" "deny[] 에 없음/JSON 파손"
+deny_has 'Edit(./ETHOS.md)'  && ok "B4 forbidden_paths → Edit deny (JSON 파싱)" || ng "B4 Edit deny" "deny[] 에 없음"
+deny_has 'Write(./ETHOS.md)' && ok "B5 forbidden_paths → Write deny (JSON 파싱)" || ng "B5 Write deny" "deny[] 에 없음"
+deny_has 'Bash(sed:*)'       && ok "B5b acceptEdits 자동승인 변이 Bash 도 deny" || ng "B5b Bash deny" "sed 가 안 막혔다"
+
+# B6 known-negative — 전부 none 이면 규칙 0건이고 --settings 를 안 붙인다
+r=$(mk_repo '---
+satellite_profile: v1
+forbidden_paths: [none]
+output_location: signals
+egress_sinks: [none]
+---
+'); run_runner "$r"
+[ "$RC" -ne 4 ] && ok "B6 명시적 none → 통과" || ng "B6 none" "rc=4 (과차단)"
+grep -qx -- '--settings' "$STUB_ARGV_OUT" 2>/dev/null \
+    && ng "B7 none 인데 --settings" "빈 deny 를 붙였다" || ok "B7 none → --settings 안 붙음"
+
+echo "── C. block list 표기 ──"
+r=$(mk_repo '---
+satellite_profile: v1
+forbidden_paths:
+  - ETHOS.md
+output_location: signals
+egress_sinks:
+  - .env
+---
+'); run_runner "$r"
+deny_has 'Read(./.env)' && ok "C1 block list 도 파싱된다" || ng "C1 block list" "미파싱"
+
+echo "── B8. 산출 자리 대조 (선언 ≠ 실제) ──"
+r=$(mk_repo "$FM_FULL"); LOGD="$TMPROOT/log.b8"; mkdir -p "$LOGD"
+STUB_ARGV_OUT="$TMPROOT/argv.b8"; export STUB_ARGV_OUT
+# 프로필은 signals 라고 선언했는데 러너는 elsewhere 로 떨어뜨린다
+FD_FH_DIR="$r" FD_OUT_DIR=elsewhere FD_PROFILE=.satellite-profile.md \
+  FD_LOG_DIR="$LOGD" FD_CLAUDE_BIN="$TMPROOT/claude.stub" bash "$RUNNER" >/dev/null 2>&1
+[ $? -eq 4 ] && ok "B8 선언≠실제 → fail-closed" || ng "B8 산출자리 대조" "불일치를 통과시켰다"
+grep -q '산출 자리 불일치' "$LOGD"/*.log 2>/dev/null && ok "B8b 양쪽 값이 로그에" || ng "B8b 로그" "미기록"
+
+echo "── D. JSON 조립 방어 ──"
+r=$(mk_repo '---
+satellite_profile: v1
+forbidden_paths: [bad"quote.md]
+output_location: signals
+egress_sinks: [none]
+---
+'); run_runner "$r"
+[ "$RC" -eq 4 ] && ok "D1 인용부호 → fail-closed" || ng "D1 인용부호" "rc=$RC (기대 4)"
+
+echo "── E. 프로필 부재/미설정 ──"
+r=$(mk_repo); LOGD="$TMPROOT/log.e"; mkdir -p "$LOGD"; STUB="$TMPROOT/claude.stub"; mk_stub "$STUB"
+STUB_ARGV_OUT="$TMPROOT/argv.e"; export STUB_ARGV_OUT
+FD_FH_DIR="$r" FD_OUT_DIR=signals FD_PROFILE=.satellite-profile.md \
+  FD_LOG_DIR="$LOGD" FD_CLAUDE_BIN="$STUB" bash "$RUNNER" >/dev/null 2>&1
+[ $? -eq 4 ] && ok "E1 FD_PROFILE 지정인데 파일 부재 → rc=4" || ng "E1 파일 부재" "rc≠4"
+
+# E2 — FD_PROFILE 미설정 **+ 엔진 자기 레포**(= FH 자기 런) 만 게이트를 건너뛴다.
+# 🟥 초판은 여기서 **임시 레포**를 썼다 — 그건 «FH 자기 런»이 아니라 **위성 모양**이고,
+#    그래서 이 레인이 S1 우회(프로필 없이 dispatch)를 «정상»으로 초록 고정하고 있었다.
+#    판정 대상이 «FD_PROFILE 유무»가 아니라 «어느 레포에서 도는가»로 바뀌었으므로 픽스처도 바뀐다.
+# 실제 FH 레포를 FD_FH_DIR 로 쓰되, 산출·로그는 임시 절대경로로 빼서 실트리를 안 건드린다.
+ENGDIR="$(cd "$(dirname "$RUNNER")/.." && pwd -P)"
+OUTTMP="$TMPROOT/fhrun.out"; mkdir -p "$OUTTMP"
+LOGD="$TMPROOT/log.e2"; mkdir -p "$LOGD"
+STUB_ARGV_OUT="$TMPROOT/argv.e2"; export STUB_ARGV_OUT
+FD_FH_DIR="$ENGDIR" FD_OUT_DIR="$OUTTMP" FD_LOG_DIR="$LOGD" FD_CLAUDE_BIN="$STUB" \
+  bash "$RUNNER" >/dev/null 2>&1
+rc=$?
+[ "$rc" -ne 4 ] && ok "E2 프로필 미설정 → 게이트 skip (FH 경로 무변경)" || ng "E2 미설정" "rc=4 (FH 런을 막았다)"
+grep -q 'profile gate' "$LOGD"/*.log 2>/dev/null && ng "E2b" "미설정인데 게이트가 발화" || ok "E2b 미설정이면 게이트 침묵"
+
+echo "── F. 산출 자리 절대경로 (처방 2) ──"
+OUTABS="$TMPROOT/outside.$RANDOM"; mkdir -p "$OUTABS"
+# 🟥 프로필의 output_location 도 같은 절대경로여야 한다 — B8 대조가 이제 살아 있어서,
+#    선언과 실제가 갈리면(초판 픽스처가 그랬다) 이 레인은 산출자리 불일치로 죽는다.
+FM_ABS="---
+satellite_profile: v1
+forbidden_paths: [none]
+output_location: $OUTABS
+egress_sinks: [none]
+---
+"
+r=$(mk_repo "$FM_ABS"); LOGD="$TMPROOT/log.f"; mkdir -p "$LOGD"
+STUB_ARGV_OUT="$TMPROOT/argv.f"; export STUB_ARGV_OUT
+FD_FH_DIR="$r" FD_OUT_DIR="$OUTABS" FD_PROFILE=.satellite-profile.md \
+  FD_LOG_DIR="$LOGD" FD_CLAUDE_BIN="$STUB" bash "$RUNNER" >/dev/null 2>&1
+grep -q "Save the digest to ${OUTABS}/" "$STUB_ARGV_OUT" 2>/dev/null \
+    && ok "F1 절대 FD_OUT_DIR 가 레포 밖으로 간다" || ng "F1 절대경로" "프롬프트가 레포 안을 가리킨다"
+[ -d "$r/$OUTABS" ] && ng "F2" "레포 안에 중첩 경로가 생겼다" || ok "F2 레포 트리에 중첩 안 생김"
+
+echo "── G. cross-family 지적 회귀 앵커 (2026-08-19) ──"
+# G1 [S1] 위성 런인데 FD_PROFILE 미설정 → 이제 fail-closed 여야 한다.
+#    초판은 여기서 통과했고, 레인 E2 가 그걸 «FH 경로 무변경»으로 초록 고정하고 있었다.
+r=$(mk_repo "$FM_FULL"); LOGD="$TMPROOT/log.g1"; mkdir -p "$LOGD"
+STUB_ARGV_OUT="$TMPROOT/argv.g1"; export STUB_ARGV_OUT
+FD_FH_DIR="$r" FD_OUT_DIR=signals FD_LOG_DIR="$LOGD" FD_CLAUDE_BIN="$TMPROOT/claude.stub" \
+  bash "$RUNNER" >/dev/null 2>&1
+[ $? -eq 4 ] && ok "G1 위성인데 프로필 미설정 → fail-closed" || ng "G1 위성 우회" "프로필 없이 dispatch 까지 갔다"
+[ -s "$TMPROOT/argv.g1" ] && ng "G1b" "claude 가 실제로 떴다" || ok "G1b dispatch 자체가 안 일어남"
+
+# G2 [A6] 프로필에 절대경로 → `.//abs` 가 되면 안 된다
+ABSSINK="/etc/hosts"
+r=$(mk_repo "---
+satellite_profile: v1
+forbidden_paths: [none]
+output_location: signals
+egress_sinks: [$ABSSINK]
+---
+"); run_runner "$r"
+deny_has "Read($ABSSINK)" && ok "G2 절대경로 sink → Read(/abs)" || ng "G2 절대경로" "'.//' 이중 접두 또는 미생성"
+
+# G3 [B8] control char → fail-closed
+r=$(mk_repo "$(printf -- '---\nsatellite_profile: v1\nforbidden_paths: [bad\tTAB.md]\noutput_location: signals\negress_sinks: [none]\n---\n')"); run_runner "$r"
+[ "$RC" -eq 4 ] && ok "G3 control char → fail-closed" || ng "G3 control char" "rc=$RC (기대 4)"
+
+echo
+printf 'PASS=%d FAIL=%d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/test_satellite_publish_gate_lanes.sh
+++ b/scripts/test_satellite_publish_gate_lanes.sh
@@ -286,7 +286,11 @@ _prev_pick() {
   : > "$td/out/frontier_digest_${d}.md"           # 오늘 것 (제외 대상)
   # 러너의 선택 표현을 그대로 떼어 쓴다 — 우회하면 앵커가 장식이 된다
   local expr; expr=$(sed -n '/prev=\$(find/,/tail -1)/p' "$ROOT/scripts/frontier_digest_daily.sh")
-  local got; got=$( cd "$td" && FH_DIR="$td" OUT_DIR=out TODAY="$d" bash -c "$expr; basename \"\$prev\"" )
+  # 🟥 2026-08-19: 러너가 `${FH_DIR}/${OUT_DIR}` 조립을 `OUT_ABS` 로 뽑아내면서(레포 밖
+  #    절대경로 지원) 이 추출 표현식이 **레인이 안 세팅한 변수**를 참조하게 됐다 →
+  #    `find ""` → got=[]. 앵커를 실물에서 떼어 쓰는 대가이고, 끊긴 것이 즉시 적색으로 났다.
+  #    OUT_ABS 는 러너와 **같은 규칙**으로 만든다(상대경로 분기).
+  local got; got=$( cd "$td" && FH_DIR="$td" OUT_DIR=out OUT_ABS="$td/out" TODAY="$d" bash -c "$expr; basename \"\$prev\"" )
   rm -rf "$td"; echo "$got"
 }
 t "R5 표기가 섞여도 «직전»은 날짜상 최신이다" "frontier_digest_2026_08_17.md" "$(_prev_pick)"


### PR DESCRIPTION
## 왜

2026-08-18 ⓓ 3자대면(대상 = gstack)이 낸 **설계 결함**: 위성 프로필 스키마가 「금지 파일 · 산출 자리 · 이 레포의 sink 정의」를 **요구하지 않는다.** the-bible 프로필에 금지선 5개가 있는 건 내가 그 도메인을 알아서 쓴 것이지 스키마가 요구해서가 아니다 — 다음 위성에서 그 자리가 비면 **조용히** 빠진다.

그리고 위성 대상은 두 경우뿐이다(운영자 정의 2026-08-19): ⓐ 운영자 소유 레포 · ⓑ **남의 레포인데 그 주인이 FH 로 신청한** 경우. ⓑ 가 존재하는 순간 이 세 필드는 위생이 아니라 **권한·동의 표면**이다 — 주인이 「내 레포에서 뭘 건드리지 마라 / 뭐가 나가면 안 되나」를 선언하는 자리가 그것뿐이다.

## 무엇을

```
프로필 맨 앞 frontmatter 4필드 필수 → 없으면 dispatch «전에» rc=4
  forbidden_paths → Edit/Write deny  ┐
  egress_sinks    → Read deny        ├→ claude --settings <JSON> 으로 런 단위 주입
  (+ acceptEdits 자동승인 변이 Bash)  ┘   🟥 대상 레포 파일을 한 줄도 안 고친다
  output_location → 실제 FD_OUT_DIR 과 «대조» (존재검사 아님)
FD_OUT_DIR 절대경로 허용 → 산출을 레포 트리 밖에 (처방 2)
```

검사 성격은 **채널**이다(있나 · 타입 맞나 · 비공허한가). 값이 「옳은가」는 안 본다 — §Mechanization Boundary. `egress_sinks: [none]` 같은 명시적 없음은 정당한 값이고 금지되는 건 **안 적는 것**뿐이다.

**FH 프로덕션 무변경**: `FD_*` 미설정이면 `IS_SATELLITE=0` 이라 게이트를 아예 안 타고, 상대경로 조립은 종전과 바이트 동일.

## 검증

| 축 | 결과 |
|---|---|
| known-pair **7런** | deny 없음 → 센티넬 유출 **1** / 주입 → **0**. Bash(`cat`·`python3`) 경로도 같은 쌍으로 갈렸고 **컨트롤이 유출했으므로** 「headless 라 Bash 가 원래 안 돈다」는 반증됐다 — 막은 것은 deny 다 |
| 레인 | **32/32**, 실러너 실행 + argv 를 **JSON 파싱**해 `.permissions.deny[]` 멤버십 확인 |
| 되돌림 3회 | 호출부 제거 → **17 적색** · 위성판정만 제거 → **G1·G1b 만** · Bash deny 만 제거 → **B5b 만**. 셋 다 복원 후 초록 |
| 첫 실사용 | 실물 프로필 2종이 실제 게이트 통과, deny **13건/9건** 정상 조립 |
| cross-family | codex/gpt-5.5 **10건** — S1 1 · A 4 · B 2 반영, B 2 문서화 |

### 🟥 cross-family S1 — 자력 적발 0

`FD_PROFILE` 미설정이 게이트를 **통째로 건너뛰어** 위성 런도 프로필 없이 dispatch 됐다. 게이트를 끄는 방법이 「필드를 안 적는 것」이었다. 더 나쁜 건 **내가 쓴 레인 E2 가 그 우회를 「FH 경로 무변경」이라며 초록으로 고정**하고 있었다는 것 — 수리와 같은 어휘로 레인을 쓰면 안 잡힌다. 판정을 「어느 레포에서 도는가」(`FH_DIR≠ENGINE_DIR`)로 교체하고 E2 픽스처를 의도에 맞췄다.

**A4**: `acceptEdits` 는 공식 문서상 `mkdir·touch·rm·rmdir·mv·cp·sed` 를 **자동 승인**한다 — `sed -i` 한 줄로 `forbidden_paths` 의 파일을 고칠 수 있었다.

## 명시하는 잔여

- 🟥 **subprocess 우회는 미측정**. 공식 문서가 「임의 subprocess 엔 Read deny 가 안 걸린다 — OS 레벨은 sandbox」라고 명시하고, 내 arm 은 «python 이 막혔다»와 «시도조차 안 했다»를 **구분 못 한다**(reps=1). 닫혔다고 안 적었다.
- **프로필 본문 자체는 프롬프트에 통째로 실려 나간다** — `egress_sinks` 가 그걸 안 막는다.
- 디렉토리 deny 는 `Read` 로 쟀고 실물은 `Edit` — 경로 의미론 공유는 문서 근거일 뿐.
- 변이 Bash deny 는 경로별이 아니라 **명령별**이라 coarse.
- awk 파싱은 YAML 부분집합(인용 스칼라·값 안 쉼표·인라인 주석 오판). 방향은 fail-closed.
- ⓒ 격리 그라운딩 · ⓓ 이 델타 대상 3자대면 **미실시**.
- 🟥 **대상 레포 첫 실발화는 08-20**. 오늘 10:00/11:00 은 08-19 다이제스트가 이미 있어 「Already ran today」로 빠져 이 게이트를 안 탄다. 매니페스트에 그걸 검증 조건으로 박았다.

## 짝 커밋 (별도 레포, 이미 머지됨)

`the-bible@6eaa27f` · `forge-wiki@6897a7a` — 두 프로필에 스키마 frontmatter. **이 PR 이 머지되기 전에 그쪽이 먼저 들어가 있어야** 08-20 위성이 fail-closed 되지 않는다(순서 충족).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4gtrgMVh6YVxwEEJQ8msk