### PR TITLE
feat(gate): 파괴적-op 훅이 조용히 망가지는 것을 CI 가 상시 재검증한다

### DIFF
--- a/.github/workflows/destructive-op-anchor.yml
+++ b/.github/workflows/destructive-op-anchor.yml
@@ -1,0 +1,145 @@
+name: Destructive-Op Anchor
+
+# ── WHY THIS WORKFLOW EXISTS ──────────────────────────────────────────────────────────────────
+# CLAUDE.md §Destructive-Op Gate names templates/.git-hooks/pre-push as the MECHANICAL FLOOR for
+# the git-side irreversible surfaces (remote branch delete · force / non-ff push · tag delete).
+# Its known-pair anchors existed but were re-run in only two places, both of which are the
+# author's own machine: the local pre-commit hook (and only when the diff happens to touch the
+# guard files) and `npm test`.
+#
+# Measured 2026-08-22:
+#   • scripts/prepush_guard_check.sh (20 pairs)   — NOT referenced by scripts/selfcheck.sh, so it
+#     never ran in CI. Invoked only by pre-commit, conditionally on the diff touching the hook.
+#   • templates/predelete_check.test.sh (6 lanes) — was executed by NOTHING until the 'Anchor 3/3'
+#     step below. Structurally invisible to scripts/lane_runner_check.sh, whose suite glob is
+#     `scripts/*.sh` matching `test_*|*_lanes`; this file is `templates/*.test.sh` and falls outside
+#     its field of view. That is why the lane-runner reported all-wired while this suite had no
+#     runner at all — the detector is not wrong, its scope is a name convention, and this file is
+#     outside it.
+#     ⚠️ Two self-descriptions in this block were wrong on 2026-08-22 and are corrected here rather
+#     than silently: "executed by NOTHING" became false the moment this workflow added the step (a
+#     present-tense claim about a state the file itself changes), and the wired count read "62/62"
+#     when the lane-runner reports 66 suites / 66 wired. Re-measured, not re-asserted.
+#     🟥 THE ORPHAN CAN RETURN SILENTLY, and the guard for that is NOT here. If this workflow is
+#     deleted, the two `scripts/test_*` anchors below are caught (lane_runner_check.sh globs
+#     .github/workflows/*.yml as a caller surface, and selfcheck.sh runs it inside the required
+#     `validate` check) — but predelete_check.test.sh is not, because nothing can see it. Stage ⑥
+#     of scripts/test_prepush_destructive_liveness.sh asserts it still has a REACHABLE executing
+#     runner. "Reachable" is load-bearing and was added 2026-08-22 R2: the counter scans BOTH
+#     `.github/workflows/*.yml` and `*.yaml` (GitHub executes both, so renaming THIS file would
+#     have read as ORPHANED while CI kept running it) plus package.json scripts, and it discards
+#     text that names the runner but never runs it — a `workflow_dispatch`-only trigger, an
+#     `if: false` step, or (R3) a `push:` key that is not actually inside the `on:` block. Each rule
+#     has its own known pair in ⑥-cal, in BOTH directions.
+#     🟥 SCOPE, STATED SO IT IS NOT READ AS MORE: stage ⑥ is a COMMON-FORM MATCHER over workflow and
+#     script text, not a YAML or shell semantics analyzer, and it does not claim its rejection list
+#     is complete — an R2 comment did claim that and R3 falsified it in one try. What it misses is
+#     enumerated in that file under §NAMED LIMITS (expression-valued `if:`, job-level `if:`,
+#     `needs:`/`workflow_call` indirection, never-matching `paths:` filters, shell dead code). It
+#     folds unrecognised shapes to NOT-reachable, so its errors surface as a loud false ORPHAN
+#     rather than as a silent green. ⑥ guards that the step below still EXISTS; only the step
+#     itself, by running, establishes that the subject actually executes.
+#
+# The failure mode being closed is the one an anchor cannot report about itself: a gate that is
+# silently broken while its anchor still exists. An anchor that only re-runs on the author's
+# machine can tell you the gate was correct once; it cannot tell you it is correct now. The
+# irreversible surfaces are exactly where "once, somewhere else" is not good enough.
+#
+# ── WHY IT RUNS ON EVERY PUSH, NOT ON A paths: FILTER ─────────────────────────────────────────
+# A paths: filter would re-run these anchors only when the guard's own files change — i.e. exactly
+# when the author is already thinking about the guard. The regressions worth catching come from
+# somewhere else: a shared library the hook sources, a helper script it calls, a runner image
+# change. Both prior fail-opens in this hook were authored while repairing something else, and
+# `bash -n` passed on one of them (a `${...}` bad substitution is a RUNTIME fault). So: always.
+# Cheap to do — public repo, three local suites, no network.
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [main]
+
+jobs:
+  destructive-op-anchor:
+    name: Destructive-Op known-pair re-execution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Git identity for throwaway fixture repos
+        run: |
+          # Every suite below builds mktemp repos and commits into them. Each sets its own
+          # per-repo user.email/user.name, but a runner with no global identity makes any missed
+          # spot fail with a confusing "please tell me who you are" that reads like a lane failure.
+          git config --global user.email "ci@example.com"
+          git config --global user.name  "ci"
+          git --version
+
+      - name: Anchors present (fail-closed — an absent anchor is never a pass)
+        run: |
+          # A missing suite is HARNESS_ERROR, not a skip. `not found` is not `0`: rendering an
+          # absent instrument as a clean run is the exact defect these anchors exist to prevent,
+          # and it is the cheapest place for it to reappear.
+          missing=0
+          for f in scripts/test_prepush_destructive_lanes.sh \
+                   scripts/prepush_guard_check.sh \
+                   templates/predelete_check.test.sh \
+                   templates/.git-hooks/pre-push \
+                   templates/predelete_check.sh; do
+            if [ -f "$f" ]; then
+              echo "  present: $f"
+            else
+              echo "::error::HARNESS_ERROR — required anchor or subject missing: $f"
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ]
+
+      - name: 'Anchor 1/3 — pre-push destructive-op verdict (12 known pairs)'
+        run: |
+          # Known pairs for the hook's inline per-ref verdict: force/non-ff, branch delete
+          # REVIEW/CHECK/SAFE, integration-branch PROTECTED, tag delete, unresolvable base, and
+          # the DESTRUCTIVE_OP_OK override + its log. Known-negatives included on purpose: a
+          # blanket-deny gate would pass every positive lane and be useless, and over-blocking
+          # trains the override that disarms the gate.
+          bash scripts/test_prepush_destructive_lanes.sh
+
+      - name: 'Anchor 2/3 — pre-push publish-boundary guards (20 known pairs)'
+        run: |
+          # Sibling surface on the same hook: confidentiality content scan over the commits a push
+          # would publish, main-PR-only, tag/version, stacked-branch advisory. Ran in CI for the
+          # first time here.
+          bash scripts/prepush_guard_check.sh
+
+      - name: 'Anchor 3/3 — predelete_check enumerate tool (6 lanes)'
+        run: |
+          # The operator's enumerate tool from CLAUDE.md's "enumerate → recover → destroy" order.
+          # No hook executes it (CLAUDE.md says so explicitly), which makes it MORE important that
+          # its own regression lanes re-run: nothing else would notice it rotting.
+          bash templates/predelete_check.test.sh
+
+      - name: Anchor liveness control (a green suite must be capable of going red)
+        run: |
+          # 🟥 THE CONTROL. Every anchor above can pass because the gate is healthy — or because
+          # the suite stopped testing anything. Those are byte-identical in a green log, and the
+          # second is how an anchor becomes decorative. This step disables one guard ON A COPY and
+          # requires the suite to go RED on the specific lane that guard backs. If it stays green,
+          # the anchors above certified nothing and this job says so.
+          #
+          # Seven stages. ①–③ are the decorative-anchor probe above; ④–⑦ were added 2026-08-22:
+          #   ④ portability   — the suite still runs on git < 2.28 (no `init -b`), measured with a
+          #                     shim that is itself known-pair calibrated
+          #   ⑤ setup-loudness— an unbuildable fixture aborts with HARNESS_ERROR and scores ZERO
+          #                     lanes. It used to score six, off the real working tree, because
+          #                     `cd ""` is a no-op success in bash
+          #   ⑥ orphan        — templates/predelete_check.test.sh still has a runner matching the
+          #                     reachable-invocation FORM (.yml + .yaml + package.json surfaces;
+          #                     manual-only, `if: false`, and a `push:` outside the `on:` block do
+          #                     not count). 12 known pairs, both directions. A form matcher, not a
+          #                     semantics analyzer — limits enumerated in the script
+          #   ⑦ containment   — a full suite run leaves the real repo byte-identical
+          #                     (status · HEAD · refs · tags · index)
+          #
+          # Kept as a script rather than inline YAML so it also runs LOCALLY, before the push —
+          # CLAUDE.md §Local Execution First: CI confirms, it does not discover.
+          bash scripts/test_prepush_destructive_liveness.sh

--- a/package.json
+++ b/package.json
@@ -164,6 +164,8 @@
     "scripts/test_degrade_scan_shell_probes.sh",
     "scripts/gate_pathspec_check.sh",
     "scripts/prepush_guard_check.sh",
+    "templates/predelete_check.test.sh",
+    "scripts/test_prepush_destructive_lanes.sh",
     "scripts/psa_scan_lib.sh",
     "scripts/test_psa_singlefile_lanes.sh",
     "scripts/session_close_check.sh",

