### PR TITLE
docs(readme): 게이트만 쓸 사람이 4스크롤 뒤에 답을 만나던 것을 첫 화면으로 올린다

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -99,15 +99,28 @@ cd ~/projects/forge-harness && claude
 | プロジェクトごとに同じ設定を繰り返す | ハブに一度つなげば全プロジェクトで共有 |
 | チームの AI ノウハウが人の頭の中にしかない | コードに刻んで全員で共有 |
 | 作業が積み上がるほど AI が*より良く*なってほしい | スキルとパターンがセッションを重ねて複利で積み上がる |
-| AI が生成したコードにガバナンス層が必要だ | `fh-gate` がどんなコーディングエージェントでも生成後ゲートで包む |
+| AI が生成したコードにガバナンス層が必要だ | `fh-gate` がどんなコーディングエージェントでも生成後ゲートで包む — `npx --package @chrono-meta/fh-gate fh-gate` |
 
 > **この文書は人間のためのものです。** AI 運用ルール → `CLAUDE.md` · コマンドリファレンス → `CHEATSHEET.md`
+
+**どの入口があなた向きか?**
+
+| あなたは… | ここから始める |
+|---|---|
+| 個人開発者、プロジェクト1つ、まず試したい | [`templates/starter_profile.md`](templates/starter_profile.md) — コマンド1つ、厳選された最初の5つのスキル |
+| プロジェクトが複数、複利で積み上がるハブが欲しい | ハブをクローン（上の«2分で試せます»の節） |
+| CI / 非 Claude ランタイム、ゲートだけ欲しい | `npx --package @chrono-meta/fh-gate fh-gate`（インストール不要のガバナンスゲート） |
+| `npx`/`npm` より `brew` がいい | `brew tap chrono-meta/forge-harness && brew install forge-harness` — 内容は100%同一、インストール体験だけが違います（コミュニティ tap; まだ Homebrew Core には入っていないので、先に tap しないと `brew search` では見つかりません） |
 
 ---
 
 ## 2分で始める
 
-**前提条件**: Claude Code CLI — `claude --version` で確認
+この前提は**ハブ・プラグイン経路**に限られ、**上の表のすべての行に当てはまるわけではありません。**
+下の3ステップが「2分」のすべてです。前提は Claude Code CLI ひとつだけで（`claude --version` で確認）、
+プラグインのインストールとハブのクローンはその3ステップの中に入っています。
+Claude Code は使わずゲートだけが必要なら、この3ステップの代わりに `fh-gate` の
+1行で済みます（上の表の「CI / 非 Claude ランタイム」の行、そして下の «AI 生成コードのためのガバナンス層» の節）。
 
 <details><summary><b>任意: 1つのゲートが Python + PyYAML を必要とします</b> — 無いと <code>npm test</code> が赤くなります</summary>
 
@@ -179,15 +192,6 @@ cd ~/projects/{your-project} && claude
 > 方法論層）です。
 > 各スキルは孤立していても同じように動きます。抜けるのは、それらをセッションをまたいで複利にする
 > オーケストレーションのほうです。道具だけでなく全体セットが欲しくなったら、ハブをクローンしてください（上記参照）。
-
-**どの入口があなた向きか?**
-
-| あなたは… | ここから始める |
-|---|---|
-| 個人開発者、プロジェクト1つ、まず試したい | [`templates/starter_profile.md`](templates/starter_profile.md) — コマンド1つ、厳選された最初の5つのスキル |
-| プロジェクトが複数、複利で積み上がるハブが欲しい | ハブをクローン（上のクイックスタート） |
-| CI / 非 Claude ランタイム、ゲートだけ欲しい | `npx --package @chrono-meta/fh-gate fh-gate`（インストール不要のガバナンスゲート） |
-| `npx`/`npm` より `brew` がいい | `brew tap chrono-meta/forge-harness && brew install forge-harness` — 内容は100%同一、インストール体験だけが違います（コミュニティ tap; まだ Homebrew Core には入っていないので、先に tap しないと `brew search` では見つかりません） |
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -96,15 +96,28 @@ cd ~/projects/forge-harness && claude
 | 프로젝트마다 같은 설정을 반복한다 | 허브에 한 번 연결하면 모든 프로젝트가 공유 |
 | 팀의 AI 노하우가 사람 머릿속에만 있다 | 코드로 박아 모두가 공유 |
 | 작업이 쌓일수록 AI가 *더 나아지길* 원한다 | 스킬과 패턴이 세션을 거듭하며 복리로 쌓임 |
