### PR TITLE
fix(gate): 마커의 ①영혼 은 6주째 의무인데 읽는 코드가 0줄이었다 — ⓒ 를 사전 선언으로 확장

### DIFF
--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -544,6 +544,7 @@ for _pair in \
   ".github/workflows/regression-guard.yml|scripts/test_regression_guard_ci_lanes.sh" \
   "templates/.git-hooks/pre-commit|scripts/test_marker_standpoint_lanes.sh" \
   "templates/.git-hooks/pre-commit|scripts/test_marker_thirdparty_lanes.sh" \
+  "templates/.git-hooks/pre-commit|scripts/test_marker_soul_check_lanes.sh" \
   "scripts/residency_closure_scan.py|scripts/test_residency_closure_lanes.sh" \
   "scripts/reviewer_capability_corpus.tsv|scripts/test_reviewer_capability_conformance.sh" \
   "scripts/field_canon_preload.sh|scripts/test_field_canon_lanes.sh" \

--- a/scripts/test_marker_soul_check_lanes.sh
+++ b/scripts/test_marker_soul_check_lanes.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# test_marker_soul_check_lanes.sh — regression fixtures for pre-commit's
+# validate_soul_check_leg
+# (ⓒ 격리 그라운딩 — 사전 선언으로 확장, 2026-08-21).
+#
+# 🟥 NOT a seventh axis. `fh_three_layer_canon.md §1-a-2` splits axes by «무엇을 받았는가», and
+# ⓒ already receives «저자가 쓴 문장 + 지금의 트리» — identical to this leg's input. Tense
+# (사전 선언 vs 사후 주장) is a posture, not an axis.
+#
+# WHY: `①영혼` has been required on every marker since 2026-08-09 and is written 4/4 on the real
+# corpus, with ZERO consuming code (measured with a control: `crossfamily` = 21 hits in the hook,
+# `①영혼`/`soul` = 0 lines that read it; `fh_4axis_gate.md` does not name the field). Slot with no
+# consumer → presence does the judging → always "done".
+#
+# SCOPE — channel, not judgment. These lanes assert the RECORD's properties: single · closed enum ·
+# non-vacuous · not wearing another axis's tokens · consistent with the ①영혼 line in the SAME file.
+# They never assert the read-back reached the right conclusion.
+#
+# 🟥 NAMED RESIDUAL — a fabricated `reflected(<fluent reason>)` on a marker that DOES carry an
+# ①영혼 line PASSES. Provenance is not checkable from a file (the hook says so at the ①영혼
+# comment, and that part is correct). The hole is §4-b's — cross-family reads the marker.
+#
+# Fixtures assert BOTH directions (known-pair): every intended shape is admitted, and every hole
+# the lane closes still blocks.
+#
+# Usage: bash scripts/test_marker_soul_check_lanes.sh   Exit: 0 = all behave; 1 = regression.
+
+set -uo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$REPO_ROOT/templates/.git-hooks/pre-commit"
+T=$(mktemp -d); trap 'rm -rf "$T"' EXIT
+
+sed -n '/^validate_soul_check_leg()/,/^}/p' "$HOOK" > "$T/fn.sh"
+
+# Instrument calibration — an empty extraction would let every fixture "pass" against nothing.
+if ! grep -q 'DEGRADED_NO_SOUL' "$T/fn.sh"; then
+  echo "❌ HARNESS-ERROR — validate_soul_check_leg did not extract from $HOOK."
+  echo "   Fixtures below would measure an empty function. Aborting rather than reporting green."
+  exit 1
+fi
+
+SOUL='①영혼: 성공 정의 = «소비자 경로에서 완주해 rc=0 을 내고 컨트롤로 가른다». 절대 안 함 = «FAIL 을 SKIP 으로 바꾸는 것»'
+
+FAIL=0
+lane() { # $1 = id  $2 = expect(BLOCK|PASS)  $3 = marker body
+  local id="$1" expect="$2" body="$3" rc out
+  printf '%s\n' "$body" > "$T/m.marker"
+  out=$( bash -c 'set -uo pipefail; . "$1"; validate_soul_check_leg "$2"' _ "$T/fn.sh" "$T/m.marker" 2>&1 ); rc=$?
+  local got=PASS; [ $rc -ne 0 ] && got=BLOCK
+  if [ "$got" = "$expect" ]; then
+    printf '  ✅ %-40s %s\n' "$id" "$got"
+  else
+    printf '  ❌ %-40s expected %s, got %s\n     %s\n' "$id" "$expect" "$got" "$(printf '%s' "$out" | head -3)"
+    FAIL=1
+  fi
+}
+
+echo "== soul-check lanes — BLOCK side (holes that must stay closed) =="
+lane G1-not-in-enum          BLOCK "$SOUL
+soul-check: done"
+lane G2-bare-reflected       BLOCK "$SOUL
+soul-check: reflected"
+lane G3-vacuous-grounds      BLOCK "$SOUL
+soul-check: reflected(ok)"
+lane G4-duplicate-line       BLOCK "$SOUL
+soul-check: UNKNOWN
+soul-check: reflected(cross-family agy 가 델타를 성공정의에 비춰 2건 지적)"
+lane G5-crossaxis-tier2      BLOCK "$SOUL
+soul-check: tier2(qasp)"
+lane G6-crossaxis-checked    BLOCK "$SOUL
+soul-check: checked(prior art 없음)"
+lane G7-crossaxis-panel      BLOCK "$SOUL
+soul-check: panel(codex,agy)"
+echo "  -- the consistency check (two fields, one record) --"
+lane G8-reflected-no-soul    BLOCK "axis2-model: opus
+soul-check: reflected(델타를 성공정의에 비춰 봤고 어긋남 없음)"
+lane G9-reflected-empty-soul BLOCK "①영혼: 없음
+soul-check: reflected(델타를 성공정의에 비춰 봤고 어긋남 없음)"
+lane G10-violated-no-soul    BLOCK "axis2-model: opus
+soul-check: violated(절대안함 을 어겼다 — SKIP 으로 바꿨다)"
+lane G11-nosoul-but-soul-is  BLOCK "$SOUL
+soul-check: DEGRADED_NO_SOUL(영혼 줄이 없어서 되비출 대상 자체가 없다)"
+lane G11b-nosoul-but-soul-key BLOCK "soul: 성공 정의 = 소비자 경로에서 완주한다. 절대 안 함 = FAIL 을 SKIP 으로 바꾸지 않는다
+soul-check: DEGRADED_NO_SOUL(영혼 줄이 없어서 되비출 대상 자체가 없다)"
+
+echo "== soul-check lanes — PASS side (intended shapes must be admitted) =="
+lane G12-absent-is-grace     PASS  "$SOUL
+axis2-model: opus"
+lane G13-reflected-ok        PASS  "$SOUL
+soul-check: reflected(agy/gemini 가 델타를 성공정의에 비춰 재검 — 절대안함 위반 0, 성공정의 미달 0)"
+lane G13b-reflected-soul-key PASS  "soul: 성공 정의 = 소비자 경로에서 완주한다. 절대 안 함 = FAIL 을 SKIP 으로 바꾸지 않는다
+soul-check: reflected(codex 가 soul 필드를 성공정의에 비춰 재검 — 위반 0)"
+lane G14-violated-is-legal   PASS  "$SOUL
+soul-check: violated(절대안함 «FAIL 을 SKIP 으로» 를 어겼다 — 되돌리고 주체를 이름으로 찍게 고쳤다)"
+lane G15-unknown-bare-ok     PASS  "$SOUL
+soul-check: UNKNOWN"
+lane G16-degraded-not-run    PASS  "$SOUL
+soul-check: DEGRADED_NOT_RUN(되비출 사이드카가 없어 이번 커밋에선 안 돌렸다)"
+lane G17-nosoul-when-truly   PASS  "axis2-model: opus
+soul-check: DEGRADED_NO_SOUL(경량 예외 커밋이라 영혼 줄을 안 썼다)"
+lane G18-not-applicable      PASS  "$SOUL
+soul-check: not-applicable(문서 오타 수정이라 성공정의에 걸리는 델타가 없다)"
+lane G19-em-dash-reason      PASS  "$SOUL
+soul-check: reflected(codex 가 성공정의 대조 — 어긋남 없음) — 2026-08-21"
+
+
+# ── ①영혼 presence lane (validate_soul_present_leg) ───────────────────────────
+sed -n '/^validate_soul_present_leg()/,/^}/p' "$HOOK" > "$T/fnp.sh"
+if ! grep -q 'SOUL_PRESENT_GRACE' "$T/fnp.sh" && ! grep -q '①영혼 line' "$T/fnp.sh"; then
+  echo "❌ HARNESS-ERROR — validate_soul_present_leg did not extract. Aborting."
+  exit 1
+fi
+GRACE=$(grep -m1 '^SOUL_PRESENT_GRACE_DATE=' "$HOOK" | sed -E 's/.*"(.*)"/\1/')
+
+planep() { # $1=id $2=expect $3=filename-date $4=body
+  local id="$1" expect="$2" d="$3" body="$4" rc out f
+  f="$T/.axes_23_passed_fix_x_${d}.marker"
+  printf '%s\n' "$body" > "$f"
+  out=$( bash -c 'set -uo pipefail; SOUL_PRESENT_GRACE_DATE="$3"; . "$1"; validate_soul_present_leg "$2"' \
+         _ "$T/fnp.sh" "$f" "$GRACE" 2>&1 ); rc=$?
+  local got=PASS; [ $rc -ne 0 ] && got=BLOCK
+  if [ "$got" = "$expect" ]; then printf '  ✅ %-40s %s\n' "$id" "$got"
+  else printf '  ❌ %-40s expected %s, got %s\n     %s\n' "$id" "$expect" "$got" "$(printf '%s' "$out"|head -2)"; FAIL=1; fi
+}
+
+echo
+echo "== ①영혼 presence lanes (grace = $GRACE) =="
+planep P1-missing-post-grace   BLOCK "$GRACE" 'axes-run: ⓐ=codex ⓑ=→standpoint
+crossfamily: panel(codex,agy) — 겹친 지적 0'
+# 🟥 P2 flipped BLOCK→PASS on 2026-08-21: a bare `없음` is the value CLAUDE.md §자기 대조
+# explicitly permits, and blocking it punished the honest form while a padded «I didn't write
+# one» paragraph passed. Found by a peer session's first real use, not by this suite.
+planep P2-declared-absent-ok   PASS  "$GRACE" '①영혼: 없음
+axes-run: ⓐ=codex'
+planep P2b-empty-field-blocks  BLOCK "$GRACE" 'soul:
+axes-run: ⓐ=codex'
+planep P2c-absent-heading-form PASS  "$GRACE" '## ①영혼 — 없음
+axes-run: ⓐ=codex'
+# fixture updated 2026-08-21: `없음` became a legal declared-absence value, so a truly vacuous
+# field is now the discriminating input (the point of codex's lane was masking-by-next-field,
+# not the token `없음`).
+planep P2b-vacuous-before-fields BLOCK "$GRACE" '①영혼: ok
+axis2-engine: steel-quench
+axis2-model: opus
+floor-status: ok
+axes-run: ⓐ=codex ⓑ=→standpoint ⓒ=x ⓓ=x ⓔ=x ⓕ=x
+controls: alive — known-positive x 1 hit · known-negative 0'
+planep P3-present-korean       PASS  "$GRACE" "$SOUL
+axes-run: ⓐ=codex"
+planep P4-present-soul-key     PASS  "$GRACE" 'soul: 성공 정의 = 소비자 경로에서 완주한다. 절대 안 함 = FAIL 을 SKIP 으로 바꾸지 않는다
+axes-run: ⓐ=codex'
+planep P5-grace-old-exempt     PASS  "2026-08-01" 'axes-run: ⓐ=codex
+crossfamily: panel(codex,agy) — 겹친 지적 0'
+planep P6-real-corpus-negative BLOCK "$GRACE" "$(cat "$REPO_ROOT/tracks/_meta/.axes_23_passed_feat_target-freeze-gate_2026-08-18.marker" 2>/dev/null || echo 'axes-run: x')"
+planep P7-real-corpus-positive PASS  "$GRACE" "$(cat "$REPO_ROOT/tracks/_meta/.axes_23_passed_fix_witness-two-commit-discipline_2026-08-17.marker" 2>/dev/null || echo '①영혼: 성공 정의 = 하나 둘 셋 넷 다섯 여섯')"
+
+echo
+echo "== cross-family findings — regression lanes (codex/gpt-5.5, diff 축, 2026-08-21) =="
+# F1 self-referential FP: codex's own alignment fix flipped G8 to PASS because the
+# `soul-check:` line contains 「성공정의」 and matched as its own evidence.
+lane F1-selfref-soulcheck-only BLOCK 'axis2-model: opus
+soul-check: reflected(델타를 성공정의에 비춰 봤고 절대 안 함 도 안 어겼다)'
+# F4 grounds outside the parens
+lane F4-grounds-outside-parens BLOCK "$SOUL
+soul-check: reflected() — 아주 길고 그럴듯한 꼬리말이 여기 붙어 있어서 길이를 채운다"
+# F3 near-miss key reads as absent
+lane F3-nearmiss-key           BLOCK "$SOUL
+soul_check: reflected(델타를 성공정의에 비춰 재검했다)"
+lane F3b-nearmiss-space        BLOCK "$SOUL
+soul-check : reflected(델타를 성공정의에 비춰 재검했다)"
+planep F1b-presence-selfref    BLOCK "$GRACE" 'axes-run: ⓐ=codex
+soul-check: reflected(성공 정의 대조 · 절대 안 함 확인)'
+planep F1c-comment-not-soul    BLOCK "$GRACE" '# 성공 정의 를 나중에 쓸 예정이다 절대 안 함 도
+axes-run: ⓐ=codex'
+# F2: unparseable date must NOT take the grace exit (was fail-open)
+printf 'axes-run: a=codex\n' > "$T/.axes_23_passed_nodate.marker"
+_o=$( bash -c 'set -uo pipefail; SOUL_PRESENT_GRACE_DATE="$3"; . "$1"; validate_soul_present_leg "$2"' \
+      _ "$T/fnp.sh" "$T/.axes_23_passed_nodate.marker" "$GRACE" 2>&1 ); _r=$?
+if [ $_r -ne 0 ]; then printf '  ✅ %-40s %s\n' "F2-unparseable-date-not-exempt" "BLOCK"
+else printf '  ❌ %-40s expected BLOCK, got PASS\n' "F2-unparseable-date-not-exempt"; FAIL=1; fi
+
+echo
+echo "== cross-family findings — regression lanes (agy/gemini-3.1-pro, 주장·기록 축) =="
+# A6 [S]: grounds counted with ${#} passed on a single long Korean token. Word count now.
+lane A6-korean-onetoken-grounds BLOCK "$SOUL
+soul-check: reflected(어긋남없음확인완료했음)"
+# A6b [S]: the two legs disagreed on the SAME soul block (6 vs 4 words). Aligned to 6.
+# 5 words under `wc -w` — passed the old 4-word floor in the check leg while the present leg
+# demanded 6 on the SAME block. Empirically calibrated, not guessed: `wc -w` does not equal a
+# human word count on Korean («①영혼: 완주» reports 3), so the fixture was measured, not reasoned.
+lane A6b-threshold-aligned      BLOCK '①영혼: 성공 정의
+soul-check: reflected(델타를 성공정의에 비춰 재검했고 어긋남 없음)'
+# A6-control: a genuinely grounded, multi-word reason still passes (this lane must NOT block).
+lane A6c-control-passes         PASS "$SOUL
+soul-check: reflected(codex 가 성공정의 대조 — 어긋남 없음)"
+
+echo
+echo "== 첫 실사용 findings — peer session (forge-harness-59, 2026-08-21) =="
+# A marker that declares NO success definition cannot claim to have reflected against one.
+lane N1-absent-soul-vs-reflected BLOCK 'soul: 없음
+soul-check: reflected(델타를 성공정의에 비춰 재검했고 어긋남 없음)'
+lane N2-absent-soul-degraded-ok  PASS  'soul: 없음
+soul-check: DEGRADED_NO_SOUL(설계 전에 성공 정의를 쓰지 않았다 — 되비출 대상이 없다)'
+# The padded confession that passed in the field: it IS a real declaration of absence, and once
+# `없음` is a first-class value the padded form is no longer the only way through.
+lane N3-padded-confession        PASS  'soul: 없음 — 설계 전에 안 썼다. 사후 재구성이 아니라 그 사실을 적는다. 붙잡고 있던 것은 범위 결정 하나였다
+axes-run: ⓐ=codex'
+
+echo
+if [ $FAIL -eq 0 ]; then echo "SOUL LANES: PASS"; else echo "SOUL LANES: FAIL"; fi
+exit $FAIL

