### PR TITLE
fix(psa): cross-family 3라운드 반례 11건 — 그중 7건은 내 수리가 만들었다

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,6 +220,7 @@
     "scripts/judgment_circuit_lint.sh",
     "scripts/novelty_claim_check.sh",
     "templates/settings.Compaction.snippet.json",
+    "scripts/fh_hub_identity.sh",
     "scripts/fh_track_resolve.sh",
     "scripts/test_track_resolve_lanes.sh",
     "scripts/field_canon_preload.sh",

--- a/scripts/outbound_query_guard.sh
+++ b/scripts/outbound_query_guard.sh
@@ -84,8 +84,26 @@ fi
 # 로 읽으므로, 질의에 개행+탭이 있으면 **토큰이 path 필드로 들어가 스캔 대상에서 빠진다.**
 # 실제 우회 경로였다. 한 레코드로 눌러 넣는다.
 Q_FLAT="$(printf '%s' "$Q" | tr '\n\t\r' '   ')"
-OUT="$(printf 'outbound-query\t%s' "$Q_FLAT" | psa_scan_tagged 2>&1)"; RC=$?
+# 🟥 P3 동형: 조건문 안의 대입이라야 `set -e` 아래서 안 죽는다.
+if OUT="$(printf 'outbound-query\t%s' "$Q_FLAT" | psa_scan_tagged 2>&1)"; then RC=0; else RC=$?; fi
+# 🟥 P2 (cross-family 3라운드): 초판은 «비영이면 override 로 통과» 였다. 그러면 **rc=3 미측정**
+#    까지 승인된 것처럼 지나간다 — pre-commit·pre-push 에서 닫은 바로 그 구멍이 **세 번째
+#    호출부에 그대로** 있었고, 나는 그것을 「호출부 셋 다 닫혔다」고 적었다(전수 주장이 틀렸다).
+#    override 는 «봤고 괜찮다» 는 뜻이라 **본 것(rc=1)에만** 쓸 수 있다. 안 본 것(rc=3)엔 못 쓴다.
+# 🟥 R4-4/5: 판정점을 **하나로** 만든다. 초판은 «rc=3 선차단» + «override 에 `-le 1` 조건»
+#    두 겹이었는데, 앞이 막아버려 뒤 술어는 **되돌려도 레인이 안 빨개졌다**(장식 앵커).
+#    그리고 rc=2 는 어느 쪽도 안 잡아 **«유출 발견»(exit 1)으로 오분류**됐다 — 안 본 것을
+#    본 것으로 렌더하는 방향이다. 「측정된 값」은 0 과 1 뿐이고 **나머지는 전부 미측정**이다.
+case "$RC" in
+  0|1) ;;
+  *) echo "🚫 OUTBOUND BLOCKED — 스캐너가 측정값을 안 냈다 (rc=$RC). NOT SCANNED 는 깨끗함이 아니다." >&2
+     echo "   OUTBOUND_QUERY_OK 로도 통과 못 한다 — 승인은 «봤다» 는 뜻이고, 이건 안 본 것이다." >&2
+     echo "$OUT" >&2
+     exit 3 ;;
+esac
 if [ "$RC" -ne 0 ] || [ -n "$OUT" ]; then
+  # 여기 도달했다는 것은 위 `case` 에 의해 RC ∈ {0,1} 이 **구조적으로 보장**된 상태다.
+  # 초판의 `&& [ "$RC" -le 1 ]` 는 그래서 중복이었고, 중복은 앵커가 안 붙는다 — 지운다.
   if [ "${OUTBOUND_QUERY_OK:-0}" = "1" ]; then
     printf '%s\tOUTBOUND_QUERY_OK\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${Q:0:60}" \
       >> "$FH/tracks/_meta/.outbound_query_override_log" 2>/dev/null || true

