### PR TITLE
docs(playbook): 「두 얼굴」의 기전은 뜨거움이 아니라 **뜨거움과 차가움의 쌍**이다

### DIFF
--- a/knowledge/shared/dialogue/ai_dialogue_playbook.md
+++ b/knowledge/shared/dialogue/ai_dialogue_playbook.md
@@ -179,8 +179,20 @@ construction. Neither finding was self-caught by its author.
 
 ⚠️ **An observed effect, not a promotion to default.** Concurrency costs coordination, and it is
 where the same day's two shared-checkout accidents came from. The claim is narrow: *some* effects
-are unobtainable without it. Whether that is worth the cost is a per-task call, and this operator's
-standing preference remains delegation-in-conversation over standing parallelism.
+are unobtainable without it.
+
+**So how to hold it** (operator, 2026-08-21): *"디폴트 승격은 안 해도 되. 다만 병렬세션 띄워서
+운영자가 작업할 때 얻게 되는 **반사이익**이라고 보면 되지. 아니면 **네가 권유해도 괜찮음**.
+「병렬세션으로 나눠서 작업해도 좋을 것 같습니다」 이런 식으로"*.
+
+Two things follow, and the second is a permission most sessions will not assume they have:
+- **It is a by-product, not a reason.** The operator opens parallel sessions for their own reasons;
+  contention is what they *also* get. Do not argue for concurrency on the strength of this effect
+  alone.
+- 🟥 **You may propose it.** When work has separable threads and a second face would help — a
+  decision you would otherwise ratify alone, a claim only its author has read — say so plainly:
+  *"병렬세션으로 나눠서 작업해도 좋을 것 같습니다."* Proposing is invited; deciding is not yours,
+  and the standing preference remains delegation-in-conversation over standing parallelism.
 
 **Context Card** (required for non-trivial dispatch):
 ```

--- a/knowledge/shared/dialogue/ai_dialogue_playbook.md
+++ b/knowledge/shared/dialogue/ai_dialogue_playbook.md
@@ -91,6 +91,97 @@ API 키 대화창 기록 방지 — Write 툴로 `.env` 직접 생성 (대화창
 
 **Forbidden response**: "I can't do that — I'm not in that project's cwd." Always check if Agent dispatch covers it first.
 
+🟥 **A live peer session is a different thing from a subagent — and the default reading is wrong.**
+Operator, 2026-08-21, correcting exactly that: *"이작업을 분할하라는게 아니라 논의를 해보라는
+뜻이었어 작업은 니가하고"* → *"주위피어에는 **두뇌를빌려서 네 수행에 대한 판단**을 도움받아보라는
+거였으니"*.
+
+| | you dispatch it | you ask a peer |
+|---|---|---|
+| what moves | **the work** | **the judgment** |
+| what comes back | a completed unit | a verdict on *your* execution |
+| the peer's own work | — | keeps running; you did not take it |
+
+The reflex is to read "talk to the peers" as "split the task across the peers", because a peer
+looks like a bigger subagent. It is not. The operator's own framing, same day:
+
+> *"예열되어 다른갈래로 뻗어있는 자신의 다른 면모들은 하나의 **별개하네스(동일맥락을 공유하는)**
+> 로도 동작도가능하므로 인사이트를 얻을수있다"*
+
+A peer is **pre-warmed on its own branch of the same context** — a separate harness that shares
+your origin but not your recent path. The operator's sharper form, same day:
+
+> *"동일 하네스에서 분화한 세션이라도 **그 세션으로 뜨거워진 지점에서는 다른 양상과 관점을
+> 지니게 된다. 그 세션만큼은 두 얼굴이 생기는거다.**"*
+>
+> *"**자신에 대해서는 뜨겁게, 남에 대해서는 그만큼 차갑게** (동일 하네스라도)"*
+
+The divergence is not in how context is *delivered* — the peer genuinely **holds a different
+aspect** at the point it got hot. The second line names the mechanism, and it is the half that
+is easy to miss: the same heat that makes a session sharp on **its own** thread makes it
+correspondingly **cold on yours**. Both halves are load-bearing and they buy different things:
+
+| | what it buys |
+|---|---|
+| **hot on its axis** | it sees what you structurally cannot — it did that work |
+| **cold on yours** | it does not carry your optimism, your sunk cost, or your reading of your own claim |
+
+The second is why "read it again, more carefully" never substitutes: **you cannot make yourself
+cold about your own output.** Dividing the work destroys both properties at once — a peer given
+part of your task becomes hot on it, and is then judging its own output.
+
+🟥 **Two operating consequences, which follow from the mechanism rather than from etiquette:**
+- **Ask the peer about the axis it got hot on.** Off that axis a peer wears *your* face — asking
+  buys nothing and costs a round trip.
+- **A subagent or your own re-read cannot substitute.** The second face comes from that session
+  having actually done the work; a prompt cannot manufacture heat, and nothing manufactures
+  coldness toward your own output.
+
+**Measured, and it is not one good day.** Scanned this hub's own records for peer-attributed
+catches: **119 mentions across 35 files spanning 13 distinct dates (2026-08-08 → 08-21)**;
+cross-family sidecar catches count separately at **113** — comparable in size, a *different*
+axis. Eight sampled hits were hand-verified as genuine peer attribution, and at least two run
+the **other way** (a peer's misdiagnosis reversed by measurement here) — so the shape is mutual
+contention, not one-way review.
+⚠️ Named residuals: these are *mentions*, not deduplicated incidents (one event can be described
+in several files); attribution is self-reported in this hub's own records; the window is the
+~2-week parallel-session era only.
+
+🟥 **Whether this is a verification axis in its own right is an OPEN OPERATOR DECISION, not
+settled here.** The operator also said *"이것도 6축검증법에 속한다"*, which places peer discussion
+inside the canonical six axes — but which axis, or whether it is a seventh, is unresolved: it is
+closest to ⓒ isolated-grounding (someone re-verifies *your record*), yet a peer is precisely
+**not** isolated. Do not cite this paragraph as if the axis question were closed.
+See `tracks/_meta/fh_signal_2026-08-21_peer-axis-canon-claim.md`.
+
+**So the ask to a peer is a question, not a work item.** The operator's own modelling of the
+boundary, same day, on a branch belonging to another session: *"그 브랜치는 08d6fe75 갈래
+것이고 **여기서 손댈 게 아니다. 판단만 낸다.**"* — when the artifact belongs to another
+session, produce a verdict, never an edit. This is about **scope of authority** and is separate
+from the shared-checkout rules (which are about not clobbering); both apply at once.
+
+### The effect that needs 2+ concurrent — and why it is not a preference
+
+Operator, 2026-08-21, arriving at it against their own habit:
+
+> *"내가 두개이상을 동시에 잘 쓰려고는 안하는데 아이러니하게도 **두개이상을 동시에 써야 얻을수
+> 있는 효과**도있어보이네"* → *"**2명~3명이 하네스를 굴려서 경합시키는 모양새**가 나오니까"*
+
+The shape is not "parallel work". It is **contention** — two or three sessions *driving the same
+harness* and colliding. What that produces cannot be reached serially, because both halves of the
+hot/cold table must exist **at the same time**: one session hot on a thread while another is cold
+on it. Run them in sequence and you get one face twice.
+
+Same day, in both directions: the wiring-hot session found a defect in this session's delta; this
+session found a drift defect inside *that* session's delta — and the check that caught it fires on
+*"did main change today"*, not *"did I change it"*, which is a contention-shaped trigger by
+construction. Neither finding was self-caught by its author.
+
+⚠️ **An observed effect, not a promotion to default.** Concurrency costs coordination, and it is
+where the same day's two shared-checkout accidents came from. The claim is narrow: *some* effects
+are unobtainable without it. Whether that is worth the cost is a per-task call, and this operator's
+standing preference remains delegation-in-conversation over standing parallelism.
+
 **Context Card** (required for non-trivial dispatch):
 ```
 [Session Context Card]