-| AI가 생성한 코드에 거버넌스 층이 필요하다 | `fh-gate`가 어떤 코딩 에이전트든 생성-후 게이트로 감쌈 |
+| AI가 생성한 코드에 거버넌스 층이 필요하다 | `fh-gate`가 어떤 코딩 에이전트든 생성-후 게이트로 감쌈 — `npx --package @chrono-meta/fh-gate fh-gate` |
 
 > **이 문서는 사람을 위한 것입니다.** AI 운영 규칙 → `CLAUDE.md` · 명령어 레퍼런스 → `CHEATSHEET.md`
+
+**어느 진입 경로가 당신에게 맞나?**
+
+| 당신은… | 여기서 시작 |
+|---|---|
+| 1인 개발자, 프로젝트 하나, 일단 써보는 중 | [`templates/starter_profile.md`](templates/starter_profile.md) — 명령 하나, 엄선된 첫 5개 스킬 |
+| 프로젝트 여럿, 복리 허브를 원함 | 허브 클론(위 «2분이면 됩니다» 절) |
+| CI / 비-Claude 런타임, 게이트만 | `npx --package @chrono-meta/fh-gate fh-gate` (무설치 거버넌스 게이트) |
+| `npx`/`npm`보다 `brew`를 선호 | `brew tap chrono-meta/forge-harness && brew install forge-harness` — 100% 동일한 내용, 설치 UX만 다름(커뮤니티 탭; 아직 Homebrew Core에 없어서 탭을 먼저 추가하지 않으면 `brew search`로는 안 잡힙니다) |
 
 ---
 
 ## 2분 만에 시작하기
 
-**전제 조건**: Claude Code CLI — `claude --version`으로 확인
+이 전제는 **허브·플러그인 경로**에 한하고, **위 표의 모든 행에 적용되는 것이 아닙니다.**
+아래 3단계가 「2분」의 전부입니다. 전제는 Claude Code CLI 하나뿐이고(`claude --version`으로 확인),
+플러그인 설치와 허브 클론은 그 3단계 안에 들어 있습니다.
+Claude Code를 쓰지 않고 게이트만 필요하다면 이 3단계 대신 `fh-gate` 한 줄로 갑니다(위 표의 「CI /
+비-Claude 런타임」 행, 그리고 아래 «AI 생성 코드를 위한 거버넌스 층» 절).
 
 <details><summary><b>선택: 게이트 하나가 Python + PyYAML을 필요로 합니다</b> — 없으면 <code>npm test</code>가 빨갛습니다</summary>
 
@@ -174,15 +187,6 @@ cd ~/projects/{your-project} && claude
 > 맥락(`tracks/` 메모리 축적, `harvest-loop` 학습; 방법론 층)이 빠집니다.
 > 각 스킬은 고립돼서도 동일하게 작동하지만, 빠지는 것은 그것들을 세션에 걸쳐 복리로 만드는
 > 오케스트레이션입니다. 도구만이 아니라 전체 세트를 원하면 허브를 클론하세요(위 참조).
-
-**어느 진입 경로가 당신에게 맞나?**
-
-| 당신은… | 여기서 시작 |
-|---|---|
-| 1인 개발자, 프로젝트 하나, 일단 써보는 중 | [`templates/starter_profile.md`](templates/starter_profile.md) — 명령 하나, 엄선된 첫 5개 스킬 |
-| 프로젝트 여럿, 복리 허브를 원함 | 허브 클론(위 빠른 시작) |
-| CI / 비-Claude 런타임, 게이트만 | `npx --package @chrono-meta/fh-gate fh-gate` (무설치 거버넌스 게이트) |
-| `npx`/`npm`보다 `brew`를 선호 | `brew tap chrono-meta/forge-harness && brew install forge-harness` — 100% 동일한 내용, 설치 UX만 다름(커뮤니티 탭; 아직 Homebrew Core에 없어서 탭을 먼저 추가하지 않으면 `brew search`로는 안 잡힙니다) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -98,15 +98,26 @@ Everything below this line is reference for when you want it, not homework befor
 | You repeat the same setup across projects | Connect once to the hub, share across all projects |
 | Team AI know-how lives only in people's heads | Codify it so everyone shares it |
 | You want AI to get *better* as work accumulates | Skills and patterns compound session over session |
