### PR TITLE
fix(psa): 유출 스캐너가 zsh 에서 죽고 그 죽음이 「깨끗함」과 바이트 동일이었다

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,6 +36,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+
+      # 🟥 zsh 를 설치한다 — 장식이 아니라 **커버리지 구멍을 닫는 것**이다.
+      # 2026-08-21 실측: `psa_scan_tagged` 가 `local path` 때문에 **zsh 에서만** 죽었고 그 죽음이
+      # 「깨끗한 스캔」과 바이트 동일이었다(유출 스캐너가 무음 통과). 그 축의 레인(Z1~Z4 ·
+      # E2~E5/zsh)은 `command -v zsh` 조건부라 zsh 없는 러너에서 **8개가 통째로 SKIP** 된다 —
+      # 즉 그 결함을 고친 PR 이 CI 에서 **한 번도 검증되지 않는다.** macOS 기본 셸이 zsh 이고
+      # public-surface-audit 스킬 본문이 그 셸로 실행되므로 이건 **소비자 표면**이다.
+      # ⚠️ 스킵은 실패가 아니라 레인 플로어가 조건부로 계산된다 — 그래서 이 설치가 없어도 CI 는
+      #    초록인데, **그 초록이 이 축에 대해서는 미측정**이다. 그 구별이 이 스텝의 존재 이유다.
+      - name: Install zsh (second shell arm for the psa lanes — see comment)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq zsh
+          zsh --version
       - name: Check for operator-private token residue
         run: |
           echo "=== Scanning for generic operator-private patterns ==="

--- a/plugins/fh-meta/skills/public-surface-audit/SKILL_detail.md
+++ b/plugins/fh-meta/skills/public-surface-audit/SKILL_detail.md
@@ -25,9 +25,24 @@ if [ -r "scripts/psa_scan_lib.sh" ]; then
   # Feed every tracked file as path<TAB>line, the stream psa_scan_tagged consumes. Sourcing the lib
   # without these calls is a no-op scan — measured on this repo (PSA_STREAM stayed unset), so the
   # calls are spelled out here rather than pointed at.
+  # 🟥 rc 를 반드시 받아라 (2026-08-21 배선 리뷰 S-1). 이 파이프는 **원래 뚫렸던 바로 그 진입점**이고,
+  #    바로 아래 coverage 조건이 `$?` 를 덮으므로 여기서 안 받으면 계약이 소실된다.
+  #    계약: 0=신고할 것 없음 · 1=유출(이미 인쇄됨) · 3=NOT SCANNED(계기 사망)
+  #    ⚠️ `_psa_rc=0` 은 반드시 `while` **밖**에 둔다 — 안에 두면 루프 본문이라 매 줄 초기화되고
+  #       파이프 서브셸에 갇힌다(초판이 그렇게 넣었고 `bash -n` 은 통과했다. 문법은 맞고 의미가 틀린다).
+  _psa_rc=0
   while IFS= read -r f; do
     awk -v p="$f" '{printf "%s\t%s\n", p, $0}' "$f" 2>/dev/null
-  done < /tmp/_psa_tracked.txt | psa_scan_tagged
+  done < /tmp/_psa_tracked.txt | psa_scan_tagged || _psa_rc=$?
+  # 🟥 3 은 «깨끗» 이 아니라 «안 쟀다» 다. 여기서 멈춰야 한다 — 이 스킬은 publish 직전에
+  #    Pre-Publish Gate 가 1번으로 체이닝하는 렌즈이고, 그 자리에서 미측정을 통과시키면
+  #    아래 coverage 줄이 «defaults-only 로는 스캔했다» 는 인상까지 얹는다.
+  if [ "$_psa_rc" -eq 3 ]; then
+    echo "⛔ INSTRUMENT DEAD: the scanner did not run (rc=3). NOT SCANNED is not clean."
+    echo "   Fix first — run under bash (zsh special vars can blank PATH inside the matcher),"
+    echo "   and confirm psa_load ran (PSA_STREAM non-empty). Do NOT report a verdict from this run."
+    exit 3
+  fi
   [ "$PSA_OVERRIDE_PRESENT" -eq 1 ] \
     || echo "coverage: defaults-only — operator literals NOT CONFIGURED (identity/company classes UNSCANNED)"
 else