--- a/scripts/package_coverage_check.sh
+++ b/scripts/package_coverage_check.sh
@@ -127,6 +127,40 @@ ACCEPTED_ABSENT=(
   #     「출하된 레인의 **주체**가 출하되나」를 안 본다. 그 갭은 아직 안 닫혔다(명시 잔여).
   "scripts/test_satellite_publish_gate_lanes.sh"
   "scripts/test_satellite_profile_schema_lanes.sh"
+  #   · 2026-08-22, 파괴적-op 앵커 배선이 만든 셋. **같은 선례의 재현이고, 이 검사기가 또 잡았다** —
+  #     `test_prepush_destructive_lanes.sh` 를 files[] 에 넣고 `selfcheck.sh` 의 pair-표에 전체
+  #     경로 두 줄을 쓴 순간, 그 두 파일이 이름 대는 것들이 팬텀이 됐다. 위 블록이 예고한 그대로다.
+  #     ⓐ test_prepush_destructive_liveness.sh — 일부러 안 싣는다. 7단계 중 둘이 **레포-개발 전용
+  #       컨트롤**이라 소비자 install 에서 정직할 수 없다: ⑥ orphan 은 주체
+  #       `templates/predelete_check.test.sh` 가 미출하라 **부재로 FAIL**(옳지 않은 red), ⑦
+  #       containment 는 소비자 트리가 보통 git work tree 가 아니라 **잴 게 없다**. 싣게 하려면
+  #       패키지-모드 라우팅을 그 두 단계에 심어야 하는데 그건 소비자에게 값이 없는 코드다.
+  #     ⓑ 🟥 **철회 — 이 자리에 있던 `test_new_code_anchor_lanes.sh` 항목을 뺐다.** 그 항목이
+  #       필요했던 유일한 이유는 `test_prepush_destructive_lanes.sh` 의 한 주석이 그 파일을 경로로
+  #       인용했기 때문인데, **그 인용이 이번 라운드에 재조준됐다**(추적되는 선례로). 단독 착지
+  #       준비 중 발견 — 안 고쳤으면 **커밋되지 않는 파일을 가리키는 팬텀 참조**를 출하할 뻔했다.
+  #       인용이 사라지면 예외도 사라져야 한다. **소비되지 않는 예외는 다음 진짜 누락을 삼킨다.**
+  #     ⓒ templates/predelete_check.test.sh — 주체 `templates/predelete_check.sh` 는 **출하되는데**
+  #       이 앵커는 안 나간다. 🟥 위 test_chamber_run_lanes 와 **같은 모양의 빚**이고, 클린한 답이
+  #       아니다. 여기 등재하는 이유도 같다: files[] 추가는 소비자-대면 변경이라 false-FAIL 이
+  #       없음을 tarball 모드로 따로 증명해야 하는데, 이 델타는 **배선 델타**다. 카드로 이월.
+  "scripts/test_prepush_destructive_liveness.sh"
+  #     🟥 ⓒ 는 **철회했다 — cross-family R2 지적이 맞았다.** 초판이
+  #       `templates/predelete_check.test.sh` 를 여기 넣고 «위 chamber 건과 같은 빚» 이라고 적었는데,
+  #       그 둘은 같지 않다: chamber 는 «주체가 출하되는데 앵커가 안 나간다» 를 **빚으로 남긴** 것이고,
+  #       여기 등재는 그 빚을 **침묵시킨다**. 이 목록의 뜻은 「출하 안 하는 게 옳다」이지
+  #       「출하해야 하는데 아직 안 했다」가 아니다. 후자를 여기 넣으면 **다음 사람이 같은 누락을
+  #       만나도 이 예외에 걸려 안 보인다** — 지적 원문: *"A future shipped reference to this same
+  #       missing anchor will also be accepted, not surfaced."*
+  #       ⇒ `files[]` 에 실었다. 주체 `templates/predelete_check.sh` 가 이미 출하되므로 소비자는
+  #       자기 enumerate 도구를 검증할 수 있게 되고, 부수로 liveness stage ⑥ 의 오탐(주체 부재로
+  #       ORPHANED)도 닫힌다.
+  #     ⓓ 🟥 **그리고 ⓑ 의 사유를 쓰자 그 사유가 팬텀을 만들었다.** 위 주석이 주체 이름을
+  #       경로로 적는데 **이 파일 자신이 shipped 문서**라, 「안 싣는 이유」를 설명한 행위가
+  #       곧 「shipped 문서가 미출하 경로를 가리킴」이 됐다. 계기가 자기 수리를 잡은 것이고,
+  #       위 블록이 예고한 형태(*전체 경로를 shipped 파일에 쓰면 팬텀이 된다*)의 **3차 재현**이다.
+  #       주체 자신도 같은 사유로 등재한다 — 신규 게이트 둘은 **이 레포 전용**이다(추가 파일을
+  #       이 레포 레인 코퍼스에 대고 판정한다). 소비자 트리엔 판정 대상이 없다.
   "scripts/residency_closure_scan.py"
   "scripts/test_residency_closure_lanes.sh"
   # ── The two settings destinations, surfaced 2026-08-13 by fixing this file's own extractor ────

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -536,6 +536,8 @@ for _pair in \
   "scripts/degrade_probe_capability.sh|scripts/test_capability_entrypoint_shipping.sh" \
   "scripts/chamber_run.sh|scripts/test_chamber_run_lanes.sh" \
   "scripts/destructive_pre_gate.sh|scripts/test_destructive_pre_gate_lanes.sh" \
+  "templates/.git-hooks/pre-push|scripts/test_prepush_destructive_lanes.sh" \
+  "templates/.git-hooks/pre-push|scripts/test_prepush_destructive_liveness.sh" \
   "scripts/env_purity_scan.sh|scripts/test_env_purity_lanes.sh" \
   "scripts/frontier_digest_daily.sh|scripts/test_frontier_digest_retry.sh" \
   "scripts/knowledge_seam_check.sh|scripts/test_knowledge_seam_lanes.sh" \

--- a/scripts/test_prepush_destructive_lanes.sh
+++ b/scripts/test_prepush_destructive_lanes.sh
@@ -1,0 +1,366 @@
+#!/usr/bin/env bash
+# test_prepush_destructive_lanes.sh — known pairs for the pre-push hook's DESTRUCTIVE-OP verdict.
+#
+# ── WHY THIS FILE EXISTS (the hole it closes) ────────────────────────────────────────────────
+# CLAUDE.md §Destructive-Op Gate names `templates/.git-hooks/pre-push` as the MECHANICAL FLOOR for
+# the git-side irreversible surfaces (remote branch delete · force / non-ff push · tag delete), and
+# is explicit that `templates/predelete_check.sh` is the operator's HUMAN enumerate tool which no
+# hook executes. So the floor is the hook's own inline per-ref verdict block (pre-push:595-677 —
+# banner at :595, `BLOCK=0` at :598, file ends :677; re-measured 2026-08-22, the old "600-676"
+# was approximate).
+#
+# Measured 2026-08-22, bookshelf pass before writing a line of this file:
+#   • scripts/test_destructive_pre_gate_lanes.sh anchors scripts/destructive_pre_gate.sh — the
+#     PreToolUse *advisory text-pattern* guard over a proposed command. A DIFFERENT subject.
+#   • scripts/prepush_guard_check.sh anchors the same hook but only its PUBLISH boundary: all 20 of
+#     its pairs are confidentiality / main-PR-only / tag-version. Grepped for delete|force verdict
+#     pairs: ZERO — measured with a known-positive control (the same grep hits 14 times in THIS
+#     file, so the zero is a measurement and not a dead grep).
+#     ⚠️ "13" stood here until 2026-08-22 and was wrong; the count is 20. The `ZERO` half was
+#     re-measured with the control above and survived. A count nobody re-runs decays silently.
+#   • templates/predelete_check.test.sh anchors the enumerate tool, and WAS executed by nothing.
+#     ⚠️ Corrected 2026-08-22 R2: that present-tense claim went stale the same day it was written —
+#     .github/workflows/destructive-op-anchor.yml step 'Anchor 3/3' now runs it, and stage ⑥ of
+#     scripts/test_prepush_destructive_liveness.sh guards that runner. A file describing its own
+#     machine in a tense that no longer holds is [[feedback_rule_misdescribes_its_own_machine]];
+#     it is left visible as a correction rather than quietly overwritten.
+#   ⇒ The inline block that actually blocks a force-push or a branch delete had NO known-pair
+#     anchor anywhere, and therefore never re-ran in CI. An anchor that never re-runs cannot tell
+#     you the gate broke; it tells you it was correct once, on the author's machine.
+#
+# ── DISCIPLINE THIS SUITE INHERITS FROM ITS SIBLING (scripts/prepush_guard_check.sh) ──────────
+#  (a) Run the hook FOR REAL. `bash -n` is not an instrument: a `${...}` bad substitution is a
+#      RUNTIME fault that parses clean, aborts the hook, and still exits 0 — every push allowed.
+#  (b) A runtime fault is checked BEFORE the verdict, else an aborted hook scores as a clean pass.
+#  (c) "It blocked" is NOT "it blocked correctly". A missing dependency also exits non-zero and
+#      would score every BLOCK pair green while the gate was broken. So a block must NAME a
+#      destructive cause; a block for a harness reason is reported as its own distinct failure.
+#  (d) A pass must show its marker line — proof the hook ran far enough to make a claim. A hook
+#      killed by a signal prints no fault text and rc alone would read as a pass.
+#
+# ── 🟥 WHAT THIS SUITE CLAIMS, AND WHAT IT DOES NOT (narrowed 2026-08-22 R3) ──────────────────
+# It claims: on THESE 12 constructed inputs, the hook reached a verdict, the verdict matched the
+# expected direction, and the hook ATTRIBUTED it to the named cause. That is a known-pair anchor.
+# It does NOT claim to be an analyzer of the hook's execution semantics. Two places where this
+# suite, like its liveness control, matches FORM rather than meaning — named rather than implied:
+#   • (a)/(b)'s runtime-fault detector is a fixed vocabulary of bash's own error strings
+#     (bad substitution · unbound variable · syntax error · command not found). A runtime fault
+#     that words itself differently, or one whose message goes to a closed fd, is not recognised
+#     and the lane falls through to the verdict check. Deliberately a vocabulary and not a
+#     `set -e` harness: the failure it guards against (a parse-clean `${...}` fault aborting the
+#     hook while it exits 0) does emit one of these, and every widening of the list adds false
+#     "RUNTIME FAULT" reds on hooks that merely print the word.
+#   • (c)/(d)'s attribution is `grep` over the hook's own output. It establishes that the hook
+#     SAID the cause, not that the code path that said it is the one that decided.
+# Neither is a defect to be repaired by a bigger regex — a regex chasing shell semantics loses at
+# the edges in both directions at once, which is the class that produced the R3 findings. The
+# thing that settles these is the hook running for real against a real destructive ref, which is
+# what each lane below actually does.
+#
+# Runs entirely in mktemp throwaway repos: never touches this repo's index, worktree, or refs.
+# Portability: git + coreutils only. No `stat -f` (BSD-first breaks the Linux runner), no
+# `|| echo 0` pipefail fallbacks (that disarms the very guard being measured).
+#
+# Usage: bash scripts/test_prepush_destructive_lanes.sh   → exit 0 all pairs hold, 1 otherwise.
+set -uo pipefail
+
+# FH_TEST_SUBJECT_ROOT points the suite at a COPY of the tree. It exists for the revert probe
+# ("disable the gate on a copy — does exactly this suite go red?"), which is the only way to tell a
+# live anchor from a decorative one without mutating a shared checkout. It selects WHICH subject is
+# measured; it changes no verdict logic and cannot turn a red lane green.
+REPO_ROOT="${FH_TEST_SUBJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+HOOK_SRC="$REPO_ROOT/templates/.git-hooks/pre-push"
+DEF_SRC="$REPO_ROOT/.claude/rules/.public-surface-patterns.defaults"
+ZERO="0000000000000000000000000000000000000000"
+
+# Fail-closed on a missing subject. A suite that cannot find what it measures reports HARNESS_ERROR
+# and exits non-zero — it never renders "could not measure" as a zero-findings pass.
+if [ ! -f "$HOOK_SRC" ]; then
+  echo "HARNESS_ERROR — pre-push hook not found at $HOOK_SRC (subject absent; NOT a pass)"; exit 1
+fi
+
+# Test the STAGED blob when the hook is staged, same reasoning as the sibling anchor: an anchor that
+# reads the worktree is bypassed by staging a regression and restoring the worktree.
+WORK=$(mktemp -d) || exit 1
+trap 'rm -rf "$WORK"' EXIT
+_status=$(git -C "$REPO_ROOT" -c core.quotePath=false diff --cached --name-status --no-renames 2>/dev/null \
+          | awk -F'\t' '$2 == "templates/.git-hooks/pre-push" { print $1; exit }')
+case "$_status" in
+  D)  echo "❌ FAIL — pre-push is being DELETED from the index — fail-closed."; exit 1 ;;
+  '') cp "$HOOK_SRC" "$WORK/hook" ;;
+  *)  git -C "$REPO_ROOT" show ":templates/.git-hooks/pre-push" > "$WORK/hook" 2>/dev/null \
+        || { echo "❌ FAIL — staged pre-push blob unreadable — fail-closed."; exit 1; } ;;
+esac
+HOOK="$WORK/hook"
+
+PASSED=0; FAILED=0
+
+# ── fixture ──────────────────────────────────────────────────────────────────────────────────
+# A repo with: main, a real `refs/remotes/origin/main` (the hook's default BASE is `origin/main`
+# and an unresolvable base is itself one of the lanes — it must be resolvable everywhere else, or
+# every delete lane would block for the WRONG reason and the suite would be green for nothing).
+newrepo() {
+  local d; d=$(mktemp -d) || return 1
+  mkdir -p "$d/.claude/rules" "$d/templates/.git-hooks" "$d/tracks/_meta" "$d/scripts" || return 1
+  [ -f "$DEF_SRC" ] && cp "$DEF_SRC" "$d/.claude/rules/.public-surface-patterns.defaults"
+  [ -f "$REPO_ROOT/scripts/psa_scan_lib.sh" ] && cp "$REPO_ROOT/scripts/psa_scan_lib.sh" "$d/scripts/psa_scan_lib.sh"
+  printf '.claude/rules/.public-surface-patterns\n' > "$d/.gitignore"
+  cp "$HOOK" "$d/templates/.git-hooks/pre-push" || return 1
+  printf 'base\n' > "$d/a.txt"
+  (
+    cd "$d" || exit 1
+    # `git init -b main` needs git >= 2.28 and is rejected outright by anything older ("unknown
+    # switch `b'", rc 129). scripts/test_stale_clone_guard_lanes.sh:34 already builds its fixture
+    # via symbolic-ref for exactly this reason; this suite did not, so on an older git
+    # it died in SETUP — see the require_repo note below for why that was worse than a red lane.
+    # symbolic-ref also pins the branch name against init.defaultBranch differing per machine
+    # (main on this operator's, master on a stock image) — the fixture's `main` is load-bearing:
+    # the P4 PROTECTED lane and the origin/main base ref both name it.
+    git init -q                                  || exit 1
+    git symbolic-ref HEAD refs/heads/main        || exit 1
+    git config user.email t@example.com          || exit 1
+    git config user.name t                       || exit 1
+    git add -A >/dev/null 2>&1                   || exit 1
+    git commit -qm base >/dev/null 2>&1          || exit 1
+    # Materialise the base ref the hook resolves against.
+    git update-ref refs/remotes/origin/main HEAD || exit 1
+  ) || return 1
+  printf '%s' "$d"
+}
+
+# 🟥 SETUP FAILURE MUST BE LOUD — and until 2026-08-22 it was the opposite of loud.
+# `newrepo` signals failure by returning 1 without echoing, so `R=$(newrepo)` leaves R EMPTY.
+# `cd ""` is a NO-OP SUCCESS in bash (measured: `cd /tmp; cd "" ; pwd` → /tmp; control:
+# `cd /no/such/dir` → rc 1). So every `( cd "$repo" && ... )` in this file silently ran in the
+# CURRENT directory — this repo — and the lanes graded the operator's REAL tree.
+# Measured on a git<2.28 shim, pre-fix: 6 passed / 6 failed, with P7 and P8 scoring **PASS** off
+# the real repo's own hook output. That is the [[feedback_not_found_is_not_zero_family]] shape at
+# its quietest: not a missing measurement rendered as zero, but a FAILED fixture rendered as a
+# green lane, on the irreversible surface this suite exists to guard. The TOTAL==0 dead-instrument
+# control at the bottom cannot see it either — the lanes did run; they ran against the wrong thing.
+require_repo() {   # $1 = candidate repo path, $2 = lane name
+  if [ -z "${1:-}" ] || [ ! -d "$1/.git" ]; then
+    echo "HARNESS_ERROR — fixture repo not built for $2 (setup failed; NOT a pass)"
+    echo "   path='${1:-}' — an empty path makes \`cd\` a no-op, so this lane would have graded"
+    echo "   the REAL working tree instead of a throwaway fixture. Aborting rather than scoring."
+    exit 1
+  fi
+}
+
+# check <name> <repo> <expect: block|pass> <cause-regex> <refline...>
+#   cause-regex — what the verdict must be ATTRIBUTED to. For a block, the hook must name this
+#   destructive cause; for a pass, this marker must appear. Both directions require the hook to
+#   have reached the point of making a claim, so neither can be satisfied by an abort.
+check() {
+  local name="$1" repo="$2" expect="$3" cause="$4"; shift 4
+  local out rc got
+  require_repo "$repo" "$name"   # fail-closed: never grade a lane whose fixture did not build
+  out=$(printf '%s\n' "$@" | ( cd "$repo" && bash templates/.git-hooks/pre-push origin git@example:x/y.git 2>&1 )); rc=$?
+
+  # (b) runtime fault first — an aborted hook is not a hook that passed.
+  if printf '%s' "$out" | grep -qiE 'bad substitution|unbound variable|syntax error|command not found'; then
+    echo "  ❌ $name — RUNTIME FAULT in the hook (aborted, not passed)"
+    printf '%s\n' "$out" | grep -iE 'bad substitution|unbound|syntax error|command not found' | sed 's/^/       /' | head -3
+    FAILED=$((FAILED+1)); return
+  fi
+
+  if [ "$rc" -ne 0 ]; then
+    # (c) blocked — but was it blocked for a DESTRUCTIVE reason? A harness error also exits 1.
+    if printf '%s' "$out" | grep -qE 'FH Destructive-Op Gate'; then
+      got=block
+    else
+      echo "  ❌ $name — blocked, but NOT by the Destructive-Op gate (harness reason ≠ finding)"
+      printf '%s\n' "$out" | sed 's/^/       | /' | head -8
+      FAILED=$((FAILED+1)); return
+    fi
+  else
+    got=pass
+  fi
+
+  if [ "$got" != "$expect" ]; then
+    echo "  ❌ $name — expected $expect, got $got"
+    printf '%s\n' "$out" | sed 's/^/       | /' | head -10
+    FAILED=$((FAILED+1)); return
+  fi
+
+  # (d) the verdict must be attributed — for BOTH directions.
+  if ! printf '%s' "$out" | grep -qE "$cause"; then
+    echo "  ❌ $name — verdict $got is correct but UNATTRIBUTED (missing: $cause)"
+    printf '%s\n' "$out" | sed 's/^/       | /' | head -10
+    FAILED=$((FAILED+1)); return
+  fi
+
+  echo "  ✅ $name (expected $expect)"
+  PASSED=$((PASSED+1))
+}
+
+echo "[prepush-destructive] known-pair anchor for the pre-push destructive-op verdict"
+echo ""
+echo "── KNOWN-NEGATIVE (must PASS — over-blocking trains the override that disarms the gate) ──"
+
+# N1 — ordinary fast-forward push of a feature branch. Nothing destructive.
+#      Marker: the hook must reach the publish check, proving it ran past classification.
+R=$(newrepo)
+require_repo "$R" "N1"
+B=$(cd "$R" && git rev-parse HEAD)
+( cd "$R" && printf 'x\n' >> a.txt && git commit -qam ff >/dev/null )
+check "N1 ordinary fast-forward push        → PASS " "$R" pass 'FH Pre-Publish' \
+      "refs/heads/feat $(cd "$R" && git rev-parse HEAD) refs/heads/feat $B"
+rm -rf "$R"
+
+# N2 — deleting a FULLY MERGED branch. The enumerate is load-bearing: nothing unique is lost,
+#      so the gate must allow it. This is the lane that proves the gate is not a blanket deny.
+R=$(newrepo)
+require_repo "$R" "N2"
+( cd "$R" && git branch merged-branch ) >/dev/null 2>&1
+TIP=$(cd "$R" && git rev-parse merged-branch)
+check "N2 delete FULLY-MERGED branch        → PASS " "$R" pass 'SAFE: fully merged' \
+      "(delete) $ZERO refs/heads/merged-branch $TIP"
+rm -rf "$R"
+
+echo ""
+echo "── KNOWN-POSITIVE (must BLOCK — and be attributed to the right destructive cause) ──"
+
+# P1 — force / non-fast-forward push (history rewrite). Always blocks: a rewrite loses commits.
+R=$(newrepo)
+require_repo "$R" "P1"
+B=$(cd "$R" && git rev-parse HEAD)
+( cd "$R" && printf 'x\n' >> a.txt && git commit -qam one >/dev/null \
+   && git checkout -q --detach "$B" && printf 'y\n' >> a.txt && git commit -qam divergent >/dev/null )
+check "P1 FORCE / non-ff push               → BLOCK" "$R" block 'FORCE / non-fast-forward' \
+      "refs/heads/feat $(cd "$R" && git rev-parse HEAD) refs/heads/feat $(cd "$R" && git rev-parse main)"
+rm -rf "$R"
+
+# P2 — delete a branch carrying UNIQUE PATHS → REVIEW. Recovery is mandatory before deleting.
+R=$(newrepo)
+require_repo "$R" "P2"
+( cd "$R" && git checkout -q -b unique-work && printf 'only here\n' > unique.txt \
+   && git add unique.txt && git commit -qm unique >/dev/null && git checkout -q main )
+TIP=$(cd "$R" && git rev-parse unique-work)
+check "P2 delete branch w/ UNIQUE PATHS     → BLOCK" "$R" block 'REVIEW: .* unique path' \
+      "(delete) $ZERO refs/heads/unique-work $TIP"
+rm -rf "$R"
+
+# P3 — delete a branch with commits off base but ZERO unique paths → CHECK. This is the SILENT
+#      loss class: a shared file (an unmerged session card) may hold NEWER content. A gate that
+#      only looked at unique paths would auto-SAFE this one.
+R=$(newrepo)
+require_repo "$R" "P3"
+( cd "$R" && git checkout -q -b newer-content && printf 'newer\n' >> a.txt \
+   && git commit -qam newer >/dev/null && git checkout -q main )
+TIP=$(cd "$R" && git rev-parse newer-content)
+check "P3 delete branch, 0 uniq but NEWER   → BLOCK" "$R" block 'CHECK: .* commit' \
+      "(delete) $ZERO refs/heads/newer-content $TIP"
+rm -rf "$R"
+
+# P4 — delete the INTEGRATION branch. Trivially "merged into itself" (n=0, uniq=0), so without an
+#      explicit guard it would auto-pass the SAFE branch. The most dangerous auto-pass in the block.
+R=$(newrepo)
+require_repo "$R" "P4"
+TIP=$(cd "$R" && git rev-parse main)
+check "P4 delete INTEGRATION branch (main)  → BLOCK" "$R" block 'PROTECTED' \
+      "(delete) $ZERO refs/heads/main $TIP"
+rm -rf "$R"
+
+# P5 — delete a TAG. predelete_check walks branches only, so tags have no unique-path verdict; a
+#      release tag is an external anchor and deleting it is irreversible for consumers.
+R=$(newrepo)
+require_repo "$R" "P5"
+( cd "$R" && git tag v9.9.9 ) >/dev/null 2>&1
+TIP=$(cd "$R" && git rev-parse v9.9.9)
+check "P5 delete TAG (non-branch ref)       → BLOCK" "$R" block 'DELETE \(non-branch ref\)' \
+      "(delete) $ZERO refs/tags/v9.9.9 $TIP"
+rm -rf "$R"
+
+# P6 — remote tip not fetched. An unfetched tip makes a force indistinguishable from a
+#      fast-forward, so "cannot decide" must never render as "allowed".
+#
+#      🟥 MEASURED WHILE WRITING THIS SUITE — the destructive block's `CANNOT CLASSIFY` branch is
+#      SHADOWED on the default path. The same condition (remote_sha absent locally) also makes the
+#      push RANGE unreadable, and the confidentiality guard fail-closes at pre-push:357 — before
+#      classification at :598 ever runs. The first draft of this lane asserted the destructive
+#      cause, went red, and the honest diagnosis was that the lane's expectation was wrong, not
+#      the hook. Two lanes now, because they assert different things:
+#        P6a — the SAFETY property on the path a real push takes: it fail-closes. Whichever guard
+#              wins, the push does not proceed. This is what protects the operator.
+#        P6b — the destructive branch itself, reached by unshadowing the earlier guard with
+#              PUBLIC_SURFACE_OK=1. Without this lane that code path is UNMEASURED, and an
+#              unmeasured branch is where a silent regression lives.
+#      Named residual, not closed here: on the default path :609's CANNOT CLASSIFY line is
+#      unreachable. Both guards fail closed so this is not a safety hole — it is a decorative
+#      line, and it is recorded rather than deleted because deleting it is a hook change and this
+#      file is an anchor, not a repair.
+R=$(newrepo)
+require_repo "$R" "P6"
+( cd "$R" && printf 'x\n' >> a.txt && git commit -qam ff >/dev/null )
+FAKE=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+# Asserted directly, NOT through check(): check() requires a block to be attributed to the
+# destructive gate, and here a DIFFERENT guard legitimately wins. Reusing check() would either
+# fail a correct behaviour or force the attribution test to be loosened for every other lane —
+# and that test is what stops a harness error from scoring as a finding.
+out=$(printf 'refs/heads/feat %s refs/heads/feat %s\n' "$(cd "$R" && git rev-parse HEAD)" "$FAKE" \
+      | ( cd "$R" && bash templates/.git-hooks/pre-push origin git@example:x/y.git 2>&1 )); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qF 'unread history is not a clean one'; then
+  echo "  ✅ P6a remote tip NOT FETCHED → BLOCK, fail-closed (push-range guard wins; see note)"
+  PASSED=$((PASSED+1))
+else
+  echo "  ❌ P6a remote tip NOT FETCHED — expected a fail-closed block, rc=$rc"
+  printf '%s\n' "$out" | sed 's/^/       | /' | head -8; FAILED=$((FAILED+1))
+fi
+
+out=$(printf 'refs/heads/feat %s refs/heads/feat %s\n' "$(cd "$R" && git rev-parse HEAD)" "$FAKE" \
+      | ( cd "$R" && PUBLIC_SURFACE_OK=1 bash templates/.git-hooks/pre-push origin git@example:x/y.git 2>&1 )); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qF 'CANNOT CLASSIFY (remote tip not fetched)'; then
+  echo "  ✅ P6b CANNOT CLASSIFY branch (unshadowed) → BLOCK (expected block)"; PASSED=$((PASSED+1))
+else
+  echo "  ❌ P6b CANNOT CLASSIFY branch (unshadowed) — expected an attributed block, rc=$rc"
+  printf '%s\n' "$out" | sed 's/^/       | /' | head -8; FAILED=$((FAILED+1))
+fi
+rm -rf "$R"
+
+# P7 — base ref unresolvable → ALL branch deletes blocked. Same fail-closed direction as P6, on a
+#      different input: the gate cannot verify SAFE, so it must not grant SAFE.
+R=$(newrepo)
+require_repo "$R" "P7"
+( cd "$R" && git branch merged-branch && git update-ref -d refs/remotes/origin/main ) >/dev/null 2>&1
+TIP=$(cd "$R" && git rev-parse merged-branch)
+check "P7 base ref UNRESOLVABLE             → BLOCK" "$R" block "unresolvable" \
+      "(delete) $ZERO refs/heads/merged-branch $TIP"
+rm -rf "$R"
+
+echo ""
+echo "── OVERRIDE CHANNEL (explicit + logged — the only sanctioned way past a real block) ──"
+
+# P8 — DESTRUCTIVE_OP_OK=1 converts P2's REVIEW block into an allow, AND must leave a record.
+#      Two assertions, because an override that proceeds without logging is an UNRECORDED
+#      irreversible act — the override channel's whole value is the audit trail it leaves.
+R=$(newrepo)
+require_repo "$R" "P8"
+( cd "$R" && git checkout -q -b unique-work && printf 'only here\n' > unique.txt \
+   && git add unique.txt && git commit -qm unique >/dev/null && git checkout -q main )
+TIP=$(cd "$R" && git rev-parse unique-work)
+out=$(printf '%s\n' "(delete) $ZERO refs/heads/unique-work $TIP" \
+      | ( cd "$R" && DESTRUCTIVE_OP_OK=1 bash templates/.git-hooks/pre-push origin git@example:x/y.git 2>&1 )); rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -qF 'allowed by DESTRUCTIVE_OP_OK=1'; then
+  echo "  ✅ P8 DESTRUCTIVE_OP_OK=1 overrides REVIEW  → PASS (expected pass)"; PASSED=$((PASSED+1))
+else
+  echo "  ❌ P8 DESTRUCTIVE_OP_OK=1 overrides REVIEW — expected allow, rc=$rc"
+  printf '%s\n' "$out" | sed 's/^/       | /' | head -8; FAILED=$((FAILED+1))
+fi
+if [ -s "$R/tracks/_meta/.destructive_op_override_log" ]; then
+  echo "  ✅ P8b override was LOGGED (unrecorded override would defeat the channel)"; PASSED=$((PASSED+1))
+else
+  echo "  ❌ P8b override proceeded but wrote NO log entry"; FAILED=$((FAILED+1))
+fi
+rm -rf "$R"
+
+echo ""
+# Dead-instrument control. If the suite somehow ran zero pairs, that is HARNESS_ERROR — never a
+# pass. `all/any/count==0` all read clean on an empty set; this is the explicit empty-input answer.
+TOTAL=$((PASSED+FAILED))
+if [ "$TOTAL" -eq 0 ]; then
+  echo "HARNESS_ERROR — prepush-destructive 캘리브레이션: 0 pairs executed (dead instrument, NOT a pass)"
+  exit 1
+fi
+echo "prepush-destructive 캘리브레이션: $PASSED passed, $FAILED failed ($TOTAL pairs)"
+[ "$FAILED" -eq 0 ]