-| You need a governance layer for AI-generated code | `fh-gate` wraps any coding agent as a post-generation gate |
+| You need a governance layer for AI-generated code | `fh-gate` wraps any coding agent as a post-generation gate — `npx --package @chrono-meta/fh-gate fh-gate` |
 
 > **This document is for humans.** AI operating rules → `CLAUDE.md` · Command reference → `CHEATSHEET.md`
+
+**Which entry path is for you?**
+
+| You are… | Start with |
+|---|---|
+| Solo dev, one project, just trying it | [`templates/starter_profile.md`](templates/starter_profile.md) — one command, curated first-five skills |
+| Multiple projects, want the compounding hub | Clone the hub (quickstart above) |
+| CI / non-Claude runtime, gates only | `npx --package @chrono-meta/fh-gate fh-gate` (zero-install governance gate) |
+| Prefer `brew` over `npx`/`npm` | `brew tap chrono-meta/forge-harness && brew install forge-harness` — same 100%-parity content, different install UX (community tap; not yet in Homebrew Core, so `brew search` won't find it without the tap first) |
 
 ---
 
 ## Requirements
 
-**Prerequisite**: Claude Code CLI — verify with `claude --version`
+**Prerequisite** — this applies to the **hub** and **plugin-only** paths, not to every row of the table
+above: Claude Code CLI, verify with `claude --version`. The **gates-only** row is a separate path and
+does not go through this quickstart — it is the one `npx` line in that row.
 
 <details><summary><b>Optional: one gate needs Python + PyYAML</b> — <code>npm test</code> is red without it</summary>
 
@@ -174,15 +185,6 @@ cd ~/projects/{your-project} && claude
 > Each skill runs the same in isolation; what's missing is the orchestration that makes them compound
 > across sessions. Clone the hub (above) when you want the full set, not just the tools.
 
-**Which entry path is for you?**
-
-| You are… | Start with |
-|---|---|
-| Solo dev, one project, just trying it | [`templates/starter_profile.md`](templates/starter_profile.md) — one command, curated first-five skills |
-| Multiple projects, want the compounding hub | Clone the hub (quickstart above) |
-| CI / non-Claude runtime, gates only | `npx --package @chrono-meta/fh-gate fh-gate` (zero-install governance gate) |
-| Prefer `brew` over `npx`/`npm` | `brew tap chrono-meta/forge-harness && brew install forge-harness` — same 100%-parity content, different install UX (community tap; not yet in Homebrew Core, so `brew search` won't find it without the tap first) |
-
 ---
 
 ## Two version numbers, and they measure different things
@@ -192,10 +194,10 @@ misread the project's status, so they are named here rather than only in the can
 
 | Counter | Where you see it | What it means |
 |---|---|---|
-| **Package version** (currently **2.7.0**) | npm, the plugin manifests, `git tag v2.x` | *what you install.* Ordinary release numbering: fixes → patch, new assets and gate lanes → minor, a capability **class** appearing or the thing being rebuilt → major |
+| **Package version** (currently **2.8.0** — hardcoded here, so a release must update this cell by hand; the lockstep bump does not reach it) | npm, the plugin manifests, `git tag v2.x` | *what you install.* Ordinary release numbering: fixes → patch, new assets and gate lanes → minor, a capability **class** appearing or the thing being rebuilt → major |
 | **Identity-maturity release** (currently **identity-v0.4.0**) | the GitHub **Releases** page | *how far along the harness is.* `0.x` carries an incomplete-but-honest status **by design**; **the all-green ship is reserved for `identity-v1.0.0`** — every one of the five identities at 🟢, none 🔵/🟡/🔴 |
 
-🟥 **A high package number does not mean maturity.** `2.7.0` is not "ahead of" `identity-v0.4.0`; they are not on
+🟥 **A high package number does not mean maturity.** `2.8.0` is not "ahead of" `identity-v0.4.0`; they are not on
 the same scale. The maturity track is deliberately allowed to sit at `0.x` while the package ships and
 improves, because the thing `0.x` refuses to do is **lie** — it says out loud that not every identity has
 cleared its bar yet, and each release names exactly which real run is still missing.

--- a/README.zh.md
+++ b/README.zh.md
@@ -94,15 +94,27 @@ cd ~/projects/forge-harness && claude
 | 你在每个项目里重复相同的设置 | 一次连接到中枢，跨所有项目共享 |
 | 团队的 AI 经验只留在个人脑子里 | 把它编码固化，让所有人共享 |
 | 你希望工作越积累，AI 越 *变好* | 技能与模式随会话逐次复利累积 |
-| 你需要给 AI 生成的代码一层治理 | `fh-gate` 把任何编码 agent 包裹为一道生成后门禁 |
+| 你需要给 AI 生成的代码一层治理 | `fh-gate` 把任何编码 agent 包裹为一道生成后门禁 —— `npx --package @chrono-meta/fh-gate fh-gate` |
 
 > **本文档面向人类。** AI 运行规则 → `CLAUDE.md` · 命令参考 → `CHEATSHEET.md`
+
+**哪条入口适合你？**
+
+| 你是…… | 从这里开始 |
+|---|---|
+| 单人开发者，一个项目，只想先试试 | [`templates/starter_profile.md`](templates/starter_profile.md) —— 一条命令，一份精选的头五个技能 |
+| 有多个项目，想要那个复利累积的中枢 | 克隆中枢（见上面的«两分钟就能试»一节） |
+| CI / 非 Claude 运行时，只要门禁 | `npx --package @chrono-meta/fh-gate fh-gate`（零安装的治理门禁） |
+| 比起 `npx`/`npm` 更习惯 `brew` | `brew tap chrono-meta/forge-harness && brew install forge-harness` —— 内容 100% 一致，只是安装体验不同（社区 tap；尚未进入 Homebrew Core，所以不先加 tap 的话 `brew search` 找不到它） |
 
 ---
 
 ## 2 分钟上手
 
-**前置条件**：Claude Code CLI —— 用 `claude --version` 确认
+这个前置只限于**中枢与插件路径**，**并不适用于上表的每一行。**
+下面三步就是"两分钟"的全部。前置只有 Claude Code CLI 一个（用 `claude --version` 确认），插件安装
+与中枢克隆都包含在这三步里。如果你不用 Claude Code、只需要那道门禁，那就不走
+这三步，一行 `fh-gate` 即可（见上表"CI / 非 Claude 运行时"那一行，以及下面的«面向 AI 生成代码的治理层»一节）。
 
 <details><summary><b>可选：有一道门禁需要 Python + PyYAML</b> —— 少了它 <code>npm test</code> 是红的</summary>
 
@@ -167,15 +179,6 @@ cd ~/projects/{your-project} && claude
 > `CLAUDE.md` 治理（主动引导、4 轴门禁、模式分支；自动化层）和复利式上下文（`tracks/` 记忆
 > 累积、`harvest-loop` 学习；方法论层）。每个技能在隔离状态下运行效果相同；缺的是让它们在
 > 会话之间复利累积的那层编排。当你想要完整套装而不只是工具时，请克隆中枢（见上）。
-
-**哪条入口适合你？**
-
-| 你是…… | 从这里开始 |
-|---|---|
-| 单人开发者，一个项目，只想先试试 | [`templates/starter_profile.md`](templates/starter_profile.md) —— 一条命令，一份精选的头五个技能 |
-| 有多个项目，想要那个复利累积的中枢 | 克隆中枢（见上面的快速上手） |
-| CI / 非 Claude 运行时，只要门禁 | `npx --package @chrono-meta/fh-gate fh-gate`（零安装的治理门禁） |
-| 比起 `npx`/`npm` 更习惯 `brew` | `brew tap chrono-meta/forge-harness && brew install forge-harness` —— 内容 100% 一致，只是安装体验不同（社区 tap；尚未进入 Homebrew Core，所以不先加 tap 的话 `brew search` 找不到它） |
 
 ---
 


### PR DESCRIPTION
진입경로 표를 「이 문서는 사람을 위한 것」 줄 직후로 올리고(4언어), 문제표 셀에 실행 명령을 박고, `Prerequisite: Claude Code CLI` 가 표 전체를 덮는 것처럼 읽히던 것을 허브·plugin-only 경로로 스코핑했다. **게이트만 필요한 소비자에게는 CLI 가 전제가 아니다.**

곁가지로 §Two version numbers 의 하드코딩 버전이 `2.7.0` 에 멈춰 있어 2.8.0 으로 갱신하고, 셀 안에 «여기는 손으로 고쳐야 한다 — 락스텝 범프가 여기까지 안 온다»를 적었다.

## 🟥 이 커밋의 목적 문장이 4파일 중 1파일에만 착지해 있었다

EN 의 «위 표의 모든 행에 적용되는 것이 아니다»라는 **명시적 부정절이 ko/ja/zh 에 없었다.** 스코핑이 다음 문장의 **암시**로만 전달돼서, 첫 문장만 훑는 독자에겐 **고치기 전과 같은 과일반화가 그대로 남았다.** 수리가 번역본에 약하게 착지한 반쪽-픽스이고, 하필 이 델타의 헤드라인이다.

판별을 「번역이 약하다」는 인상이 아니라 **주장 6항의 유무 분해**로 한 것이 핵심이다 — 그래야 재현되고, 다음 언어가 추가돼도 같은 검사가 돈다. 재검 4/4, 컨트롤(없는 리터럴 0/4).

같이 나온 둘:
- 번역 3종만 «뭘 더 깔아두고 시작할 필요 없다»를 주장하는데 바로 아래 `<details>` 가 Python+PyYAML 을 요구한다 → **삭제**(괄호 예외는 원래 없던 주장을 굳히는 방향이라 안 골랐다)
- 방향 포인터가 가리키는 절 이름이 아래 절 이름과 충돌해 다음 사람이 또 뒤집을 자리였다 → **절 이름을 박아** 닫았다

## 수리가 죽은 포인터를 만들었고, 좌표 대조가 잡았다

표를 옮기면서 `quickstart above` 를 `below` 로 뒤집었다. **원문이 옳았다** — 표는 이동 전후 모두 퀵스타트 아래이고, 이동은 아래쪽 안에서 위로 간 것이지 퀵스타트를 넘어간 적이 없다. 원리를 맞게 알고 방향을 반대로 판단한 형태이고 4언어 전부 깨졌다. 판별은 「읽어보니 맞다」가 아니라 **헤딩 행번호와 표 행번호의 부등호**로 했다.

## 부채를 적어놓고 두지 않았다

마커가 `standpoint: DEGRADED_NOT_RUN` 이라고 적은 축을 실제로 돌렸다 — `npm pack` → 전개 → 대조. README 4종이 tarball 에 실리고 워킹트리와 `shasum` **4/4 IDENTICAL**. 상대 링크 **고유 29개 전수**, 컨트롤 동반(존재하는 것 → True, 없는 이름 → False). 표 문법·앞뒤 빈 줄 4/4, 컨트롤로 깨진 픽스처 3건 적발.

**F1 은 일부러 안 고쳤다** — `tracks/_contrib/README.md` 가 tarball 에서 죽은 링크(`tracks/` 가 `files[]` 에 없다)인데, 선재 결함이고 이 델타와 무관하다. 같이 고치면 «수리가 새 검토면을 만든다»를 그대로 재생산한다. 별건으로 남긴다.

## 검증

`selfcheck.sh` rc=0 · `count_check.sh` rc=0(`PASS count: README header`) · `package_coverage_check.sh` rc=0 — 전부 `out=$(...); rc=$?` 로 캡처. 줄 수 en 855→857 · ko 838→842 · ja 805→809 · zh 756→759.

**안 한 것**: 브라우저 렌더 · 재-pack(추론이지 측정 아님) · ja/zh 부정절 원어민 검토 · 사람 독자 콜드리드. 마커에 값으로 남겼다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ5j1CS87eUQALCWfaxy2F