--- a/scripts/psa_scan_lib.sh
+++ b/scripts/psa_scan_lib.sh
@@ -208,9 +208,73 @@ psa_detect_operator_context() {
 # Why path-tagged input: the LOW allowlist is per FILE, so a scanner that flattens content loses the
 # only information needed to apply it. The push copy did exactly that and blocked its own first real
 # push on a companion-store name inside the script whose job is to sync to the companion store.
+# _psa_in_selftest — «지금 psa_require_live 안에서 불린 것인가»를 **호출 스택**으로 판별한다.
+# 🟥 변수 표식을 쓰면 안 된다: 외부가 `_PSA_IN_SELFTEST=1` 을 미리 export 하는 것만으로
+#    자가검사가 통째로 생략된다(cross-family 반례 1b, 실행 재현). 전역 상태를 권한 표식처럼
+#    믿는 형태다. 호출 스택은 **호출자가 미리 심을 수 없다.**
+# bash=FUNCNAME · zsh=funcstack. 둘 다 없으면 판별 불가이므로 **재진입이 아니라고 답한다** —
+# 그러면 자가검사가 한 번 더 돌 뿐(무한재귀는 psa_require_live 가 이 함수를 한 겹만 부르므로
+# 발생하지 않는다), 반대로 «재진입이다」로 접으면 그게 fail-open 이다.
+_psa_in_selftest() {
+  local _st=""
+  # shellcheck disable=SC2154
+  if [ -n "${FUNCNAME[*]:-}" ]; then _st=" ${FUNCNAME[*]} "
+  elif [ -n "${funcstack[*]:-}" ]; then _st=" ${funcstack[*]} "
+  else return 1; fi
+  case "$_st" in *" psa_require_live "*) return 0 ;; esac
+  return 1
+}
+
 psa_scan_tagged() {
-  local input hit=0 row sev re path body tok
-  input=$(cat)
+  # 🟥 `path` 를 지역선언하지 마라 — zsh 에서 `path` 는 `PATH` 와 **tied 된 특수 배열**이라
+  #    `local path` 하는 순간 그 스코프의 `PATH` 가 빈 문자열이 되고, 바로 다음 줄의
+  #    `$(cat)` 부터 `command not found: cat` 으로 죽는다. 그런데 이 함수의 계약이
+  #    「빈 입력 = 신고할 것 없음 = return 0」이라 **계기 사망이 «깨끗한 스캔»과 바이트 단위로
+  #    같은 출력**이 된다 — 이 저장소가 이름 붙인 «미측정을 0으로 렌더» 의 가장 조용한 얼굴이다.
+  #    실측 2026-08-21: zsh 에서 known-positive·known-negative 가 **둘 다 rc=0** 이었다.
+  #    형제 특수변수(`fpath` `status` `argv` `cdpath` …)도 같은 함정이다.
+  local input hit=0 row sev re _psa_path body tok
+
+  # ── E: 진입 생존성 가드 (2026-08-21, cross-family FAIL 판정 후 재작성) ─────────────
+  # 🟥 **초판 E 는 fail-open 을 못 닫았다.** codex/gpt-5.6-sol 이 반례 6개를 전부 실행으로
+  #    재현했고 판정은 FAIL 이었다. 초판의 구조적 맹점: **«자가검사가 한 번 통과했다»를
+  #    «그 뒤의 실제 스캔도 실행됐다»로 확장**한 것. 그 사이엔 시간·전역상태·파이프라인
+  #    상태라는 단절점이 셋 있다. 재작성이 닫는 것과 못 닫는 것을 아래에 이름으로 적는다.
+  #
+  # 🟥 **캐시 제거.** 초판은 `_PSA_LIVE_OK` 로 프로세스당 1회만 검사했다 — 첫 양성 뒤
+  #    grep 을 죽이면 같은 양성이 rc=0 이 됐다(codex 재현). 그리고 **캐시는 뚫린 쪽(긴
+  #    스킬 세션)에서만 위험하고 안전한 쪽(짧은 훅)에서만 이득**이라 방향이 반대였다.
+  #    비용은 **실측했다: psa_require_live 1회 ≈ 64ms** (훅 경로 최대 4회 = 0.26초).
+  #    초판은 이 비용을 **안 재고** 캐시를 정당화했다 — 그게 진짜 결함이었다.
+  #
+  # 🟥 **재진입 표식은 `local` 로 «동적 스코프»에 둔다.** 초판은 전역 변수를 권한 표식처럼
+  #    믿어서, 외부가 `_PSA_IN_SELFTEST=1` 을 미리 export 하면 자가검사가 **통째로 생략**됐다
+  #    (codex 재현: `grep(){ return 127; }` 상태에서 known-positive 가 rc=0 무출력).
+  #    `local` 선언은 외부 값을 **가리고**, 함수가 끝나면 **자동 복구**된다 — unset 실패나
+  #    시그널·트랩으로 값이 남는 경로가 없어진다.
+  if ! _psa_in_selftest; then
+    # 🟥 실제 패턴 스트림을 여기서 본다. 자가검사는 PSA_STREAM 을 카나리아로 **바꿔치기**
+    #    하므로 «진짜 패턴이 비었거나 깨졌는지»를 구조적으로 못 본다(codex 반례 3).
+    if [ -z "${PSA_STREAM:-}" ]; then
+      echo "  ❌ INSTRUMENT DEAD — PSA_STREAM is empty; nothing to match against. NOT SCANNED."
+      echo "  ❌ INSTRUMENT DEAD — PSA_STREAM is empty; NOT SCANNED (call psa_load first)." >&2
+      return 3
+    fi
+    if ! psa_require_live >/dev/null 2>&1; then
+      echo "  ❌ INSTRUMENT DEAD — psa_scan_tagged self-test failed. NOT SCANNED."
+      echo "  ❌ INSTRUMENT DEAD — psa_scan_tagged self-test failed. NOT SCANNED." >&2
+      echo "     A 0 from this scanner is UNMEASURED, not clean. Re-run under bash." >&2
+      return 3
+    fi
+  fi
+
+  # 🟥 `cat` 의 상태를 버리지 마라 (codex 반례 1). 초판은 `input=$(cat)` 로 대입만 하고
+  #    rc 를 버려서, cat 이 죽어 입력이 비면 그게 곧 «신고할 것 없음»이 됐다.
+  if ! input=$(cat); then
+    echo "  ❌ INSTRUMENT DEAD — could not read stdin. NOT SCANNED."
+    echo "  ❌ INSTRUMENT DEAD — could not read stdin. NOT SCANNED." >&2
+    return 3
+  fi
   [ -n "$input" ] || return 0
   while IFS= read -r row; do
     case "$row" in ''|\#*) continue;; esac
@@ -218,15 +282,15 @@ psa_scan_tagged() {
     sev="${row%%$'\t'*}"
     while IFS= read -r line; do
       [ -z "$line" ] && continue
-      path="${line%%$'\t'*}"; body="${line#*$'\t'}"
+      _psa_path="${line%%$'\t'*}"; body="${line#*$'\t'}"
       # EVERY match on the line. Taking only the first let a documented placeholder earlier on the
       # line shield a real token later on it.
       while IFS= read -r tok; do
         [ -z "$tok" ] && continue
         printf '%s' "$tok" | grep -qiE "$PSA_PLACEHOLDER" && continue
-        if [ "$sev" = "LOW" ] && psa_low_allowlisted "$path"; then continue; fi
-        if psa_pair_allowlisted "$path" "$tok"; then continue; fi
-        echo "  ❌ $sev leak — ${path}: '$tok'"
+        if [ "$sev" = "LOW" ] && psa_low_allowlisted "$_psa_path"; then continue; fi
+        if psa_pair_allowlisted "$_psa_path" "$tok"; then continue; fi
+        echo "  ❌ $sev leak — ${_psa_path}: '$tok'"
         hit=1
       done <<PSA_TOK
 $(printf '%s' "$body" | grep -oiE "$re" 2>/dev/null || true)

--- a/scripts/test_outbound_query_lanes.sh
+++ b/scripts/test_outbound_query_lanes.sh
@@ -69,6 +69,10 @@ echo "── L10 CONTROL — 상태값이 오염돼도 fail-open 하지 않는�
 cat > "$T/badlib.sh" <<'STUB'
 psa_load(){ PSA_DEFAULTS_OK=oops; PSA_BAD_ROWS=0; PSA_OVERRIDE_PRESENT=1; return 0; }
 psa_require_live(){ return 0; }
+# 🟥 **테스트 더블이다 — psa 회귀를 구조적으로 못 잡는다** (2026-08-21 배선 리뷰 S-2).
+# 이 레인의 대상은 outbound-guard 의 «질의 평탄화·override·로깅» 이지 스캐너가 아니다.
+# 단위 경계로서는 정당하지만 **«psa 전수 커버»에 세면 안 된다** — 실물이 아니라 더블을 잰다
+# ([[feedback_anchor_can_be_decorative]]). 스캐너 회귀는 test_psa_singlefile_lanes.sh 가 잡는다.
 psa_scan_tagged(){ cat >/dev/null; return 0; }
 STUB
 rc10=$(PSA_LIB_FILE="$T/badlib.sh" PSA_DEFAULTS_FILE="$T/defaults" PSA_OVERRIDE_FILE="$T/override" \

--- a/scripts/test_psa_singlefile_lanes.sh
+++ b/scripts/test_psa_singlefile_lanes.sh
@@ -291,7 +291,11 @@ case "$out" in *SURVIVED*) ok "L21b caller survives the attribute case" ;; *) ba
 #    **둘 다 출하되고**(npm pack 산출물로 확인), 그 스킬 본문은 무가드 psa_scan_tagged 직접
 #    호출을 지시하며, macOS 기본 셸은 zsh 다. ⇒ 소비자 스킬 경로가 같은 상태였다.
 # 🟥 `bash -n`/`zsh -n` 은 못 잡는다 — 문법이 아니라 런타임 의미론이다. 실행으로만 성립한다.
+# 🟥 조건부 레인 수를 세어 둔다. 플로어를 상수로 박으면 zsh 없는 러너에서 «INSTRUMENT ERROR»
+#    가 난다 — 실제로 CI(ubuntu-latest, zsh 미설치)에서 그렇게 났다. 스킵은 실패가 아니다.
+_cond_lanes=0
 if command -v zsh >/dev/null 2>&1; then
+  _cond_lanes=$((_cond_lanes + 4))
   _ztmp=$(mktemp -d)
   printf 'contains LANECANARY here\n' > "$_ztmp/pos.md"
   printf 'clean prose\n' > "$_ztmp/neg.md"
@@ -335,7 +339,8 @@ _erun() { # $1=shell $2=prelude → rc
   "$1" -c ". '$LIB'; export PSA_STREAM=\$(printf 'HIGH\\tLANECANARY') PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1; $2 printf 'p\tLANECANARY\n' | psa_scan_tagged >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1
 }
 for _sh in bash zsh; do
-  command -v "$_sh" >/dev/null 2>&1 || { echo "  SKIP E2~E4 ($_sh 없음) — PASS 아님"; continue; }
+  command -v "$_sh" >/dev/null 2>&1 || { echo "  SKIP E2~E5 ($_sh 없음) — PASS 아님, 미검사다"; continue; }
+  [ "$_sh" = "zsh" ] && _cond_lanes=$((_cond_lanes + 4))
   # E2 — `cat` 이 죽으면 빈 입력이 «신고할 것 없음»이 됐다 (반례 1)
   _r=$(_erun "$_sh" 'cat(){ return 7; };')
   [ "$_r" = "3" ] && ok "E2/$_sh cat 사망 → rc=3 (빈 입력이 «깨끗»으로 안 접힌다)" || bad "E2/$_sh cat 사망 rc=[$_r], 3 이어야"
@@ -403,5 +408,11 @@ fi
 
 echo "[psa single-file lanes] pass=$pass fail=$fail"
 [ "$fail" -eq 0 ] || exit 1
-[ "$pass" -ge 40 ] || { echo "  ❌ INSTRUMENT ERROR — only $pass lanes ran; expected >=40"; exit 3; }
+# 🟥 플로어는 **조건부 레인을 반영한 값**이다. 33 = zsh 없는 러너의 기저(Z1~Z4 · E2~E5/zsh 스킵).
+#    zsh 가 있으면 +8. 상수 하나로 박으면 «스킵 = 계기 오류» 가 되어 러너를 거짓 적색으로 만든다.
+#    ⚠️ 그리고 이 수식이 말하는 진짜 사실을 잊지 마라: **zsh 축은 zsh 가 있는 곳에서만 검증된다.**
+#    CI 에 zsh 를 설치한 이유가 그것이고(.github/workflows/validate.yml), 그게 없으면 이 PR 이
+#    고친 결함의 축이 CI 에서 **한 번도** 안 돌아간다.
+_floor=$((33 + _cond_lanes))
+[ "$pass" -ge "$_floor" ] || { echo "  ❌ INSTRUMENT ERROR — only $pass lanes ran; expected >=$_floor (zsh 조건부 +$_cond_lanes)"; exit 3; }
 exit 0

--- a/scripts/test_psa_singlefile_lanes.sh
+++ b/scripts/test_psa_singlefile_lanes.sh
@@ -282,7 +282,126 @@ out=$(bash -c "
 check "L21 declare -i (attribute rejects the value) → REFUSED, caller survives" 0 "$rc" "REFUSED" "$out"
 case "$out" in *SURVIVED*) ok "L21b caller survives the attribute case" ;; *) bad "L21b caller died on the attribute case" ;; esac
 
