### PR TITLE
feat(listing-watch): 등재가 «조용히» 뒤집히는 걸 4일 뒤 우연히 아는 대신 세션 시작에 잡는다

### DIFF
--- a/package.json
+++ b/package.json
@@ -236,6 +236,8 @@
     ".claude/capabilities",
     "scripts/prior_art_prompt.sh",
     "scripts/test_prior_art_prompt_lanes.sh",
-    "templates/settings.PriorArt.snippet.json"
+    "templates/settings.PriorArt.snippet.json",
+    "scripts/listing_watch.sh",
+    "scripts/test_listing_watch_lanes.sh"
   ]
 }

--- a/scripts/listing_watch.sh
+++ b/scripts/listing_watch.sh
@@ -37,6 +37,24 @@ done
 
 say() { printf '%s\n' "$*"; }
 
+# 🟥 **`stat -f %m` 을 «먼저» 쓰면 리눅스에서 조용히 깨진다** — GNU stat 의 `-f` 는
+#    «파일시스템 정보»라 **실패가 아니라 성공하며 다른 값을 뱉고**, 그래서 `||` 폴백이 안 탄다.
+#    CI 가 실제로 그렇게 잡았다(`Type: ext2/ext3 … syntax error in expression`).
+#    ⇒ 순서를 뒤집는 것으로 끝내지 않고 **숫자인지 검증**한다. 순서만 바꾸면 반대 플랫폼에서
+#    같은 얼굴이 다시 난다. `[[feedback_wiring_surfaces_hidden_failures]]`
+_mtime() {
+  local m
+  m=$(stat -c %Y "$1" 2>/dev/null)
+  case "$m" in ''|*[!0-9]*) m=$(stat -f %m "$1" 2>/dev/null) ;; esac
+  case "$m" in ''|*[!0-9]*) m=0 ;; esac
+  printf '%s' "$m"
+}
+
+# 🟥 grep 패턴의 `\t` 는 **이식되지 않는다** — GNU grep 은 리터럴 `t` 로 읽어 0건이 되고,
+#    그러면 「FAILED 를 매번 보고한다」는 규율이 리눅스에서만 조용히 죽는다(CI 적발).
+#    실제 탭 문자를 만들어 `-F` 로 쓴다.
+TAB=$(printf '\t')
+
 # 🟥 테스트 seam: 레인이 «gh 없는 호스트» 를 흉내내려고 PATH 를 깎으면 호스트에 따라
 #    결과가 갈린다(리눅스의 /usr/bin 에 gh 가 있을 수 있다 — cross-family 지목).
 #    명령 이름을 주입 가능하게 두면 레인이 호스트와 무관해진다.
@@ -102,7 +120,7 @@ fi
 # ── 스로틀: 24h 안에 돌았으면 조용히 넘어간다 ────────────────────────────
 if [ "$FORCE" != "1" ] && [ -f "$STATE" ]; then
   now=$(date +%s)
-  mt=$(stat -f %m "$STATE" 2>/dev/null || stat -c %Y "$STATE" 2>/dev/null || echo 0)
+  mt=$(_mtime "$STATE")
   if [ $(( (now - mt) / 3600 )) -lt "$THROTTLE_H" ]; then exit 0; fi
 fi
 
@@ -145,12 +163,12 @@ fi
 # 🟥 `grep -c ... || echo 0` 을 쓰지 않는다: grep -c 는 무매치에서 **"0" 을 출력하고 exit 1** 이라
 #    폴백이 "0\n0" 을 만들고 `[` 가 «integer expression expected» 로 죽는다(내 수리가 낸 결함).
 #    `[[feedback_pipefail_fallback_disarms_guard]]` 일가 — 값을 먼저 잡고 따로 판정한다.
-NFAIL=$(grep -c '\tFAILED\t' "$NEW" 2>/dev/null)
+NFAIL=$(grep -cF "${TAB}FAILED${TAB}" "$NEW" 2>/dev/null)
 case "$NFAIL" in ''|*[!0-9]*) NFAIL=0 ;; esac
 if [ "$NFAIL" -gt 0 ]; then
   say ""
   say "  ⚠️  [listing-watch] 채널 $NFAIL 개를 **읽지 못했다**(FAILED) — «변화 없음» 이 아니다."
-  grep '\tFAILED\t' "$NEW" 2>/dev/null | while IFS= read -r l; do say "       $(printf '%s' "$l" | cut -f1)"; done
+  grep -F "${TAB}FAILED${TAB}" "$NEW" 2>/dev/null | while IFS= read -r l; do say "       $(printf '%s' "$l" | cut -f1)"; done
   say "       흔한 원인: gh 인증 만료(\`gh auth status\`) · 레포/번호 오타 · 비공개 전환."
   say "       🟥 이 줄이 안 보일 때까지는 그 채널의 상태를 **모르는 것**이다."
 fi