--- a/scripts/psa_scan_lib.sh
+++ b/scripts/psa_scan_lib.sh
@@ -233,7 +233,7 @@ psa_scan_tagged() {
   #    같은 출력**이 된다 — 이 저장소가 이름 붙인 «미측정을 0으로 렌더» 의 가장 조용한 얼굴이다.
   #    실측 2026-08-21: zsh 에서 known-positive·known-negative 가 **둘 다 rc=0** 이었다.
   #    형제 특수변수(`fpath` `status` `argv` `cdpath` …)도 같은 함정이다.
-  local input hit=0 row sev re _psa_path body tok
+  local input hit=0 row sev re _psa_path body tok _line_hits _tok_hits _lg _tg
 
   # ── E: 진입 생존성 가드 (2026-08-21, cross-family FAIL 판정 후 재작성) ─────────────
   # 🟥 **초판 E 는 fail-open 을 못 닫았다.** codex/gpt-5.6-sol 이 반례 6개를 전부 실행으로
@@ -280,11 +280,29 @@ psa_scan_tagged() {
     case "$row" in ''|\#*) continue;; esac
     re="${row#*$'\t'}"; [ "$re" = "$row" ] && continue
     sev="${row%%$'\t'*}"
+    # 🟥 grep 상태를 «매치 없음» 으로 접지 마라 (cross-family 반례 2, 2026-08-21).
+    #    `2>/dev/null || true` 는 rc 0(매치)·1(없음)·**2 이상(계기 오류)**을 하나로 뭉갠다.
+    #    실측 도달 경로: 패턴 파일에 **깨진 정규식**이 한 줄 있으면 그 행만 조용히 아무것도
+    #    안 잡고 스캔은 rc=0 «깨끗» 을 낸다. 자가검사는 자기 카나리아 패턴을 쓰므로
+    #    **진짜 패턴의 깨짐을 구조적으로 못 본다** — 그래서 여기서 봐야 한다.
+    _line_hits=$(printf '%s\n' "$input" | grep -iE "$re" 2>/dev/null); _lg=$?
+    if [ "$_lg" -gt 1 ]; then
+      echo "  ❌ INSTRUMENT DEAD — grep failed (rc=$_lg) on pattern: $re"
+      echo "  ❌ INSTRUMENT DEAD — grep failed (rc=$_lg) on pattern: $re" >&2
+      echo "     A broken pattern row scans NOTHING and reads as clean. NOT SCANNED." >&2
+      return 3
+    fi
     while IFS= read -r line; do
       [ -z "$line" ] && continue
       _psa_path="${line%%$'\t'*}"; body="${line#*$'\t'}"
       # EVERY match on the line. Taking only the first let a documented placeholder earlier on the
       # line shield a real token later on it.
+      _tok_hits=$(printf '%s' "$body" | grep -oiE "$re" 2>/dev/null); _tg=$?
+      if [ "$_tg" -gt 1 ]; then
+        echo "  ❌ INSTRUMENT DEAD — grep -o failed (rc=$_tg) on pattern: $re"
+        echo "  ❌ INSTRUMENT DEAD — grep -o failed (rc=$_tg) on pattern: $re" >&2
+        return 3
+      fi
       while IFS= read -r tok; do
         [ -z "$tok" ] && continue
         printf '%s' "$tok" | grep -qiE "$PSA_PLACEHOLDER" && continue
@@ -293,10 +311,10 @@ psa_scan_tagged() {
         echo "  ❌ $sev leak — ${_psa_path}: '$tok'"
         hit=1
       done <<PSA_TOK
-$(printf '%s' "$body" | grep -oiE "$re" 2>/dev/null || true)
+$_tok_hits
 PSA_TOK
     done <<PSA_LINES
-$(printf '%s\n' "$input" | grep -iE "$re" 2>/dev/null || true)
+$_line_hits
 PSA_LINES
   done <<PSA_PAT
 $PSA_STREAM
@@ -368,8 +386,22 @@ psa_require_live() {
   PSA_STREAM="$_canary"
   PSA_ALLOWLIST=/dev/null
   printf 'PSA_SELFTEST_CANARY\n' > "$tmpd/canary" 2>/dev/null
-  # Same pipeline shape as psa_scan_file: awk tags the file, psa_scan_tagged matches it.
-  if out=$(awk -v P="psa/selftest" '{print P "\t" $0}' "$tmpd/canary" 2>&1 | psa_scan_tagged 2>&1); then
+  # 🟥 생산자와 매처를 **분리해서** 상태를 각각 본다 (cross-family 반례 4, 2026-08-21).
+  #    초판은 `awk … | psa_scan_tagged` 한 파이프의 최종 rc 만 봤는데, 그러면
+  #    **«생산자 실패의 rc=1»** 과 **«스캐너가 유출을 찾음의 rc=1»** 이 같은 값으로 합쳐진다.
+  #    실측 위조: 실패하는 `awk` 가 카나리아 행을 인쇄하고 `return 1` 하게 만들면
+  #    양 셸에서 `psa_require_live` 가 **rc=0(살아있음)** 을 냈다. 즉 자가검사 판정 자체가
+  #    위조 가능했다. 태깅 결과를 먼저 **물질화**하고 그 rc 를 따로 확인한다.
+  _tagged=$(awk -v P="psa/selftest" '{print P "\t" $0}' "$tmpd/canary" 2>&1); _tag_rc=$?
+  if [ "$_tag_rc" -ne 0 ] || [ -z "$_tagged" ]; then
+    rm -rf "$tmpd" 2>/dev/null || :
+    if [ -n "${saved_stream_set:-}" ]; then PSA_STREAM="$saved_stream"; else unset PSA_STREAM; fi
+    if [ -n "${saved_allow_set:-}" ]; then PSA_ALLOWLIST="$saved_allow"; else unset PSA_ALLOWLIST; fi
+    echo "  ❌ INSTRUMENT DEAD — the self-test PRODUCER (awk) failed (rc=$_tag_rc)." >&2
+    echo "     A canary printed by a failing producer is not evidence the matcher ran." >&2
+    return 1
+  fi
+  if out=$(printf '%s\n' "$_tagged" | psa_scan_tagged 2>&1); then
     rc=0
   else
     rc=$?

--- a/scripts/psa_scan_lib.sh
+++ b/scripts/psa_scan_lib.sh
@@ -112,7 +112,19 @@ psa_low_allowlisted() {
 # Prints diagnostics for every degraded state; sets the flags above. NEVER exits — the caller owns
 # the degrade direction, because it differs by surface (see the header).
 psa_load() {
-  local defaults="$1" override="$2" raw ov
+  local defaults="$1" override="$2" raw ov _tabtest
+  # 🟥 R5-3: 이 라이브러리는 `$'\t'` (ANSI-C quoting) 에 의존한다 — **POSIX 가 아니다.**
+  #    dash 에서는 리터럴 `$\t` 로 읽혀 정상 행이 «TAB 없음» 으로 떨어지고, 스트림이 통째로
+  #    비면서 **bad=1 · stream=[] 로 조용히 무력화**됐다(cross-family 실측). 그건 미측정이지
+  #    「패턴이 없다」가 아니다. 지원 범위는 bash/zsh 이고, 그걸 산문이 아니라 여기서 확인한다.
+  #    판별은 길이다 — 실측: bash/zsh `len=1`(진짜 TAB) · dash `len=3`(리터럴 `$\t`).
+  _tabtest=$'\t'
+  if [ "${#_tabtest}" -ne 1 ]; then
+    echo "  ❌ INSTRUMENT DEAD — this shell does not support \$'\\t' (ANSI-C quoting)." >&2
+    echo "     psa_scan_lib.sh requires bash or zsh. Re-run under one of them; NOT SCANNED." >&2
+    PSA_STREAM=""; PSA_DEFAULTS_OK=0; PSA_OVERRIDE_PRESENT=0; PSA_BAD_ROWS=1
+    return 3
+  fi
   PSA_STREAM=""; PSA_DEFAULTS_OK=0; PSA_OVERRIDE_PRESENT=0; PSA_BAD_ROWS=0
 
   # Layer 1 — committed defaults. This file ships with the repo, so missing/unreadable/empty is a
@@ -156,9 +168,21 @@ $ov"; PSA_OVERRIDE_PRESENT=1
       echo "  ❌ unusable pattern row (no TAB between severity and regex): ${line%%$'\t'*}"
       PSA_BAD_ROWS=$((PSA_BAD_ROWS+1)); continue
     fi
-    printf '' | grep -E "$re" >/dev/null 2>&1; rc=$?    # 0/1 = compiled; >=2 = regex error
+    # 🟥 R4-1: 여기도 `cmd; rc=$?` 였다 — P3 를 스캔 경로에서만 고치고 **로더 경로로 전파를 안 봤다**.
+    #    정상 패턴은 빈 입력에 rc=1 을 내므로 `set -e` 호출자는 psa_load 에서 죽는다(선재, 양 셸 실측).
+    if printf '' | grep -E "$re" >/dev/null 2>&1; then rc=0; else rc=$?; fi    # >=2 = regex error
     if [ "$rc" -ge 2 ]; then
       echo "  ❌ unusable pattern (invalid regex) — this detector would match nothing: [${line%%$'\t'*}]"
+      PSA_BAD_ROWS=$((PSA_BAD_ROWS+1)); continue
+    fi
+    # 🟥 P4 (선재 결함): 판별력 없는 패턴을 거부한다 — 빈 패턴 · `^` · `a*` · `SECRET|^$`.
+    #    모든 입력에 매치하므로 검출기로 **쓸 수 없는데** 초판 로더는 유효로 받아들였다.
+    #    🟥 그리고 이 검사는 **위의 컴파일 검사로는 못 한다**: `printf ''` 는 줄을 0개 주므로
+    #    grep 이 매치할 대상 자체가 없어 **어떤 패턴이든 rc=1** 이다(실측). 위 주석의
+    #    「0 = 컴파일됨」은 도달 불가능한 값을 서술한 것이었다. 빈 «줄» 을 따로 먹인다.
+    if printf '\n' | grep -E "$re" >/dev/null 2>&1; then rc=0; else rc=$?; fi
+    if [ "$rc" -eq 0 ]; then
+      echo "  ❌ unusable pattern (matches the EMPTY string — no discrimination): [${line%%$'\t'*}]"
       PSA_BAD_ROWS=$((PSA_BAD_ROWS+1)); continue
     fi
     valid="$valid
@@ -260,6 +284,18 @@ psa_scan_tagged() {
       echo "  ❌ INSTRUMENT DEAD — PSA_STREAM is empty; NOT SCANNED (call psa_load first)." >&2
       return 3
     fi
+    # 🟥 R4-6: **부분 로드된 패턴 집합으로 «깨끗»을 말하지 않는다.** 초판은 이것을 «호출자
+    #    계약»으로 두었고(헤더가 그렇게 적어뒀다), cross-family 가 그 계약을 안 지키는 호출자를
+    #    실측 재현했다 — `SECRET|^$` 한 행이 떨어져 나간 집합으로 `SECRET` 입력이 rc=0 «깨끗».
+    #    산문 계약을 라이브러리 층으로 내린다: 안 실린 검출기가 있으면 그건 미측정이다.
+    #    (psa_load 를 안 부른 호출자는 PSA_BAD_ROWS 가 미설정이고, 그 경로는 위 빈-스트림
+    #     검사가 이미 잡는다. `case` 로 보는 이유는 비수치 오염에서 fail-open 하지 않기 위해서다.)
+    case "${PSA_BAD_ROWS:-0}" in
+      0) ;;
+      *) echo "  ❌ INSTRUMENT DEAD — ${PSA_BAD_ROWS} pattern row(s) were dropped; the detector set is PARTIAL. NOT SCANNED."
+         echo "  ❌ INSTRUMENT DEAD — ${PSA_BAD_ROWS} pattern row(s) dropped — a partial set cannot report clean." >&2
+         return 3 ;;
+    esac
     if ! psa_require_live >/dev/null 2>&1; then
       echo "  ❌ INSTRUMENT DEAD — psa_scan_tagged self-test failed. NOT SCANNED."
       echo "  ❌ INSTRUMENT DEAD — psa_scan_tagged self-test failed. NOT SCANNED." >&2
@@ -285,7 +321,8 @@ psa_scan_tagged() {
     #    실측 도달 경로: 패턴 파일에 **깨진 정규식**이 한 줄 있으면 그 행만 조용히 아무것도
     #    안 잡고 스캔은 rc=0 «깨끗» 을 낸다. 자가검사는 자기 카나리아 패턴을 쓰므로
     #    **진짜 패턴의 깨짐을 구조적으로 못 본다** — 그래서 여기서 봐야 한다.
-    _line_hits=$(printf '%s\n' "$input" | grep -iE "$re" 2>/dev/null); _lg=$?
+    # 🟥 P3 동형: grep 의 정상 «미매치»(rc=1)가 `set -e` 호출자를 죽인다.
+    if _line_hits=$(printf '%s\n' "$input" | grep -iE "$re" 2>/dev/null); then _lg=0; else _lg=$?; fi
     if [ "$_lg" -gt 1 ]; then
       echo "  ❌ INSTRUMENT DEAD — grep failed (rc=$_lg) on pattern: $re"
       echo "  ❌ INSTRUMENT DEAD — grep failed (rc=$_lg) on pattern: $re" >&2
@@ -297,7 +334,7 @@ psa_scan_tagged() {
       _psa_path="${line%%$'\t'*}"; body="${line#*$'\t'}"
       # EVERY match on the line. Taking only the first let a documented placeholder earlier on the
       # line shield a real token later on it.
-      _tok_hits=$(printf '%s' "$body" | grep -oiE "$re" 2>/dev/null); _tg=$?
+      if _tok_hits=$(printf '%s' "$body" | grep -oiE "$re" 2>/dev/null); then _tg=0; else _tg=$?; fi
       if [ "$_tg" -gt 1 ]; then
         echo "  ❌ INSTRUMENT DEAD — grep -o failed (rc=$_tg) on pattern: $re"
         echo "  ❌ INSTRUMENT DEAD — grep -o failed (rc=$_tg) on pattern: $re" >&2
@@ -308,7 +345,9 @@ psa_scan_tagged() {
         printf '%s' "$tok" | grep -qiE "$PSA_PLACEHOLDER" && continue
         if [ "$sev" = "LOW" ] && psa_low_allowlisted "$_psa_path"; then continue; fi
         if psa_pair_allowlisted "$_psa_path" "$tok"; then continue; fi
-        echo "  ❌ $sev leak — ${_psa_path}: '$tok'"
+        # 🟥 P5: zsh 의 `echo` 는 백슬래시를 해석한다 — 경로 `dir\two` 가 탭으로 변해
+        #    증거 문자열이 손상됐다(실측). fail-open 은 아니나 증거는 증거여야 한다.
+        printf '  ❌ %s leak — %s: \x27%s\x27\n' "$sev" "${_psa_path}" "$tok"
         hit=1
       done <<PSA_TOK
 $_tok_hits
@@ -367,15 +406,42 @@ _psa_can_assign() {
 #     the caller's shell before the restore line. Status capture is now inside an `if`.
 psa_require_live() {
   local saved_stream saved_allow saved_stream_set saved_allow_set tmpd out rc _canary
+  local _nonce _tag_rc
   saved_stream="${PSA_STREAM-}"; saved_allow="${PSA_ALLOWLIST-}"
   saved_stream_set=""; saved_allow_set=""
   [ "${PSA_STREAM+x}" = "x" ] && saved_stream_set=1
   [ "${PSA_ALLOWLIST+x}" = "x" ] && saved_allow_set=1
   tmpd=$(mktemp -d 2>/dev/null) || { echo "  ❌ INSTRUMENT DEAD — mktemp unavailable." >&2; return 1; }
+  # 🟥 P1 (cross-family 3라운드): 카나리아가 **고정 문자열**이면, 입력을 읽지도 않고
+  #    그 문자열을 rc=0 으로 뱉는 위조 생산자가 자가검사를 통과한다. 세 라운드가 공유한
+  #    얼굴 —「상태(rc=0)를 의미(생산이 유효하다)로 확장」— 의 마지막 잔재다.
+  #    실행마다 새 nonce 를 만들면 **하드코딩된 위조는 그 값을 알 수 없다.**
+  _nonce=$(head -c 12 /dev/urandom 2>/dev/null | od -An -tx1 2>/dev/null | tr -d ' \n')
+  # 🟥 **신뢰 경계 — 여기서 라운드를 멈추는 이유(2026-08-21, 6라운드 후 판정).**
+  #    이 자가검사가 막는 것: 생산자가 **깨졌거나**(awk 부재·crash·출력 훼손), **PATH 로
+  #    가려졌거나**(외부 바이너리 shadowing), 입력을 **안 읽고** 고정/유도값을 뱉는 경우.
+  #    이 자가검사가 **못** 막는 것: 이 라이브러리를 **소싱한 셸 안에서 함수를 정의할 수 있는**
+  #    상대. 그 상대는 `psa_scan_tagged(){ return 0; }` 한 줄이면 끝이라 nonce·cmp·심링크를
+  #    아무리 조여도 소용이 없다 — **이미 신뢰 안쪽**이다. 6라운드 반례 둘이 정확히 그 부류였고
+  #    (`cmp(){ return 0; }` · `ln -sf` 로 tagged 바꿔치기), 값싼 두 수리(`command cmp` ·
+  #    심링크 거부)는 했지만 **그 축을 닫았다고 주장하지 않는다.**
+  # 🟥 R5-1: **fallback 을 없앴다.** 5라운드 실측 —
+  #      `${tmpd##*/}` 파생 → 생산자가 경로를 인자로 받으므로 유도 가능 (4라운드에서 교체)
+  #      `${RANDOM}${RANDOM}$$${SECONDS}` → **생산자가 같은 셸에서 그대로 재계산해 통과**(zsh 실측 rc=0),
+  #      `RANDOM`/`SECONDS` 가 unset 이면 사실상 `$$` 하나라 `ps` 로도 읽힌다(bash 실측 rc=0)
+  #    ⇒ 「예측 불가한 값」은 **커널 엔트로피에서만** 나온다. 못 얻으면 그건 약한 nonce 가 아니라
+  #      **미측정**이다. 두 번째 출처(openssl)까지 시도하고, 그것도 없으면 fail-closed.
+  [ -n "$_nonce" ] || _nonce=$(openssl rand -hex 12 2>/dev/null | tr -cd 'A-Za-z0-9')
+  if [ -z "$_nonce" ]; then
+    echo "  ❌ INSTRUMENT DEAD — no kernel entropy source (/dev/urandom, openssl); cannot mint an unguessable nonce." >&2
+    echo "     A guessable nonce is not a weaker probe, it is NO probe — a producer can replay it." >&2
+    rm -rf "$tmpd" 2>/dev/null || :
+    return 1
+  fi
   # Round 4 refuted the round-3 fix: `|| :` does NOT rescue an assignment to a readonly variable —
   # bash aborts the shell before the `||` is ever considered. So the only safe move is to REFUSE
   # before mutating anything. Detected, reported as DEAD, and the caller survives.
-  _canary=$(printf 'HIGH\tPSA_SELFTEST_CANARY')
+  _canary=$(printf 'HIGH\tPSA_SELFTEST_CANARY_%s' "$_nonce")
   if ! _psa_can_assign PSA_STREAM "$_canary" || ! _psa_can_assign PSA_ALLOWLIST /dev/null; then
     echo "  ❌ INSTRUMENT DEAD — PSA_STREAM/PSA_ALLOWLIST cannot take the values the self-test needs." >&2
     echo "     (readonly, or an attribute such as \`declare -i\` that rejects the value)" >&2
@@ -385,23 +451,47 @@ psa_require_live() {
   fi
   PSA_STREAM="$_canary"
   PSA_ALLOWLIST=/dev/null
-  printf 'PSA_SELFTEST_CANARY\n' > "$tmpd/canary" 2>/dev/null
+  printf 'PSA_SELFTEST_CANARY_%s\n' "$_nonce" > "$tmpd/canary" 2>/dev/null
   # 🟥 생산자와 매처를 **분리해서** 상태를 각각 본다 (cross-family 반례 4, 2026-08-21).
   #    초판은 `awk … | psa_scan_tagged` 한 파이프의 최종 rc 만 봤는데, 그러면
   #    **«생산자 실패의 rc=1»** 과 **«스캐너가 유출을 찾음의 rc=1»** 이 같은 값으로 합쳐진다.
   #    실측 위조: 실패하는 `awk` 가 카나리아 행을 인쇄하고 `return 1` 하게 만들면
   #    양 셸에서 `psa_require_live` 가 **rc=0(살아있음)** 을 냈다. 즉 자가검사 판정 자체가
   #    위조 가능했다. 태깅 결과를 먼저 **물질화**하고 그 rc 를 따로 확인한다.
-  _tagged=$(awk -v P="psa/selftest" '{print P "\t" $0}' "$tmpd/canary" 2>&1); _tag_rc=$?
-  if [ "$_tag_rc" -ne 0 ] || [ -z "$_tagged" ]; then
+  # 🟥 P3: `x=$(cmd); rc=$?` 는 `set -e` 아래서 **셸을 즉시 죽인다** — 아래 복원문과
+  #    `rm -rf` 에 도달하지 못하고 PSA_STREAM 이 **카나리아인 채로 남는다**(실측, bash).
+  #    조건문 안의 대입은 errexit 면제다.
+  # 🟥 R4-3: `$(...)` 는 **후행 개행을 지운다** — 정답 줄 뒤에 빈 줄을 아무리 붙여도
+  #    문자열 비교가 통과했다(실측 rc=0). 「정확한 문자열 대조」라고 적어놓고 정확하지 않았다.
+  #    생산자 출력을 **파일로 물질화**해서 `cmp` 로 바이트 비교한다. stderr 는 따로 받는다.
+  if awk -v P="psa/selftest" '{print P "\t" $0}' "$tmpd/canary" > "$tmpd/tagged" 2>"$tmpd/err"; then _tag_rc=0; else _tag_rc=$?; fi
+  # 🟥 P1: 상태(rc)만이 아니라 **내용**을 대조한다. 생산자가 «입력을 읽어서 태깅했는가» 는
+  #    rc 로 알 수 없고, nonce 를 포함한 정확한 문자열 일치로만 알 수 있다.
+  # 🟥 R5-2: 초판은 기대값도 `$tmpd/expect` 파일에 뒀는데, **생산자는 `$tmpd/canary` 를 인자로
+  #    받으므로 `$tmpd` 를 알고 expect 를 덮어쓸 수 있다** — 틀린 바이트를 양쪽에 써넣으면
+  #    `cmp` 가 통과했다(양 셸 실측 rc=0). 기대값은 **프로세스 안에만** 두고 파이프로 먹인다.
+  #    (`cmp file -` 는 stdin 을 두 번째 피연산자로 읽는다. cmp 부재는 rc≠0 → fail-closed, 실측.)
+  # 🟥 R6-1: `cmp` 를 셸이 해석하면 **함수로 가려진다** — `cmp(){ return 0; }` 하나로 대조가
+  #    통째로 무력화됐다(양 셸 실측 rc=0). `command` 는 함수를 건너뛴다.
+  # 🟥 R6-2: 생산자는 `$tmpd` 를 알므로 stdout 에는 틀린 바이트를 쓰고 `tagged` 를 **정답 파일로
+  #    가는 심링크로 바꿔치기**할 수 있다(양 셸 실측 rc=0). 비교 대상이 «awk 가 실제로 쓴 파일»
+  #    인지 먼저 확인한다 — 심링크가 아닌 보통 파일이어야 한다.
+  if [ -L "$tmpd/tagged" ] || [ ! -f "$tmpd/tagged" ]; then
     rm -rf "$tmpd" 2>/dev/null || :
     if [ -n "${saved_stream_set:-}" ]; then PSA_STREAM="$saved_stream"; else unset PSA_STREAM; fi
     if [ -n "${saved_allow_set:-}" ]; then PSA_ALLOWLIST="$saved_allow"; else unset PSA_ALLOWLIST; fi
-    echo "  ❌ INSTRUMENT DEAD — the self-test PRODUCER (awk) failed (rc=$_tag_rc)." >&2
-    echo "     A canary printed by a failing producer is not evidence the matcher ran." >&2
+    echo "  ❌ INSTRUMENT DEAD — the self-test output was replaced (symlink or non-regular file)." >&2
     return 1
   fi
-  if out=$(printf '%s\n' "$_tagged" | psa_scan_tagged 2>&1); then
+  if [ "$_tag_rc" -ne 0 ] || ! printf 'psa/selftest\tPSA_SELFTEST_CANARY_%s\n' "$_nonce" | command cmp -s "$tmpd/tagged" -; then
+    rm -rf "$tmpd" 2>/dev/null || :
+    if [ -n "${saved_stream_set:-}" ]; then PSA_STREAM="$saved_stream"; else unset PSA_STREAM; fi
+    if [ -n "${saved_allow_set:-}" ]; then PSA_ALLOWLIST="$saved_allow"; else unset PSA_ALLOWLIST; fi
+    echo "  ❌ INSTRUMENT DEAD — the self-test PRODUCER did not tag this run's nonce (rc=$_tag_rc)." >&2
+    echo "     A canary printed by a failing — or input-ignoring — producer is not evidence the matcher ran." >&2
+    return 1
+  fi
+  if out=$(psa_scan_tagged < "$tmpd/tagged" 2>&1); then
     rc=0
   else
     rc=$?
@@ -413,7 +503,7 @@ psa_require_live() {
   if [ -n "${saved_stream_set:-}" ]; then PSA_STREAM="$saved_stream"; else unset PSA_STREAM; fi
   if [ -n "${saved_allow_set:-}" ]; then PSA_ALLOWLIST="$saved_allow"; else unset PSA_ALLOWLIST; fi
   case "$out" in
-    *PSA_SELFTEST_CANARY*) [ "$rc" -eq 1 ] && return 0 ;;
+    *"PSA_SELFTEST_CANARY_$_nonce"*) [ "$rc" -eq 1 ] && return 0 ;;
   esac
   echo "  ❌ INSTRUMENT DEAD — the scanner did not report a synthetic known-positive." >&2
   echo "     self-test rc=$rc out=[$out]" >&2

--- a/scripts/test_psa_singlefile_lanes.sh
+++ b/scripts/test_psa_singlefile_lanes.sh
@@ -431,6 +431,199 @@ else
                    || bad "H2 컨트롤 실패 rc=[$_hl] — 픽스처가 다른 이유로 막힌다, H1 판정 무효"
 fi
 
+# ── N 레인 : cross-family 3라운드 반례 P1~P5 (2026-08-21) ────────────────────────────────
+# 🟥 세 라운드가 같은 얼굴이었다 — **상태를 의미로 확장**. rc=0 을 «유효», «분리했다» 를
+#    «생산이 옳다», «자가검사 통과» 를 «그 뒤 스캔도 실행» 으로 읽었다. N 레인은 그 축을 친다.
+for _sh in bash zsh; do
+  command -v "$_sh" >/dev/null 2>&1 || { echo "  SKIP N1/N2/N4/N5 ($_sh 없음) — PASS 아님, 미검사다"; continue; }
+  # N1 — P1: 입력을 읽지도 않고 rc=0 으로 «고정» 카나리아를 뱉는 위조 생산자
+  _r=$("$_sh" -c ". '$LIB'; export PSA_STREAM=\$(printf 'HIGH\tX') PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1;
+       awk(){ printf 'psa/selftest\tPSA_SELFTEST_CANARY\n'; return 0; };
+       psa_require_live >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1)
+  [ "$_r" != "0" ] && ok "N1/$_sh rc=0 위조 생산자 → «살아있음» 아님 (nonce 불일치, rc=$_r)" \
+                   || bad "N1/$_sh 자가검사가 rc=0 위조에 뚫렸다 — P1 이 안 닫혔다"
+  # N1b — P1 의 **문자열 대조** 를 따로 친다. N1(고정 카나리아)은 nonce 만으로도 막히므로
+  #       대조문이 없어도 초록이었다(되돌림 실측 → 적색 0). 이 레인은 «입력은 읽었는데
+  #       태그가 틀린» 생산자를 쓴다 — nonce 는 통과하고 대조문만이 잡는다.
+  _r=$("$_sh" -c ". '$LIB'; export PSA_STREAM=\$(printf 'HIGH\tX') PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1;
+       awk(){ for _a; do :; done; printf 'WRONGPREFIX\t%s\n' \"\$(cat \"\$_a\")\"; return 0; };
+       psa_require_live >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1)
+  [ "$_r" != "0" ] && ok "N1b/$_sh 입력은 읽되 태그가 틀린 생산자 → «살아있음» 아님 (rc=$_r)" \
+                   || bad "N1b/$_sh 태그 대조가 없다 — 생산자가 무엇을 뱉든 통과한다"
+  # N2 ★컨트롤 — 정상 환경에서는 여전히 살아있다고 해야 한다 (N1 이 «항상 실패» 가 아니다)
+  _r=$("$_sh" -c ". '$LIB'; export PSA_STREAM=\$(printf 'HIGH\tX') PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1;
+       psa_require_live >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1)
+  [ "$_r" = "0" ] && ok "N2/$_sh ★컨트롤 정상 자가검사 → rc=0" || bad "N2/$_sh 컨트롤 rc=[$_r], 0 이어야"
+  # N4 — P4: 판별력 없는 패턴(빈·^·a*)은 거부되고 정상 패턴만 남는다
+  _T=$(mktemp -d); printf 'HIGH\t\nHIGH\t^\nHIGH\ta*\nHIGH\tREALSECRET\n' > "$_T/def"; : > "$_T/ovr"
+  _r=$("$_sh" -c ". '$LIB'; export PSA_DEFAULTS_OK=1; psa_load '$_T/def' '$_T/ovr' >/dev/null 2>&1;
+       printf '%s/%s\n' \"\$(printf '%s' \"\$PSA_STREAM\" | grep -c .)\" \"\$PSA_BAD_ROWS\"" 2>/dev/null | tail -1)
+  [ "$_r" = "1/3" ] && ok "N4a/$_sh 무판별 패턴 3행 거부, 정상 1행 생존 ($_r)" \
+                    || bad "N4a/$_sh 유효행/거부행=[$_r], 1/3 이어야 — P4 가 안 닫혔다"
+  # N4b ★컨트롤 — 거부가 «전부 버리기» 가 아니다: **깨끗한** 패턴 파일이면 정상 검출한다.
+  #    🟥 초판은 위 «혼합» 파일로 rc=1 을 기대했는데, R4-6 이후 그 파일은 bad_rows>0 이라
+  #    rc=3(부분집합=미측정)이 정답이다. 컨트롤은 깨끗한 파일로 분리한다.
+  printf 'HIGH\tREALSECRET\n' > "$_T/clean"
+  _r=$("$_sh" -c ". '$LIB'; export PSA_DEFAULTS_OK=1; PSA_ALLOWLIST=/dev/null; psa_load '$_T/clean' '$_T/ovr' >/dev/null 2>&1;
+       printf 'p\tREALSECRET here\n' | psa_scan_tagged >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1)
+  [ "$_r" = "1" ] && ok "N4b/$_sh ★컨트롤 깨끗한 패턴 파일 → 정상 검출 rc=1" \
+                  || bad "N4b/$_sh 컨트롤 rc=[$_r], 1 이어야 — 거부가 과했다"
+  # N4c — R4-6: **부분 로드된 집합은 «깨끗»도 «유출»도 말할 수 없다.** cross-family 4라운드가
+  #    `SECRET|^$` 한 행이 떨어진 집합에서 `SECRET` 입력이 rc=0 «깨끗» 을 내는 것을 실측했다.
+  _r=$("$_sh" -c ". '$LIB'; export PSA_DEFAULTS_OK=1; PSA_ALLOWLIST=/dev/null; psa_load '$_T/def' '$_T/ovr' >/dev/null 2>&1;
+       printf 'p\tREALSECRET here\n' | psa_scan_tagged >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1)
+  [ "$_r" = "3" ] && ok "N4c/$_sh 행이 떨어진 부분집합 → rc=3 (부분 로드는 미측정)" \
+                  || bad "N4c/$_sh 부분집합 rc=[$_r], 3 이어야 — R4-6 이 안 닫혔다"
+  rm -rf "$_T"
+  # N5 — P5: 백슬래시가 든 경로가 증거에 그대로 남는다 (zsh 의 echo 가 해석하던 자리)
+  _r=$("$_sh" -c ". '$LIB'; export PSA_STREAM=\$(printf 'HIGH\tSEEKRET') PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1;
+       printf 'dir\\\\two\tSEEKRET\n' | psa_scan_tagged 2>&1 | grep -c 'dir\\\\two'" 2>/dev/null | tail -1)
+  [ "$_r" = "1" ] && ok "N5/$_sh 백슬래시 경로가 증거에 보존된다" \
+                  || bad "N5/$_sh 증거 손상 (일치=[$_r]) — P5 가 안 닫혔다"
+  [ "$_sh" = "zsh" ] && _cond_lanes=$((_cond_lanes + 7))
+done
+
+# R 레인 : cross-family 4라운드 반례 (2026-08-21, 수리에 대한 재검)
+# 🟥 이 라운드의 교훈은 **「수리가 새 결함의 주된 출처」**다 — P3 를 스캔 경로에서만 고치고
+#    로더 경로로 전파를 안 봤고(R4-1), 「정확한 문자열 대조」가 후행 개행에 뚫렸다(R4-3).
+for _sh in bash zsh; do
+  command -v "$_sh" >/dev/null 2>&1 || { echo "  SKIP R1/R2/R3 ($_sh 없음) — PASS 아님, 미검사다"; continue; }
+  _RT=$(mktemp -d); printf 'HIGH\tREALSECRET\n' > "$_RT/def"; : > "$_RT/ovr"
+  # R1 — psa_load 가 `set -e` 호출자를 죽이지 않는다 (정상 패턴은 빈 입력에 rc=1 을 낸다)
+  _r=$("$_sh" -c "set -e; . '$LIB'; psa_load '$_RT/def' '$_RT/ovr' >/dev/null 2>&1; echo SURVIVED" 2>/dev/null | tail -1)
+  [ "$_r" = "SURVIVED" ] && ok "R1/$_sh set -e 호출자가 psa_load 를 살아서 통과" \
+                        || bad "R1/$_sh psa_load 가 errexit 호출자를 죽인다 [$_r] — P3 전파 미완"
+  # R2 — fallback nonce 가 생산자 인자에서 유도되지 않는다
+  _r=$("$_sh" -c ". '$LIB'; export PSA_STREAM=\$(printf 'HIGH\tX') PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1;
+       head(){ return 1; };
+       awk(){ for _a; do :; done; _d=\${_a%/*}; _d=\${_d##*/}; _d=\$(printf %s \"\$_d\" | tr -cd 'A-Za-z0-9');
+              printf 'psa/selftest\tPSA_SELFTEST_CANARY_%s\n' \"\$_d\"; return 0; };
+       psa_require_live >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1)
+  [ "$_r" != "0" ] && ok "R2/$_sh urandom 부재 fallback 이 경로에서 유도 안 됨 (rc=$_r)" \
+                   || bad "R2/$_sh fallback nonce 가 인자에서 유도된다 — 위조 통과"
+  # R3 — 정답 줄 + 후행 빈 줄은 «바이트 동일» 이 아니다 ($(...) 가 후행 개행을 지운다)
+  _r=$("$_sh" -c ". '$LIB'; export PSA_STREAM=\$(printf 'HIGH\tX') PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1;
+       awk(){ for _a; do :; done; printf 'psa/selftest\t%s\n\n\n' \"\$(cat \"\$_a\")\"; return 0; };
+       psa_require_live >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1)
+  [ "$_r" != "0" ] && ok "R3/$_sh 후행 빈 줄이 붙은 산출 → 통과 안 됨 (rc=$_r)" \
+                   || bad "R3/$_sh 후행 개행이 대조를 뚫었다 — 「바이트 동일」이 아니다"
+  rm -rf "$_RT"
+  [ "$_sh" = "zsh" ] && _cond_lanes=$((_cond_lanes + 3))
+done
+
+# S 레인 : cross-family 5라운드 반례 (2026-08-21). 🟥 **4라운드 수리 자체가 낸 결함들**이다.
+for _sh in bash zsh; do
+  command -v "$_sh" >/dev/null 2>&1 || { echo "  SKIP S1/S2 ($_sh 없음) — PASS 아님, 미검사다"; continue; }
+  # S1 — 엔트로피 출처가 둘 다 없으면 «약한 nonce» 가 아니라 **미측정**이다.
+  #      4라운드 fallback(`$RANDOM$RANDOM$$$SECONDS`)은 생산자가 같은 셸에서 재계산해 통과했다.
+  _r=$("$_sh" -c ". '$LIB'; export PSA_STREAM=\$(printf 'HIGH\tX') PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1;
+       head(){ return 1; }; openssl(){ return 1; };
+       awk(){ for _a; do :; done; _n=\$(printf '%s%s%s%s' \"\${RANDOM:-}\" \"\${RANDOM:-}\" \"\$\$\" \"\${SECONDS:-}\" | tr -cd 'A-Za-z0-9');
+              printf 'psa/selftest\tPSA_SELFTEST_CANARY_%s\n' \"\$_n\"; return 0; };
+       psa_require_live >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1)
+  [ "$_r" != "0" ] && ok "S1/$_sh 엔트로피 부재 → 예측가능 nonce 로 통과 안 됨 (rc=$_r)" \
+                   || bad "S1/$_sh 생산자가 재계산한 nonce 로 통과했다 — 추측 가능한 nonce 는 nonce 가 아니다"
+  # S2 — 생산자는 `$tmpd/canary` 를 인자로 받으므로 `$tmpd` 를 안다. 기대값이 그 안에 있으면 덮인다.
+  _r=$("$_sh" -c ". '$LIB'; export PSA_STREAM=\$(printf 'HIGH\tX') PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1;
+       awk(){ for _a; do :; done; _d=\${_a%/*}; _n=\$(cat \"\$_a\");
+              printf 'wrong/path\t%s\n' \"\$_n\" > \"\$_d/expect\";
+              printf 'wrong/path\t%s\n' \"\$_n\"; return 0; };
+       psa_require_live >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1)
+  [ "$_r" != "0" ] && ok "S2/$_sh 생산자가 기대값 파일을 덮어써도 통과 안 됨 (rc=$_r)" \
+                   || bad "S2/$_sh 기대값이 생산자 사정권에 있다 — cmp 가 자기 자신과 비교했다"
+  # T1 — R6-1: `cmp` 가 함수로 가려져도 대조가 무력화되지 않는다 (`command cmp`)
+  _r=$("$_sh" -c ". '$LIB'; export PSA_STREAM=\$(printf 'HIGH\tX') PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1 PSA_BAD_ROWS=0;
+       cmp(){ return 0; };
+       awk(){ for _a; do :; done; printf 'WRONGPREFIX\t%s\n' \"\$(cat \"\$_a\")\"; return 0; };
+       psa_require_live >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1)
+  [ "$_r" != "0" ] && ok "T1/$_sh cmp 함수 가림 → 통과 안 됨 (rc=$_r)" \
+                   || bad "T1/$_sh 대조가 셸 함수로 무력화됐다 — command 우회가 없다"
+  # T2 — R6-2: 생산자가 stdout 은 틀리게 쓰고 tagged 를 정답 파일 심링크로 바꿔치기
+  _r=$("$_sh" -c ". '$LIB'; PSA_STREAM=\$(printf 'HIGH\tX'); export PSA_STREAM PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1 PSA_BAD_ROWS=0;
+       awk(){ for _a; do :; done; _d=\${_a%/*}; _n=\$(cat \"\$_a\");
+              printf 'WRONGPREFIX\t%s\n' \"\$_n\";
+              printf 'psa/selftest\t%s\n' \"\$_n\" > \"\$_d/alt\"; ln -sf alt \"\$_d/tagged\"; return 0; };
+       psa_require_live >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1)
+  [ "$_r" != "0" ] && ok "T2/$_sh tagged 심링크 스왑 → 통과 안 됨 (rc=$_r)" \
+                   || bad "T2/$_sh 비교 대상이 생산자가 실제로 쓴 파일이 아니다"
+  [ "$_sh" = "zsh" ] && _cond_lanes=$((_cond_lanes + 4))
+done
+# S3 — dash 는 `$'"'"'\t'"'"'` 를 리터럴로 읽어 정상 행이 통째로 떨어졌다(bad=1 stream=[]).
+#      그건 «패턴이 없다» 가 아니라 **미측정**이므로 로드 자체를 거부한다.
+if command -v dash >/dev/null 2>&1; then
+  _ST=$(mktemp -d); printf 'HIGH\tREALSECRET\n' > "$_ST/def"; : > "$_ST/ovr"
+  _r=$(dash -c ". '$LIB'; psa_load '$_ST/def' '$_ST/ovr' >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1)
+  [ "$_r" = "3" ] && ok "S3 dash → psa_load rc=3 (조용한 빈 스트림이 아니라 명시적 미측정)" \
+                  || bad "S3 dash psa_load rc=[$_r], 3 이어야 — 무능한 셸이 «패턴 없음» 으로 접힌다"
+  # S3b ★컨트롤 — 같은 파일로 bash 는 정상 로드 (S3 가 «항상 거부» 가 아니다)
+  _r=$(bash -c ". '$LIB'; psa_load '$_ST/def' '$_ST/ovr' >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1)
+  [ "$_r" = "0" ] && ok "S3b ★컨트롤 bash 는 같은 파일을 정상 로드 → rc=0" \
+                  || bad "S3b 컨트롤 rc=[$_r], 0 이어야 — 셸 검사가 과차단이다"
+  rm -rf "$_ST"
+  _cond_lanes=$((_cond_lanes + 2))
+else
+  echo "  SKIP S3/S3b (dash 없음) — PASS 아님, 미검사다"
+fi
+
+# N3 — 🟥 **교차조건 레인**: `set -e` × 실패 생산자. codex 가 「세 라운드가 공유한 갭」으로 지목한 것.
+#      한 조건씩 보면 둘 다 통과하는데, 겹치면 복원문에 **도달하지 못하고** PSA_STREAM 이
+#      카나리아인 채로 남는다. EXIT trap 으로 «중단돼도» 상태를 회수한다 —
+#      ⚠️ `|| true` 를 붙이면 errexit 가 꺼져서 계기 자체가 죽는다(첫 판이 그랬다).
+#      bash 전용: zsh 는 `-c` + errexit 중단에서 EXIT trap 이 발화하지 않아 회수 채널이 없다(미검사).
+_N3=$(mktemp -d)
+bash -c "set -e; . '$LIB'; PSA_STREAM=ORIGINAL; PSA_ALLOWLIST=/dev/null; PSA_DEFAULTS_OK=1;
+  trap 'printf \"%s\" \"\$PSA_STREAM\" > '$_N3'/v' EXIT
+  awk(){ return 1; }
+  psa_require_live >/dev/null 2>&1" >/dev/null 2>&1
+_r=$(cat "$_N3/v" 2>/dev/null); rm -rf "$_N3"
+[ "$_r" = "ORIGINAL" ] && ok "N3 ★교차조건 set -e × 실패 생산자 → PSA_STREAM 복원됨" \
+                       || bad "N3 교차조건에서 복원 미도달 — PSA_STREAM=[$_r] (카나리아 잔류 = P3 미해결)"
+
+# N6 — P2: outbound guard 의 override 가 «미측정» 까지 통과시키면 안 된다.
+#      🟥 첫 판 픽스처는 `FH=` 로 뿌리를 바꾸려 했는데 그 변수는 스크립트가 자기 것으로 계산한다
+#         → 가드가 **실제 레포를 스캔하고 깨끗하다고 통과했다**. 죽은 픽스처였다.
+#         가드가 이미 제공하는 주입점(PSA_LIB_FILE / PSA_DEFAULTS_FILE / PSA_OVERRIDE_FILE)을 쓴다.
+# 🟥 이 블록은 **조건부**다 — `outbound_query_guard.sh` 는 npm `files[]` 에 없어서
+#    **소비자 설치본에는 존재하지 않는다.** 초판은 조건부인데 `_cond_lanes` 에 안 세서,
+#    포장본에서 `pass=80 < floor 84` 로 **거짓 INSTRUMENT ERROR** 를 냈다(실측 rc=3).
+#    정적으로는 안 보였고 **포장본에서 실행하자마자** 나왔다 — standpoint 실행 팔이 잡은 것.
+_GUARD="$REPO_ROOT/scripts/outbound_query_guard.sh"
+if [ -f "$_GUARD" ]; then
+  _cond_lanes=$((_cond_lanes + 4))
+  _S6=$(mktemp -d)
+  # 스텁 라이브러리: 앞단 게이트는 전부 통과시키고 **스캔만 rc=3(미측정)** 을 내게 한다.
+  # 이래야 P2 가 고친 «그 분기»(RC 판정 직후의 override)에 실제로 도달한다.
+  cat > "$_S6/lib_unmeasured.sh" <<'STUB'
+psa_load() { PSA_DEFAULTS_OK=1; PSA_BAD_ROWS=0; PSA_OVERRIDE_PRESENT=1; return 0; }
+psa_require_live() { return 0; }
+psa_scan_tagged() { return 3; }
+STUB
+  # 대조 스텁: 같은 모양인데 스캔이 rc=1(유출을 «봤다») 을 낸다
+  sed 's/return 3/return 1/' "$_S6/lib_unmeasured.sh" > "$_S6/lib_leak.sh"
+  _n6() { OUTBOUND_QUERY_OK=1 PSA_LIB_FILE="$1" bash "$_GUARD" "some outbound question" >/dev/null 2>&1; echo $?; }
+  _r=$(_n6 "$_S6/lib_unmeasured.sh")
+  [ "$_r" = "3" ] && ok "N6a override + 스캔 미측정(rc=3) → 여전히 차단 (rc=3)" \
+                  || bad "N6a OUTBOUND_QUERY_OK=1 이 미측정을 승인했다 rc=[$_r] — P2 가 안 닫혔다"
+  # N6b ★컨트롤 — 같은 override 가 «본» 히트(rc=1)에서는 여전히 통과해야 한다
+  #      (N6a 가 «override 를 통째로 죽였다» 가 아님을 보인다)
+  _r=$(_n6 "$_S6/lib_leak.sh")
+  [ "$_r" = "0" ] && ok "N6b ★컨트롤 override + 히트(rc=1) → 통과 (override 가 죽지 않았다)" \
+                  || bad "N6b 컨트롤 rc=[$_r], 0 이어야 — 과차단이다"
+  # R5 — rc=2 는 «유출 발견» 이 아니라 **미측정** 이다. 초판은 exit 1 로 오분류했다.
+  printf '%s\n' 'psa_load(){ PSA_DEFAULTS_OK=1; PSA_BAD_ROWS=0; PSA_OVERRIDE_PRESENT=1; return 0; }' \
+                 'psa_require_live(){ return 0; }' 'psa_scan_tagged(){ return 2; }' > "$_S6/lib_rc2.sh"
+  _r=$(_n6 "$_S6/lib_rc2.sh")
+  [ "$_r" = "3" ] && ok "R5 스캐너 rc=2 → 미측정(3) 으로 분류 (유출 1 로 접히지 않는다)" \
+                  || bad "R5 rc=2 가 [$_r] 로 분류됐다, 3 이어야"
+  # N6c ★컨트롤 — override 없이 미측정이면 당연히 차단 (N6a 가 override 덕이 아님을 가른다)
+  _r=$(PSA_LIB_FILE="$_S6/lib_unmeasured.sh" bash "$_GUARD" "some outbound question" >/dev/null 2>&1; echo $?)
+  [ "$_r" = "3" ] && ok "N6c ★컨트롤 override 없는 미측정 → 차단 (rc=3)" \
+                  || bad "N6c 컨트롤 rc=[$_r], 3 이어야"
+  rm -rf "$_S6"
+else
+  echo "  SKIP N6a/N6b/N6c/R5 (outbound_query_guard.sh 부재 — 배포 산출물) — PASS 아님, 미검사다"
+fi
+
 echo "[psa single-file lanes] pass=$pass fail=$fail"
 [ "$fail" -eq 0 ] || exit 1
 # 🟥 플로어는 **조건부 레인을 반영한 값**이다. 33 = zsh 없는 러너의 기저(Z1~Z4 · E2~E5/zsh 스킵).
@@ -438,6 +631,6 @@ echo "[psa single-file lanes] pass=$pass fail=$fail"
 #    ⚠️ 그리고 이 수식이 말하는 진짜 사실을 잊지 마라: **zsh 축은 zsh 가 있는 곳에서만 검증된다.**
 #    CI 에 zsh 를 설치한 이유가 그것이고(.github/workflows/validate.yml), 그게 없으면 이 PR 이
 #    고친 결함의 축이 CI 에서 **한 번도** 안 돌아간다.
-_floor=$((37 + _cond_lanes))
+_floor=$((52 + _cond_lanes))
 [ "$pass" -ge "$_floor" ] || { echo "  ❌ INSTRUMENT ERROR — only $pass lanes ran; expected >=$_floor (zsh 조건부 +$_cond_lanes)"; exit 3; }
 exit 0

--- a/scripts/test_psa_singlefile_lanes.sh
+++ b/scripts/test_psa_singlefile_lanes.sh
@@ -575,6 +575,8 @@ bash -c "set -e; . '$LIB'; PSA_STREAM=ORIGINAL; PSA_ALLOWLIST=/dev/null; PSA_DEF
   trap 'printf \"%s\" \"\$PSA_STREAM\" > '$_N3'/v' EXIT
   awk(){ return 1; }
   psa_require_live >/dev/null 2>&1" >/dev/null 2>&1
+# portability-noqa: 이 파일은 set -e 가 아니다 — 린트가 잡은 `set -e` 는 위 `bash -c` 문자열 «안»의 것이고
+#                   그건 자식 셸의 설정이다. 파일 스코프 판별의 오탐이며, 그 오탐 자체가 N3 가 재현하는 결함이다.
 _r=$(cat "$_N3/v" 2>/dev/null); rm -rf "$_N3"
 [ "$_r" = "ORIGINAL" ] && ok "N3 ★교차조건 set -e × 실패 생산자 → PSA_STREAM 복원됨" \
                        || bad "N3 교차조건에서 복원 미도달 — PSA_STREAM=[$_r] (카나리아 잔류 = P3 미해결)"

--- a/scripts/test_psa_singlefile_lanes.sh
+++ b/scripts/test_psa_singlefile_lanes.sh
@@ -356,6 +356,31 @@ for _sh in bash zsh; do
   [ "$_r" = "1" ] && ok "E5/$_sh ★컨트롤 정상 양성 → rc=1 (E2~E4 가 «항상 3» 이 아니다)" || bad "E5/$_sh 컨트롤 rc=[$_r], 1 이어야"
 done
 
+# ── G/F 레인 : cross-family 반례 2·4 (2026-08-21, 2차) ──────────────────────────────────
+# 🟥 둘 다 «자가검사가 통과했으니 그 뒤 스캔도 실행됐다» 는 확장의 잔재다.
+#   G = 진짜 패턴이 깨졌을 때. 자가검사는 **자기 카나리아 패턴**을 쓰므로 구조적으로 못 본다.
+#       실측 도달: 패턴 파일에 깨진 정규식 한 줄 → 그 행만 조용히 아무것도 안 잡고 rc=0 «깨끗».
+#   F = 자가검사 판정 자체의 위조. 초판은 파이프 최종 rc 하나만 봐서 «생산자 실패의 1» 과
+#       «스캐너가 유출을 찾음의 1» 이 합쳐졌다 — 실패하는 awk 가 카나리아를 뱉으면 통과했다.
+for _sh in bash zsh; do
+  command -v "$_sh" >/dev/null 2>&1 || { echo "  SKIP G/F ($_sh 없음) — PASS 아님, 미검사다"; continue; }
+  _cond_lanes=$((_cond_lanes + 0))
+  _gp() { "$1" -c ". '$LIB'; export PSA_STREAM=\$(printf 'HIGH\\t%s') PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1; printf 'p\\t%s\\n' | psa_scan_tagged >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1; }
+  _r=$("$_sh" -c ". '$LIB'; export PSA_STREAM=\$(printf 'HIGH\t[unclosed') PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1; printf 'p\t[unclosed here\n' | psa_scan_tagged >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1)
+  [ "$_r" = "3" ] && ok "G1/$_sh 깨진 정규식 → rc=3 (조용한 미스캔이 «깨끗»으로 안 접힌다)" || bad "G1/$_sh 깨진 정규식 rc=[$_r], 3 이어야"
+  # ★컨트롤 — 정상 패턴은 여전히 1/0 을 낸다(G1 이 «항상 3» 이 아니다)
+  _r=$("$_sh" -c ". '$LIB'; export PSA_STREAM=\$(printf 'HIGH\tOKTOK') PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1; printf 'p\tOKTOK\n' | psa_scan_tagged >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1)
+  [ "$_r" = "1" ] && ok "G2/$_sh ★컨트롤 정상 패턴 → rc=1" || bad "G2/$_sh 컨트롤 rc=[$_r], 1 이어야"
+  # F — 실패하는 생산자가 카나리아를 뱉어도 «살아있음» 이 아니어야
+  _r=$("$_sh" -c ". '$LIB'; export PSA_STREAM=\$(printf 'HIGH\tX') PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1; awk(){ printf 'PSA_SELFTEST_CANARY\n'; return 1; }; psa_require_live >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1)
+  [ "$_r" != "0" ] && ok "F1/$_sh 실패한 생산자의 카나리아 → 자가검사 «살아있음» 아님(rc=$_r)" || bad "F1/$_sh 자가검사 판정이 위조됐다 rc=0"
+  # ★컨트롤 — 정상 환경에서 psa_require_live 는 살아있다고 해야 한다
+  _r=$("$_sh" -c ". '$LIB'; export PSA_STREAM=\$(printf 'HIGH\tX') PSA_ALLOWLIST=/dev/null PSA_DEFAULTS_OK=1; psa_require_live >/dev/null 2>&1; echo \$?" 2>/dev/null | tail -1)
+  [ "$_r" = "0" ] && ok "F2/$_sh ★컨트롤 정상 자가검사 → rc=0 (F1 이 «항상 실패» 가 아니다)" || bad "F2/$_sh 컨트롤 rc=[$_r], 0 이어야"
+  _cond_lanes=$((_cond_lanes + 0))
+  [ "$_sh" = "zsh" ] && _cond_lanes=$((_cond_lanes + 4))
+done
+
 # ── H 레인 : 훅이 «계기 사망(3)» 과 «유출(1)» 을 가르는가 (2026-08-21) ────────────────────
 # 🟥 왜 [실행 확인]: 초판 훅은 `if ! … | psa_scan_tagged` 로 **비영을 전부 유출로 뭉갰다.**
 #    그래서 `PUBLIC_SURFACE_OK=1` 이 **계기 사망까지 «승인된 유출»로 통과**시켰다 — 비가역
@@ -413,6 +438,6 @@ echo "[psa single-file lanes] pass=$pass fail=$fail"
 #    ⚠️ 그리고 이 수식이 말하는 진짜 사실을 잊지 마라: **zsh 축은 zsh 가 있는 곳에서만 검증된다.**
 #    CI 에 zsh 를 설치한 이유가 그것이고(.github/workflows/validate.yml), 그게 없으면 이 PR 이
 #    고친 결함의 축이 CI 에서 **한 번도** 안 돌아간다.
-_floor=$((33 + _cond_lanes))
+_floor=$((37 + _cond_lanes))
 [ "$pass" -ge "$_floor" ] || { echo "  ❌ INSTRUMENT ERROR — only $pass lanes ran; expected >=$_floor (zsh 조건부 +$_cond_lanes)"; exit 3; }
 exit 0


### PR DESCRIPTION
## 무엇

직전 커밋(`db66b57`)의 마커에 `crossfamily: DEGRADED_PANEL_UNUSED` 로 **「발주했으나 안 기다렸다 · 반례가 오면 후속 커밋으로 반영한다」**고 적어뒀다. 왔고, 한 번이 아니었다. 이 PR 은 그 약속의 이행이다.

## 3라운드 누계 — 지적 11 · 수리 11 · 반증 0

| R | 지적 | 무엇 |
|---|---|---|
| **4** | 6 | 로더 `set -e` 잔여 · fallback nonce 가 경로에서 유도됨 · `$()` 후행개행이 「정확한 문자열 대조」를 무력화 · N6a **장식 앵커** · `rc=2` 를 유출로 오분류 · **부분 로드된 패턴 집합이 「깨끗」을 냄** |
| **5** | 3 | 예측가능 fallback 을 생산자가 **재계산해 통과** · `expect` 파일이 생산자 사정권 · **dash 에서 정상 행이 통째로 떨어지며 조용히 무력화** |
| **6** | 2 | `cmp` 가 셸 함수로 가려짐 · `tagged` 를 심링크로 바꿔치기 |

🟥 **11건 중 7건이 직전 라운드 수리의 산물이고, 자력 적발은 0이다.** 「수리가 신규 결함의 주된 출처」가 세 번 연속 맞았다.

## 6라운드에서 멈춘 근거 — 「지적 0」이 아니라 **「지적의 성격」**

R6 반례 둘은 **라이브러리를 소싱한 셸 안에서 함수를 정의할 수 있는** 상대에게서 온다. 그 상대는 `psa_scan_tagged(){ return 0; }` 한 줄이면 끝이라 nonce·cmp·심링크를 아무리 조여도 닫히지 않는다 — **이미 신뢰 안쪽**이다. 값싼 두 수리(`command cmp` · 심링크 거부)는 했지만 **그 축을 닫았다고 주장하지 않는다.** 신뢰 경계를 산문이 아니라 `psa_require_live` 상단 **코드 주석**에 박았다.

## standpoint 실행 팔이 하나 더 잡았다

```
npm pack → tar xzf → 포장본 안에서 레인 실행
  pass=80 fail=0
  ❌ INSTRUMENT ERROR — only 80 lanes ran; expected >=84     rc=3
```
outbound-guard 4레인이 조건부인데(`outbound_query_guard.sh` 는 `files[]` 에 없다) `_cond_lanes` 에 안 세어져 **포장본에서만 거짓 적색**이었다. 🟥 **정적 읽기로는 안 보였다** — cross-family 가 floor 산술을 독립 검산까지 했는데 「레포 트리 기준으로」 맞았을 뿐이다.

수리 후 **세 환경 전부 정확 일치**: 레포 `84` · 포장본 `80` · 무-zsh `56`.

## 계기 자신의 결함 4건은 컨트롤이 잡았다

- 되돌림 프로브가 `|| true` 로 **errexit 를 자가해제**
- N6 픽스처가 `FH=` 로 뿌리를 못 바꿔 **실제 레포를 스캔하고 통과**
- R5-2 되돌림 **위치 오류**로 살아있는 앵커를 「장식」이라 오판
- 셸 능력 검사 초판이 **bash/zsh 까지 과차단**

## 검증

```
레인        49 → 84
되돌림      15/15   각 픽스를 되돌리면 정확히 그 레인만 적색
floor 생사  T 블록 삭제 → 실제 INSTRUMENT ERROR (장식 아님)
과차단      진짜 패턴 파일 27행 → 수리 후에도 27행
degrade     dash rc=3 · ksh rc=3 · cmp 부재 rc=1 — 전부 fail-closed
회귀        selfcheck PASS · outbound-query 11/11
```

## 🟥 잔여 (이름으로)

1. **2번째 계열(agy/gemini)은 2회 발주 모두 죽은 계기** — 프롬프트를 안 읽고 자기 모델을 설명하는 응답을 냈다. 그 축은 **미검사**이며 「검사했는데 지적 0」이 **아니다**
2. 소싱 셸 내부 적대자는 구조적으로 막을 수 없다(명시된 경계)
3. `outbound_query_guard.sh` 는 `files[]` 에 없어 소비자 설치본에서 그 4레인이 **항상 SKIP** — 배포 여부는 별건 결정
4. 같은 셸 계열 7건이 호출부에 의존해 잠들어 있다(3라운드부터 이월, 미수리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAFGdGNiQ9YvNkhr9T4p2C