+# ── Z 레인 : 셸 이식성 (2026-08-21) ──────────────────────────────────────────────────────
+# 🟥 왜 [실측]: psa_scan_tagged 가 `local path` 를 선언했는데 **zsh 에서 `path` 는 `PATH` 와
+#    tied 된 특수 배열**이라 그 스코프의 PATH 가 비어 `cat` 부터 죽었다. 이 함수 계약이
+#    「빈 입력 = return 0」이라 **계기 사망이 «깨끗한 스캔»과 바이트 단위로 같은 출력**이 됐다 —
+#    known-positive·known-negative 가 zsh 에서 **둘 다 rc=0**.
+# 🟥 이 머신만의 문제가 아니었다: psa_scan_lib.sh 와 public-surface-audit/SKILL_detail.md 가
+#    **둘 다 출하되고**(npm pack 산출물로 확인), 그 스킬 본문은 무가드 psa_scan_tagged 직접
+#    호출을 지시하며, macOS 기본 셸은 zsh 다. ⇒ 소비자 스킬 경로가 같은 상태였다.
+# 🟥 `bash -n`/`zsh -n` 은 못 잡는다 — 문법이 아니라 런타임 의미론이다. 실행으로만 성립한다.
+if command -v zsh >/dev/null 2>&1; then
+  _ztmp=$(mktemp -d)
+  printf 'contains LANECANARY here\n' > "$_ztmp/pos.md"
+  printf 'clean prose\n' > "$_ztmp/neg.md"
+  _zrun() {
+    "$1" -c ". '$LIB'; export PSA_STREAM=\$(printf 'HIGH\\tLANECANARY') PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1; cat '$2' | psa_scan_tagged '$2' >/dev/null 2>&1; echo \$?"
+  }
+  _zp=$(_zrun zsh  "$_ztmp/pos.md"); _zn=$(_zrun zsh  "$_ztmp/neg.md")
+  _bp=$(_zrun bash "$_ztmp/pos.md"); _bn=$(_zrun bash "$_ztmp/neg.md")
+  [ "$_zp" = "1" ] && ok "Z1 zsh known-positive → 1 (계기가 zsh 에서 살아 있다)" || bad "Z1 zsh 양성이 1 이 아니다: got $_zp"
+  [ "$_zn" = "0" ] && ok "Z2 zsh known-negative → 0 (오탐 없음)"                  || bad "Z2 zsh 음성이 0 이 아니다: got $_zn"
+  # ★컨트롤 — 두 팔이 갈리면 이식성 결함 잔존, 두 팔이 같이 죽으면 Z1/Z2 통과가 공허하다
+  [ "$_bp" = "$_zp" ] && ok "Z3 ★컨트롤 bash 양성 = zsh 양성 (두 팔 일치, $_bp)" || bad "Z3 두 팔 불일치: bash=$_bp zsh=$_zp"
+  [ "$_bn" = "$_zn" ] && ok "Z4 ★컨트롤 bash 음성 = zsh 음성 ($_bn)"             || bad "Z4 두 팔 불일치: bash=$_bn zsh=$_zn"
+  rm -rf "$_ztmp"
+else
+  echo "  SKIP Z 레인 (zsh 없음) — 🟥 PASS 가 아니라 미검사다"
+fi
+
+# ── E 레인 : 계기 사망은 «깨끗함»이 아니라 NOT SCANNED(3) 로 ──────────────────────────────
+# 무가드 직접 호출부(pre-commit ×3 · pre-push · outbound-guard)는 전부 **비영 = 차단**으로
+# 읽으므로 3 은 셋 모두에서 fail-closed 다. 0 이면 셋 다 «깨끗»으로 통과한다.
+# 🟥 **초판 E1 은 두 번 결함이었다** (cross-family + 되돌림 프로브가 각각 하나씩 잡았다):
+#   ⓐ 기본 분기가 `ok` 여서 rc=3 이 아닌 «모든» 출력(빈 출력 포함)을 PASS 로 셌다
+#   ⓑ 판정을 **종료코드가 아니라 문자열 `*rc=3*`** 로 했는데, 가드가 stdout 에 찍는 문구
+#      자체에 `(rc=3)` 이 들어 있다 → **페이로드가 자기 판정 문자열을 인쇄**한다. 가드의
+#      `return 3` 을 `return 0` 으로 사보타주해도 레인이 초록이었다. 앵커가 장식이었다.
+#   ⇒ 판정은 **숫자 rc 하나**로만. 메시지는 증거지 판정이 아니다.
+_erc=$(bash -c "
+  . '$LIB'
+  psa_load '$PWD/.claude/rules/.public-surface-patterns.defaults' '$PWD/.claude/rules/.public-surface-patterns' >/dev/null 2>&1
+  PATH=/nonexistent-psa-probe
+  printf 'p\tLANECANARY\n' | psa_scan_tagged >/dev/null 2>&1
+  echo \$?
+" 2>/dev/null | tail -1)
+[ "$_erc" = "3" ] && ok "E1 계기 사망 → rc=3 NOT SCANNED (숫자로 판정, 0 으로 안 접힌다)" \
+                  || bad "E1 계기 사망이 rc=3 이 아니다 — got rc=[$_erc]"
+
+# ── E2~E4 : cross-family(codex/gpt-5.6-sol) 가 실행으로 재현한 반례들. 판정 FAIL 이었다.
+#    전부 «자가검사가 한 번 통과했다 → 그 뒤 실제 스캔도 실행됐다» 로 확장한 초판의 맹점이다.
+_erun() { # $1=shell $2=prelude → rc
+  "$1" -c ". '$LIB'; export PSA_STREAM=\$(printf 'HIGH\\tLANECANARY') PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1; $2 printf 'p\tLANECANARY\n' | psa_scan_tagged >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1
+}
+for _sh in bash zsh; do
+  command -v "$_sh" >/dev/null 2>&1 || { echo "  SKIP E2~E4 ($_sh 없음) — PASS 아님"; continue; }
+  # E2 — `cat` 이 죽으면 빈 입력이 «신고할 것 없음»이 됐다 (반례 1)
+  _r=$(_erun "$_sh" 'cat(){ return 7; };')
+  [ "$_r" = "3" ] && ok "E2/$_sh cat 사망 → rc=3 (빈 입력이 «깨끗»으로 안 접힌다)" || bad "E2/$_sh cat 사망 rc=[$_r], 3 이어야"
+  # E3 — 🟥 외부가 가드 표식을 미리 export 하면 자가검사가 통째로 생략됐다 (반례 1b)
+  #      수리: 재진입 판별을 **호출 스택**으로 바꿨다 — 호출자가 미리 심을 수 없다
+  _r=$(_erun "$_sh" 'export _PSA_IN_SELFTEST=1; export _PSA_LIVE_OK=1; grep(){ return 127; };')
+  [ "$_r" = "3" ] && ok "E3/$_sh 가드 표식 선설정 → 여전히 rc=3 (전역 상태가 권한이 아니다)" || bad "E3/$_sh 선설정으로 우회됨 rc=[$_r]"
+  # E4 — 자가검사는 PSA_STREAM 을 카나리아로 바꿔치기하므로 «진짜 패턴이 비었는지»를 못 본다 (반례 3)
+  _r=$(_erun "$_sh" "PSA_STREAM='';")
+  [ "$_r" = "3" ] && ok "E4/$_sh 빈 PSA_STREAM → rc=3 (자가검사 통과해도 실제 패턴을 본다)" || bad "E4/$_sh 빈 STREAM rc=[$_r], 3 이어야"
+  # ★컨트롤 — 위 셋의 통과가 «전부 3 을 내서» 인지 확인. 정상 입력은 1/0 이어야 한다
+  _r=$(_erun "$_sh" '')
+  [ "$_r" = "1" ] && ok "E5/$_sh ★컨트롤 정상 양성 → rc=1 (E2~E4 가 «항상 3» 이 아니다)" || bad "E5/$_sh 컨트롤 rc=[$_r], 1 이어야"
+done
+
+# ── H 레인 : 훅이 «계기 사망(3)» 과 «유출(1)» 을 가르는가 (2026-08-21) ────────────────────
+# 🟥 왜 [실행 확인]: 초판 훅은 `if ! … | psa_scan_tagged` 로 **비영을 전부 유출로 뭉갰다.**
+#    그래서 `PUBLIC_SURFACE_OK=1` 이 **계기 사망까지 «승인된 유출»로 통과**시켰다 — 비가역
+#    표면에서 가장 나쁜 조합이다. override 는 «알고 있는 언급»을 승인하는 것이지 «안 잰
+#    표면»을 승인하는 게 아니다. 되돌림 실측: 옛 훅 rc=0 · 새 훅 rc=1.
+_HOOK="$PWD/templates/.git-hooks/pre-commit"
+if [ ! -f "$_HOOK" ] || ! command -v git >/dev/null 2>&1; then
+  echo "  SKIP H 레인 (훅 또는 git 없음) — PASS 아님, 미검사"
+else
+  _hrun() { # $1=hook path → rc  (계기를 죽인 픽스처에서 PUBLIC_SURFACE_OK=1 로 커밋 시도)
+    local T; T=$(mktemp -d); git init -q "$T"
+    ( cd "$T"
+      git config user.email t@t; git config user.name t; git config commit.gpgsign false
+      mkdir -p .githooks .claude/rules tracks/_meta scripts
+      cp "$1" .githooks/pre-commit; chmod +x .githooks/pre-commit
+      git config core.hooksPath .githooks
+      cp "$OLDPWD/.claude/rules/.public-surface-patterns.defaults" .claude/rules/ 2>/dev/null
+      cp "$OLDPWD/.claude/rules/.public-surface-patterns" .claude/rules/ 2>/dev/null
+      cp "$OLDPWD/scripts/psa_scan_lib.sh" scripts/
+      # 계기를 죽인다 — 원인은 무엇이든 좋다. 중요한 건 «안 쟀다» 가 «깨끗» 으로 안 읽히는 것
+      sed -i.bak 's/^psa_require_live() {/psa_require_live() { return 1/' scripts/psa_scan_lib.sh && rm -f scripts/psa_scan_lib.sh.bak
+      printf 'x\n' > seed.md; git add seed.md; git commit -qm seed --no-verify >/dev/null 2>&1
+      printf 'just prose\n' > probe.md; git add probe.md
+      PUBLIC_SURFACE_OK=1 git commit -qm probe >/dev/null 2>&1; echo $? )
+    rm -rf "$T"
+  }
+  _h=$(_hrun "$_HOOK")
+  [ "$_h" = "1" ] && ok "H1 계기 사망 + PUBLIC_SURFACE_OK=1 → **차단**(override 가 미측정을 안 덮는다)" \
+                  || bad "H1 계기 사망이 override 로 통과했다 rc=[$_h] — 이 수리가 되돌아갔다"
+  # ★컨트롤 — 계기가 살아 있으면 같은 픽스처가 통과해야 한다. 아니면 H1 은 «항상 막힌다» 일 뿐이다
+  _hrun_live() {
+    local T; T=$(mktemp -d); git init -q "$T"
+    ( cd "$T"
+      git config user.email t@t; git config user.name t; git config commit.gpgsign false
+      mkdir -p .githooks .claude/rules tracks/_meta scripts
+      cp "$_HOOK" .githooks/pre-commit; chmod +x .githooks/pre-commit
+      git config core.hooksPath .githooks
+      cp "$OLDPWD/.claude/rules/.public-surface-patterns.defaults" .claude/rules/ 2>/dev/null
+      cp "$OLDPWD/.claude/rules/.public-surface-patterns" .claude/rules/ 2>/dev/null
+      cp "$OLDPWD/scripts/psa_scan_lib.sh" scripts/
+      printf 'x\n' > seed.md; git add seed.md; git commit -qm seed --no-verify >/dev/null 2>&1
+      printf 'just prose\n' > probe.md; git add probe.md
+      git commit -qm probe >/dev/null 2>&1; echo $? )
+    rm -rf "$T"
+  }
+  _hl=$(_hrun_live)
+  [ "$_hl" = "0" ] && ok "H2 ★컨트롤 계기 생존 + 깨끗한 내용 → 통과 (H1 이 «항상 막힘» 이 아니다)" \
+                   || bad "H2 컨트롤 실패 rc=[$_hl] — 픽스처가 다른 이유로 막힌다, H1 판정 무효"
+fi
+
 echo "[psa single-file lanes] pass=$pass fail=$fail"
 [ "$fail" -eq 0 ] || exit 1
-[ "$pass" -ge 26 ] || { echo "  ❌ INSTRUMENT ERROR — only $pass lanes ran; expected >=26"; exit 3; }
+[ "$pass" -ge 40 ] || { echo "  ❌ INSTRUMENT ERROR — only $pass lanes ran; expected >=40"; exit 3; }
 exit 0

--- a/templates/.git-hooks/pre-commit
+++ b/templates/.git-hooks/pre-commit
@@ -356,6 +356,7 @@ else
     fi
   else
     PSA_LEAK=0
+    PSA_DEAD=0
     # NUL-delimited (regression caught by the refactor's own cross-family review): the pre-refactor
     # loop read this list with `read -r -d ''`, and the rewrite dropped back to a line-oriented read.
     # `core.quotePath=false` stops git quoting NON-ASCII names, but a path holding a backslash or a
@@ -367,7 +368,11 @@ else
       added=$(git diff --cached -- "$f" 2>/dev/null | grep -E '^\+' | sed 's/^\+//' || true)
       [ -z "$added" ] && continue
       # Per-line pass, path-tagged so the LOW file allowlist applies.
-      if ! printf '%s\n' "$added" | sed "s|^|$f	|" | psa_scan_tagged; then PSA_LEAK=1; fi
+      # 🟥 rc 를 «비영» 으로 뭉개지 마라 (cross-family, 2026-08-21): 1=유출 · 3=계기 사망.
+      #    둘을 합치면 아래 PUBLIC_SURFACE_OK 가 **계기 사망까지 «승인된 유출»로 통과**시킨다.
+      _psa_rc=0
+      printf '%s\n' "$added" | sed "s|^|$f	|" | psa_scan_tagged || _psa_rc=$?
+      case "$_psa_rc" in 0) ;; 3) PSA_DEAD=1 ;; *) PSA_LEAK=1 ;; esac
       # Split-token backstop (pre-commit ONLY — this surface is a DIFF, so a literal can be wrapped
       # mid-word across two added lines and neither line matches). TIGHT-join, no separator, so
       # "fh-\nbe" becomes "fh-be". Accepted residual, verified not a missed fix: two whitespace-