--- a/scripts/listing_watch.sh
+++ b/scripts/listing_watch.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# listing_watch.sh — 외부 큐레이션 목록에 낸 제출의 «조용한 상태 전이»를 잡는다.
+#
+# 왜 있나 (실측 근거, 2026-08-19):
+#   `awesome-claude-code` #1961 이 2026-06-07 에 validation-PASSED 였다가, 우리가 아무것도
+#   안 건드린 채 2026-08-15 에 **validation-FAILED 로 뒤집혔다** — 그쪽이 허용 카테고리
+#   목록을 바꾸고 봇이 기존 이슈를 재검증하면서 떨어진 것이다. 아무도 안 알려줬고,
+#   `validation-failed` 는 «리뷰 대기열에서 빠진» 상태다. 4일 뒤 **우연히** 발견했다.
+#   ⇒ 통과는 영구적이지 않고, 알림은 오지 않는다. 그래서 이쪽에서 스냅샷을 떠서 대조한다.
+#
+# 설계 규율 (전부 이 저장소의 실측에서 나온 것):
+#   · **항상 exit 0 + stdout 보고** — 훅은 비영 종료 시 stdout 이 버려지고 stderr 도 안 온다
+#     (`feedback_hook_nonzero_exit_is_silent`). 이 스크립트는 판정을 «출력»하지 종료코드로
+#     말하지 않는다.
+#   · **미측정을 0 으로 접지 않는다** — 상태는 넷이다: DISABLED / SKIPPED / FAILED / EXECUTED
+#     (`feedback_not_found_is_not_zero_family`). `gh` 가 없으면 «통과» 가 아니라 «SKIPPED» 다.
+#   · **파이프로 판정하지 않는다** — `out=$(cmd); rc=$?` 형태만 쓴다
+#     (`feedback_pipefail_fallback_disarms_guard`).
+#   · **부재 주장엔 컨트롤** — `--selftest` 가 known-positive/known-negative 를 돌린다
+#     (`feedback_absence_measurement_needs_control`).
+#   · bash 3.2 (macOS 기본) 호환 — 연관배열 안 쓴다.
+#
+# 채널 목록은 **이 파일에 안 박는다** — 운영자의 실제 제출은 사설 정보다.
+#   매니페스트: tracks/_meta/listing_watch_channels.tsv   (gitignored)
+#   형식(TAB 구분, `#` 주석):   owner/repo <TAB> number <TAB> pr|issue <TAB> 목록에서_찾을_문자열
+#
+# 사용:  bash scripts/listing_watch.sh [--force] [--selftest]
+
+HUB="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+MANIFEST="$HUB/tracks/_meta/listing_watch_channels.tsv"
+STATE="$HUB/tracks/_meta/.listing_watch_state.tsv"
+THROTTLE_H=24
+FORCE=0; SELFTEST=0
+for a in "$@"; do
+  case "$a" in --force) FORCE=1 ;; --selftest) SELFTEST=1 ;; esac
+done
+
+say() { printf '%s\n' "$*"; }
+
+# 🟥 테스트 seam: 레인이 «gh 없는 호스트» 를 흉내내려고 PATH 를 깎으면 호스트에 따라
+#    결과가 갈린다(리눅스의 /usr/bin 에 gh 가 있을 수 있다 — cross-family 지목).
+#    명령 이름을 주입 가능하게 두면 레인이 호스트와 무관해진다.
+GH="${LISTING_WATCH_GH:-gh}"
+
+# ── 도구 가용성: 없으면 «SKIPPED, not passed» ─────────────────────────────
+if ! command -v "$GH" >/dev/null 2>&1; then
+  say "  ⚠️  [listing-watch] SKIPPED (not passed) — \`$GH\` 없음. 등재 상태를 **확인하지 못했다**."
+  exit 0
+fi
+
+# ── 한 채널의 현재 상태를 한 줄로 (owner/repo#num<TAB>STATE<TAB>labels<TAB>listed) ──
+probe() {  # $1=repo $2=num $3=kind $4=needle
+  local repo="$1" num="$2" kind="$3" needle="$4" st lab listed out rc
+  # 🟥 라벨 «개수» 를 같이 싣는다 — join(",") 만으로는 ["a,b"](1개) 와 ["a","b"](2개) 가
+  #    구분이 안 돼 진짜 라벨 전이가 스냅샷에서 같게 비친다(cross-family 지목).
+  out=$($GH api "repos/$repo/issues/$num" --jq '"\(.state)|\(.pull_request.merged_at // "null")|\([.labels[].name]|length)|\([.labels[].name] | sort | join(","))"' 2>&1); rc=$?
+  if [ $rc -ne 0 ]; then printf '%s#%s\tFAILED\t-\t-\n' "$repo" "$num"; return 0; fi
+  st=$(printf '%s' "$out" | cut -d'|' -f1)
+  local merged n_lab; merged=$(printf '%s' "$out" | cut -d'|' -f2); n_lab=$(printf '%s' "$out" | cut -d'|' -f3)
+  lab=$(printf '%s' "$out" | cut -d'|' -f4-)
+  [ "$merged" != "null" ] && st="MERGED"
+  [ -z "$lab" ] && lab="-"
+  lab="${n_lab}:${lab}"
+  listed="unknown"
+  if [ -n "$needle" ] && [ "$needle" != "-" ]; then
+    local body brc dec
+    body=$($GH api "repos/$repo/contents/README.md" --jq '.content' 2>/dev/null); brc=$?
+    if [ $brc -eq 0 ] && [ -n "$body" ]; then
+      # base64 플래그가 갈린다: GNU/신 macOS 는 -d, 구 macOS 는 -D. 둘 다 시도한다.
+      dec=$(printf '%s' "$body" | base64 -d 2>/dev/null) || true
+      [ -z "$dec" ] && dec=$(printf '%s' "$body" | base64 -D 2>/dev/null) || true
+      if [ -z "$dec" ]; then
+        listed="unreadable"   # 🟥 디코드 실패를 «absent» 로 접으면 계기 고장이 «미등재» 로 읽힌다
+      elif printf '%s' "$dec" | grep -qF -- "$needle"; then listed="LISTED"
+      else listed="absent"; fi
+    else
+      listed="unreadable"   # ← «없음» 이 아니라 «못 읽었음». 접지 않는다
+    fi
+  fi
+  printf '%s#%s\t%s\t%s\t%s\n' "$repo" "$num" "$st" "$lab" "$listed"
+}
+
+# ── 컨트롤: 계기가 살아 있는지 (known-positive / known-negative) ──────────
+if [ "$SELFTEST" = "1" ]; then
+  say "[listing-watch selftest] 컨트롤 2종"
+  kp=$(probe "walkinglabs/awesome-harness-engineering" 33 pr "forge-harness")
+  say "  known-positive  walkinglabs#33 (MERGED 로 알려짐): $kp"
+  case "$kp" in *MERGED*) say "    ✅ 양성 검출" ;; *) say "    ❌ 계기 고장 — 알려진 MERGED 를 못 읽었다" ;; esac
+  kn=$(probe "walkinglabs/awesome-harness-engineering" 99999999 pr "-")
+  say "  known-negative  없는 번호 #99999999: $kn"
+  case "$kn" in *FAILED*) say "    ✅ 없는 것을 «없다»로 (지어내지 않음)" ;; *) say "    ❌ 없는 것에 상태를 만들어냈다" ;; esac
+  exit 0
+fi
+
+# ── 매니페스트 없으면 DISABLED (기능 자체가 안 켜진 것 — 실패가 아니다) ──
+if [ ! -f "$MANIFEST" ]; then
+  say "  ℹ️  [listing-watch] DISABLED — 채널 매니페스트 없음 ($MANIFEST)."
+  say "     켜려면 TAB 구분으로: owner/repo <TAB> 번호 <TAB> pr|issue <TAB> 목록에서_찾을_문자열"
+  exit 0
+fi
+
+# ── 스로틀: 24h 안에 돌았으면 조용히 넘어간다 ────────────────────────────
+if [ "$FORCE" != "1" ] && [ -f "$STATE" ]; then
+  now=$(date +%s)
+  mt=$(stat -f %m "$STATE" 2>/dev/null || stat -c %Y "$STATE" 2>/dev/null || echo 0)
+  if [ $(( (now - mt) / 3600 )) -lt "$THROTTLE_H" ]; then exit 0; fi
+fi
+
+NEW=$(mktemp); CHANGED=0; ROWS=0
+# 🟥 `IFS=$'\t' read` 를 쓰지 않는다 — 탭은 IFS 공백류라 **연속 탭이 합쳐져** 빈 칸이 있는
+#    행에서 필드가 밀린다(cross-family 재현). 줄을 통째로 읽고 `cut` 으로 자른다.
+# 🟥 `|| [ -n "$line" ]` 이 없으면 **개행 없는 마지막 행이 통째로 누락**된다(재현: 2행 중 1행).
+while IFS= read -r line || [ -n "$line" ]; do
+  case "$line" in ''|\#*) continue ;; esac
+  repo=$(printf '%s' "$line" | cut -f1)
+  num=$(printf '%s' "$line" | cut -f2)
+  kind=$(printf '%s' "$line" | cut -f3)
+  needle=$(printf '%s' "$line" | cut -f4)
+  case "$repo" in ''|\#*) continue ;; esac
+  [ -z "$num" ] && continue
+  ROWS=$((ROWS+1))
+  line=$(probe "$repo" "$num" "${kind:-pr}" "${needle:--}")
+  printf '%s\n' "$line" >> "$NEW"
+  key=$(printf '%s' "$line" | cut -f1)
+  if [ -f "$STATE" ]; then
+    old=$(grep -F "$key	" "$STATE" 2>/dev/null | head -1)
+    if [ -n "$old" ] && [ "$old" != "$line" ]; then
+      [ "$CHANGED" = "0" ] && say "" && say "🔔 [listing-watch] **등재 채널 상태가 바뀌었다** — 아무도 안 알려주는 종류다"
+      CHANGED=$((CHANGED+1))
+      say "   $key"
+      say "     이전: $(printf '%s' "$old"  | cut -f2-)"
+      say "     지금: $(printf '%s' "$line" | cut -f2-)"
+    fi
+  fi
+done < "$MANIFEST"
+
+if [ "$ROWS" = "0" ]; then
+  say "  ℹ️  [listing-watch] DISABLED — 매니페스트에 유효한 채널 행이 0개다."
+  rm -f "$NEW"; exit 0
+fi
+
+# 🟥 **FAILED 는 «변화» 가 아니라 «상태» 로 매번 보고한다.** 안 그러면 인증 만료가 첫 실행에
+#    스냅샷으로 굳고, 이후 FAILED==FAILED 라 **영구 무출력**이 된다 — 이 스크립트 헤더가
+#    스스로 금지한 `not_found ≠ 0` 을 스크립트 자신이 저지르고 있었다(cross-family 지목, 재현됨).
+# 🟥 `grep -c ... || echo 0` 을 쓰지 않는다: grep -c 는 무매치에서 **"0" 을 출력하고 exit 1** 이라
+#    폴백이 "0\n0" 을 만들고 `[` 가 «integer expression expected» 로 죽는다(내 수리가 낸 결함).
+#    `[[feedback_pipefail_fallback_disarms_guard]]` 일가 — 값을 먼저 잡고 따로 판정한다.
+NFAIL=$(grep -c '\tFAILED\t' "$NEW" 2>/dev/null)
+case "$NFAIL" in ''|*[!0-9]*) NFAIL=0 ;; esac
+if [ "$NFAIL" -gt 0 ]; then
+  say ""
+  say "  ⚠️  [listing-watch] 채널 $NFAIL 개를 **읽지 못했다**(FAILED) — «변화 없음» 이 아니다."
+  grep '\tFAILED\t' "$NEW" 2>/dev/null | while IFS= read -r l; do say "       $(printf '%s' "$l" | cut -f1)"; done
+  say "       흔한 원인: gh 인증 만료(\`gh auth status\`) · 레포/번호 오타 · 비공개 전환."
+  say "       🟥 이 줄이 안 보일 때까지는 그 채널의 상태를 **모르는 것**이다."
+fi
+
+if [ ! -f "$STATE" ]; then
+  say "  ℹ️  [listing-watch] 최초 실행 — 채널 $ROWS 개 스냅샷을 떴다. 다음 실행부터 «변화»를 낸다."
+elif [ "$CHANGED" -gt 0 ]; then
+  say "   ⚠️  통과는 영구적이지 않다 — 남의 스키마가 바뀌면 과거 제출이 소급 무효가 된다."
+  say "      새로 내기 전에 라벨 이력부터: gh api repos/<r>/issues/<n>/timeline"
+fi
+if ! mv "$NEW" "$STATE" 2>/dev/null; then
+  say "  ⚠️  [listing-watch] 스냅샷 **저장 실패** ($STATE) — 다음 실행이 이번 관측을 못 본다."
+  say "       변화 검출이 이 시점부터 **멈춘 것**이지 «변화 없음» 이 아니다."
+  rm -f "$NEW"
+fi
+exit 0

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -1064,6 +1064,21 @@ else
   fail=1
 fi
 