--- a/templates/.git-hooks/pre-commit
+++ b/templates/.git-hooks/pre-commit
@@ -1051,6 +1051,263 @@ validate_thirdparty_leg() { # $1 = marker path
   return 0
 }
 
+SOUL_PRESENT_GRACE_DATE="2026-08-21"
+validate_soul_present_leg() { # $1 = marker path
+  # ── ①영혼 존재 검사 (2026-08-21) ──────────────────────────────────────────────
+  # CLAUDE.md §자기 대조 has mandated an ①영혼 line (성공 정의 / 절대 안 함) on every marker
+  # since 2026-08-09. MEASURED on the real corpus this day, with the instrument calibrated over
+  # EIGHT spellings and two controls (`axes-run` and `axis2-engine` = 98/98): of 98 post-grace
+  # markers, 61 carry it and **37 (37.8%) carry no form of it at all**.
+  #
+  # 🟥 The first pass of that same measurement grepped only the exact `①영혼` string and returned
+  # "92.9% missing". That would have been a false alarm ([[feedback_measured_scope_vs_claimed_scope]]
+  # — hand-enumerating spellings). The union + hand-verification of one negative sample is what
+  # makes the 37 real: `.axes_23_passed_feat_target-freeze-gate_2026-08-18.marker` was opened by
+  # eye — a panel-reviewed, 28-lane, controls-alive marker with every OTHER field filled, and no
+  # soul line in any spelling.
+  #
+  # 🟥 WHY THIS IS NOT THE THING THE ①영혼 COMMENT BELOW DECLINES. That comment refuses to check
+  # «was it written BEFORE designing» — unverifiable from a file, correctly excluded, and this
+  # lane does not check it. PRESENCE is a different question and is trivially decidable. The
+  # impossible question carried the possible one out on its ticket.
+  #
+  # SCOPE — channel, not judgment. Asserts the field EXISTS and is not vacuous. Says nothing about
+  # whether the success definition is good, was honoured, or was written in advance.
+  local m="$1" n body words
+  # Grace: only markers dated on/after the grace date are required to carry it. Retroactive
+  # enforcement would block every in-flight branch, and that over-block trains `--no-verify`,
+  # which would disarm the Destructive-Op gate living in this same hook.
+  local mdate
+  mdate=$(printf '%s' "$m" | sed -nE 's/.*_([0-9]{4}-[0-9]{2}-[0-9]{2})\.marker$/\1/p')
+  # 🟥 An unparseable date used to `return 0` — fail-OPEN. The hook itself builds this filename
+  # as `..._${TODAY}.marker`, so a name without a date is unexpected, not old. Unknown is not
+  # exempt ([[feedback_not_found_is_not_zero_family]]); it falls through to the presence check.
+  [ -z "$mdate" ] || { [ "$mdate" \< "$SOUL_PRESENT_GRACE_DATE" ] && return 0; }
+  # 🟥 agy (claims axis): the comment above says the MEASUREMENT swept eight spellings; this
+  # regex carries FOUR alternatives (①영혼 · a `soul:` key · 성공[ ]?정의 · 절대 안 함). Both are
+  # true and they are different instruments — but writing only the first invites reading the
+  # second's coverage off it ([[feedback_rule_misdescribes_its_own_machine]]). The four are the
+  # ones the corpus actually uses as a FIELD; the other four measured spellings appeared only
+  # inside prose, which this leg deliberately excludes.
+  # 🟥 The soul detector must NOT read the `soul-check:` line itself. codex's alignment fix widened
+  # the pattern and G8 flipped to PASS: `soul-check: reflected(…성공정의…)` matched as its own
+  # evidence — self-referential FP ([[feedback_lane_runner_self_referential_fp]]). The claim can
+  # never be its own ground. Same reason comment/prose lines are excluded: a marker that merely
+  # SAYS 성공 정의 in narration has not declared one.
+  # 🟥 A DECLARATION, not a MENTION. First real use (isolated clone, 2026-08-21) broke this on
+  # attempt #1: this very delta's marker says «change: 마커의 ①영혼 슬롯에 소비처가 0이던 것을…»
+  # in a prose FIELD VALUE, and the leg reported "①영혼 present: 10 words" for a marker that
+  # declares nothing. Excluding `#` and `soul-check:` was not enough — any field whose value
+  # discusses the axis satisfies a substring test, and markers ABOUT this axis always will.
+  # 39 lanes, codex (diff axis) and agy (claims axis) all missed it; running it once did not
+  # ([[feedback_adversarial_review_not_substitute_for_first_use]]).
+  # So the token must sit at LINE START as the key (a leading markdown `#` is allowed — the real
+  # corpus writes «## ①영혼 — 설계 전에 쓴 …» as a heading, and P7 flipped to BLOCK when the first
+  # version of this regex forbade it. The known-pair caught that in one run).
+  # Prose inside a field VALUE can no longer vote.
+  _soul_src=$(grep -E '^[[:space:]]*#*[[:space:]]*(①영혼|soul|절대 안 함|성공 ?정의)[[:space:]]*[:—-]' "$m" 2>/dev/null \
+              | grep -vE '^[[:space:]]*soul-check[[:space:]]*:')
+  n=$(printf '%s\n' "$_soul_src" | grep -cE '①영혼|^[[:space:]]*soul:|성공 ?정의|절대 안 함'); n=${n:-0}
+  if [ "$n" -eq 0 ]; then
+    echo "  ❌ FAIL — marker carries no ①영혼 line (성공 정의 / 절대 안 함)."
+    echo "     CLAUDE.md §자기 대조 requires it on every marker. Measured 2026-08-21: 37 of 98"
+    echo "     post-grace markers had none — including panel-reviewed ones with every other"
+    echo "     field filled. Nothing read the field, so nothing noticed."
+    echo "     Write, before the design: 성공 정의 = «…». 절대 안 함 = «…»."
+    echo "     🟥 This checks PRESENCE, not provenance. «Was it written first» stays unverifiable"
+    echo "     and unchecked — see the ①영혼 comment below. Presence is not that question."
+    return 1
+  fi
+  # Non-vacuity — counted in WORDS, not characters (Korean corpus; ${#} is locale-dependent).
+  body=$(awk '/①영혼|^[[:space:]]*soul:|성공 ?정의|절대 안 함/{if (!f) f=1}
+              f && /^[[:space:]]*$/{exit}
+              f && seen && /^[[:space:]]*[A-Za-z][A-Za-z0-9_-]*:/{exit}
+              f{print; seen=1}' <<< "$_soul_src")
+  words=$(printf '%s' "$body" | wc -w | tr -d ' '); words=${words:-0}
+  # 🟥 A DECLARED ABSENCE IS A VALUE, not a gap. CLAUDE.md §자기 대조 explicitly permits
+  # «없으면 `없음`», and the first version of this leg BLOCKED a bare `soul: 없음` (2 words) while
+  # PASSING a 33-word paragraph whose content was «I did not write one». That punishes the honest
+  # form and rewards padding — [[feedback_unreachable_done_when_trains_evasion]] exactly. Found by
+  # a peer session's first real use of this gate (forge-harness-59, 2026-08-21); self-detection 0,
+  # and 41 lanes + two cross-family panels had all passed.
+  # Same shape as the sibling axes' `UNKNOWN`: recorded, not silent, and never free of a record.
+  # 🟥 `$body` — this leg's own local. The first version read `$soul_body`, which is the OTHER
+  # leg's variable name; unset here, so the case never matched and the fix was inert while the
+  # lane suite stayed green ([[feedback_unedited_parts_of_my_own_file]] · half-fix).
+  _sbare=$(printf '%s' "$body" | sed -E 's/^[[:space:]]*#*[[:space:]]*(①영혼|soul|절대 안 함|성공 ?정의)[[:space:]]*[:—-]*//' | tr -d '[:space:].·]')
+  case "$_sbare" in
+    없음|없음—|none|None|NONE|n/a|N/A|-|해당없음)
+      echo "  ⚠️  ①영혼: 없음 — declared absent. Recorded, not silent."
+      echo "     🟥 A marker that declares no success definition cannot carry"
+      echo "     soul-check: reflected(...) — there is nothing to reflect against."
+      return 0 ;;
+  esac
+  if [ "$words" -lt 6 ]; then
+    echo "  ❌ FAIL — ①영혼 line is vacuous ($words word(s)). Name the success definition AND"
+    echo "     the 절대 안 함. A one-word placeholder trains the ritual this field exists to avoid."
+    return 1
+  fi
+  echo "  ✅ ①영혼 present: $words word(s)"
+  return 0
+}
+
+validate_soul_check_leg() { # $1 = marker path
+  # ── ⓒ 격리 그라운딩 — 사전 선언으로 확장 (2026-08-21) ─────────────────────────
+  # 🟥 NOT a seventh axis. Classified against `fh_three_layer_canon.md §1-a-2`, whose
+  # discriminator is explicit: «축은 «얼마나 적대적인가»로 갈리지 않는다. «무엇을 받았는가»로
+  # 갈린다.» ⓒ 격리 그라운딩 receives «저자가 쓴 문장 + 지금의 트리» — which is, character for
+  # character, what this leg receives (①영혼 is 저자가 쓴 문장; the delta is 지금의 트리).
+  # The tense differs (사전 선언 vs 사후 주장) and tense is a posture, not an axis, exactly as
+  # that section says adversarialness is («적대성은 자세지 축이 아니다»).
+  # Precedent, in the canon itself: the author attributed 5 findings to ⓓ and two independent
+  # cross-family classifiers reclassified 3 of them — «그 셋은 축이 필요했던 게 아니라 다른 축이
+  # 놓친 것이다». Minting ⓖ would have been that mistake a second time.
+  # ⇒ ⓒ's 「받는 것」 widens to «저자가 쓴 문장(사후 주장 및 **사전 선언**)», and `soul-check:`
+  # is ⓒ's own field in the same shape `standpoint:` is ⓑ's. The six axes stay six.
+  # WHY: CLAUDE.md §자기 대조 has required an `①영혼` line (성공 정의 / 절대 안 함) on every
+  # marker since 2026-08-09, and it is written 4/4 on the real corpus. NOTHING has ever read it
+  # back. Measured this day with a control: `crossfamily` = 21 hits in this hook, `①영혼`/`soul`
+  # = 0 lines of consuming code anywhere in templates/ or scripts/; `fh_4axis_gate.md` does not
+  # even name the field. That is the half-externalization shape — a slot with zero consumers,
+  # which always reports "done" because presence is doing the judging.
+  #
+  # 🟥 The reason this hook gave for NOT checking the field answers a DIFFERENT question. Line
+  # ~1058 declines it because «did you write it BEFORE designing» is unverifiable from a file —
+  # true, and correctly excluded. But «was it then SATISFIED» is a separate question that was
+  # never asked, and it rode out on the first one's ticket.
+  #
+  # SCOPE — channel, not judgment (CLAUDE.md §Mechanization Boundary). This lane asserts
+  # properties of the RECORD: single · closed enum · non-vacuous · not wearing another axis's
+  # tokens · **and consistent with the ①영혼 line in the same file**. It never asserts the
+  # read-back reached the right conclusion. A fabricated `reflected(...)` with a fluent reason
+  # PASSES — that hole is §4-b's (cross-family reads the marker), not this lane's, and it is
+  # named here rather than papered over.
+  local m="$1" line val reason n soul_n soul_body
+  n=$(grep -cE '^[[:space:]]*soul-check:' "$m" 2>/dev/null); n=${n:-0}
+  if [ "$n" -eq 0 ]; then
+    # 🟥 A near-miss key reads as "absent" and takes the grace exit — silent, and the author
+    # believes they recorded it. Absent is legal; MISSPELLED is not.
+    if grep -qE '^[[:space:]]*(soul[ _-]?check[[:space:]]*:|soulcheck:|soul-checks:)' "$m" 2>/dev/null \
+       && ! grep -qE '^[[:space:]]*soul-check:' "$m" 2>/dev/null; then
+      echo "  ❌ FAIL — a line looks like a soul-check key but is not exactly 'soul-check:'."
+      grep -nE '^[[:space:]]*(soul[ _-]?check[[:space:]]*:|soulcheck:|soul-checks:)' "$m" | sed 's/^/       /'
+      return 1
+    fi
+    return 0   # genuinely absent — adoption is incremental, same as thirdparty:
+  fi
+  if [ "$n" -gt 1 ]; then
+    echo "  ❌ FAIL — marker carries MORE THAN ONE 'soul-check:' line."
+    grep -nE '^[[:space:]]*soul-check:' "$m" | sed 's/^/       /'
+    echo "     Readers take the first, so an appended correction is silently shadowed."
+    return 1
+  fi
+  line=$(grep -m1 -E '^[[:space:]]*soul-check:' "$m" | sed -E 's/^[[:space:]]*soul-check:[[:space:]]*//')
+  val=$(printf '%s' "$line" | sed -E 's/\(.*$//' | sed -E 's/[[:space:]]*(—|--).*$//' | sed -E 's/[[:space:]]+$//')
+
+  # Cross-axis contamination — the other three axes ask different questions.
+  case "$val" in
+    tier1|tier1b|tier2|tier2b|tier3|panel|declined|checked|none-found|peer-review|\
+DEGRADED_SINGLE_FAMILY|DEGRADED_PANEL_UNUSED|DEGRADED_NO_TARGET_ACCESS|DEGRADED_NO_ACCESS)
+      echo "  ❌ FAIL — '$val' belongs to another axis, not soul-check:."
+      echo "     standpoint = whose repo was ground truth · crossfamily = which model family reviewed"
+      echo "     thirdparty = was this already done outside · soul-check = was THIS marker's own"
+      echo "     ①영혼 (성공 정의 / 절대 안 함) read back against the delta."
+      return 1 ;;
+  esac
+
+  # Is there an ①영혼 line in this same marker, and does it carry content?
+  # 🟥 The soul detector must NOT read the `soul-check:` line itself. codex's alignment fix widened
+  # the pattern and G8 flipped to PASS: `soul-check: reflected(…성공정의…)` matched as its own
+  # evidence — self-referential FP ([[feedback_lane_runner_self_referential_fp]]). The claim can
+  # never be its own ground. Same reason comment/prose lines are excluded: a marker that merely
+  # SAYS 성공 정의 in narration has not declared one.
+  # 🟥 A DECLARATION, not a MENTION. First real use (isolated clone, 2026-08-21) broke this on
+  # attempt #1: this very delta's marker says «change: 마커의 ①영혼 슬롯에 소비처가 0이던 것을…»
+  # in a prose FIELD VALUE, and the leg reported "①영혼 present: 10 words" for a marker that
+  # declares nothing. Excluding `#` and `soul-check:` was not enough — any field whose value
+  # discusses the axis satisfies a substring test, and markers ABOUT this axis always will.
+  # 39 lanes, codex (diff axis) and agy (claims axis) all missed it; running it once did not
+  # ([[feedback_adversarial_review_not_substitute_for_first_use]]).
+  # So the token must sit at LINE START as the key (a leading markdown `#` is allowed — the real
+  # corpus writes «## ①영혼 — 설계 전에 쓴 …» as a heading, and P7 flipped to BLOCK when the first
+  # version of this regex forbade it. The known-pair caught that in one run).
+  # Prose inside a field VALUE can no longer vote.
+  _soul_src=$(grep -E '^[[:space:]]*#*[[:space:]]*(①영혼|soul|절대 안 함|성공 ?정의)[[:space:]]*[:—-]' "$m" 2>/dev/null \
+              | grep -vE '^[[:space:]]*soul-check[[:space:]]*:')
+  soul_n=$(printf '%s\n' "$_soul_src" | grep -cE '①영혼|^[[:space:]]*soul:|성공 ?정의|절대 안 함'); soul_n=${soul_n:-0}
+  # Body = the ①영혼 block only: stop at a blank line OR at the next ASCII field key. An earlier
+  # draft ran the range to EOF, so a marker reading «①영혼: 없음» followed by any other field was
+  # scored as having content — the fixture G9 caught it.
+  # 🟥 Counted in WORDS, not characters. `${#var}` on Korean text is bytes-or-chars depending on
+  # locale, and this corpus is Korean — a char threshold silently changes meaning per machine
+  # ⚠️ Honest caveat, measured: `wc -w` is NOT a human word count on Korean either («①영혼: 완주»
+  # reports 3, not 2). It is stable per-machine and monotonic, which is all a floor needs — but
+  # every threshold here was calibrated by RUNNING it, never by reasoning about word counts.
+  # ([[feedback_instrument_vs_target_and_budget]], 단위 혼동). Word count is locale-independent.
+  soul_body=$(awk '/①영혼|^[[:space:]]*soul:|성공 ?정의|절대 안 함/{if (!f) f=1}
+                   f && /^[[:space:]]*$/{exit}
+                   f && seen && /^[[:space:]]*[A-Za-z][A-Za-z0-9_-]*:/{exit}
+                   f{print; seen=1}' "$m" 2>/dev/null \
+              | sed -E '1s/^[[:space:]]*(①영혼|soul)[^[:alnum:]«]*//')
+  soul_words=$(printf '%s' "$soul_body" | wc -w | tr -d ' ')
+  soul_words=${soul_words:-0}
+
+  case "$val" in
+    UNKNOWN)
+      echo "  ⚠️  soul-check leg: UNKNOWN — 안 봤다. Recorded, not silent." ;;
+    reflected|violated|DEGRADED_NOT_RUN|DEGRADED_NO_SOUL|not-applicable)
+      case "$line" in *\(*) ;; *)
+        echo "  ❌ FAIL — '$val' without a (<grounds>) parenthetical."
+        echo "     A read-back that names neither WHAT read it nor WHAT came back is"
+        echo "     indistinguishable from not running it."
+        return 1 ;;
+      esac
+      # 🟥 Measure INSIDE the parens. The old form took everything after the first `(`, so
+      # `reflected() — <long tail>` passed on text that was never grounds (codex, diff axis).
+      reason=$(printf '%s' "$line" | sed -E 's/^[^(]*\(//; s/\)[^)]*$//')
+      # 🟥 agy (claims axis, 2026-08-21): this leg's own comment above condemns `${#var}` on
+      # Korean text and then used `${#reason}` twelve lines later — [[feedback_citing_a_rule_is_not_obeying_it]],
+      # verbatim. Inherited from the sibling legs, which does not excuse it here. Word count.
+      _rwords=$(printf '%s' "$reason" | wc -w | tr -d ' '); _rwords=${_rwords:-0}
+      if [ "$_rwords" -lt 3 ]; then
+        echo "  ❌ FAIL — '$val(...)' grounds are vacuous. Name what read the ①영혼 line back,"
+        echo "     against what, and what came back."
+        return 1
+      fi
+      # ── the consistency check that makes this lane non-decorative ──────────────
+      # Two fields in ONE record, mechanically decidable. Not a conclusion.
+      case "$val" in
+        reflected|violated)
+          if [ "$soul_n" -eq 0 ] || [ "$soul_words" -lt 6 ]; then
+            echo "  ❌ FAIL — '$val' claims the ①영혼 line was read back, but this marker has"
+            echo "     no ①영혼 line with content (found: $soul_n line(s), $soul_words word(s))."
+            echo "     🟥 Reflecting against an absent success-definition is the exact"
+            echo "     half-externalization this lane exists to catch. Write ①영혼 first,"
+            echo "     or record DEGRADED_NO_SOUL(<why>)."
+            return 1
+          fi ;;
+        DEGRADED_NO_SOUL)
+          if [ "$soul_n" -gt 0 ] && [ "$soul_words" -ge 6 ]; then
+            echo "  ❌ FAIL — 'DEGRADED_NO_SOUL' says there is nothing to reflect against, but"
+            echo "     this marker DOES carry an ①영혼 line with content ($soul_n line(s))."
+            echo "     A recorded absence contradicted by the same record is worse than silence."
+            return 1
+          fi ;;
+      esac
+      echo "  ✅ soul-check leg: $val" ;;
+    *)
+      echo "  ❌ FAIL — '$val' is not a member of the soul-check: enum."
+      echo "     Closed enum: reflected(<what came back — 어긋남 여부. NOT just who reviewed:
+     that is crossfamily's column, and duplicating it double-counts one event>) ·"
+      echo "     violated(<which half broke — 성공정의 미달 / 절대안함 위반 — and what was done>) ·"
+      echo "     DEGRADED_NOT_RUN(<why>) · DEGRADED_NO_SOUL(<why>) · UNKNOWN · not-applicable(<why>)"
+      echo "     🟥 'violated' is a legal value ON PURPOSE. A recorded violation is worth more"
+      echo "     than a hidden one, and a lane that only admits success trains erasure."
+      return 1 ;;
+  esac
+  return 0
+}
+
 
 
 # ── 4축 자기 대조 — «어느 축을 돌렸고 어느 축을 안 돌렸나» 형식 검사 ────────────