@@ -375,7 +380,10 @@ else
       # PUBLIC_SURFACE_OK escape. A sentinel separator would close the fusion but RE-OPEN the split
       # catch, which is the more important case since real literals have no internal whitespace.
       joined=$(printf '%s' "$added" | tr -d '\n\r')
-      if ! printf '%s\t%s\n' "$f" "$joined" | psa_scan_tagged >/dev/null 2>&1; then
+      _psa_rc2=0
+      printf '%s\t%s\n' "$f" "$joined" | psa_scan_tagged >/dev/null 2>&1 || _psa_rc2=$?
+      [ "$_psa_rc2" = "3" ] && PSA_DEAD=1
+      if [ "$_psa_rc2" != "0" ] && [ "$_psa_rc2" != "3" ]; then
         # Only report if the per-line pass did not already flag this file, to avoid double-reporting.
         if ! printf '%s\n' "$added" | sed "s|^|$f	|" | psa_scan_tagged >/dev/null 2>&1; then :; else
           printf '%s\t%s\n' "$f" "$joined" | psa_scan_tagged | sed 's/leak —/leak (line-split) —/'
@@ -383,7 +391,16 @@ else
         fi
       fi
     done < <(git -c core.quotePath=false diff --cached --name-only --no-renames --diff-filter=ACMR -z 2>/dev/null || true)