+# listing_watch — 같은 형태. 🟥 이 블록을 «레인을 짓는 같은 커밋에서» 붙인다: 바로 위 주석이
+# 기록한 「레인은 지었는데 selfcheck 배선을 안 했다」 재발이 최소 세 번이고, 그 셋 다 CI 나
+# lane-runner 가 뒤늦게 잡았다. 순서를 바꾸는 것이 유일한 처방이라 여기서 그렇게 한다.
+if [ ! -f scripts/listing_watch.sh ]; then
+  echo "FAIL  scripts/listing_watch.sh is in package.json files[] but absent — a deleted subject, not a skip"
+  fail=1
+elif [ -f scripts/test_listing_watch_lanes.sh ]; then
+  if ! bash scripts/test_listing_watch_lanes.sh; then
+    fail=1
+  fi
+else
+  echo "FAIL  test_listing_watch_lanes.sh: listing_watch.sh present but its anchor is missing"
+  fail=1
+fi
+
 # residency_admission — 같은 형태. 🟥 그리고 **또 같은 얼굴이었다**: 2026-08-20 에 이 레인을
 # 지으면서 여기 배선을 안 했고, `lane-runner` 가 «돌리는 게 없는 스위트는 산문이다» 로 CI 에서
 # 잡았다. 아래 target_freeze 주석이 기록한 그 형태의 **최소 세 번째**다 — 즉 이건 개인 부주의가