@@ -117,6 +208,34 @@ Note: {constraints the agent must know}
 - Session with only exploration, no conclusion ❌
 
 **Format**: `tracks/{project}/session_YYYY_MM_DD_{slug}.md` with YAML frontmatter. See `sync_push_protocols.md`.
+
+---
+
+## Approval Must Be Evaluable — never hand over a blind stamp
+
+Operator, 2026-08-21: *"내가 판단해야하는건 내가 알아볼수있게 쉽게 브리핑해줘 **승인하더라도
+블라인드 도장은 찍고싶지않아**."*
+
+An approval request is not done when it is *complete*; it is done when the approver can **reach
+the verdict themselves**. A dump of everything measured technically discloses more and decides
+less — the approver ends up ratifying your conclusion rather than forming one.
+
+**What a decision-ready item carries:**
+```
+the decision       stated as a choice, not as a status report
+what it costs      what becomes irreversible, what stays open
+the evidence       the number AND how it was measured (an uncalibrated number is not evidence)
+your recommendation  named as yours, so it can be rejected without re-deriving everything
+what you did NOT check  the residual, by name — this is the half that makes the rest trustworthy
+```
+
+🟥 **The failure mode is not withholding — it is volume.** Burying the one load-bearing fact in a
+complete record is the same defect as omitting it: either way the approver cannot separate what
+matters. If it takes the approver a re-derivation to decide, the briefing has handed them a blind
+stamp with extra steps.
+
+**Applies to every approval surface**, not only long briefs: a one-line "merge this?" still owes
+the choice, the cost, and the residual.
 
 ---
 