-    if [ "$PSA_LEAK" -eq 1 ]; then
+    # 🟥 계기 사망은 override 대상이 **아니다.** override 는 «알고 있는 언급»을 승인하는 것이지
+    #    «안 잰 표면»을 승인하는 게 아니다. 초판은 1 과 3 을 합쳐서, PUBLIC_SURFACE_OK=1 이면
+    #    스캐너가 죽은 상태도 통과했다 — 비가역 표면에서 가장 나쁜 조합이다.
+    if [ "${PSA_DEAD:-0}" -eq 1 ]; then
+      echo "  ⛔ INSTRUMENT DEAD — the public-surface scan did NOT run (rc=3). NOT SCANNED is not clean."
+      echo "     PUBLIC_SURFACE_OK does NOT cover this. Fix the scanner, then commit:"
+      echo "       · run under bash (zsh special vars can blank PATH inside the matcher)"
+      echo "       · confirm psa_load ran and PSA_STREAM is non-empty"
+      FAILED=1
+    elif [ "$PSA_LEAK" -eq 1 ]; then
       if [ "${PUBLIC_SURFACE_OK:-0}" = "1" ]; then
         echo "  ⚠️  public-surface hit(s) allowed by PUBLIC_SURFACE_OK=1 (conscious, reviewed intent)"
         echo "$(date +%Y-%m-%dT%H:%M:%S) PUBLIC_SURFACE_OK override — branch $BRANCH — review suppressed hit(s) above" \