--- a/scripts/test_listing_watch_lanes.sh
+++ b/scripts/test_listing_watch_lanes.sh
@@ -108,5 +108,55 @@ n=$(grep -c . "$SB/tracks/_meta/.listing_watch_state.tsv" 2>/dev/null || echo 0)
 # ── L12: 라벨 개수를 실어 ["a,b"] 와 ["a","b"] 를 가른다 ──
 case "$s9" in *"	"[0-9]*:*) ok "L12 라벨 필드가 «개수:목록» 형태" ;; *) ng "L12" "N:labels" "$s9" ;; esac
 
+# ── L13/L14: 🟥 **반대 플랫폼 흉내** — 이 둘이 이 스위트의 하중선이다.
+#    2026-08-21 실측: 로컬(macOS) 16/16 초록인데 **CI(리눅스)에서 L7·L9 가 죽었다.**
+#    원인 둘 다 «한 플랫폼에서만 나는» 형태였다:
+#      ⓐ `stat -f %m` 은 GNU 에서 **실패가 아니라 성공하며 파일시스템 정보를 뱉는다**
+#         → `||` 폴백이 안 타고 산술식이 깨진다
+#      ⓑ grep 패턴의 `\t` 를 GNU grep 은 **리터럴 t** 로 읽는다 → FAILED 보고가 0건
+#    로컬 초록이 증거가 못 된다는 뜻이므로, **여기서 반대 플랫폼을 스텁으로 만든다.**
+mkstub state
+printf 'walkinglabs/x\t33\tpr\tchrono-meta/forge-harness\n' > "$SB/tracks/_meta/listing_watch_channels.tsv"
+rm -f "$SB/tracks/_meta/.listing_watch_state.tsv"
+
+# L13: `stat -f` 가 «성공하면서 쓰레기» 를 내는 플랫폼(=GNU)에서도 스로틀이 산다
+cat > "$SB/bin/stat" <<'STUB'
+#!/usr/bin/env bash
+# GNU 흉내: -f 는 성공하며 파일시스템 정보(비숫자)를 낸다 · -c %Y 만 mtime
+if [ "$1" = "-f" ]; then echo "  ID: deadbeef Namelen: 255  Type: ext2/ext3"; exit 0; fi
+if [ "$1" = "-c" ]; then echo 1000000000; exit 0; fi
+exit 1
+STUB
+chmod +x "$SB/bin/stat"
+run --force >/dev/null 2>&1            # 스냅샷 생성
+o=$(run 2>&1)                          # --force 없음 → 스로틀이 조용해야
+case "$o" in
+  *"syntax error"*|*"ext2"*) ng "L13 GNU-stat 흉내에서 스로틀 붕괴" "(빈 출력)" "$o" ;;
+  "") ok "L13 GNU-stat 흉내에서도 스로틀 정상 (비숫자 mtime 방어)" ;;
+  *) ng "L13" "(빈 출력)" "$o" ;;
+esac
+rm -f "$SB/bin/stat"
+
+# L14: grep 패턴의 `\t` 를 리터럴 t 로 읽는 플랫폼(=GNU grep)에서도 FAILED 가 보고된다
+#      → 실제 탭을 쓰는지 확인. 스크립트가 `\t` 를 패턴에 쓰면 여기서 죽는다.
+cat > "$SB/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+chmod +x "$SB/bin/gh"
+cat > "$SB/bin/grep" <<'STUB'
+#!/usr/bin/env bash
+# GNU 흉내: 패턴 안의 백슬래시-t 는 «리터럴 t» 다 (탭이 아니다)
+args=(); for a in "$@"; do case "$a" in *'\t'*) a="${a//\\t/t}" ;; esac; args+=("$a"); done
+exec /usr/bin/grep "${args[@]}"
+STUB
+chmod +x "$SB/bin/grep"
+printf 'r/x\t1\tpr\t-\n' > "$SB/tracks/_meta/listing_watch_channels.tsv"
+rm -f "$SB/tracks/_meta/.listing_watch_state.tsv"
+run --force >/dev/null 2>&1
+o=$(run --force 2>&1)
+case "$o" in *"읽지 못했다"*|*FAILED*) ok "L14 GNU-grep 흉내에서도 FAILED 보고 (실제 탭 사용)" ;; *) ng "L14 grep \\t 이식성" "FAILED 보고" "${o:-（무출력）}" ;; esac
+rm -f "$SB/bin/grep"
+
 printf '\nLISTING_WATCH_LANES: %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/test_listing_watch_lanes.sh