@@ -1382,7 +1639,17 @@ if [ "$GATE_MODE" = "full" ]; then
     if grep -qE '^[[:space:]]*floor-status:[[:space:]]*(sonnet-floor|below-floor)' "$MARKER"; then
       validate_defense_leg "$MARKER" || _DEFENSE_OK=0
     fi
-    if [ "$_DEFENSE_OK" -eq 1 ] && validate_marker_floor "$MARKER" && validate_marker_axes_run "$MARKER"; then
+    # ⓒ 사전 선언 (①영혼) — scope is EVERY marker (CLAUDE.md §자기 대조 mandates ①영혼 on all of them), so it
+    # belongs HERE and not in the load-bearing block below.
+    # 🟥 It was first wired there, exactly like `validate_defense_leg` above — the real condition
+    # would have been "load-bearing AND has a marker" while the doctrine says every marker. The
+    # note recording that precedent is ~8 lines above this one and was in the file at the time;
+    # the same defect was made one day later anyway ([[feedback_unedited_parts_of_my_own_file]]).
+    # Caught by the operator asking «배선 완료되었나?», not by a lane and not by cross-family.
+    _SOUL_OK=1
+    validate_soul_present_leg "$MARKER" || _SOUL_OK=0
+    validate_soul_check_leg "$MARKER" || _SOUL_OK=0
+    if [ "$_DEFENSE_OK" -eq 1 ] && [ "$_SOUL_OK" -eq 1 ] && validate_marker_floor "$MARKER" && validate_marker_axes_run "$MARKER"; then
       echo "  ✅ PASS (marker confirmed + floor/axes fields valid:"
       echo "     .axes_23_passed_${BRANCH_SLUG}_${TODAY}.marker)"
     else