--- a/scripts/test_prepush_destructive_liveness.sh
+++ b/scripts/test_prepush_destructive_liveness.sh
@@ -1,0 +1,636 @@
+#!/usr/bin/env bash
+# test_prepush_destructive_liveness.sh — the CONTROL for scripts/test_prepush_destructive_lanes.sh.
+#
+# ── WHAT THIS ANSWERS THAT THE SUITE CANNOT ANSWER ABOUT ITSELF ──────────────────────────────
+# A green lane suite has two possible causes: the gate is healthy, or the suite stopped testing
+# anything. In a log those are byte-identical, and the second is how an anchor becomes decorative
+# (CLAUDE.md / [[feedback_anchor_can_be_decorative]]: "되돌려도 초록"). Presence of a control is
+# not discrimination — the question is whether the suite is CAPABLE of going red, and the only way
+# to know is to break the gate on purpose and watch.
+#
+# So: disable one guard ON A COPY, re-run the suite against that copy, and require it to go red on
+# the SPECIFIC lane that guard backs. Red-for-any-reason is not enough — a suite that dies from a
+# missing dependency is also non-zero and would satisfy a bare exit-code check while proving
+# nothing ([[feedback_gate_verification_must_execute]]: "막혔다"≠"옳게 막혔다").
+#
+# ── WHY A COPY ───────────────────────────────────────────────────────────────────────────────
+# The real tree is never touched. This repo is a SHARED CHECKOUT (CLAUDE.md §병렬세션): mutating a
+# tracked file here, even with an intended restore, puts another session's worktree at risk and can
+# be swallowed into someone else's commit. Copy-mutate-discard has no restore step to forget.
+#
+# Seven stages, in order, each of which can fail the probe on its own:
+#   ① APPLY  — verify the mutation actually landed (an unapplied mutation makes "still green" mean
+#              nothing, which is the failure mode this whole file exists to name)
+#   ② RUN    — the suite must exit non-zero AND name the expected lane
+#   ③ DISCARD— drop the copy
+#   ④ PORTABILITY  — the suite must still be GREEN under a git that has no `init -b` (< 2.28)
+#   ⑤ SETUP-LOUDNESS — when the fixture cannot be built at all, the suite must abort with
+#              HARNESS_ERROR and score ZERO lanes, never grade the real tree
+#   ⑥ ORPHAN   — templates/predelete_check.test.sh still has a REACHABLE executing runner (no other
+#              detector can see that file — it is outside lane_runner_check.sh's glob). The counter
+#              carries its own known pairs (⑥-cal): one per surface (.yml · .yaml · package.json)
+#              and one per reachability rule (manual-only trigger · `if: false` · comment-only ·
+#              `on:`-scope). 🟥 It is a COMMON-FORM MATCHER, not a YAML/shell semantics analyzer —
+#              what it does and does not catch is enumerated at §NAMED LIMITS above count_execs,
+#              and unrecognised shapes fold to NOT-reachable (the loud direction) on purpose
+#   ⑦ CONTAINMENT — running the suite leaves the REAL repository byte-identical
+#
+# ④–⑦ were added 2026-08-22 as the regression anchors for that day's repairs, and they live here
+# rather than in the suite because each is a question ABOUT the suite ("is it still runnable · is
+# it honest when it cannot run · is its subject still wired · does it stay inside its sandbox")
+# which a suite cannot ask about itself.
+#
+# Portability, stated because the suite it controls claims "git + coreutils only" and this file does
+# NOT: stage ① uses `python3` for the mutation (already a de-facto dependency here —
+# scripts/selfcheck.sh, scripts/lane_runner_check.sh and scripts/residency_closure_scan.py all need
+# it; re-grounded 2026-08-22 R3 against TRACKED files only, because the first draft cited a sibling
+# script from an unlanded branch and would have shipped a phantom reference) and stage ⑦'s diff uses bash
+# process substitution. Named rather than assumed; if python3 is absent, stage ① fails LOUDLY
+# ("LIVENESS PROBE INVALID") and never reports "still green".
+#
+# Usage: bash scripts/test_prepush_destructive_liveness.sh   → exit 0 anchor is live, 1 otherwise.
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+HOOK="$REPO_ROOT/templates/.git-hooks/pre-push"
+SUITE="$REPO_ROOT/scripts/test_prepush_destructive_lanes.sh"
+
+for f in "$HOOK" "$SUITE"; do
+  [ -f "$f" ] || { echo "HARNESS_ERROR — missing: $f (absent instrument is NOT a pass)"; exit 1; }
+done
+
+# ── CONTAINMENT BASELINE — taken BEFORE any suite is run (see stage ⑦ for why the position is the
+# check). Every invocation this probe makes is inside the window it covers.
+git_state() {   # $1 = root to snapshot (default: the real repo)
+  local r="${1:-$REPO_ROOT}"
+  git -C "$r" status --porcelain 2>&1
+  echo "--HEAD--";     git -C "$r" rev-parse HEAD 2>&1
+  echo "--SYMREF--";   git -C "$r" symbolic-ref -q HEAD 2>&1
+  echo "--BRANCHES--"; git -C "$r" for-each-ref --format='%(refname) %(objectname)' refs/heads 2>&1
+  echo "--TAGS--";     git -C "$r" for-each-ref --format='%(refname) %(objectname)' refs/tags 2>&1
+  echo "--STAGED--";   git -C "$r" diff --cached --name-status 2>&1
+}
+# Not a git work tree (an unpacked tarball, a consumer's node_modules) → stage ⑦ has nothing to
+# compare and every snapshot would be the same error text: equal, green, and meaningless. Say so
+# rather than banking a vacuous pass — `not found` is not `0`.
+CONTAINMENT=on
+git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 || CONTAINMENT=skip
+_before=$(git_state)
+# Known-positive control for the COMPARATOR: an empty or constant snapshot would match anything and
+# make stage ⑦ green by construction. Presence of a control is not discrimination unless it can fail.
+if [ "$CONTAINMENT" = "on" ]; then
+if [ -z "$_before" ] || [ "$_before" = "$(printf -- '--HEAD--\n--SYMREF--\n--BRANCHES--\n--TAGS--\n--STAGED--')" ]; then
+  echo "❌ CONTAINMENT CONTROL INVALID — git-state snapshot is empty/degenerate; it would match anything."
+  exit 1
+fi
+  # 🟥 THE DISCRIMINATION HALF, and the first version of it was a TAUTOLOGY (found 2026-08-22 R2).
+  # It read `[ "$_before" = "${_before}"$'\n'"?? planted_control_entry" ]` — a string compared to
+  # ITSELF PLUS A SUFFIX. That is false for every possible input (proved: 1000 random strings, 0
+  # fires; control: an ordinary equality test does fire), so the branch was unreachable and the
+  # "comparator can distinguish two states" claim was never actually measured. A control that
+  # cannot fail is decorative, which is the exact defect this whole file exists to name
+  # ([[feedback_anchor_can_be_decorative]] · [[feedback_control_presence_is_not_discrimination]]).
+  #
+  # The replacement is a genuine known pair: snapshot a DIFFERENT repository and require the two
+  # snapshots to differ. If git_state ever degrades into a constant (a hardcoded root, a swallowed
+  # error path), this fires. Building the probe repo is itself fail-closed — an unbuildable control
+  # is HARNESS_ERROR, never a silent skip.
+  _cmpdir=$(mktemp -d) || { echo "❌ CONTAINMENT CONTROL — cannot mktemp; NOT a pass"; exit 1; }
+  if ! git -C "$_cmpdir" init -q >/dev/null 2>&1; then
+    rm -rf "$_cmpdir"
+    echo "❌ CONTAINMENT CONTROL — could not build the comparison repo; discrimination UNPROVEN (not a pass)"
+    exit 1
+  fi
+  _othersnap=$(git_state "$_cmpdir")
+  rm -rf "$_cmpdir"
+  if [ "$_before" = "$_othersnap" ]; then
+    echo "❌ CONTAINMENT CONTROL INVALID — two DIFFERENT repositories produce the same snapshot."
+    echo "   git_state is returning a constant, so stage ⑦ would be green by construction."
+    exit 1
+  fi
+fi
+
+# The guard being disabled, and the lane that backs it. Kept as a pair on purpose: a probe that
+# mutates one thing and asserts another is a probe that cannot fail honestly.
+GUARD_LINE='if [ "$r" = "refs/heads/${BASE_BRANCH}" ] || [ "$r" = "refs/heads/master" ] || [ "$r" = "refs/heads/main" ]; then'
+EXPECT_LANE='P4 delete INTEGRATION branch'
+
+C=$(mktemp -d) || exit 1
+trap 'rm -rf "$C"' EXIT   # ③ DISCARD — unconditional, including on an early exit
+mkdir -p "$C/templates/.git-hooks" "$C/.claude/rules" "$C/scripts"
+cp "$HOOK" "$C/templates/.git-hooks/pre-push"
+[ -f "$REPO_ROOT/.claude/rules/.public-surface-patterns.defaults" ] \
+  && cp "$REPO_ROOT/.claude/rules/.public-surface-patterns.defaults" "$C/.claude/rules/"
+[ -f "$REPO_ROOT/scripts/psa_scan_lib.sh" ] && cp "$REPO_ROOT/scripts/psa_scan_lib.sh" "$C/scripts/"
+
+# ── ① APPLY ──────────────────────────────────────────────────────────────────────────────────
+# Disabling the integration-branch PROTECTED check makes deleting `main` trivially "merged into
+# itself" (n=0, uniq=0), so it auto-passes the SAFE branch. A FAIL-OPEN — the direction that
+# matters, and the most dangerous auto-pass in the block.
+GUARD_LINE="$GUARD_LINE" python3 - "$C/templates/.git-hooks/pre-push" <<'PY'
+import os, sys
+path = sys.argv[1]
+src = open(path).read()
+old = os.environ['GUARD_LINE']
+if old not in src:
+    sys.stderr.write("mutation target not found — the guard was reworded\n")
+    sys.exit(3)
+open(path, 'w').write(src.replace(old, 'if false; then', 1))
+PY
+mrc=$?
+
+if [ "$mrc" -ne 0 ]; then
+  echo "❌ LIVENESS PROBE INVALID — could not apply the mutation (rc=$mrc)."
+  echo "   The PROTECTED guard in templates/.git-hooks/pre-push was reworded."
+  echo "   Re-point GUARD_LINE in this file at the current wording. Do NOT delete this probe:"
+  echo "   a probe that cannot apply its mutation must fail loudly, never report 'still green'."
+  exit 1
+fi
+if cmp -s "$HOOK" "$C/templates/.git-hooks/pre-push"; then
+  echo "❌ LIVENESS PROBE INVALID — the copy is byte-identical after mutation."
+  exit 1
+fi
+echo "① mutation applied to the copy (PROTECTED guard disabled); real tree untouched"
+
+# ── ② RUN ────────────────────────────────────────────────────────────────────────────────────
+out=$(FH_TEST_SUBJECT_ROOT="$C" bash "$SUITE" 2>&1); rc=$?
+
+if [ "$rc" -eq 0 ]; then
+  echo "❌ DECORATIVE ANCHOR — the gate was disabled and the suite still PASSED."
+  echo "   Every green run of test_prepush_destructive_lanes.sh certifies nothing."
+  printf '%s\n' "$out" | sed 's/^/   | /'
+  exit 1
+fi
+if ! printf '%s' "$out" | grep -qF "$EXPECT_LANE"; then
+  echo "❌ Suite went red, but NOT on the expected lane ($EXPECT_LANE)."
+  echo "   It failed for an unrelated reason, so liveness is UNPROVEN — not established, not refuted."
+  printf '%s\n' "$out" | sed 's/^/   | /'
+  exit 1
+fi
+
+# Precision: disabling ONE guard should redden ONE lane. A mutation that reddens many means the
+# lanes are entangled and none of them isolates what it claims to.
+reds=$(printf '%s\n' "$out" | grep -c '❌')
+echo "② suite went red on cue — reddened lanes: $reds"
+printf '%s\n' "$out" | grep -E '❌|캘리브레이션' | sed 's/^/   /'
+if [ "$reds" -ne 1 ]; then
+  echo "⚠️  expected exactly 1 reddened lane, got $reds — lanes may not be isolating what they name."
+  exit 1
+fi
+
+echo ""
+
+# ── ④ PORTABILITY CONTROL ────────────────────────────────────────────────────────────────────
+# Regression anchor for the 2026-08-22 `git init -b main` repair. `-b` needs git >= 2.28; anything
+# older rejects it outright ("unknown switch `b'", rc 129) and the fixture never gets built. The
+# runner image and the operator's macOS both ship a new git, so NOTHING here would notice the
+# reintroduction — which is precisely why it survived review the first time.
+#
+# The shim is a targeted reproduction, not a whole old git: it removes the ONE switch whose absence
+# defines git < 2.28 and passes everything else through. Named scope: it does not reproduce other
+# 2.28-era differences, and `git --version` still reports the real version.
+#
+# 🟥 WHAT THAT UNMEASURED SCOPE DOES AND DOES NOT AFFECT (adjudicated 2026-08-22 R2, because an
+# unqualified "partial reproduction" reads as "the repair might be wrong", and it is not):
+#   • It does NOT affect the repair's justification. The repair swapped `git init -b main` for
+#     `git init` + `git symbolic-ref HEAD refs/heads/main`. Its correctness needs only that the
+#     replacement predates 2.28 — `symbolic-ref` and `update-ref` are 1.x-era plumbing — and that
+#     `-b` is genuinely the breaking switch, which the shim's own known pair measures directly.
+#   • It DOES bound what stage ④ can claim. ④ proves "no dependency on `init -b`", not "runs on
+#     git 2.27". Enumerated rather than assumed: every git call in the lanes suite is
+#     add · branch · checkout (incl. --detach, 1.7.5) · commit · config · init -q · rev-parse
+#     (incl. --show-toplevel, 1.7.x) · symbolic-ref · tag · update-ref — all pre-2.28, so the
+#     residual is a coverage limit on the CONTROL, not an open question about the SUBJECT.
+#   • Closing it properly needs a real old git (a container with 2.27), which is a CI decision, not
+#     something a shim can fake. Recorded as a named limit; not claimed closed.
+SHIM=$(mktemp -d) || exit 1
+trap 'rm -rf "$C" "$SHIM"' EXIT
+REALGIT=$(command -v git) || { echo "HARNESS_ERROR — no git on PATH"; exit 1; }
+cat > "$SHIM/git" <<EOF
+#!/bin/bash
+if [ "\${1:-}" = "init" ]; then
+  for a in "\$@"; do
+    case "\$a" in
+      -b|--initial-branch|--initial-branch=*)
+        echo "error: unknown switch \\\`b'" >&2; exit 129 ;;
+    esac
+  done
+fi
+exec "$REALGIT" "\$@"
+EOF
+chmod +x "$SHIM/git"
+
+# Known pair for the SHIM ITSELF. A shim that silently stopped intercepting would make stage ④ a
+# guaranteed green that measures nothing — the decorative-anchor failure, one level down.
+_kn=$(mktemp -d); ( cd "$_kn" && PATH="$SHIM:$PATH" git init -q . ) >/dev/null 2>&1; _knrc=$?
+_kp=$(mktemp -d); ( cd "$_kp" && PATH="$SHIM:$PATH" git init -q -b main . ) >/dev/null 2>&1; _kprc=$?
+rm -rf "$_kn" "$_kp"
+if [ "$_knrc" -ne 0 ] || [ "$_kprc" -eq 0 ]; then
+  echo "❌ PORTABILITY CONTROL INVALID — shim does not discriminate"
+  echo "   known-negative (plain \`git init\`) rc=$_knrc (want 0); known-positive (\`init -b\`) rc=$_kprc (want ≠0)"
+  exit 1
+fi
+
+pout=$(PATH="$SHIM:$PATH" bash "$SUITE" 2>&1); prc=$?
+if [ "$prc" -ne 0 ]; then
+  echo "❌ PORTABILITY REGRESSION — the suite does not run on git < 2.28 (rc=$prc)."
+  echo "   Build fixtures with \`git init\` + \`git symbolic-ref HEAD refs/heads/main\`, never \`init -b\`."
+  printf '%s\n' "$pout" | grep -E '❌|HARNESS_ERROR|unknown switch|캘리브레이션' | sed 's/^/   | /' | head -10
+  exit 1
+fi
+echo "④ portability: suite is GREEN under a git with no \`init -b\` — $(printf '%s' "$pout" | grep -c '✅') lanes"
+
+# ── ⑤ SETUP-LOUDNESS CONTROL ─────────────────────────────────────────────────────────────────
+# Regression anchor for the 2026-08-22 fail-open repair. `cd ""` is a NO-OP SUCCESS in bash, so a
+# fixture that failed to build left an empty path that redirected every lane into the CURRENT
+# directory — the real shared checkout. Measured pre-fix: 6 lanes scored ✅ off the operator's own
+# tree, and the run created branches, a tag and an index entry there.
+#
+# The assertion is deliberately THREE-part. rc≠0 alone is not enough: the pre-fix suite ALSO
+# exited 1 (some lanes failed). What distinguishes honest from fail-open is that zero lanes were
+# scored and the abort is named. ([[feedback_gate_verification_must_execute]]: "막혔다"≠"옳게 막혔다".)
+DEAD=$(mktemp -d) || exit 1
+trap 'rm -rf "$C" "$SHIM" "$DEAD"' EXIT
+cat > "$DEAD/git" <<EOF
+#!/bin/bash
+if [ "\${1:-}" = "init" ]; then echo "fatal: simulated init failure" >&2; exit 1; fi
+exec "$REALGIT" "\$@"
+EOF
+chmod +x "$DEAD/git"
+
+sout=$(PATH="$DEAD:$PATH" bash "$SUITE" 2>&1); src=$?
+sgreen=$(printf '%s\n' "$sout" | grep -c '✅')
+if [ "$src" -eq 0 ]; then
+  echo "❌ SETUP FAIL-OPEN — no fixture could be built and the suite still exited 0."; exit 1
+fi
+if ! printf '%s' "$sout" | grep -qF 'HARNESS_ERROR — fixture repo not built'; then
+  echo "❌ SETUP FAILURE IS UNNAMED — the suite went red without saying the fixture never built."
+  echo "   An unnamed red is indistinguishable from a real finding, and the next reader 'fixes' the gate."
+  printf '%s\n' "$sout" | tail -8 | sed 's/^/   | /'; exit 1
+fi
+if [ "$sgreen" -ne 0 ]; then
+  echo "❌ FAIL-OPEN — $sgreen lane(s) scored ✅ with NO fixture repo. Those lanes graded the REAL tree."
+  printf '%s\n' "$sout" | grep '✅' | sed 's/^/   | /' | head -8; exit 1
+fi
+echo "⑤ setup-loudness: unbuildable fixture → rc=$src, named HARNESS_ERROR, 0 lanes scored"
+
+
+# ── ⑥ ORPHAN CONTROL — templates/predelete_check.test.sh ─────────────────────────────────────
+# The other two anchors in this family are `scripts/test_*.sh`, so scripts/lane_runner_check.sh
+# already covers them: it globs scripts/*.sh as suites and .github/workflows/*.yml as a caller
+# surface (lane_runner_check.sh:291), and selfcheck.sh:488 runs it inside the required `validate`
+# check. Delete their workflow and `validate` goes red. That is a real backstop.
+#
+# templates/predelete_check.test.sh has NO such backstop. It is `templates/*.test.sh`, outside the
+# lane-runner's `scripts/*.sh` field of view — measured: the lane-runner reports 66 suites, 66
+# wired, and never names this file. So the moment whatever executes it goes away, it returns to
+# being executed by nothing, and the detector reports 66/66 the whole time. A detector that is
+# silent about the file it cannot see is exactly [[feedback_built_but_not_wired]] with the alarm
+# disconnected — so the alarm is wired here instead, in a file the lane-runner DOES watch.
+SUBJ_ORPHAN="templates/predelete_check.test.sh"
+if [ ! -f "$REPO_ROOT/$SUBJ_ORPHAN" ]; then
+  echo "❌ ORPHAN CONTROL — subject missing: $SUBJ_ORPHAN (absent is not a pass)"; exit 1
+fi
+
+# Count REACHABLE EXECUTING callers — not mentions, and not text in something that never runs.
+# A comment naming the path is how this file was described as wired while nothing ran it; the
+# pattern therefore requires an invocation form and drops comment lines.
+#
+# 🟥 The SURFACE LIST is the part that has been wrong, and it was wrong in a direction that produces
+# a FALSE ORPHAN (over-block), not a false pass. Two repairs, both 2026-08-22 R2:
+#   • `.yaml` — GitHub executes BOTH `.github/workflows/*.yml` AND `*.yaml`. Renaming
+#     destructive-op-anchor.yml to .yaml would leave the runner fully live in CI while this stage
+#     reported ORPHANED. Measured: no `.yaml` exists in .github today, so nothing here would have
+#     noticed — the same "the runner image happens to agree with me" blindness that let `init -b`
+#     through in stage ④.
+#   • `package.json` — `npm test` / `prepublishOnly` are real executing surfaces; a suite wired
+#     only from there was invisible. Verified NOT to false-positive on the `files[]` entry for this
+#     very path (files[] has no `bash `/`sh ` prefix, so the exec pattern does not match it).
+# Named residual (unclosed, measured): `bin/*.js` is NOT in the list — probed, and no file there
+# executes a shell suite today (`grep -nE 'bash '` over bin/*.js → 0 hits, control: the same grep
+# hits in scripts/*.sh). If a JS entrypoint ever shells out to a suite, this list is short again.
+#
+# 🟥 REACHABILITY (ⓒ) — presence of the invocation text is not execution. A workflow triggered only
+# by `workflow_dispatch`, or whose step is `if: false`, contains the exact line and runs never. That
+# is [[feedback_not_found_is_not_zero_family]] inverted: a DEAD path rendered as EXECUTED. Workflow
+# files therefore additionally require a push/pull_request trigger and no `if: false`.
+#
+# 🟥 WHAT THIS COUNTER CLAIMS, STATED NARROWLY (rewritten 2026-08-22 R3 after a codex reproduction).
+# It is a COMMON-FORM MATCHER, not a YAML/shell semantics analyzer, and it never claimed to be one
+# without leaking. The R2 wording called both tests "file-scoped greps … coarse on purpose", which
+# reads as one accepted imprecision; measuring it showed the coarseness ran in BOTH directions at
+# once, and one of those directions is unsafe:
+#   • UNSAFE (fixed) — the trigger test matched any indented `push:` ANYWHERE in the file, so a
+#     manual-only workflow with `env:\n  push: not-a-trigger` was counted REACHABLE. A dead runner
+#     certified as live is a green ⑥ over a returned orphan, which is the one outcome this stage
+#     exists to prevent. Measured pre-fix: fixture `envpush` → 1 (want 0).
+#   • OVER-BLOCK (also fixed, because it was silent) — that same colon-anchored pattern REJECTED
+#     `on: push` and `on: [push, pull_request]`, the two ordinary inline spellings. Measured
+#     pre-fix: `onscalar` → 0 and `oninline` → 0 (want 1 each). Nobody would have noticed until a
+#     rename of the real runner's trigger style turned ⑥ red for a reason that is not a finding.
+#
+# The replacement is a purpose-built `on:`-BLOCK EXTRACTOR, not a YAML parser — deliberately, since
+# a parser is both a dependency this suite does not have and the scope R3 judged too large. It
+# recognises exactly one YAML structure: a top-level key ends where the next column-0 key begins.
+# That is enough, and the reason it is enough is specific rather than optimistic: the whole defect
+# class here is "a `push:` token that belongs to some OTHER top-level key", and top-level key
+# boundaries are the minimum structure that separates those. Anything finer (anchors, merge keys,
+# multi-line flow scalars spanning column 0) is out of scope and folds the safe way, below.
+#
+# 🟥 DEGRADE DIRECTION, FIXED AND EXPLICIT — when the shape is not recognised, fold to NOT REACHABLE.
+# The two errors are not symmetric: an undercount makes ⑥ print "❌ ORPHANED" (loud, red, a human
+# looks at a file that is in fact fine), while an overcount makes ⑥ print a green line while nothing
+# executes the subject (silent, and indistinguishable from health — [[feedback_not_found_is_not_zero_family]]).
+# One is a wasted five minutes; the other is the anchor this stage guards going missing without a
+# sound. So: no `on:` block found · an unrecognised trigger spelling · a `push:` nested deeper than a
+# direct child of `on:` → all count as NOT reachable. The over-block twins (`oninline` · `onscalar` ·
+# `onquoted`) exist so that this bias is measured rather than allowed to drift into blocking
+# everything ([[feedback_overblock_traded_for_failopen]]).
+#
+# 🟥 NAMED LIMITS — what this counter does NOT catch (it is a matcher; these need real semantics):
+#   • `if: false` is still FILE-scoped, not step-scoped: an `if: false` on an unrelated step
+#     disqualifies the whole file. Left as-is on purpose — that is the over-block direction.
+#   • Only the literal `false` is recognised. `if: ${{ false }}`, `if: github.event_name == 'never'`,
+#     or a job-level `if:` are not modelled; a step guarded that way counts as reachable (overcount).
+#   • A `paths:`/`branches:` filter that can never match is not modelled — such a workflow counts as
+#     reachable.
+#   • Shell dead code counts: `if false; then bash …; fi`, or an invocation inside a function that
+#     is never called, is an executing runner as far as this counter is concerned.
+#   • A `jobs:`-level `if:`, a `needs:` chain that can never satisfy, and reusable-workflow
+#     (`workflow_call`) indirection are all unmodelled.
+#   • In the OVER-BLOCK direction (loud, so accepted rather than fixed): only `push`/`pull_request`
+#     count as triggers. A runner reached solely by `schedule:`, `release:`, `workflow_run:` or
+#     `workflow_call:` really does execute and would be reported ORPHANED. Measured, not assumed —
+#     a `schedule:`-only fixture reads `dead` here. Widening the set is a one-line change IF such a
+#     runner ever exists; today none does, and every added trigger widens the unsafe direction too.
+#   The only thing that truly settles reachability is EXECUTING the runner and watching the subject
+#   run, which is what CI's 'Anchor 3/3' step does; ⑥ guards that step's existence, it does not
+#   replace it ([[feedback_gate_binding_point_not_check_point]]).
+
+# Extract the top-level `on:` block: the `on:` line itself (so inline forms `on: push` and
+# `on: [push, …]` are visible) plus every following line until the next column-0 key. Handles the
+# YAML-1.1 quoting workarounds (`"on":` / `'on':`) that exist because bare `on` is a boolean there.
+_on_block() {   # $1 = workflow file
+  awk '
+    /^[[:space:]]*#/ { next }
+    /^[^[:space:]#]/ {
+      if ($0 ~ /^("on"|'"'"'on'"'"'|on)[[:space:]]*:/) { inblk = 1; print; next }
+      inblk = 0; next
+    }
+    inblk { print }
+  ' "$1"
+}
+
+# Reachable iff the `on:` block names push/pull_request as a TRIGGER — either inline on the `on:`
+# line, or as a direct child key. The 1–4 space band is the direct-child depth for both 2-space and
+# 4-space styles; anything deeper is a descendant of some other trigger (a `workflow_dispatch`
+# input named `push`, fixture `ondeep`) and folds to not-reachable per the degrade rule above.
+_wf_triggered() {   # $1 = workflow file → rc 0 if reachable
+  local blk head rhs
+  blk=$(_on_block "$1")
+  [ -n "$blk" ] || return 1                                   # no on: block → not reachable
+  # (a) inline forms — everything to the right of the `on:` colon, e.g. `on: push`,
+  #     `on: [push, pull_request]`. Empty rhs = block form, which falls through to (b).
+  head=$(printf '%s\n' "$blk" | head -1)
+  rhs=${head#*:}
+  case "$rhs" in
+    *push*|*pull_request*) return 0 ;;
+  esac
+  # (b) block form — a DIRECT child key of `on:`.
+  printf '%s\n' "$blk" | grep -qE '^[[:space:]]{1,4}(push|pull_request):([[:space:]]|$)'
+}
+
+count_execs() {  # $1 = path to look for; $2 = root to scan (default: the real repo)
+  local n=0 f root="${2:-$REPO_ROOT}"
+  for f in "$root"/scripts/*.sh "$root"/.github/workflows/*.yml "$root"/.github/workflows/*.yaml \
+           "$root"/templates/.git-hooks/* "$root"/package.json; do
+    [ -f "$f" ] || continue
+    case "$f" in *"$(basename "$0")") continue ;; esac   # this probe's own mention is not a runner
+    grep -vE '^[[:space:]]*#' "$f" 2>/dev/null \
+      | grep -qE "(bash|sh|\./)[[:space:]]+[^[:space:]]*$1" || continue
+    case "$f" in
+      *.yml|*.yaml)
+        _wf_triggered "$f" || continue        # manual-only / unrecognised `on:` → not reachable
+        # `- if: false` (the step-list form) is the spelling that actually occurs; anchoring on
+        # `^[[:space:]]*if:` alone missed it and the ⑥-cal lane caught that while writing this
+        # ([[feedback_fixture_must_use_the_breaking_spelling]]).
+        grep -qE '^[[:space:]]*-?[[:space:]]*if:[[:space:]]*false[[:space:]]*$' "$f" && continue
+        ;;
+    esac
+    n=$((n+1))
+  done
+  printf '%s' "$n"
+}
+
+# ── ⑥-cal — KNOWN PAIRS FOR count_execs ITSELF, on purpose-built fixtures ────────────────────
+# The single control below ("a path nobody executes scores 0") measures only that the counter is
+# not stuck-on. It cannot see a counter that is stuck-OFF for a whole surface, which is exactly the
+# `.yaml` defect: presence of a control is not discrimination
+# ([[feedback_control_presence_is_not_discrimination]]). These lanes give each surface and each
+# reachability rule its own known-positive AND known-negative.
+_CALROOT=$(mktemp -d) || exit 1
+trap 'rm -rf "$C" "$SHIM" "$DEAD" "$_CALROOT"' EXIT
+_calfix() {  # $1 = subdir, $2 = relative file to create, $3 = contents
+  mkdir -p "$_CALROOT/$1/$(dirname "$2")" || return 1
+  printf '%s\n' "$3" > "$_CALROOT/$1/$2"
+}
+_WF_LIVE='on:
+  push:
+    branches: ["**"]
+jobs:
+  j:
+    steps:
+      - run: bash templates/predelete_check.test.sh'
+
+_calfix yml    .github/workflows/a.yml  "$_WF_LIVE"
+_calfix yaml   .github/workflows/a.yaml "$_WF_LIVE"          # B — the twin GitHub also executes
+_calfix none   README.md                'no runner here'      # known-negative
+_calfix pkg    package.json             '{ "scripts": { "test": "bash templates/predelete_check.test.sh" } }'
+# The three reachability fixtures are deliberately `.yml`, NOT `.yaml`: on `.yaml` they would be
+# green under the pre-repair counter too — for the wrong reason (that surface was invisible), which
+# makes the lane unable to attribute its own result. Measured while writing this: the first draft
+# used .yaml and the fail-before probe showed manual/iffalse "passing" with reachability removed.
+_calfix manual .github/workflows/a.yml 'on:
+  workflow_dispatch:
+jobs:
+  j:
+    steps:
+      - run: bash templates/predelete_check.test.sh'
+_calfix iffalse .github/workflows/a.yml 'on:
+  push:
+    branches: ["**"]
+jobs:
+  j:
+    steps:
+      - if: false
+        run: bash templates/predelete_check.test.sh'
+_calfix mention .github/workflows/a.yml 'on:
+  push:
+    branches: ["**"]
+jobs:
+  j:
+    steps:
+      # bash templates/predelete_check.test.sh   <- a comment, not a runner
+      - run: echo templates/predelete_check.test.sh'
+# 🟥 THE `on:`-SCOPE PAIR (added 2026-08-22 R3, from a codex reproduction). The trigger test used
+# to be FILE-scoped: any indented `push:` anywhere in the file satisfied it. `envpush` is that
+# reproduction — a manual-only workflow with an unrelated `push:` key under `env:` — and it was
+# counted as REACHABLE, i.e. a dead runner certified as live. That is the unsafe direction (a green
+# ⑥ while the orphan is back), which is why it is fixed rather than named as a residual.
+# The three positives beside it are the OVER-BLOCK twins: tightening the scope must not turn the
+# legitimate `on:` spellings into false ORPHANs ([[feedback_overblock_traded_for_failopen]]).
+_calfix envpush .github/workflows/a.yml 'on:
+  workflow_dispatch:
+env:
+  push: not-a-trigger
+jobs:
+  j:
+    steps:
+      - run: bash templates/predelete_check.test.sh'
+_calfix oninline .github/workflows/a.yml 'on: [push, pull_request]
+jobs:
+  j:
+    steps:
+      - run: bash templates/predelete_check.test.sh'
+_calfix onscalar .github/workflows/a.yml 'on: push
+jobs:
+  j:
+    steps:
+      - run: bash templates/predelete_check.test.sh'
+_calfix onquoted .github/workflows/a.yml '"on":
+  pull_request:
+    branches: [main]
+jobs:
+  j:
+    steps:
+      - run: bash templates/predelete_check.test.sh'
+# Not a trigger, and NOT the same shape as `envpush`: here the `push:` key lives INSIDE the `on:`
+# block but as a deep descendant (a workflow_dispatch input name), so block-extraction alone does
+# not reject it — only the direct-child depth band does. Separate lane because it fails for a
+# different reason ([[feedback_candidate_list_completeness]]).
+_calfix ondeep .github/workflows/a.yml 'on:
+  workflow_dispatch:
+    inputs:
+      push:
+        description: not-a-trigger
+jobs:
+  j:
+    steps:
+      - run: bash templates/predelete_check.test.sh'
+
+_calfail=0
+_cal() {  # $1 = fixture subdir, $2 = expected count, $3 = what it proves
+  local got; got=$(count_execs "templates/predelete_check.test.sh" "$_CALROOT/$1")
+  if [ "$got" = "$2" ]; then
+    echo "   ✅ ⑥-cal $1 → $got (want $2) — $3"
+  else
+    echo "   ❌ ⑥-cal $1 → $got (want $2) — $3"
+    _calfail=$((_calfail+1))
+  fi
+}
+_cal yml     1 "known-positive: the surface that already worked"
+_cal yaml    1 "B: GitHub runs .yaml too — a rename must not read as ORPHANED"
+_cal pkg     1 "npm scripts are an executing surface"
+_cal none    0 "known-negative: no runner anywhere scores 0"
+_cal manual  0 "ⓒ: workflow_dispatch-only contains the text and never runs"
+_cal iffalse 0 "ⓒ: an \`if: false\` step contains the text and never runs"
+_cal mention 0 "a commented invocation is a mention, not a runner"
+_cal envpush  0 "ⓒ-scope: a \`push:\` under \`env:\` is not a trigger (codex repro — the unsafe direction)"
+_cal ondeep   0 "ⓒ-scope: \`push:\` as a workflow_dispatch INPUT NAME is not a trigger"
+_cal oninline 1 "over-block twin: \`on: [push, pull_request]\` is a real trigger"
+_cal onscalar 1 "over-block twin: \`on: push\` (scalar) is a real trigger"
+_cal onquoted 1 "over-block twin: YAML-1.1 \`\"on\":\` quoting is a real trigger"
+if [ "$_calfail" -ne 0 ]; then
+  echo "❌ ORPHAN COUNTER MISCALIBRATED — $_calfail of its own known pairs failed."
+  echo "   The ≥1 assertion below would be satisfied (or denied) by a broken counter, not by a runner."
+  exit 1
+fi
+
+# Known pair against the REAL tree: a path nobody executes must score 0, or the "≥1" below is
+# satisfied by a broken counter rather than by a real runner.
+_ctrl=$(count_execs "templates/no_such_suite_xyzzy.test.sh")
+_real=$(count_execs "$SUBJ_ORPHAN")
+if [ "$_ctrl" -ne 0 ]; then
+  echo "❌ ORPHAN CONTROL INVALID — the counter scores $_ctrl runners for a file that does not exist."
+  exit 1
+fi
+if [ "$_real" -lt 1 ]; then
+  echo "❌ ORPHANED — $SUBJ_ORPHAN is executed by NOTHING again."
+  echo "   scripts/lane_runner_check.sh cannot see it (templates/*.test.sh is outside its"
+  echo "   scripts/*.sh glob), so nothing else will tell you. Restore a runner — the intended one"
+  echo "   is .github/workflows/destructive-op-anchor.yml, step 'Anchor 3/3'."
+  exit 1
+fi
+echo "⑥ orphan control: $SUBJ_ORPHAN has $_real runner(s) matching the reachable-invocation FORM"
+echo "   (control: nonexistent path → $_ctrl · form-matcher, not a semantics analyzer — §NAMED LIMITS)"
+
+# 🟥 RESIDUAL 4, RE-ADJUDICATED TWICE — "⑥ counts CALLERS, not EXECUTIONS".
+# The R1 wording conceded the whole axis; the R2 wording then overclaimed the opposite. Both are
+# corrected here rather than overwritten, because the overclaim is the instructive half:
+#   R2 said "CLOSED for workflows — manual-only and `if: false` are THE two ways a workflow can hold
+#     the invocation text and never run it". 🟥 That "the two" was a completeness claim made without
+#     enumerating the candidates, and R3 falsified it in one try: a `push:` key under `env:` is a
+#     third way, and the file-scoped trigger grep counted it as live
+#     ([[feedback_candidate_list_completeness]]). The honest statement is NARROWER and is not a
+#     count: three SPELLINGS are now rejected with their own known pairs (manual-only · `if: false` ·
+#     a `push:` outside the `on:` block or below its direct children). No claim is made that the
+#     list is complete — §NAMED LIMITS above enumerates the ones known to be missing.
+#   OPEN, and measured rather than hand-waved: an invocation sitting in a dead branch of a SHELL
+#     runner (`if false; then bash …`, an uncalled function) still counts, and a `paths:` filter
+#     that never matches is not modelled. Live exposure TODAY is ZERO: the only counted runner is
+#     .github/workflows/destructive-op-anchor.yml (measured with a control — the same scan finds 5
+#     runners for scripts/selfcheck.sh, so the single hit is a measurement, not a dead grep), and
+#     it triggers on `push: branches: ['**']`. So the open half is a future exposure, not a
+#     present one.
+#   The only form that truly closes it is EXECUTING the runner and observing the subject run —
+#     which is what CI's 'Anchor 3/3' step does. ⑥ is the guard on that step's continued
+#     existence, not a substitute for it ([[feedback_gate_binding_point_not_check_point]]).
+
+
+# ── ⑦ CONTAINMENT CONTROL — the suite must not touch the REAL repo ───────────────────────────
+# 🟥 This is the anchor for a leak that actually happened, on 2026-08-22, in this shared checkout:
+# a run of the pre-fix suite created branches (merged-branch · newer-content · unique-work), a tag
+# (v9.9.9), an untracked a.txt, left `unique.txt` STAGED IN THE INDEX, and stranded HEAD on a
+# fixture branch. A sibling lane's session found it, not this one.
+#
+# Mechanism, reproduced rather than guessed: `newrepo` returns 1 WITHOUT echoing, so `R=$(newrepo)`
+# is empty, and `cd ""` is a NO-OP SUCCESS in bash — every `( cd "$R" && git … )` then ran with cwd
+# = the real repo. Repair ⑤ closes the door (no fixture → abort). THIS stage is the independent
+# check on the OUTCOME, because a future leak may arrive through a door ⑤ does not watch: a lane
+# that forgets `cd`, a `git -C` pointed at the wrong root, a helper that resolves REPO_ROOT.
+# Door-check and outcome-check are different axes; ⑤ alone would have been the same class of
+# half-measure ([[feedback_gate_binding_point_not_check_point]]).
+#
+# In a SHARED CHECKOUT the stake is higher than a dirty tree: a staged fixture file is committed by
+# whoever commits next ([[feedback_shared_checkout_ops_touch_others_work]]).
+
+# 🟥 THE BASELINE IS TAKEN AT THE TOP OF THIS FILE, NOT HERE — and that placement is the whole
+# check. A first draft snapshotted at this point, i.e. AFTER stages ②/④/⑤ had each already run the
+# suite. A revert probe with a deliberately-leaking stand-in then reported "byte-identical": the
+# leak had already landed during ④, so it was inside the baseline and the comparison saw no delta.
+# An IDEMPOTENT leak (create-if-absent, add-if-unstaged) is invisible to any baseline taken after
+# the first run. Anchors are measured by what they can still catch, not by what they caught once
+# ([[feedback_anchor_can_be_decorative]]) — so the baseline moved to before the first invocation
+# and now covers every suite run this probe performs.
+cout=$(bash "$SUITE" 2>&1); crc=$?
+_after=$(git_state)
+
+if [ "$crc" -ne 0 ]; then
+  echo "❌ CONTAINMENT stage could not measure — the suite itself failed (rc=$crc)."
+  printf '%s\n' "$cout" | grep -E '❌|HARNESS_ERROR' | sed 's/^/   | /' | head -6; exit 1
+fi
+if [ "$CONTAINMENT" = "skip" ]; then
+  echo "⑦ containment: SKIPPED — $REPO_ROOT is not a git work tree (nothing to compare; NOT a pass)"
+elif [ "$_before" != "$_after" ]; then
+  echo "❌ FIXTURE LEAK — running the suite CHANGED the real repository."
+  echo "   Fixtures must live only under mktemp. In a shared checkout a staged fixture file is"
+  echo "   committed by whoever commits next. Diff of git state (before → after):"
+  diff <(printf '%s\n' "$_before") <(printf '%s\n' "$_after") | sed 's/^/   | /' | head -20
+  exit 1
+else
+  echo "⑦ containment: real repo byte-identical across a full suite run (status·HEAD·refs·tags·index)"
+fi
+
+echo ""
+echo "✅ LIVENESS 캘리브레이션: anchor is LIVE (1 guard disabled → exactly 1 lane red, the right one)"
+echo "   + portability, setup-loudness, orphan and containment controls all hold"


### PR DESCRIPTION
## 왜

`CLAUDE.md §Destructive-Op Gate` 는 「enumerate → recover → destroy」를 못박아두고, 그 첫 단계가 **사람이 돌리는 것이고 어떤 훅도 실행하지 않는다**고 스스로 적는다. 즉 그 게이트가 조용히 망가지면 아무도 모른다. 이 PR 이 그 자리를 메운다 — pre-push 훅의 파괴적-op 판정 **12쌍**을 CI 에서 상시 재실행한다.

기법은 qasp `mirror-guard-anchor` 이식이다(2026-08-22 시너지 스캔 T1 — **door ④ 첫 실사용**). 구현은 우리 것이고 그쪽 스크립트를 복사하지 않았다.

## 무엇이 드러났나

방치돼 있던 앵커 둘을 **처음으로 실행**시켰다:

| 앵커 | 결과 | 그동안 |
|---|---|---|
| `prepush_guard_check` | 20/20 | selfcheck 미배선 — 훅 diff 를 건드릴 때만 돌았다 |
| `templates/predelete_check.test.sh` | 6/6 | **아무것도 실행하지 않았다** |

🟥 **이식성 지적(B급)을 고치다 그것이 A급임이 드러났다.**
```
newrepo 실패 시 echo 없이 return 1  →  R=$(newrepo) 가 빈 문자열
cd "" 는 bash 에서 no-op SUCCESS     →  ( cd "$R" && git … ) 가 실제 레포에서 돌았다
```
옛-git shim 재현에서 `6 passed, 6 failed` 인데 **P7·P8 이 실제 레포의 훅 출력으로 통과**를 받았다. 바닥의 `TOTAL==0` 데드-계기 컨트롤은 이걸 구조적으로 못 본다 — 레인은 돌았다, **틀린 대상에 대해**. `require_repo()` 로 닫고 컨테인먼트 프로브를 앵커로 박았다.

🟥 **그 컨테인먼트 「컨트롤」이 항상 거짓이었다.** 문자열이 자기+접미사와 같을 수 없어 영원히 발화 불가. 무작위 1000 입력 0회 발화로 증명(컨트롤: 평범한 동등 비교는 발화). 실물 known-pair 로 교체했고, 구 컨트롤은 열화된 상태를 **조용히 초록**으로 통과시켰다.

## 주장을 좁혔다

cross-family 3라운드(codex/gpt-5.5)의 A급이 **한 클래스**였다 — 정규식으로 실행 의미론을 근사하다 가장자리에서 **양방향으로** 샌다. 그래서 무엇을 주장하는지를 내렸다:

- **COMMON-FORM MATCHER, not a YAML/shell semantics analyzer**
- 출력: `reachable executing runner` → `runner(s) matching the reachable-invocation FORM` + §NAMED LIMITS 포인터
- **완결성 주장 철회** — 「수동 전용과 `if: false` 가 **그 둘**」이라 적었는데 한 번에 반증됐다. 지금은 「세 표기를 거부한다, 목록이 완전하다고 주장하지 않는다」
- **못 막는 것을 이름으로** 파일에 적었다(overcount 무음 6종 · over-block 시끄러운 2종)

**degrade 방향**: 인식 못 한 형태 → **도달 불가**. 비대칭이라 그렇다 — undercount 는 시끄러운 빨강(사람이 5분 낭비), overcount 는 **아무것도 실행 안 하는데 초록**이라 건강과 구분이 안 된다. 그게 이 스테이지가 막으려는 바로 그것이다.

## 소비자 표면 — 실검했다

`test_prepush_destructive_lanes.sh` · `templates/predelete_check.test.sh` 를 `files[]` 에 실었다.
```
$ npm pack                              → 317 files
$ tar -xzf *.tgz && cd package
$ git rev-parse --show-toplevel         → fatal: not a git repository   ← 진짜 소비자 조건
$ bash scripts/test_prepush_destructive_lanes.sh
                                        → rc=0 · 12 passed, 0 failed
```
컨트롤 동반: 일부러 안 실은 둘(`liveness` · `new_code_anchor_check`)이 **정확히 부재** = `files[]` 필터가 판별력을 가진다. 소비자가 자기 `pre-push` 훅이 실제로 막는지 검증할 수 있게 됐다.

## 🟥 NOT CONVERGED 상태로 착지한다

R3 이 명시적으로 `not converged` 를 냈고 *"each repair is creating fresh review surface … land one gate at a time"* 라고 판정했다. **그 판정을 따라 같은 라운드에서 만든 세 게이트 중 이것 하나만 착지시킨다.**

```
R1  8건 (S1·A4·B3)  →  R2  6건 (S0·A3·B3)  →  R3  4건 (S0·A3·B1)
```
`caller-ratchet` 과 `new-code-anchor` 는 각각 A 1건이 열린 채 트리에 남는다 — **괜찮아서가 아니라 범위를 줄이려고.**

## 잔여 — 이름으로

1. 워크플로가 **required check 가 아니다**(현재 required = `validate` 하나). 보고하되 머지를 막지 않는다 — 승격은 운영자 결정
2. **Linux 에서 실행된 적 없다.** 전량 macOS(bash 3.2·5.3). CI 첫 실행이 **확인이 아니라 발견**이다
3. stage ④ 의 shim 은 진짜 구버전 git 이 아니다 — `init -b` 스위치만 제거. 완전히 닫으려면 2.27 컨테이너 필요
4. stage ⑥ 은 **실행을 증명하지 않는다** — 워크플로 스텝의 *존속*을 지킬 뿐. 실행 증명은 CI 의 `Anchor 3/3` 뿐
5. `package_coverage_check.sh` 가 `.github/workflows/` 를 스캔하지 않는다 — **다른 게이트의 커버리지 구멍**, 컨트롤로 측정. 이 델타 범위 밖

---
4축 마커: `.axes_23_passed_feat_destructive-op-anchor_2026-08-22.marker`
`crossfamily: panel(gpt-5.5)` · `standpoint: tier2(consumer-install)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ5j1CS87eUQALCWfaxy2F