+++ b/scripts/test_listing_watch_lanes.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# test_listing_watch_lanes.sh — listing_watch.sh 의 레인.
+# 🟥 네트워크를 안 쓴다: PATH 앞에 `gh` 스텁을 놓아 응답을 고정한다.
+#    (실망 사용 검증은 `--selftest` 가 known-pair 로 따로 한다 — 그건 네트워크가 필요하다)
+HUB="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+SUT="$HUB/scripts/listing_watch.sh"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  ✅ %s\n' "$1"; }
+ng(){ FAIL=$((FAIL+1)); printf '  ❌ %s\n     기대: %s\n     실제: %s\n' "$1" "$2" "$3"; }
+
+SB=$(mktemp -d); trap 'rm -rf "$SB"' EXIT
+mkdir -p "$SB/tracks/_meta" "$SB/bin"
+
+mkstub(){ # $1 = state|merged|badexit
+  cat > "$SB/bin/gh" <<STUB
+#!/usr/bin/env bash
+case "\$*" in
+  *"contents/README.md"*) printf '%s' "\$(printf 'chrono-meta/forge-harness' | base64)" ;;
+  # 🟥 본체 jq 는 4필드다: state|merged|라벨개수|라벨목록. 스텁이 3필드면 계기가 대상과 어긋난다.
+  *"issues/33"*)   [ "$1" = "merged" ] && printf 'open|2026-08-19T06:48:10Z|0|' || printf 'open|null|1|validation-passed' ;;
+  *"issues/999"*)  exit 1 ;;
+  *) exit 1 ;;
+esac
+STUB
+  chmod +x "$SB/bin/gh"
+}
+
+run(){ CLAUDE_PROJECT_DIR="$SB" PATH="$SB/bin:$PATH" bash "$SUT" "$@" 2>&1; }
+
+# ── L1: gh 부재 → SKIPPED (pass 아님) ─────────────────────────────
+printf 'walkinglabs/x\t33\tpr\tchrono-meta/forge-harness\n' > "$SB/tracks/_meta/listing_watch_channels.tsv"
+# 🟥 두 번 틀린 자리다. ① 초판: `PATH=/nonexistent` 가 `bash` 까지 지워 «계기» 를 시험했다.
+#    ② 2판: `/bin:/usr/bin` 은 **호스트 의존**이다 — 리눅스에선 거기 진짜 gh 가 있을 수 있고
+#    그러면 이 레인이 «대상» 이 아니라 «그 머신» 을 재게 된다(cross-family 지목).
+#    ③ 정본: 본체에 주입 seam(`LISTING_WATCH_GH`)을 두고 존재하지 않는 이름을 넣는다.
+o=$(CLAUDE_PROJECT_DIR="$SB" LISTING_WATCH_GH="gh-does-not-exist-$$" bash "$SUT" --force 2>&1); r=$?
+case "$o" in *SKIPPED*) ok "L1 gh 부재 → SKIPPED (not passed)" ;; *) ng "L1" "SKIPPED" "$o" ;; esac
+[ "$r" = "0" ] && ok "L1b gh 부재여도 exit 0 (훅 무음 방지)" || ng "L1b" "0" "$r"
+
+# ── L2: 매니페스트 부재 → DISABLED (실패 아님) ────────────────────
+mkstub state
+mv "$SB/tracks/_meta/listing_watch_channels.tsv" "$SB/m.bak"
+o=$(run --force); case "$o" in *DISABLED*) ok "L2 매니페스트 부재 → DISABLED" ;; *) ng "L2" "DISABLED" "$o" ;; esac
+mv "$SB/m.bak" "$SB/tracks/_meta/listing_watch_channels.tsv"
+
+# ── L3: 주석만 있는 매니페스트 → DISABLED (0행을 «정상»으로 안 읽는다) ──
+cp "$SB/tracks/_meta/listing_watch_channels.tsv" "$SB/m.bak"
+printf '# only a comment\n' > "$SB/tracks/_meta/listing_watch_channels.tsv"
+o=$(run --force); case "$o" in *DISABLED*) ok "L3 유효행 0 → DISABLED" ;; *) ng "L3" "DISABLED" "$o" ;; esac
+cp "$SB/m.bak" "$SB/tracks/_meta/listing_watch_channels.tsv"
+
+# ── L4: 최초 실행 → 스냅샷 생성 + 변화 «없음» ─────────────────────
+rm -f "$SB/tracks/_meta/.listing_watch_state.tsv"
+o=$(run --force)
+case "$o" in *최초*) ok "L4 최초 실행을 «변화» 로 오보하지 않는다" ;; *) ng "L4" "최초 실행 안내" "$o" ;; esac
+[ -s "$SB/tracks/_meta/.listing_watch_state.tsv" ] && ok "L4b 스냅샷 파일 생성" || ng "L4b" "비어있지 않은 스냅샷" "(없음)"
+
+# ── L5: 무변화 → 무출력 (오탐 0) ──────────────────────────────────
+o=$(run --force)
+[ -z "$o" ] && ok "L5 무변화 → 무출력" || ng "L5" "(빈 출력)" "$o"
+
+# ── L6: 상태 전이 → 검출 ★ 이 레인이 본체다 ──────────────────────
+mkstub merged
+o=$(run --force)
+# 🟥 배너 문구만 보면 «라벨만 바뀐 버그» 도 통과한다 — **관측된 전이 자체**를 단언한다.
+case "$o" in *"바뀌었다"*) ok "L6 변화 배너 발화" ;; *) ng "L6" "변화 보고" "$o" ;; esac
+case "$o" in *MERGED*) ok "L6b 전이 «내용»이 MERGED 로 찍힌다" ;; *) ng "L6b" "지금: … MERGED" "$o" ;; esac
+case "$o" in *"이전:"*) ok "L6c 이전 상태도 같이 보여준다" ;; *) ng "L6c" "이전: …" "$o" ;; esac
+
+# ── L7: 스로틀 — 24h 안이면 조용 ──────────────────────────────────
+o=$(run)   # --force 없음
+[ -z "$o" ] && ok "L7 스로틀 동작 (24h 내 재실행 조용)" || ng "L7" "(빈 출력)" "$o"
+
+# ── L8: API 실패를 «없음» 이 아니라 FAILED 로 ─────────────────────
+printf 'walkinglabs/x\t999\tpr\t-\n' > "$SB/tracks/_meta/listing_watch_channels.tsv"
+rm -f "$SB/tracks/_meta/.listing_watch_state.tsv"
+run --force >/dev/null
+s=$(cat "$SB/tracks/_meta/.listing_watch_state.tsv" 2>/dev/null)
+case "$s" in *FAILED*) ok "L8 API 실패 → FAILED (0 으로 안 접는다)" ;; *) ng "L8" "FAILED" "$s" ;; esac
+
+# ── L9: 🟥 FAILED 반복이 «무출력» 이 되면 안 된다 (자기 헤더 배반 방지) ──
+cat > "$SB/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+chmod +x "$SB/bin/gh"
+printf 'r/x\t1\tpr\t-\n' > "$SB/tracks/_meta/listing_watch_channels.tsv"
+rm -f "$SB/tracks/_meta/.listing_watch_state.tsv"
+run --force >/dev/null 2>&1          # 1회차: 스냅샷이 FAILED 로 굳는다
+o=$(run --force)                      # 2회차: 변화는 «없다» — 그래도 말해야 한다
+case "$o" in *FAILED*|*"읽지 못했다"*) ok "L9 FAILED 반복도 매번 보고 (인증만료≠변화없음)" ;; *) ng "L9" "FAILED 보고" "${o:-（무출력）}" ;; esac
+
+# ── L10: 연속 탭(빈 필드)에서 needle 이 밀리지 않는다 ──
+mkstub state
+printf 'walkinglabs/x\t33\t\tchrono-meta/forge-harness\n' > "$SB/tracks/_meta/listing_watch_channels.tsv"
+rm -f "$SB/tracks/_meta/.listing_watch_state.tsv"
+run --force >/dev/null 2>&1
+s9=$(cat "$SB/tracks/_meta/.listing_watch_state.tsv" 2>/dev/null)
+case "$s9" in *LISTED*) ok "L10 빈 필드 있어도 needle 이 제자리 (IFS 탭 축약 방지)" ;; *) ng "L10" "LISTED" "$s9" ;; esac
+
+# ── L11: 개행 없는 마지막 행도 읽는다 ──
+printf 'walkinglabs/x\t33\tpr\tchrono-meta/forge-harness\nwalkinglabs/y\t33\tpr\tchrono-meta/forge-harness' > "$SB/tracks/_meta/listing_watch_channels.tsv"
+rm -f "$SB/tracks/_meta/.listing_watch_state.tsv"
+run --force >/dev/null 2>&1
+n=$(grep -c . "$SB/tracks/_meta/.listing_watch_state.tsv" 2>/dev/null || echo 0)
+[ "$n" = "2" ] && ok "L11 개행 없는 마지막 행 누락 안 함 (2/2)" || ng "L11" "2행" "${n}행"
+
+# ── L12: 라벨 개수를 실어 ["a,b"] 와 ["a","b"] 를 가른다 ──
+case "$s9" in *"	"[0-9]*:*) ok "L12 라벨 필드가 «개수:목록» 형태" ;; *) ng "L12" "N:labels" "$s9" ;; esac
+
+printf '\nLISTING_WATCH_LANES: %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## 왜 — 실측 사건 하나가 근거다

