### PR TITLE
docs(claude): 「파일 지정 add 면 안 섞인다」는 거짓이다 — 오늘 그렇게 쓰고 섞였다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,8 +376,18 @@ claim 이 `main` 인 동안 실제 HEAD 는 peer 브랜치였다 — 두 세션�
 **남은 잔여 둘, 이름으로 남긴다**: ⓐ 게이트는 **커밋 시점**이라 `switch -c` 사고 자체는 못 막는다
 (그래서 위 두 줄이 여전히 사람 몫이다 — [[feedback_gate_binding_point_not_check_point]])
 ⓑ 반대 방향 — 내가 브랜치를 쥔 동안 남이 되돌리고 커밋하면 **내 staged 파일이 index 에 살아
-있다.** 실측 사례에서 안 섞인 것은 그 세션이 파일 지정 `add` 를 썼기 때문이지 게이트 덕이 아니다.
-⇒ **공유 체크아웃에서 `git add -A` 금지**([[feedback_shared_checkout_ops_touch_others_work]]).
+있다.** 🟥 **2026-08-21 실제로 났고, 섞은 세션은 파일 지정 `add` 를 썼다**(초판은 여기 「파일
+지정 add 를 썼기 때문에 안 섞였다」고 적었는데 거짓이다). 파일 지정 add 는 «내가 무엇을
+**추가**하나»만 통제하고 **index 에 이미 있는 것은 못 막는다.** ⇒ `git add -A` 금지는 필요조건
+이지 충분조건이 아니다. **커밋을 한 호출로 묶고 그 안에서 둘을 확인한다** — 확인은 점이고 위험은
+구간이라, 사이에 턴이 끼면 창이 다시 생긴다(같은 날 두 세션이 시점을 각각 `switch` 직전/직후로
+달리 골랐는데 **둘 다 뚫렸다**):
+```
+B=$(git branch --show-current); [ "$B" = "<내 브랜치>" ] || exit 1
+git diff --cached --name-only    # 내 것만 있나 — 남의 것은 restore --staged
+git commit …
+```
+([[feedback_shared_checkout_ops_touch_others_work]] · [[feedback_gate_binding_point_not_check_point]])
 
 **Integration branch is PR-only** (operator decision 2026-07-20). Never `git push origin main`
 directly. Normal path: `git switch -c <branch>` → push the branch → `gh pr create` → after review


### PR DESCRIPTION
## 정본이 틀렸다

`CLAUDE.md §공유 체크아웃 잔여 ⓑ` 가 이렇게 적고 있었다:

> 실측 사례에서 안 섞인 것은 그 세션이 **파일 지정 `add` 를 썼기 때문**이지 게이트 덕이 아니다.

**2026-08-21, 그 형태가 실제로 났다. 그리고 섞은 세션은 파일 지정 add 를 썼다.**

파일 지정 add 는 «내가 무엇을 **추가**하나»만 통제하고 **index 에 이미 있는 것은 못 막는다** — 남이 stage 해둔 파일은 내 커밋에 그대로 담긴다. 양쪽 세션 독립 확인, 한쪽 자백.

그 문장은 「파일 지정 add 면 안전」으로 읽히고 **다음 세션이 그걸 믿는다.** `feedback_rule_misdescribes_its_own_machine` 이라 N 임계와 무관하게 즉시 정정 대상이다.

## 🟥 시점을 고르는 문제가 아니다

같은 날 두 세션이 확인 시점을 **서로 다르게** 골랐는데 **둘 다 뚫렸다**:

```
한쪽    switch 「직전」에만 확인   →  switch ↔ 쓰기   사이가 창
다른쪽  switch 「직후」에만 확인   →  확인   ↔ 커밋   사이가 창
```

**확인은 점이고 위험은 구간이다.** 그래서 처방은 시점을 옮기는 게 아니라 **확정점(커밋)에 결박하고 한 호출로 묶는 것** — 사이에 턴이 끼면 창이 다시 생긴다. 기존 축(`gate_binding_point_not_check_point`)에 붙였고 **새 개념은 안 만들었다.**

## 처방은 훈계가 아니라 실행문

오늘 사고는 규율을 **읽고도** 났다. 읽는 세기를 올리는 것은 같은 실패를 반복시킨다. 그래서 넣은 것은 복붙 가능한 3줄뿐이다:

```bash
B=$(git branch --show-current); [ "$B" = "<내 브랜치>" ] || exit 1
git diff --cached --name-only    # 내 것만 있나 — 남의 것은 restore --staged
git commit …
```

## 상주 예산 — 게이트가 숫자를 보여줘서 줄였다

```
초안   +4,106 bytes  (+2.8%)
착지   +  725 bytes  (5.7배 축소, 같은 사실을 나른다)
```

## 🟥 명시 잔여

- **N=1** — 하루 · 한 체크아웃 · 두 세션. 다른 머신/팀에서 같은 형태가 나는지는 미측정.
- **기계 앵커 없다** — 처방은 사람이 눈으로 보는 단계다. 훅화하려면 「무엇이 남의 것인가」를 기계가 알아야 하는데 `claim` 은 **브랜치를 기록하지 파일을 기록하지 않는다**.
- **발견자는 내가 아니다** — 사고를 낸 peer 세션이 자기 사고를 정본에 비춰보고 찾았다. 자력 적발 0.
- **ⓐ계열 · ⓔ첫실사용 · ⓕ되돌림 미실시** — 산문 델타라 실행 팔이 없다. `standpoint: tier1b` 로 적은 것이 그 표시다.