--- a/templates/.git-hooks/pre-commit
+++ b/templates/.git-hooks/pre-commit
@@ -386,6 +386,10 @@ else
       if [ "$_psa_rc2" != "0" ] && [ "$_psa_rc2" != "3" ]; then
         # Only report if the per-line pass did not already flag this file, to avoid double-reporting.
         if ! printf '%s\n' "$added" | sed "s|^|$f	|" | psa_scan_tagged >/dev/null 2>&1; then :; else
+          # 🟥 **표시 전용 — 판정 경로가 아니다** (2026-08-21 배선 리뷰 R-1). 이 파이프는 비말단이라
+          #    `$?` 가 `sed` 것이다. 그래도 되는 이유는 도달 조건이 **이미 «유출 확정»** 이고 바로
+          #    다음 줄이 `PSA_LEAK=1` 을 무조건 세우기 때문이다. 판정은 위 `_psa_rc` 3분기가 쥔다.
+          #    ⚠️ 이 주석이 없으면 다음 사람이 판정 경로로 읽고 «고친다» — 그게 이 줄을 위험하게 만든다.
           printf '%s\t%s\n' "$f" "$joined" | psa_scan_tagged | sed 's/leak —/leak (line-split) —/'
           PSA_LEAK=1
         fi

--- a/templates/.git-hooks/pre-push
+++ b/templates/.git-hooks/pre-push
@@ -357,10 +357,25 @@ PPRANGES
       [ "${PUBLIC_SURFACE_OK:-0}" = "1" ] || exit 1
     fi
     if [ "${_pp_count:-0}" -gt 0 ]; then