2026-08-19: `awesome-claude-code` **#1961** 이 `2026-06-07 validation-PASSED` 였다가 **`2026-08-15 validation-FAILED` 로 뒤집혔다.** 우리는 그 사이 그 이슈를 안 건드렸다 — **그쪽이 허용 카테고리 목록을 바꾸고** 봇이 기존 이슈를 재검증하면서 떨어진 것이다.

- **아무도 안 알려준다** — 라벨이 바뀌고 봇 코멘트가 하나 붙을 뿐
- 🟥 `validation-failed` 는 *"ready for maintainer review"* 가 **아니다** — 조용히 후보에서 탈락한 상태
- **4일 만에 발견한 건 감시 덕이 아니라 우연이다**(다른 리스트 규약을 읽다 걸렸다)

⇒ **통과는 영구적이지 않고, 알림은 오지 않는다.** 이쪽에서 스냅샷을 떠서 대조한다.

## 무엇

`scripts/listing_watch.sh` — 채널별 `state · labels · 목록 실재 여부`를 스냅샷과 대조해 **변화만** 출력. SessionStart 배선, 24h 스로틀.

**공개/사설 분리가 설계의 핵심**: 스크립트는 `files[]` 로 싣고, **채널 매니페스트는 `tracks/_meta/`(gitignored)** — 운영자의 실제 제출 목록은 사설 정보다. 매니페스트가 없으면 `DISABLED` 로 빠져 **소비자에게 소음 0**. `.public-surface-patterns` 와 같은 형태.