### PR DESCRIPTION
## 무엇

운영자 통찰 셋을 `ai_dialogue_playbook.md` 에 자산화한다. 🟥 **초판에서 내가 그중 하나를 약하게 옮겼고, 정정받았다.**

## 정정된 지점

내 초판: *「변형은 **전달 방식**이지 내용이 아니다」* — **열화였다.**

> *"동일 하네스에서 분화한 세션이라도 그 세션으로 뜨거워진 지점에서는 다른 양상과 관점을 지니게 된다. **그 세션만큼은 두 얼굴이 생기는거다.**"*
> *"**자신에 대해서는 뜨겁게, 남에 대해서는 그만큼 차갑게**(동일 하네스라도)"*

차이는 배달이 아니라 **관점 자체**다. 그리고 둘째 발화가 **기전**을 준다:

| | 무엇을 사나 |
|---|---|
| **자기 축에 뜨겁다** | 내가 구조적으로 못 보는 것을 본다 — 그 일을 실제로 했으니까 |
| **내 축에 차갑다** | 내 낙관·매몰비용·«내 주장에 대한 내 독법»을 안 지고 있다 |

🟥 **둘째 절반이 하중선이다** — *「다시 꼼꼼히 읽어라」*가 왜 대체가 안 되는지를 설명한다. **자기 산출에 대해 스스로 차가워질 수는 없다.**

## 세 번째 발화 — 경합

> *"내가 두개이상을 동시에 잘 쓰려고는 안하는데 아이러니하게도 **두개이상을 동시에 써야 얻을수 있는 효과**도있어보이네"* → *"**2명~3명이 하네스를 굴려서 경합시키는 모양새**가 나오니까"*

직렬로는 못 얻는다 — 뜨거움과 차가움이 **동시에** 있어야 한다. 순차로 돌리면 같은 얼굴을 두 번 본다.

후속 정정으로 **디폴트 승격이 아니라 「반사이익」**으로 위치를 잡고, 🟥 **세션이 «병렬로 나눠서 해도 좋겠습니다» 라고 제안하는 것은 허용**됨을 명시했다(결정은 여전히 운영자 몫).

## 검증 — 운영자가 「빼박」이라 해서 셌다

```
피어 귀속 적발      119건 · 35파일 · 13개 날짜 (08-08 ~ 08-21)
cross-family 별도    113건        ← 비슷한 크기의 **다른 축**. 한 통으로 세면 안 된다
손검증 8건          전부 진짜 피어 귀속 · 그중 2건은 **반대 방향**(피어 오진을 내가 반증)
★컨트롤             known-positive 오늘자 7파일 hit · known-negative 0
```

🟥 **세는 방식이 틀렸던 것도 같이 나왔다** — 초판 스캔은 파일 공기로 49를 냈는데 손검증하니 **적발자가 섞여 있었다**(peer·cross-family·운영자·CI·레인). co-occurrence 를 사건 수로 발표할 뻔했다.

명시 잔여: mentions 이지 dedup 사건 수가 아니다 · 자기 기록 기반 자기 신고 · 창 ~2주.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAFGdGNiQ9YvNkhr9T4p2C