-      if printf '%s\n' "$_pp_added" | awk '
+      # 🟥 rc 를 «비영» 으로 뭉개지 마라 (cross-family, 2026-08-21): 1=유출 · 3=계기 사망.
+      #    합치면 아래 PUBLIC_SURFACE_OK 가 **계기 사망까지 승인**한다 — push 는 비가역이다.
+      _pp_rc=0
+      printf '%s\n' "$_pp_added" | awk '
            /^\+\+\+ b\// { f = substr($0, 7); next }
            /^\+/         { print f "\t" substr($0, 2) }
-         ' | psa_scan_tagged; then
+         ' | psa_scan_tagged || _pp_rc=$?
+      if [ "$_pp_rc" = "3" ]; then
+        echo ""
+        echo "══════════════════════════════════════════════"
+        echo " ⛔ FH Pre-Publish Gate (pre-push) — INSTRUMENT DEAD, scan did NOT run"
+        echo "══════════════════════════════════════════════"
+        echo "  rc=3 = NOT SCANNED. That is not «no token found» — nothing was measured."
+        echo "  PUBLIC_SURFACE_OK does NOT cover this: an override approves a KNOWN mention,"
+        echo "  never an unmeasured surface. Fix the scanner first (run under bash; psa_load)."
+        echo "══════════════════════════════════════════════"
+        exit 1
+      fi
+      if [ "$_pp_rc" = "0" ]; then
         echo "  ✅ FH Pre-Publish: no operator-private token in the TEXT added by ${_pp_count} commit(s)"
         echo "     (not covered: annotated-tag messages · binary blobs — named residuals)"
       else