상태 어휘는 **넷**이다: `DISABLED / SKIPPED / FAILED / EXECUTED`. `gh` 부재를 「통과」로 접으면 그게 `not_found ≠ 0` 일가의 재발이다.

## 첫 실사용이 바로 값을 냈다

**VoltAgent #928 에 `PR-in-review` 라벨**이 붙어 있었다 — 「대기열에서 기다리는 중」으로 알고 있던 것이 실제로는 **「리뷰 중」**이었다. 라벨을 안 봤으면 몰랐다.

## 🟥 cross-family 9건 — 3건은 실행으로 재현

초판 마커는 이걸 **「다음 세션 몫」으로 미뤘다. 그게 틀렸다** — 지금 돌릴 수 있는 걸 미루는 형태라 같은 세션에서 돌렸다. codex/gpt-5.5, **9건 적발·전량 반영**.

| | 결함 | 상태 |
|---|---|---|
| ⓐ | `gh` 실패가 **2회차부터 영구 무출력** — 인증 만료가 「변화 없음」으로 읽힌다 | 🟥 **재현** |
| ⓑ | `IFS=$'\t' read` 가 **연속 탭을 합쳐** needle 을 kind 자리로 민다 | 🟥 **재현** |
| ⓒ | **개행 없는 마지막 행이 통째로 누락** (2행 중 1행만 읽힘) | 🟥 **재현** |
| ⓓ~ⓘ | base64 `-d`/`-D` 이식성 + 디코드 실패의 `absent` 접힘 · `grep -F` 옵션 주입 · 라벨 join 손실 · 스냅샷 쓰기 실패 무음 · 레인 L1 호스트 의존 · L6 이 전이 «내용» 미단언 | 판독 수용 |

