### PR TITLE
fix(satellite): 착지 증언 계기가 대상 어휘를 못 읽어 위성에서 구조적으로 죽어 있었다

### DIFF
--- a/scripts/digest_landing_check.sh
+++ b/scripts/digest_landing_check.sh
@@ -100,7 +100,12 @@ CHECKER="$SELF_DIR/utterance_landing_check.sh"
 #    다중 경로 지원과의 트레이드오프라 오늘은 **문서화만** 했고 기계 검사는 없다.
 DLC_TRACKED_PATHS="${DLC_TRACKED_PATHS:-knowledge CLAUDE.md}"   # git 추적축 (커밋시각)
 DLC_IGNORED_DIR="${DLC_IGNORED_DIR-tracks/_meta}"               # gitignored 축 (mtime). 빈 값 = 그 축 없음
-SECTION_RE='^## .*Immediate Application Candidates'
+# 🟥 2026-08-19 — 이 정규식은 **FH 자기 어휘**였고 오버라이드가 없었다. 위성 산출의 절 제목은
+# 대상 프로필이 정한다(`## <대상> Application Candidates`) — 즉 계기가 **대상 레포에서는 구조적으로
+# 후보를 못 찾는다.** 실측: forge-wiki·the-bible 둘 다 rc=10. R1(디렉터리를 타깃 파일로 넘김)과
+# 같은 계열이다 — 「배선 완료」로 보고된 계기가 대상 축에서 죽어 있는 형태.
+# 기본값은 종전 그대로라 FH 자기 런은 무변경.
+SECTION_RE="${DLC_SECTION_RE:-^## .*Immediate Application Candidates}"
 
 # 후보 표에서 (id, 판별토큰 OR 정규식) 을 뽑는다. 토큰 없으면 id 만 내고 정규식은 빈 값.
 _extract() { # $1 = digest path
@@ -529,6 +534,20 @@ EOF
   printf '# digest\n## 다른 절\n내용\n' > "$T/nosection.md"
   rc=0; bash "$SELF_DIR/$(basename "${BASH_SOURCE[0]}")" "$T/nosection.md" "$T/tgt/card.md" >/dev/null 2>&1 || rc=$?
   _t "후보 절 부재 → HARNESS-ERROR(10), '0건 착지' 아님" 10 "$rc"
+
+  # N3-b — **대상 어휘 절 제목**은 기본 정규식으로 못 찾고, DLC_SECTION_RE 로는 찾는다.
+  #   🟥 2026-08-19 첫 실사용 발견: 위성 산출의 절 이름은 대상 프로필이 정하는데
+  #   (`## <대상> Application Candidates`) 체커 기본값은 FH 어휘(`Immediate ...`)라
+  #   **위성에서는 구조적으로 rc=10** 이었다(forge-wiki·the-bible 양쪽 실측).
+  #   🟥 픽스처의 후보 머리는 **`**` 형식**이어야 한다 — 평범한 `- ` 불릿은 항목으로 안 잡혀
+  #   arm 도 10 을 내고, 그러면 이 레인이 «오버라이드가 안 먹는다» 는 거짓 결론을 낸다
+  #   (초판이 그렇게 틀렸다 — 픽스처는 뚫리는 표기로 골라야 한다).
+  printf '# digest\n## the-target Application Candidates\n**[A] 후보** — `%s` 를 고친다\n' "card.md" > "$T/targetvocab.md"
+  rc=0; bash "$SELF_DIR/$(basename "${BASH_SOURCE[0]}")" "$T/targetvocab.md" "$T/tgt/card.md" >/dev/null 2>&1 || rc=$?
+  _t "★N3-b control — 대상 어휘 절은 기본 정규식으로 못 찾는다(10)" 10 "$rc"
+  rc=0; DLC_SECTION_RE='^## .*Application Candidates' \
+        bash "$SELF_DIR/$(basename "${BASH_SOURCE[0]}")" "$T/targetvocab.md" "$T/tgt/card.md" >/dev/null 2>&1 || rc=$?
+  _t "★N3-b arm — DLC_SECTION_RE 오버라이드가 절을 찾는다(10 아님)" "not10" "$([ "$rc" -eq 10 ] && echo is10 || echo not10)"
 
   # N4 — digest 파일 자체가 없음 → 10
   rc=0; bash "$SELF_DIR/$(basename "${BASH_SOURCE[0]}")" "$T/does-not-exist.md" >/dev/null 2>&1 || rc=$?

--- a/scripts/frontier_digest_daily.sh
+++ b/scripts/frontier_digest_daily.sh
@@ -374,6 +374,9 @@ landing_witness() {
            # 🟥 컨트롤 토큰도 대상축이다 — 기본값은 레포 이름이라 FH 는 무변경이지만,
            #    대상 레포에 확실히 있는 토큰을 위성이 지정할 수 있어야 계기가 산다.
            [ -n "${FD_LANDING_CONTROLS:-}" ] && export DLC_CONTROLS="$FD_LANDING_CONTROLS"
+           # 🟥 절 제목도 대상축이다 (2026-08-19). 위성 산출의 절 이름은 대상 프로필이 정하는데
+           #    체커 기본값은 FH 어휘라, 이 통과가 없으면 위성에서 **영영 rc=10** 이다.
+           [ -n "${FD_LANDING_SECTION_RE:-}" ] && export DLC_SECTION_RE="$FD_LANDING_SECTION_RE"
            bash "$checker" "$prev" 2>&1 ); rc=$?
     case "$rc" in
         0)  echo "[$(date '+%Y-%m-%d %H:%M:%S')] landing witness [$(basename "$prev")]: ALL-LANDED (rc=0)" >> "$LOG_FILE" ;;