### PR DESCRIPTION
`/public-surface-audit` 가 **「유출 없음」을 내면서 한 줄도 스캔하지 않고 있었다.**

## 뿌리

`psa_scan_tagged` 가 `local path` 를 선언했는데 **zsh 에서 `path` 는 `PATH` 와 tied 된 특수 배열**이라 그 스코프의 PATH 가 비고 다음 줄 `$(cat)` 부터 죽는다. 그런데 계약이 「빈 입력 = 신고할 것 없음 = `return 0`」이라 **계기 사망이 «깨끗한 스캔»과 바이트 단위로 같은 출력**이 된다.

```
수리 전   bash pos rc=1 · neg rc=0
          zsh  pos rc=0 · neg rc=0     ← 둘 다 «깨끗»
수리 후   양 셸  pos rc=1 · neg rc=0
```

🟥 **이 머신만의 문제가 아니었다** — 라이브러리·스킬 셋 다 출하되고(npm pack 산출물 확인), 스킬 본문이 에이전트에게 **무가드 직접 호출**을 지시하며, **macOS 기본 셸이 zsh** 다. 훅 경로는 bash shebang execve 라 안전(실행 확인).

## 🟥 초판은 이걸 못 고쳤다 — cross-family 판정 FAIL

초판이 레인 **31/31 초록**이었는데 타계열(codex/gpt-5.6-sol)이 반례 **6개를 전부 실행으로 재현**했다.

> «자가검사가 한 번 통과했다» 를 «그 뒤의 실제 스캔도 실행됐다» 로 확장했다 — 그 사이엔 **시간·전역상태·파이프라인 상태**라는 단절점이 셋 있다.

그중 하나는 **내 레인 자신이 계기 오류를 PASS 로 셌다**는 것이다. 두 번 장식이었다 — 기본 분기가 `ok` 였고, 고친 뒤에도 판정을 종료코드가 아니라 **가드가 stdout 에 찍는 문구 `(rc=3)`** 로 했다. **페이로드가 자기 판정 문자열을 인쇄**하고 있었다.

## 재작성이 닫은 것 (전부 양 셸 실행 확인)

| | |
|---|---|
| `local path` → `_psa_path` | 🟥 초판은 **대입을 빠뜨려** 오히려 전역 특수배열을 오염시켰다. 레인이 아니라 **눈**이 잡았다 |
| **캐시 제거** | 비용을 **실측**(자가검사 64ms/회, 훅 최대 4회=0.26초). 초판은 **안 재고** 정당화했고, 캐시는 **긴 스킬 세션(뚫린 쪽)에서만 위험하고 짧은 훅(안전한 쪽)에서만 이득**이라 방향이 반대였다 |
| **재진입 판별: 전역변수 → 호출 스택** | 외부가 표식을 미리 export 하면 자가검사가 **통째로 생략**됐다 |
| `cat` 상태 분류 · 실제 패턴 스트림 검사 | 자가검사는 스트림을 카나리아로 **바꿔치기**해서 진짜 패턴이 비었는지 구조적으로 못 본다 |
| 🟥 **훅이 rc 3(미측정) 과 1(유출) 을 가른다** | 초판 훅은 비영을 전부 유출로 뭉개서 **override 가 계기 사망까지 «승인된 유출»로 통과**시켰다. 되돌림 실측: 옛 훅 rc=0 · 새 훅 rc=1 |

레인 **41/41** — E 레인을 **양 셸 각각** + ★컨트롤(정상 양성 rc=1)로 «항상 3 을 내서 통과»가 아님을 증명. 훅 레인은 **실제 git 픽스처로 훅을 구동**한다. 되돌림 **4회** 전부 3단(적용확인→실행→복원)으로 정확히 해당 레인만 적색. **겹침: 리네임을 되돌려도 가드가 잡아 zsh 가 0 이 아니라 3 을 낸다.**

## 🟥 이 커밋이 한 번 막혔다 — 게이트가 옳았다

첫 시도에서 pre-commit 유출 스캔이 **내 레인 픽스처**를 막았다. known-positive 를 만들려고 실제 운영자 문자열을 박았기 때문이다 — **유출 스캐너를 고치면서 유출을 냈다.** 픽스처를 **합성 패턴**으로 바꿨고, 부수 효과로 레인이 **gitignored 패턴 파일에 의존하지 않게** 되어 소비자도 돌릴 수 있다.

## 범위 — 계열을 닫은 게 아니다

**한 실례를 닫고 나머지에 이름을 붙였다.** 안 닫힌 것:

- grep 오류가 「매치 없음」으로 변환된다 (`2>/dev/null || true` ×2)
- 자가검사 판정 자체가 위조 가능하다
- `pre-commit` 의 비말단 파이프 1곳 — 앞 단계 부작용으로 막히나 **우연에 기댄다**
- 스킬 예시가 스캔 뒤 coverage 조건으로 최종 상태를 덮는다
- 같은 셸 계열 **7건이 호출부에 의존해 잠들어 있다** — 6건은 «오늘 안전한데 호출부가 bash 라서»지 코드가 이식성 있어서가 아니다
- `bash -n`/`zsh -n` 은 이 계열을 **구조적으로 못 잡고**(문법 아닌 런타임 의미론), **shebang 린트는 무효**다 — 그 파일은 이미 bash shebang 을 갖고 있고 sourced 라 안 읽힌다. 진짜 판별자는 파일 속성이 아니라 **«호출부가 무엇인가»** 이고, 같은 파일이 훅에선 bash·스킬 본문에선 zsh 로 들어간다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAFGdGNiQ9YvNkhr9T4p2C