### PR DESCRIPTION
## 마커의 `①영혼` 은 6주째 의무였는데, 읽는 코드가 0줄이었다

`CLAUDE.md §자기 대조` 가 2026-08-09 부터 모든 마커에 **성공 정의 / 절대 안 함**을 설계 **전에** 쓰라고 요구한다. 실제로 쓰이고 있다. **그런데 그것을 읽는 코드가 어디에도 없었다.**

컨트롤 동반 실측:
```
훅에서 crossfamily 검사             21곳
①영혼 / soul 을 읽는 코드            0줄     ← templates/, scripts/ 전수
fh_4axis_gate.md 가 그 필드를 명세    0회     ← 이름조차 없다
실물 코퍼스 (2026-08-10 이후 98건)    37건이 어떤 표기로도 그 줄이 없다 (37.8%)
```
손검증한 그 하나(`.axes_23_passed_feat_target-freeze-gate_2026-08-18`)는 **codex+agy 패널 · 28레인 · controls alive · 나머지 필드 전부 채운** 마커다. **시킨 축은 다 돌렸고, 아무 기계도 안 읽는 그 한 줄만 없었다.**

슬롯이 100% 채워지고 소비처가 0이면 「됐나」를 존재로 판정하게 되고, 그러면 답은 언제나 «됐다»다.

## 🟥 새 축이 아니다 — ⓒ 격리 그라운딩의 확장이다

`fh_three_layer_canon.md §1-a-2` 의 판별자는 «**무엇을 받았는가**»이고, ⓒ 는 이미 «저자가 쓴 문장 + 지금의 트리» 를 받는다 — 사전 선언 검사의 입력과 **한 글자도 다르지 않다.** 시제(사전 선언 ↔ 사후 주장)는 적대성과 같은 **자세**지 축이 아니다.

초안은 ⓖ 로 뽑으려 했고 **운영자가 기존 카테고리 검토를 지시해 정정했다.** 그대로 갔으면 정본 6축 · `axes-run` enum · 덱 표 · 마커 190건 재해석이 전부 따라왔을 것이고, 그건 **정본 안에 이미 기록된 오류**(저자가 ⓓ에 귀속한 5건 중 3건을 다른 계열 분류자 둘이 다른 축으로 재판정 — *"축이 필요했던 게 아니라 다른 축이 놓친 것"*)의 반복이었다.

⇒ **정본 6축 · `axes-run` ⓐ~ⓕ · 덱 표 전부 그대로.** 바뀌는 것은 ⓒ 의 「받는 것」이 «사후 주장 **및 사전 선언**» 으로 넓어지는 것뿐이다.

## 검사하는 것 — 채널뿐

| | |
|---|---|
| `validate_soul_present_leg` | 선언이 있는가(**줄머리 키**) · 공허하지 않은가. **모든 마커**에서 |
| `validate_soul_check_leg` | `soul-check:` 닫힌 enum · 근거 비공허 · **같은 레코드 안 정합성** (`reflected` 를 적으려면 그 마커에 실제로 선언이 있어야 한다) |

**검사하지 않는 것**: 사전에 썼는가(파일에서 안 갈린다 — 훅이 그 이유로 명시 거절해 왔고 그 판단은 옳다) · 그 판단이 옳은가. `§Mechanization Boundary` 대로 **결론은 안 굳힌다.**

🟥 **선언된 부재는 1급 값이다.** `soul: 없음` 은 통과하되 **기록으로** 찍힌다(`⚠️ declared absent. Recorded, not silent.`). 초판은 이걸 **차단**했는데, 같은 내용을 33단어로 길게 쓰면 통과했다 — **정직한 형태가 벌받고 채우기가 보상받는** 구조였다. peer 세션의 첫 실사용이 잡았다.

## 검증

```
레인 44개          BLOCK/PASS 양방향 · 실물 코퍼스 known-pair 2쌍(양성/음성 실물 마커)
되돌림              4개 수리를 되돌리면 정확히 대응 7레인만 적색, 나머지 초록 유지
                   (3단: 적용확인 → 실행 → 복원)
격리 클론 실 커밋    선언 없음 rc=1 / 있음 rc=0 ALL AXES PASSED
selfcheck          레인 레지스트리 등재
```

🟥 **자력 적발 0 이 14건이다.** cross-family 를 **축 분리**로 발주했다 — codex/gpt-5.5 에 diff 축(fail-open·셸 함정·경계값), agy/gemini-3.1-pro 에 주장 축(주석↔코드 정합·계약 위반·enum 도피). **겹친 지적 0**, 독립 수렴 1건(날짜 파싱 fail-open).

그중 하나는 **사이드카의 수리가 새 fail-open 을 만든 것**이다: 「두 탐지기의 관대함이 갈렸다」는 지적은 참이었는데, 넓힌 탐지기가 **`soul-check:` 줄 자신의 텍스트를 증거로 잡아** BLOCK 레인이 PASS 로 뒤집혔다(자기참조 오탐). **레인 41개가 전부 초록이었고**, 잡은 것은 **격리 클론 첫실사용**이다.

## 🟥 명시 잔여 — 안 닫은 것

- **날조된 `reflected(<유창한 사유>)` 는 통과한다.** provenance 는 파일에서 안 갈린다. §4-b(cross-family 가 마커를 읽는다)의 몫이고 여기서 안 닫혔다.
- **소급 안 한다** — grace `2026-08-21`. 기존 37건은 그대로. 과차단은 `--no-verify` 를 훈련시키고 그건 같은 훅의 Destructive-Op 게이트까지 무장해제한다.
- **형제 축 문법 분열**(별건): `standpoint:` 는 근거를 em-dash 로만 받고 `thirdparty:`·`soul-check:` 는 괄호로 받는다. 괄호로 쓰면 *"is not a member of the enum"* 이라는 **오진**이 난다 — 값은 멤버가 맞고 문법만 틀렸다.
- **`wc -w` 는 한글에서 사람이 세는 단어 수가 아니다**(`①영혼: 완주` → 3). 안정적·단조라 floor 로는 충분하지만, **모든 임계를 추론이 아니라 실행으로 보정**했고 주석에 그렇게 적었다.

## BREAKING (gate)

**2026-08-21 이후 날짜의 마커는 `①영혼` 줄이 없으면 커밋이 막힌다 — 없으면 `soul: 없음` 한 줄로 통과한다.** 이 릴리스가 그 필드를 새로 요구하는 게 아니라 **처음으로 읽는다.**