### PR DESCRIPTION
## 무엇이 죽어 있었나

`scripts/digest_landing_check.sh` 의 `SECTION_RE='^## .*Immediate Application Candidates'` 는
**FH 자기 어휘**였고 **오버라이드가 없었다.** 위성 산출의 절 제목은 대상 프로필이 정한다
(`## <대상> Application Candidates`) ⇒ 계기가 대상 레포에서는 **후보를 영영 못 찾는다.**

R1(디렉터리를 타깃 파일로 넘김)과 같은 계열이다 — **「배선 완료」로 보고된 계기가 대상 축에서
죽어 있는 형태.** 이번에도 잡은 것은 **첫 실사용**이지 레인·리뷰가 아니다.

## known-pair (실물 forge-wiki 08-19 다이제스트)

```
오버라이드 없음  rc=10  「후보 절을 못 찾았다 (섹션 정규식 불일치?)」
오버라이드 있음  rc=1   + 본문 「5 건 중 1 건 미착지 — 마감 전에 기록하라」
```

🟥 `rc=1` 이 **본문 있는 판정**이라는 것이 결정적이다 — 어제 R7 이 정확히 그 혼동
(`targets[@]: unbound variable` 이라는 **셸 에러의 rc=1** 이 「SOME-UNLANDED」로 착지율
시계열에 실측값으로 유입)이었고, 오늘 00:03 로그에 그 흔적이 그대로 남아 있다.

## 변경

- `DLC_SECTION_RE` 환경 오버라이드 (**기본값 무변경** → FH 자기 런 영향 0)
- 러너가 `FD_LANDING_SECTION_RE` 로 통과 — 기존 `FD_LANDING_{TRACKED,IGNORED,CONTROLS}` 와 같은 형태, 새 개념 없음
- self-test `N3-b` control/arm 쌍 추가
- (레포 밖) 위성 plist 2종에 `FD_LANDING_SECTION_RE` 추가 + the-bible 의 `FD_LANDING_TRACKED="core docs"` 에서 **실재하지 않는 `docs`** 제거(실측 `ls`)

## 🟥 오늘은 이 수리로도 값이 안 난다 — 명시한다

| 위성 | 오늘 결과 | 이유 |
|---|---|---|
| forge-wiki (10:00) | rc=10 | prev(08-18)가 **프로필 이전 산출**이라 후보 절 자체가 없다(「Suggested follow-ups」) |
| the-bible (11:00) | rc=10 | 08-18 이후 tracked 면에 **착지한 커밋이 없다**(타깃 0건 = 설계상 HARNESS-ERROR) |

**유효는 08-20 부터**다(그때 prev = 프로필 판 08-19). 매니페스트에 그걸 검증 조건으로 박았다.

## 자력 적발 3건 중 하나는 내 레인이었다

레인 초판 픽스처가 **「뚫리는 표기」가 아니었다** — 평범한 `- ` 불릿은 항목 머리로 안 잡혀
(허용: `###+` · `**` · `N.` · `- **`) arm 도 rc=10 을 냈고, 하마터면 **「오버라이드가 안 먹는다」는
거짓 결론**을 낼 뻔했다. 픽스처를 `**` 형식으로 바꾸자 갈렸다.

## 잔여

- `rc=10` 의 「후보 절을 못 찾았다」 문구가 **두 원인을 덮는다**(절 부재 / 절은 있는데 후보 파싱 0). 문구가 스스로 「정규식 불일치?」로 추측형이다. 이번에 내가 그 혼동에 빠졌고 **이 PR 에서 고치지 않았다**(별건, N=1).
- the-bible tracked 를 `core DESIGN.md` 로 좁힌 것은 프로필의 Route 줄 근거지 전수 검증이 아니다.
- plist 는 레포 밖 운영자 설정이라 이 레포의 게이트가 안 본다.
- ⓐ cross-family · ⓒ 격리 그라운딩 · ⓓ 3자대면 **미실시**.

`selfcheck` 는 **푸시 전에** 로컬 완주시켰다(PASS) — 직전 PR 의 §Local Execution First 위반 교정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4gtrgMVh6YVxwEEJQ8msk