🟥 **ⓐ 가 가장 나쁘다 — 이 스크립트 헤더가 스스로 «미측정을 0 으로 안 접는다» 고 선언해놓고, 스크립트 자신이 정확히 그걸 저지르고 있었다.**

## 🟥 그리고 그 수리가 결함 둘을 새로 낳았다

- `grep -c … || echo 0` 이 무매치에서 **`"0\n0"`** 을 만들어 `[` 가 죽었다 (grep -c 는 «0 을 **출력하고** exit 1» 한다)
- 본체 jq 를 3→4 필드로 바꿨는데 **레인 스텁이 3필드로 남아** 계기가 대상과 어긋났다

**둘 다 방금 고친 자리에서 났고, 레인이 잡았다.** 「수리가 결함의 주된 출처」의 교과서적 재현이다.

## 앵커

```
레인          16/16  (네트워크 없이 gh 스텁 · L9~L12 가 cross-family 지적 각각에 앵커)
known-pair    양성 walkinglabs#33 → MERGED+LISTED
              음성 없는 번호      → FAILED (상태를 지어내지 않는다)
오탐 컨트롤    무변화 재실행 → 무출력
되돌림 3팔     스냅샷 조작 → «그 채널만» 적색
              레인 파일 제거 → selfcheck fail=1   본체 제거 → fail=1
배선 3곳      SessionStart(로컬) · package.json files[] · selfcheck 블록
```

selfcheck 배선을 **레인 짓는 같은 커밋에서** 했다 — 그 자리 주석이 「레인은 지었는데 배선을 안 했다」 재발을 **최소 세 번** 기록해 놨고, 셋 다 CI 가 뒤늦게 잡았다. 순서를 바꾸는 게 유일한 처방이라 여기서 그렇게 했다.

## 명시 잔여

- **스로틀 24h 는 근거 없는 상수** — #1961 이 4일 창이었으니 충분하다는 **추정이지 측정이 아니다**
- `gh` **인증 만료**와 「진짜 실패」를 안 가른다 (둘 다 `FAILED`)
- 🟥 **매니페스트에 안 적은 채널은 여전히 사각** — 오늘 「채널이 셋인 줄 알았는데 넷이었다」가 정확히 그 형태였다
- 소비자 install 의 `DISABLED` 경로는 **코드로만** 확인, clean install 재현 안 함

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWACdPFUBjshcHjYVwVeq5