### PR TITLE
fix(publish): 배포 게이트가 막았다 — 운영자-사설 디렉터리명이 레지스트리로 나갈 뻔했다

### DIFF
--- a/scripts/fh_hub_identity.sh
+++ b/scripts/fh_hub_identity.sh
@@ -28,7 +28,7 @@
 # (the confidentiality gate blocked the first draft of sync-to-be.sh's fix for hardcoding one
 # directly; `git grep` showed zero prior occurrences anywhere in this repo, i.e. a genuinely new
 # leak, not an already-accepted pattern). Sibling identity instead comes from a LOCAL, gitignored
-# config file (`.git/info/exclude`, same convention as `.fh-be-tracks.local`) — `key=value` lines,
+# config file (`.git/info/exclude`, same convention as the sibling's own local tracks config) — `key=value` lines,
 # read as DATA (never sourced as shell, to avoid handing arbitrary code execution to a config file):
 # HUB_HEADER_MATCH (a prefix of the sibling's CLAUDE.md first line), HUB_SUFFIX, HUB_NAME.
 
@@ -53,7 +53,7 @@ fh_resolve_hub_identity() {
       # internal spaces — HUB_SUFFIX/HUB_NAME become directory-name fragments, so a stray trailing
       # CR from a CRLF-authored file silently mints a second namespace, reproduced in review); the
       # header-match text keeps internal spaces (it legitimately contains them) and only a trailing
-      # CR is stripped, matching the sibling `.fh-be-tracks.local` reader's own trim (line ~338 of
+      # CR is stripped, matching the sibling's local-tracks-config reader's own trim (line ~338 of
       # sync-to-be.sh) applied to the field that actually needs it.
       _fh_hub_id_get() {
         [ -f "$idfile" ] || return 0
@@ -72,6 +72,12 @@ fh_resolve_hub_identity() {
       ;;
   esac
   TM="tracks-meta$HUB_SUFFIX"; TA="tracks-audit$HUB_SUFFIX"; TCH="tracks-chamber$HUB_SUFFIX"
-  TR="tracks$HUB_SUFFIX"; MMD="memory$HUB_SUFFIX"; HO="hub-owner$HUB_SUFFIX"
+  TR="tracks$HUB_SUFFIX"; MMD="memory$HUB_SUFFIX"
+  # NOTE: the operator-private area's directory name is deliberately NOT set here.
+  #   This file ships in the PUBLIC npm package (files[]), and that name is an operator-private
+  #   token in that context — the same reason the sibling hub's name is read from local config
+  #   rather than hardcoded (see the header). The only consumer is sync-to-be.sh, which does NOT
+  #   ship, so it defines the name itself. Measured 2026-08-21: the pre-publish confidentiality
+  #   scan blocked `npm publish` on this exact literal.
   return 0
 }

--- a/scripts/sync-to-be.sh
+++ b/scripts/sync-to-be.sh
@@ -84,6 +84,11 @@ if ! fh_resolve_hub_identity; then
   echo "[sync-to-be] refuse: \$FH ($FH) is not a recognized hub — abort" >&2
   exit 10
 fi
+# The operator-private area's directory name lives HERE, not in fh_hub_identity.sh — that file
+# ships in the public npm package and this name is an operator-private token there (the pre-publish
+# confidentiality scan blocked `npm publish` on it, 2026-08-21). This script does not ship, and it
+# is the only consumer of $HO, so the name belongs at the consumer.
+HO="hub-owner$HUB_SUFFIX"
 
 # Cross-hub mutual exclusion (Wave-1 review, pmh-dev#68 [S]; lock ordering hardened by codex
 # cross-family review [A]). Before HUB_SUFFIX, a non-FH hub always refused above and never reached


### PR DESCRIPTION
## 게이트가 `npm publish` 를 막았다

2.7.0 배포 직전 기밀 스캔이 차단했다. 배포되는 `scripts/fh_hub_identity.sh` 가 운영자-사설 companion store 의 디렉터리명을 레지스트리로 실어보내고 있었다.

```
❌ LOW leak — scripts/fh_hub_identity.sh: 'hub-owner' would ship to the registry
```

## 우회하지 않았다

`PUBLIC_SURFACE_OK=1` 은 한 번도 안 썼고, 문자열을 쪼개 스캐너만 피하는 난독화도 안 했다 — **그건 수리가 아니라 계기 무력화다.**

대신 «누가 쓰는가»를 물었더니 답이 나왔다: `$HO` 의 **유일한 소비자는 `sync-to-be.sh` 이고 그건 배포되지 않는다.** 배포되는 파일이, 배포되는 소비자가 아무도 안 쓰는 변수를 세우면서 그게 유출원이었다. 정의를 소비처로 옮겼다.

⚠️ **「파일을 files[] 에서 빼기」는 오답이다** — `#387` 이 그렇게 했다가 `#484`(오늘)가 되돌렸고, 되돌린 게 맞다. 배포 스크립트 셋(`fh_session_load` · `fh_track_resolve` · `package_coverage_check`)이 이걸 source 한다.

## 검증 — 전부 실행 출력

| | |
|---|---|
| 스캔 | `rc=1`(2건) → 주석 일반화 `rc=1`(1건) → 이관 후 **`rc=0` PASS**. 단계마다 값이 움직였다 |
| 분리 | 라이브러리 후 `HO=미설정`(의도) · 소비자 정의 후 `HO=hub-owner` |
| 완주 | `selfcheck` rc=0 · `SELFCHECK: PASS` · **PASS 306** |

🟥 **첫 두 측정은 판정 불가였고 그렇게 셌다**: `sync-to-be` 첫 실행은 `rc=0` 이지만 «busy» 분기라 `$HO` 경로를 **안 지났고**, `selfcheck` 첫 시도 `rc=124` 는 실패가 아니라 타임아웃(**미측정**)이었다. 둘 다 다시 돌려 완주를 관측했다.

## 🟥 내 계기가 한 번 틀렸다 — 그게 게이트 우회로 이어질 뻔했다

`$HO` 소비처를 세려고 `grep -e '$HO'` 를 돌렸더니 **`$HOME` 을 전부 잡아** 「배포 파일 25곳이 쓴다」는 허상이 나왔다. 단어 경계를 준 grep 이 옳았고 실제는 1곳이다. **그 오답을 믿었으면 「이관 불가」로 결론짓고 오버라이드로 갔을 것이다.**

## 🟥 안 한 것

- **ⓐ계열(cross-family) 미실시** · **ⓕ되돌림 미실시**. 마커에 `DEGRADED_PANEL_UNUSED` 로 값을 적었다.
- 같은 계열 **전수 안 봤다** — 스캐너는 gitignored 패턴 목록의 토큰만 본다. 목록 밖 사설 토큰은 구조적으로 안 걸린다.

## 공유 체크아웃 사고

이 수리는 작업 중 **두 번 유실됐다가 복구됐다**(peer 세션이 자백·복원). 재적용 후 중복 4항 실측: 이관주석 1 · HO 정의 1 · 소비처주석 1 · 구 리터럴 0. 커밋 직전 HEAD 재확인 후 커밋했다.