### PR TITLE
feat(gate): 호출자 0인 스크립트가 조용히 느는 것을 막는 라쳇 — 그리고 그 게이트가 fail-open 이었다

### DIFF
--- a/.github/workflows/caller-zero-ratchet.yml
+++ b/.github/workflows/caller-zero-ratchet.yml
@@ -1,0 +1,106 @@
+# caller-zero-ratchet — blocks a NEWLY callerless production script.
+#
+# Transplant of qasp's `caller-zero-ratchet` CI job (synergy scan 2026-08-22, pair T2). The property
+# that matters is that the verdict is keyed on WHICH scripts are callerless against a committed
+# baseline, never on HOW MANY — a count-keyed gate passes when you wire one and add another.
+#
+# WHY A SEPARATE WORKFLOW AND NOT A STEP IN validate.yml:
+#   validate.yml is a REQUIRED check on main. A brand-new gate that has never run against a real PR
+#   should not be able to wedge the merge queue on its first false positive. This runs on its own,
+#   advisory-by-position (not in required contexts) until it has a few green PRs behind it, and
+#   promoting it is a deliberate operator decision — not something this file can grant itself.
+#
+# 🟥 IT RUNS ON LINUX AND IS AUTHORED ON macOS. That split is the point: this repo has measured a
+# regex that meant different things to BSD and GNU grep, green locally and dead in CI, on the arm
+# that was supposed to fail closed. The lanes run here for the same reason the checker does.
+name: caller-zero-ratchet
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/**'
+      - 'bin/**'
+      - 'templates/.git-hooks/**'
+      - 'templates/*.json'
+      - '.claude/capabilities/**'
+      - 'package.json'
+      # 🟥 EVERY workflow, not just this one. The scanner treats `.github/workflows/*.yml` and
+      # `*.yaml` as runner surfaces, so a PR that deletes a script's ONLY dispatch out of
+      # validate.yml removes a caller — and under the old filter (which named this file alone)
+      # this job did not run on that PR. The trigger surface and the scanned surface have to be
+      # the same set, or the gate is blind on exactly the diffs that create the debt it hunts.
+      - '.github/workflows/**'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ratchet:
+    runs-on: ubuntu-latest
+    steps:
+      # 🟥 fetch-depth: 0 IS LOAD-BEARING, NOT A CONVENIENCE. The shrink-only half of the ratchet
+      # diffs the `baseline:` section against the base commit; the default depth-1 checkout has no
+      # base to diff against, and the checker would then correctly report `shrink-only: UNMEASURED`
+      # — a green job that measured nothing. It also supplies the remote-tracking ref the next step
+      # merge-bases against, and the history the HEAD~1 fallback needs. Paired with the
+      # FH_RATCHET_REQUIRE_BASE the next step COMPUTES (it is no longer hardcoded to '1' here: the
+      # step emits require=1 whenever it found a base, and require=0 only in the one case where no
+      # earlier commit exists at all, which it announces with a ::warning::).
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # 🟥 THE BASE IS NAMED HERE, NOT LEFT TO THE CHECKER'S AUTO-RESOLVER.
+      # Cross-family reproduction 2026-08-22 (codex/gpt-5.5): on `push` to main, GITHUB_BASE_REF is
+      # unset and `origin/main` resolves to the checked-out HEAD, so the checker compared the commit
+      # with ITSELF and printed "shrink-only ENFORCED" over a commit that added both a callerless
+      # script AND its `baseline:` line. Detached and shallow checkouts have the same shape. The
+      # checker now refuses a HEAD base under FH_RATCHET_REQUIRE_BASE=1, and this step supplies the
+      # base that makes the comparison real rather than merely making the job red.
+      #
+      # WHY MERGE-BASE AND NOT `pull_request.base.sha` ON PRs. base.sha is the base branch tip as of
+      # PR creation; a PR checkout is the MERGE ref, so it already contains whatever main gained
+      # since. Diffing against the stale tip would report main's own changes as this PR's additions —
+      # a false block, on the PASS-side-is-safe reasoning's opposite side. merge-base against the
+      # CURRENT base branch asks the question the gate actually means: does this PR add an entry that
+      # is not on the base branch now. base.sha stays as the fallback for when the remote-tracking
+      # ref is unavailable.
+      # 🟥 THE BODY OF THIS STEP IS A SCRIPT, NOT A `run:` BLOCK, AND THAT IS THE POINT.
+      # It was ten inline lines, and no lane can execute a `run:` block — so the one component that
+      # decides whether this gate measures anything had no anchor on it, and carried an A-grade
+      # fail-open through three review rounds: a base NAMED by the event but missing from the
+      # checkout (the force-push shape) was silently replaced by HEAD~1, and the checker then
+      # printed "shrink-only ENFORCED" over a one-commit window. Reproduced on a three-commit
+      # fixture before the extraction; the resolver's header carries the two arms verbatim, and
+      # lanes L24–L26 in scripts/test_script_caller_ratchet_lanes.sh hold it closed.
+      # It now degrades CLOSED (exit 3) instead of substituting a different comparison.
+      - name: resolve an immutable base
+        id: base
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          BASE_BRANCH: ${{ github.base_ref }}
+        run: bash scripts/ratchet_base_resolve.sh
+
+      # Lanes FIRST. A checker whose known pair has not been executed is not an instrument, and a
+      # green ratchet verdict from an unexercised checker is the fail-open this whole class of gate
+      # exists to prevent. If the lanes go red, the verdict below means nothing and the job stops.
+      - name: known-pair lanes (fixture roots, never this tree)
+        run: bash scripts/test_script_caller_ratchet_lanes.sh
+
+      # This is the merge boundary, so the shrink-only comparison degrades CLOSED here: if the base
+      # cannot be resolved the job errors (exit 2) instead of printing a labelled UNMEASURED and
+      # passing. The env var is set HERE and nowhere else — a developer's machine keeps the
+      # non-blocking labelled form on purpose, because an over-blocking local gate trains
+      # `--no-verify` and disarms the pre-commit hooks that share that channel.
+      - name: caller-zero ratchet
+        run: bash scripts/script_caller_ratchet.sh --list
+        env:
+          FH_RATCHET_BASE_REF: ${{ steps.base.outputs.base }}
+          FH_RATCHET_REQUIRE_BASE: ${{ steps.base.outputs.require }}
+
+      # Not `continue-on-error` and not `|| true`: an instrument that is allowed to fail silently
+      # reports a clean tree whenever it breaks. Exit 2 (instrument error) is as red as exit 1.

--- a/scripts/caller_zero_baseline.txt
+++ b/scripts/caller_zero_baseline.txt
@@ -1,0 +1,53 @@
+# caller_zero_baseline.txt — the committed identity list for scripts/script_caller_ratchet.sh.
+#
+# 🟥 THE RATCHET IS KEYED ON IDENTITY, NOT ON COUNT. A count-keyed gate passes when you wire one
+# script and add another; that is the regrowth this file exists to stop. What blocks is a callerless
+# script whose PATH is not written below.
+#
+# TWO SECTIONS, AND THEY MEAN DIFFERENT THINGS:
+#   exempt:    this script legitimately has no in-repo caller. It is an entry point (a human, an
+#              installer, a container, a capability runtime invokes it) or a declared research
+#              artifact. Nothing is owed. These lines are permanent until the script's role changes.
+#   baseline:  this script SHOULD have a caller and does not. Measured debt, grandfathered so the
+#              gate can be turned on today. Shrink-only: when one gets wired, delete its line.
+#              🟥 A NEW entry here is not a legal move, and as of 2026-08-22 that is ENFORCED, not
+#              merely stated: the checker diffs this section against the base commit and blocks on
+#              any added path. Until that day the sentence was true in prose and false in code —
+#              the rule was misdescribing its own machine, which is the defect class this repo has
+#              logged as the one a blind read structurally cannot catch. Removing a line, or moving
+#              one from baseline: to exempt:, always passes.
+#              ⚠️ The enforcement compares against a BASE COMMIT. Where no base is resolvable (a
+#              depth-1 clone, a non-repo fixture root) the run prints `shrink-only: UNMEASURED` and
+#              does not block — except in CI, where FH_RATCHET_REQUIRE_BASE=1 turns that into exit 2.
+#
+# Every line needs a trailing `# <reason>` of 12+ characters. That is a channel check, in this
+# repo's sense: it asserts the record is present and attributable, never that the reason is good.
+# If you cannot write the sentence, the script probably belongs in a runner instead of in this file.
+#
+# Measured 2026-08-22. The live population and runner-surface counts are printed by the checker on
+# every run and are deliberately NOT copied here: a hand-maintained number beside a self-discovering
+# scan is a second source of truth that goes stale in silence (lane_runner_check.sh carries the same
+# warning after its own header stated one figure while its code held another). Every line below was
+# hand-checked by grepping the runner surfaces for that basename before it was written here — the
+# first machine-generated draft listed 36 and was wrong: the predicate was missing three dispatch
+# idioms (dot-source, assign-then-dispatch, and quote-prefixed `"bash scripts/x.sh"` inside JSON),
+# and two more entries dissolved when `.claude/capabilities/*.cap` was added as a runner surface.
+# 36 → 13 is a repair of the instrument, not of the tree.
+
+exempt:
+  - scripts/activity_log.sh   # on-demand chronological assembler, invoked by an operator/session when a trail is wanted — its own header says on-demand
+  - scripts/push_zone_check.sh   # human-run enumerate tool, same class as templates/predelete_check.sh: "run it BEFORE a multi-repo push round"
+  - scripts/docker_phase0_verify.sh   # one-shot Docker Track 2 proof, needs a running Docker/OrbStack daemon — auto-running it in CI would fail-closed on every consumer
+  - scripts/docker_phase1_verify.sh   # same Docker Track 2 one-shot; additionally spends live codex calls, so it must stay operator-initiated
+  - scripts/docker_phase1b_verify.sh   # same Docker Track 2 one-shot; needs a local Ollama endpoint that exists on one machine only
+  - scripts/dlp_calibration.sh   # one-shot calibration run against local models; produces a number for a human to read, has no verdict a runner could gate on
+  - scripts/rtk_gross_ablation.sh   # measurement instrument, requires the rtk binary installed; run by hand when the savings claim is being re-measured
+  - scripts/tier_census_grep.sh   # census HELPER invoked by hand during a Sonnet-Floor audit — it reports, it does not judge, so nothing gates on it
+  - scripts/fh-dispatch.sh   # entry point: the host-to-container bridge an operator or a headless job invokes directly, the way bin/*.js is invoked
+  - scripts/fh-frontier-send.sh   # declared RESEARCH ARTIFACT in its own header, explicitly "not a load-bearing tool" — wiring it would give it a status it disclaims
+
+baseline:
+  - scripts/below_floor_scan.sh   # PROSE-INVOKED FLOOR. operations.md §weekly-audit step 2 says to run it and nothing does; the pre-commit hook's below-floor ack is written against a consumer that never fires
+  - scripts/chamber_candidate_collect.sh   # the discovery entrance's second half; its sibling chamber_candidate_screen.sh has callers and this one does not
+  - scripts/validate_yaml.sh   # SHIPPED via package.json files[] and named by .github/workflows/validate.yml — but only inside a COMMENT, so the frontmatter validator that guards Codex/Gemini parsing runs nowhere
+  - scripts/frontier_digest_autopilot.sh   # the tracked plist names it on a /path/to/ PLACEHOLDER launchd cannot execute; ship_readiness_gate.md already records that placeholder as an identity-④ defect and the first draft of this ratchet PASSED over it

--- a/scripts/package_coverage_check.sh
+++ b/scripts/package_coverage_check.sh
@@ -163,6 +163,26 @@ ACCEPTED_ABSENT=(
   #       이 레포 레인 코퍼스에 대고 판정한다). 소비자 트리엔 판정 대상이 없다.
   "scripts/residency_closure_scan.py"
   "scripts/test_residency_closure_lanes.sh"
+  # ── caller-zero-ratchet, 2026-08-22. 셋 다 **싣는 것이 틀렸다** — 「아직 안 실었다」가 아니다 ──
+  # 이 게이트는 「production 스크립트에 디스패처가 있나」를 **이 레포의 러너 표면**에 대고 판정한다.
+  # 그 표면의 하나가 `.github/workflows/**` 이고, **워크플로 디렉터리는 files[] 에 없다.** 그러므로
+  # 소비자 트리에서 이 검사기를 돌리면 워크플로에서만 디스패치되는 스크립트들이 전부 caller 0 으로
+  # 떨어지고, 그것들은 소비자의 `caller_zero_baseline.txt` 에 선언돼 있지 않으므로 **UNDECLARED →
+  # exit 1**. 즉 출하하면 **모든 신선한 설치에서 100% 적색**이다 — CLAUDE.md 가 「모든 새 install 을
+  # 막는 게이트는 엄격한 게이트가 아니라 우회 훈련기」라고 못박은 그 형태이고, 바로 위
+  # outbound_query_guard 블록과 **같은 사유**다.
+  # 앵커도 같이 안 나간다. 주체 부재라는 짝 규칙 말고 **자기 자신의 사유가 하나 더 있다**: 마지막
+  # 레인(L27)이 `.github/workflows/caller-zero-ratchet.yml` 을 읽어 워크플로가 리졸버를 인라인으로
+  # 되돌리지 않았는지 본다. 그 파일이 없는 트리에서 그 레인은 **부재를 결함으로 읽어 적색**이 된다.
+  # 🟥 위 ⓒ 의 교훈은 여기 **해당하지 않는다**: 저건 「주체는 출하되는데 앵커만 빠진」 빚이었고,
+  # 여기는 주체·앵커·베이스리졸버가 **셋 다** 소비자에게 판정 대상이 없다. 침묵시키는 게 아니라
+  # 애초에 그쪽 트리에 질문이 없다.
+  # ⚠️ 명시 잔여: 그래서 이 게이트는 **이 레포에서만** 회귀를 막는다. 소비자 설치본의
+  # built-but-not-wired 는 이것으로 안 잡히고, 그걸 잡으려면 러너 표면 목록을 패키지 모드로
+  # 라우팅하는 별도 설계가 필요하다 — 안 했다.
+  "scripts/script_caller_ratchet.sh"
+  "scripts/ratchet_base_resolve.sh"
+  "scripts/test_script_caller_ratchet_lanes.sh"
   # ── The two settings destinations, surfaced 2026-08-13 by fixing this file's own extractor ────
   # These were invisible until the `js|json` alternation below was corrected: every `.json`
   # reference in every shipped doc was being truncated to `.js`, a path that exists nowhere, so

--- a/scripts/ratchet_base_resolve.sh
+++ b/scripts/ratchet_base_resolve.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# ratchet_base_resolve.sh — pick the base commit scripts/script_caller_ratchet.sh diffs `baseline:`
+# against, and REFUSE to substitute a different one when the named base is gone.
+#
+# ── WHY THIS IS A SCRIPT AND NOT TEN LINES OF YAML ────────────────────────────────────────────
+# It was ten lines of YAML, inside .github/workflows/caller-zero-ratchet.yml, and that is precisely
+# why the defect below survived three adversarial review rounds: no lane can execute a `run:` block.
+# The ratchet's own doctrine is that a claim with no executable anchor is prose, so the base
+# resolver — the component that decides whether the gate measures anything at all — was the one
+# part of this gate with no anchor on it. Extracting it is the repair that makes it testable;
+# scripts/test_script_caller_ratchet_lanes.sh L24–L26 are the lanes that could not exist before.
+#
+# ── THE DEFECT, REPRODUCED 2026-08-22 BEFORE THIS FILE EXISTED ────────────────────────────────
+# The YAML resolved a candidate, tested it with `git cat-file -e`, and on failure set `B=""` and
+# fell through to `HEAD~1`. Measured on a three-commit fixture (A base · B = a callerless script
+# AND its new `baseline:` line, the illegal move · C an unrelated later commit), driving the step
+# body verbatim:
+#
+#   PUSH_BEFORE=<A, reachable>          -> base=A       -> checker exit 1, names scripts/newdebt.sh
+#   PUSH_BEFORE=<a force-pushed-away sha> -> base=HEAD~1 -> checker exit 0,
+#                                          "shrink-only ENFORCED — no new `baseline:` entry"
+#
+# Both properties are the failure, and they compound:
+#   ① the substitution is SILENT — nothing in the output says the requested comparison was refused;
+#   ② the substitute is NARROWER (one commit), so growth landed anywhere earlier in the same push
+#      is invisible — and the run still prints ENFORCED, the strongest word this gate owns.
+# It also contradicted the checker's own header, which already said in as many words that a named
+# base that does not resolve is exit 2 and "NEVER a silent fall-through to auto-detection". The
+# rule was true in the checker and false in the workflow that drives it — the same
+# rule-misdescribes-its-own-machine shape the shrink-only half was written to close.
+#
+# 🟥 A FORCE-PUSH IS EXACTLY WHEN THE COMPARISON MATTERS MOST AND EXACTLY WHEN IT DISAPPEARS.
+# That is why the fallback direction is the whole question: the base going missing is not a random
+# infrastructure hiccup, it is correlated with history being rewritten under the gate.
+#
+# ── THE RULE ──────────────────────────────────────────────────────────────────────────────────
+#   a candidate was NAMED by the event and does not resolve here  -> exit 3, degrade CLOSED.
+#       No substitution. "I could not make the comparison you asked for" and "I made it and found
+#       nothing" are different facts, and only one of them may be printed as a pass.
+#   NO candidate was named at all (workflow_dispatch · a branch's first push, before=all-zeros)
+#       -> HEAD~1 if it exists, ANNOUNCED as a one-commit window; else BOOTSTRAP (require=0).
+#       Nothing was asked for, so nothing is being substituted. This half is UNCHANGED from the
+#       YAML it replaces and is deliberately not widened here — see the residual note below.
+#
+# ⚠️ NAMED RESIDUAL, not silently absent: the no-candidate HEAD~1 window is still one commit wide,
+# and the checker will call a clean result there ENFORCED. That is a weaker version of ② above and
+# it is left open on purpose — closing it needs a fifth shrink-state in the checker, which is a
+# separate change to a separate file. It is not the reproduced defect and is not fixed here.
+#
+# Usage:  bash scripts/ratchet_base_resolve.sh [--root DIR]
+# Env in:   BASE_BRANCH   github.base_ref                       (pull_request)
+#           PR_BASE_SHA   github.event.pull_request.base.sha    (pull_request)
+#           PUSH_BEFORE   github.event.before                   (push)
+#           RATCHET_OUTPUT  file to append `base=`/`require=` to; defaults to $GITHUB_OUTPUT.
+#                           Absent -> the answer is printed and nothing is written.
+# Exit:   0 = an answer was produced (base+require written; require=0 means BOOTSTRAP)
+#         2 = instrument error — --root is not a directory, or not a git work tree
+#         3 = a NAMED base does not resolve in this checkout — degrade CLOSED, no substitution
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --root) ROOT="${2:-}"; shift 2 || exit 2 ;;
+    -h|--help) sed -n '/^# Usage:/,/^# Exit:/p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) echo "usage: $0 [--root DIR]" >&2; exit 2 ;;
+  esac
+done
+[ -d "$ROOT" ] || { echo "FAIL  ratchet-base: --root '$ROOT' is not a directory"; exit 2; }
+
+if ! git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+  echo "FAIL  ratchet-base: '$ROOT' is not a git work tree, so no base can be resolved."
+  echo "      That is an instrument error, not a bootstrap: a checkout that should be a repo and"
+  echo "      is not means the step ran somewhere nobody intended."
+  exit 2
+fi
+
+OUT="${RATCHET_OUTPUT:-${GITHUB_OUTPUT:-}}"
+emit() {   # emit <base> <require>
+  echo "base=$1"
+  echo "require=$2"
+  if [ -n "$OUT" ]; then { echo "base=$1"; echo "require=$2"; } >> "$OUT"; fi
+}
+
+ZEROS=0000000000000000000000000000000000000000
+
+# 🟥 `out=$(cmd)` then `rc=$?` on its OWN line, every time. A `|| echo` fallback anywhere in this
+# file would hand an empty string to a `[ -n ... ]` test as though it were an answer, which is the
+# whole failure mode being repaired ([[feedback_pipefail_fallback_disarms_guard]]).
+_rev() {   # _rev <ref> -> prints the commit sha, rc 0; prints nothing, rc nonzero
+  _o=$(git -C "$ROOT" rev-parse --verify --quiet "${1}^{commit}" 2>/dev/null)
+  _r=$?
+  [ "$_r" -eq 0 ] && [ -n "$_o" ] || return 1
+  printf '%s' "$_o"
+}
+
+# ── ① WAS A BASE NAMED BY THE EVENT? ──────────────────────────────────────────────────────────
+# "Named" is about the EVENT PAYLOAD, not about whether the ref happens to be present. That
+# distinction is the entire fix: the old code asked "did it resolve", got no, and could no longer
+# tell "nobody asked" apart from "what was asked for is gone".
+NAMED=""; NAMED_FROM=""
+if [ -n "${BASE_BRANCH:-}" ]; then
+  NAMED="origin/${BASE_BRANCH}"; NAMED_FROM="github.base_ref"
+elif [ -n "${PR_BASE_SHA:-}" ]; then
+  NAMED="${PR_BASE_SHA}"; NAMED_FROM="github.event.pull_request.base.sha"
+elif [ -n "${PUSH_BEFORE:-}" ] && [ "$PUSH_BEFORE" != "$ZEROS" ]; then
+  NAMED="${PUSH_BEFORE}"; NAMED_FROM="github.event.before"
+fi
+
+if [ -n "$NAMED" ]; then
+  # WHY MERGE-BASE ON A BRANCH AND A PLAIN RESOLVE ON A SHA. A PR checkout is the MERGE ref, so it
+  # already carries whatever main gained since the PR opened; diffing against the base branch TIP
+  # would report main's own additions as this PR's — a false block. merge-base asks the question
+  # the gate means. A sha candidate is already immutable and needs no merge-base.
+  BASE=""
+  case "$NAMED" in
+    origin/*)
+      _o=$(git -C "$ROOT" merge-base HEAD "$NAMED" 2>/dev/null)
+      _r=$?
+      [ "$_r" -eq 0 ] && BASE="$_o"
+      # A PR whose base-branch tracking ref is missing still has base.sha; that is a DIFFERENT
+      # naming of the same intent, not a substitution, so it is tried before giving up.
+      if [ -z "$BASE" ] && [ -n "${PR_BASE_SHA:-}" ]; then
+        BASE="$(_rev "$PR_BASE_SHA")" || BASE=""
+        [ -n "$BASE" ] && NAMED="$PR_BASE_SHA" && NAMED_FROM="github.event.pull_request.base.sha"
+      fi
+      ;;
+    *)
+      BASE="$(_rev "$NAMED")" || BASE=""
+      ;;
+  esac
+
+  if [ -z "$BASE" ]; then
+    # 🟥 DEGRADE CLOSED. No HEAD~1, no auto-detection, no labelled UNMEASURED. The event named a
+    # comparison; answering a different question and reporting it under the same word is how an
+    # instrument speaks confidently about the wrong target.
+    echo "FAIL  ratchet-base: the base named by this event does not resolve in this checkout."
+    echo "        named by : $NAMED_FROM"
+    echo "        value    : $NAMED"
+    echo "      This is the force-push / rewritten-history shape, which is exactly when the"
+    echo "      shrink-only comparison matters and exactly when its base disappears. Substituting"
+    echo "      HEAD~1 here would compare a ONE-COMMIT window and print ENFORCED over it."
+    echo "      Fix by ONE of:"
+    echo "        ① fetch the missing history (actions/checkout fetch-depth: 0)"
+    echo "        ② re-run via workflow_dispatch — no base is named there, so the shrink-only half"
+    echo "           reports BOOTSTRAP instead of a comparison it cannot make"
+    echo "        ③ if history really was rewritten, re-baseline deliberately and say so"
+    echo "::error title=caller-zero-ratchet::base named by $NAMED_FROM ($NAMED) is unreachable; refusing to substitute a narrower base"
+    exit 3
+  fi
+
+  emit "$BASE" 1
+  echo "ratchet-base: $BASE (named by $NAMED_FROM)"
+  exit 0
+fi
+
+# ── ② NOTHING WAS NAMED ───────────────────────────────────────────────────────────────────────
+# workflow_dispatch, or a branch's very first push (before = all-zeros). Nothing is being
+# substituted for anything, because nothing was requested.
+BASE="$(_rev 'HEAD~1')" || BASE=""
+if [ -n "$BASE" ]; then
+  emit "$BASE" 1
+  echo "ratchet-base: $BASE (HEAD~1 — no base was named by this event)"
+  echo "::warning title=caller-zero-ratchet::No base named by this event; comparing against HEAD~1, a ONE-COMMIT window. Growth landed in an earlier commit of this push would not be seen."
+  exit 0
+fi
+
+# 🟥 require=0 with an EMPTY base, never require=1 with an empty base — the empty-input case.
+# A require=1 paired with an empty base would reach the checker as "compare against nothing while
+# refusing to accept nothing", i.e. exit 2 for a repo whose only sin is having one commit. A gate
+# no author action can satisfy is an override-trainer and disarms the hooks beside it.
+emit "" 0
+echo "ratchet-base: BOOTSTRAP — no prior commit exists at all; the shrink-only half is unjudged."
+echo "      The UNDECLARED-callerless half is independent of the base and still enforces fully."
+echo "::warning title=caller-zero-ratchet::No prior commit resolvable; shrink-only half is BOOTSTRAP for this run."
+exit 0

--- a/scripts/script_caller_ratchet.sh
+++ b/scripts/script_caller_ratchet.sh
@@ -1,0 +1,773 @@
+#!/usr/bin/env bash
+# script_caller_ratchet.sh — a PRODUCTION script that nothing dispatches is prose, not machinery.
+#
+# ── WHY THIS EXISTS, AND WHY IT IS NOT lane_runner_check.sh ────────────────────────────────────
+# [[feedback_built_but_not_wired]] is named in memory and enforced nowhere on this population.
+# The repo already has ONE ratchet of this shape and it is deliberately narrower:
+#
+#   scripts/lane_runner_check.sh  — population: LANE SUITES (`test_*.sh` / `*_lanes.sh`) plus
+#                                   embedded `--self-test` dispatchers. Three-valued
+#                                   (WIRED / EXEMPT / DEBT), declarations live in in-script arrays.
+#                                   Wired into scripts/selfcheck.sh.
+#
+# That check answers "does anything RUN this lane suite". It cannot answer "does anything CALL this
+# production script", because a production script matches neither of its globs. Measured on this
+# tree at authoring time: `scripts/prior_art_prompt.sh` sat with zero settings registrations for a
+# stretch, and CLAUDE.md itself records `scripts/consent_registry_check.sh` as **unwired** — neither
+# is a lane suite, so neither is visible to lane_runner_check.sh, and both were found by hand.
+#
+# THE POPULATIONS ARE DISJOINT ON PURPOSE. This file EXCLUDES `test_*.sh` / `*_lanes.sh` and
+# delegates them to lane_runner_check.sh. Two instruments over one file would give the repo two
+# answers to the same question and a place for them to diverge in silence — the exact
+# duplicate-normalizer defect this repo has already logged.
+#
+# ── THE TECHNIQUE: RATCHET BY IDENTITY, NOT BY COUNT (transplanted from qasp `caller-zero-ratchet`)
+# Synergy scan 2026-08-22 pair T2. The load-bearing property is that the verdict is keyed on WHICH
+# scripts are callerless, against a committed baseline file — never on HOW MANY. A count-keyed gate
+# passes when you wire one script and add another, which is precisely the regrowth a ratchet exists
+# to stop. The outward pass on that pair also found the technique is a named, common pattern
+# ("baseline ratchet" — knip / ts-prune `--save-baseline` and friends), so this is an adoption of a
+# known shape, not an invention. No such tool covers a shell+markdown repo, which is why it is
+# hand-rolled here rather than installed.
+#
+# ── FOUR-VALUED, and the middle two are the whole point ───────────────────────────────────────
+#   WIRED      — some tracked runner dispatches it (script · git hook · CI workflow · package.json
+#                · bin/*.js · launchd plist · a tracked settings snippet under templates/)
+#   EXEMPT     — declared in the baseline file with a reason it legitimately has no caller
+#                (an entry point a human or an installer invokes; a shipped template payload)
+#   BASELINE   — declared known-callerless debt: grandfathered, printed on every run, does NOT block
+#   UNDECLARED — none of the above → **FAIL**. Today's callerless set is debt; tomorrow's is a bug.
+#
+# 🟥 ZERO CALLERS IS NOT AUTOMATICALLY A DEFECT. A human-run enumerate tool
+# (`templates/predelete_check.sh` is run by a human BY DESIGN — CLAUDE.md says so in as many words),
+# an npm entry point, a launchd payload: all legitimately have no in-repo caller. That is what
+# EXEMPT is for, and every EXEMPT entry must carry a written reason. Exclusions are declared by
+# identity in the baseline file — never by a `grep -v` in the scan — because a dead filter kills only
+# the true positives and reports green ([[feedback_deletion_beats_repair_dead_filter]]).
+#
+# ── WHAT THIS DOES NOT MEASURE (named, not silently absent) ────────────────────────────────────
+#   · `templates/**/*.sh` is OUT OF POPULATION. Those are shipped payload executed inside a
+#     CONSUMER's repo; "no caller here" is their correct state and scanning them would produce a
+#     baseline of pure noise. Their wiring is a consumer-install property, unmeasured by this file.
+#   · `.claude/settings.json` is GITIGNORED in this repo. A script dispatched ONLY from there is
+#     wired on one machine and callerless for every consumer and for CI. This scan therefore does
+#     NOT count it as a caller — but it does READ it and print a separate `local-only` line, so the
+#     state is visible rather than rendered as a plain zero.
+#   · A dispatch built at runtime from a variable path this scan cannot resolve reads as no caller.
+#     Same bounded-regex limit lane_runner_check.sh names for itself; the fix is a baseline entry.
+#   · Markdown is never a caller. CLAUDE.md naming a script is a MENTION — this repo has logged the
+#     prose-invoked-floor defect explicitly, so `.md` is not in the runner surface list.
+#
+# ── THE SECOND HALF OF THE RATCHET: baseline: IS SHRINK-ONLY, AND THAT IS ENFORCED ────────────
+# The four-value classification above answers "is anything callerless and undeclared". On its own
+# that is only half a ratchet, and the missing half is the load-bearing one: nothing stopped an
+# author from making a script callerless AND adding its path to `baseline:` in the same change,
+# which passed. Measured 2026-08-22 by the governor — the FAIL message below already said in prose
+# that this was not a legal move while the code allowed it, i.e. the rule was misdescribing its own
+# machine. The `baseline:` section is now diffed against a BASE COMMIT and additions block.
+#
+# Usage:  bash scripts/script_caller_ratchet.sh [--root DIR] [--list] [--print-baseline] [--base REF]
+#   --root DIR        scan DIR instead of the repo this script lives in (fixture isolation)
+#   --list            print the per-script verdict table
+#   --print-baseline  emit a baseline-file body for the CURRENT callerless set, to stdout, and exit
+#                     0 without judging. Bootstrap aid only — every emitted line needs a reason
+#                     written by a human before it is committed.
+#   --base REF        compare `baseline:` against REF instead of the auto-resolved base
+#                     (env twin: FH_RATCHET_BASE_REF)
+# Env:    FH_RATCHET_BASE_REF   as --base
+#         FH_RATCHET_REQUIRE_BASE=1
+#                     an UNUSABLE base becomes exit 2 instead of a labelled non-blocking line.
+#                     Unusable = no base at all (UNMEASURED) **or** a base that resolved to HEAD
+#                     itself (WORKTREE_ONLY) — the second is the one a cross-family review had to
+#                     add: on `push` to main, `origin/main` IS the checked-out HEAD, and comparing
+#                     a commit with itself can never show growth, so the pass was vacuous.
+#                     🟥 SET THIS IN CI AND NOWHERE ELSE. The split is deliberate: at the merge
+#                     boundary the shrink check degrades CLOSED, because that is the surface where
+#                     regrowth actually lands; on a developer's machine (no origin, shallow clone,
+#                     a fixture root that is not a repo) it degrades to a LABELLED UNMEASURED
+#                     rather than blocking, because an over-blocking local gate trains `--no-verify`
+#                     and disarms the neighbouring hooks along with this one.
+# Exit:   0 = every non-lane script is WIRED, EXEMPT or BASELINE, and `baseline:` did not grow
+#         1 = an UNDECLARED callerless script, or a NEW `baseline:` entry (the ratchet fired)
+#         2 = instrument error — unreadable/invalid baseline, zero scripts scanned, or an
+#             unusable base (none, or HEAD itself) under FH_RATCHET_REQUIRE_BASE=1
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SELF_DIR/.." && pwd)"
+MODE="judge"; LIST=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --root) ROOT="${2:-}"; shift 2 || exit 2 ;;
+    --list) LIST=1; shift ;;
+    --print-baseline) MODE="emit"; shift ;;
+    --base) FH_RATCHET_BASE_REF="${2:-}"; export FH_RATCHET_BASE_REF; shift 2 || exit 2 ;;
+    -h|--help) sed -n '/^# Usage:/,/^# Exit:/p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) echo "usage: $0 [--root DIR] [--list] [--print-baseline] [--base REF]" >&2; exit 2 ;;
+  esac
+done
+[ -d "$ROOT" ] || { echo "FAIL  caller-ratchet: --root '$ROOT' is not a directory"; exit 2; }
+cd "$ROOT" || exit 2
+
+BASELINE_FILE="scripts/caller_zero_baseline.txt"
+
+# The whole judgment is one python3 pass. python3 is already a hard dependency of the sibling
+# ratchet and of selfcheck.sh, so this adds no new requirement.
+#
+# 🟥 `out=$(...)` then `rc=$?` on its OWN line — never `cmd | tail` and never `|| echo 0`.
+# A fallback operator here would hand a broken instrument's empty stdout to the parser and the
+# parser would render it as "no violations" ([[feedback_pipefail_fallback_disarms_guard]]).
+out=$(python3 - "$BASELINE_FILE" "$MODE" "$LIST" <<'PY'
+import os, re, sys, glob, json
+
+BASELINE_FILE, MODE, LIST = sys.argv[1], sys.argv[2], sys.argv[3] == '1'
+SELF = 'script_caller_ratchet.sh'
+err = []
+
+def read(path):
+    try:
+        return open(path, encoding='utf-8', errors='replace').read()
+    except OSError:
+        return ''
+
+# ── POPULATION ────────────────────────────────────────────────────────────────────────────────
+# Non-lane shell scripts under scripts/. Deduped by PATH, not by basename: scripts/adapters/ may
+# legitimately carry a name that also exists at the top level, and collapsing them would let one
+# file's wiring certify the other. (The sibling ratchet keys on basename and is single-directory;
+# copying that key into a two-level tree is how a scan silently under-reports.)
+LANE = re.compile(r'^(test_.*|.*_lanes)\.sh$')
+population = sorted(
+    p for p in glob.glob('scripts/*.sh') + glob.glob('scripts/adapters/*.sh')
+    if not LANE.match(os.path.basename(p)) and os.path.basename(p) != SELF
+)
+
+# ── RUNNER SURFACES — enumerated, never assumed ───────────────────────────────────────────────
+# Every entry was hand-checked against this tree. `.md` is deliberately absent: prose that names a
+# script is a mention, and this repo has a standing rule that a prose-invoked floor is not a floor.
+RUNNER_GLOBS = (
+    'scripts/*.sh', 'scripts/adapters/*.sh',      # scripts dispatch each other
+    'scripts/*.plist',                            # launchd payloads
+    'templates/.git-hooks/*',                     # the pre-commit / pre-push gates
+    'templates/*.json', 'templates/*.jsonc',      # tracked settings snippets the wizard merges
+    '.github/workflows/*.yml', '.github/workflows/*.yaml',
+    'bin/*.js',
+    'package.json',
+    # Typed capability entry points. A `.cap` file's `entry:` line is a real dispatch — this is how
+    # scripts/psa_probe_capability.sh and scripts/degrade_probe_capability.sh are reached, and
+    # neither has any other caller. Found by hand-checking the callerless list before writing the
+    # baseline: both would otherwise have been declared EXEMPT for a reason that is not true.
+    # Extending the SURFACE list is the correct repair; an exemption would have been a false record.
+    '.claude/capabilities/*.cap', '.claude/capabilities/adapters/*.cap',
+)
+runners = []
+for pat in RUNNER_GLOBS:
+    runners += [p for p in glob.glob(pat) if os.path.isfile(p)]
+# This file names every EXEMPT and BASELINE entry (in the file it reads, not in itself) and prints
+# script paths in its own report. Scanning itself would let the report certify its own todo list.
+runners = [r for r in runners if os.path.basename(r) != SELF]
+
+# Read but NOT counted as a caller — see the header. Kept as its own surface so the state is a
+# labelled value rather than an invisible zero.
+LOCAL_ONLY_SURFACES = [p for p in ('.claude/settings.json',) if os.path.isfile(p)]
+
+def strip_line_comments(txt):
+    """`#`- and `//`-prefixed lines only. A mention is not an invocation, and the commonest mention
+    in this tree is a usage line in a header comment. Line-prefix only: a dispatch inside a heredoc
+    body or an echoed string still reads as live. That limit is inherited knowingly from
+    lane_runner_check.sh, which names the same residual for itself."""
+    keep = []
+    for ln in txt.split('\n'):
+        s = ln.strip()
+        if s.startswith('#') or s.startswith('//'):
+            continue
+        keep.append(ln)
+    return '\n'.join(keep)
+
+XML_COMMENT = re.compile(r'<!--.*?-->', re.S)
+
+# 🟥 The prefix is NOT `\b`. `\b` before the `.` alternative can never match: a POSIX dot-source is
+# written as ` . "$LIB"`, and between a space and a `.` there is no word boundary. Measured — the
+# first version of this constant used `\b` and called scripts/hook_source_lib.sh callerless while
+# two hooks dot-source it. A boundary assertion that is silently unsatisfiable for one alternative
+# is a dead filter that kills only true positives.
+# The prefix class is built with chr() for the same reason the quote class below is: keeping a
+# literal open-paren and literal quotes out of a heredoc line that bash's command-substitution
+# scanner also reads. chr(34)=" chr(39)=' chr(40)=(
+# 🟥 QUOTES ARE IN THE PREFIX CLASS ON PURPOSE. package.json spells its dispatch as
+#   "prepublishOnly": "bash scripts/prepublish_scope_note.sh && ..."
+# so the character before the verb is a double-quote. A prefix class of whitespace-and-operators
+# only dropped that file's five dispatches — measured, mid-authoring, when swapping \b for an
+# explicit class silently moved two scripts into the callerless set.
+_PRE = '(?m)(?:^|[' + chr(34) + chr(39) + chr(40) + r'\s;&|])'
+VERB = _PRE + r'(?:exec\s+)?(?:bash|sh|source|\.)'
+
+# 🟥 A BASENAME MUST MATCH AS A WHOLE PATH TOKEN, NEVER AS A SUBSTRING.
+# Measured (cross-family review 2026-08-22): a runner containing only `bash scripts/foo.sh.bak`
+# certified scripts/foo.sh as WIRED and the ratchet exited 0. The same hole runs the other way —
+# `bash scripts/myfoo.sh` certified foo.sh — and it is the worst possible direction for this gate,
+# because the FP is silent and always lands on the PASS side. Both ends are closed here:
+#   trailing  (?![\w.-])   `foo.sh.bak` · `foo.sh_old` · `foo.shx` no longer certify `foo.sh`
+#   leading   (?<![\w.-])  `myfoo.sh` · `x.foo.sh` no longer certify `foo.sh`
+# The allowed neighbours are exactly the path/shell terminators a real dispatch puts there:
+# `/` `"` `'` `(` `)` whitespace `;` `&` `|` `<` `>` and end-of-line.
+# The boundary is a lookaround pair, NOT a `grep -v` on the hit list: an exclusion applied after
+# the fact is the dead-filter shape this repo has logged, and it kills true positives first.
+def name_re(name):
+    return r'(?<![\w.\-])' + re.escape(name) + r'(?![\w.\-])'
+
+def dispatches_shell(name, body):
+    """THREE shapes, all three measured live in this tree. The first draft shipped only shape 1 and
+    reported 36 callerless scripts; a hand-check of the first eight found FIVE of them dispatched —
+    the predicate was wrong, not the tree. That is the calibration rule doing its job, and the count
+    was never published anywhere but this comment.
+
+    Shape 1 (direct): `bash|sh|source|. <...name>` on one line. `source`/`.` matter because a
+        library is dispatched by being sourced — scripts/hook_source_lib.sh is loaded that way by
+        two hooks and shape 1 without the source verb called it callerless.
+    Shape 2 (for-list): the literal name sits in a `for VAR in ...` list whose body runs $VAR.
+        Inherited from lane_runner_check.sh, which hand-verified two live cases of it.
+    Shape 3 (assign-then-dispatch): `JC_LINT="$REPO_ROOT/scripts/judgment_circuit_lint.sh"` on one
+        line and `bash "$JC_LINT"` on another. This is the DOMINANT idiom in templates/.git-hooks/
+        and in scripts/selfcheck.sh, and shape 1 structurally cannot see it: the name and the verb
+        never share a line. It is keyed to the variable actually assigned the path — not to "this
+        file mentions the name and also runs something" — so a fixture `cp "$ROOT/scripts/x.sh"`
+        does not become a caller."""
+    lines = body.split('\n')
+    NAME = name_re(name)
+    nre = re.compile(NAME)
+    direct = re.compile(VERB + r'\s+[^\n]{0,80}?' + NAME)
+    indirect = any(re.search(VERB + r'\s+' + chr(34) + r'?\$', ln) for ln in lines)
+    assigned = set()
+    for ln in lines:
+        # 🟥 The token-boundary form, not `name in ln`. A substring prefilter here re-opened the
+        # hole the boundary closes above: `JC="$R/scripts/foo.sh.bak"` registered JC as holding
+        # foo.sh, and the later `bash "$JC"` then certified foo.sh through shape 3.
+        if not nre.search(ln):
+            continue
+        if direct.search(ln):
+            return True
+        if indirect and re.match(r'\s*(for\s+\w+\s+in\b|["\']?\S*\|)', ln):
+            return True
+        m = re.match(r'\s*(?:local\s+|export\s+|declare\s+-\w+\s+)?([A-Za-z_][A-Za-z0-9_]*)=', ln)
+        if m:
+            assigned.add(m.group(1))
+    # 🟥 The quote class is built with chr() — a line inside this heredoc that carries an ODD number
+    # of literal double-quotes desynchronises bash's command-substitution scan and breaks the parse
+    # of every line after it (measured here; lane_runner_check.sh records the paren twin of it).
+    QC = '[' + chr(34) + chr(39) + ']?'
+    for var in assigned:
+        v = re.escape(var)
+        # explicit verb on the variable, or the variable in command position at line start
+        if re.search(VERB + r'\s+' + QC + r'\$\{?' + v + r'\b', body):
+            return True
+        if re.search(r'(?m)^\s*' + QC + r'\$\{?' + v + r'\}?' + QC + r'(\s|$)', body):
+            return True
+    return False
+
+PLIST_STRING = re.compile(r'<string>(.*?)</string>', re.S)
+
+# 🟥 A PLACEHOLDER PATH IS NOT A DISPATCH — launchd cannot execute it.
+# Measured 2026-08-22 (governor known-pair): scripts/com.forge-harness.frontier-digest.plist
+# carries `<string>/path/to/forge-harness/scripts/frontier_digest_autopilot.sh</string>`, and its
+# own XML header says "Replace every /path/to/... below with your own absolute paths before
+# installing" — the tracked plist is a TEMPLATE, the live one lives under ~/Library/LaunchAgents.
+# Reading it as a caller made this gate PASS over a defect that
+# knowledge/shared/harness-core/ship_readiness_gate.md had already recorded against identity ④
+# ("the daily digest launcher ships a placeholder path in its plist"). A gate that green-lights a
+# defect its own repo has written down is worse than no gate.
+#
+# 🟥 WHY THIS IS A LITERAL PLACEHOLDER LIST AND NOT A PATH-EXISTENCE TEST. The obvious repair —
+# `os.path.isfile(<the absolute path>)` — is WRONG here and would have been the over-block: a
+# CORRECT plist hardcodes the author's own absolute path (`/Users/<op>/projects/...`), which does
+# not resolve on the Linux CI runner. That test would go green locally and red in CI on a plist
+# with nothing wrong with it, which is the exact BSD/GNU-split failure this workflow's header
+# warns about. The literal list is narrower, deterministic, and identical on both platforms.
+#
+# 🟥 `$VAR` / `${VAR}` / `~` ARE IN THE LIST AS OF 2026-08-22, and why they were OUT before is worth
+# keeping written down. The first draft excluded them under this repo's N>=3-before-mechanizing rule,
+# with the reason "no measured case in this tree" — which was true of the TREE and irrelevant to the
+# GATE. A cross-family reviewer then produced the case: `<string>$HOME/projects/forge-harness/scripts/
+# daily.sh</string>` was counted as a dispatch and the ratchet exited 0 (reproduced here before this
+# edit). launchd does NOT shell-expand ProgramArguments — it execs the literal string — so that path
+# is exactly as unexecutable as `/path/to/...`: the SAME defect class wearing different characters.
+# The correction to the reasoning: the N>=3 threshold governs whether to BUILD a mechanism, not which
+# members of a class an already-built mechanism recognises. This mechanism existed; leaving a known
+# member of its own class outside it is a dead spot, not restraint.
+# Over-block guard: each added form has a known-negative control below AND a lane twin — a real
+# absolute path (`/Users/...`), which contains none of these characters, must still wire.
+PLIST_PLACEHOLDER = re.compile(
+    r'(?:^|/)(?:'
+    r'path/to'
+    r'|your[-_]?(?:path|home|dir|repo|name)'
+    r'|<[^>]+>'
+    r'|\{\{[^}]*\}\}'
+    r'|\$\{[^}]*\}'                 # ${HOME}/... — launchd does not expand it
+    r'|\$[A-Za-z_][A-Za-z0-9_]*'    # $HOME/...
+    r'|~[^/]*'                      # ~/... and ~user/... — not expanded either
+    r'|TODO|CHANGEME|REPLACE[-_]?ME'
+    r')(?:/|$)', re.I)
+
+plist_placeholder_hits = []   # (surface, script) — surfaced in the report, never a silent drop
+
+def dispatches_plist(name, txt, surface=None):
+    """A plist has no `#` comments; it has XML ones, and this repo's plist uses an XML comment to
+    name an ALTERNATIVE script you could point it at. Taking bare presence as a dispatch reads that
+    comment as a caller — measured on scripts/com.forge-harness.frontier-digest.plist, where
+    frontier_digest_daily.sh is named only inside `<!-- ... -->`. So: strip XML comments, take the
+    <string> VALUES, and require the name as a whole path token inside a value that is not a
+    placeholder."""
+    body = XML_COMMENT.sub('', txt)
+    nre = re.compile(name_re(name))
+    seen_placeholder = False
+    for val in PLIST_STRING.findall(body):
+        if not nre.search(val):
+            continue
+        if PLIST_PLACEHOLDER.search(val):
+            seen_placeholder = True
+            continue
+        return True
+    if seen_placeholder and surface is not None:
+        plist_placeholder_hits.append(surface + '  ->  ' + name)
+    return False
+
+def dispatches_js(name, txt):
+    """A node entry point reaches its script through a path.join of __dirname and the name, so the
+    shell predicate structurally cannot see it. Require the basename inside a quoted string on a
+    non-comment line. (The literal join form is spelled out in lane L12 of the fixture suite rather
+    than here, because portability-lint reads a path literal in a checker as a repo-file fixture
+    reference — a false positive, but a cheap one to avoid by not writing the literal.)
+
+    Quote characters are built with chr() rather than written as literals: this heredoc sits inside
+    a command substitution, and lane_runner_check.sh records a measured case where a line whose own
+    quote/paren balance was uneven broke bash's parse of every line after it, in THIS shape of file.
+    Keeping the literals out of the line is cheaper than re-learning that."""
+    body = strip_line_comments(txt)
+    q = chr(34) + chr(39)
+    pat = '[' + q + '][^' + q + chr(10) + ']*' + name_re(name)
+    return bool(re.search(pat, body))
+
+def has_caller(path, surfaces):
+    name = os.path.basename(path)
+    hits = []
+    for r in surfaces:
+        if os.path.abspath(r) == os.path.abspath(path):
+            continue                       # a script does not wire itself
+        txt = read(r)
+        if name not in txt:
+            continue
+        ext = os.path.splitext(r)[1]
+        if ext == '.plist':
+            ok = dispatches_plist(name, txt, surface=r)
+        elif ext == '.js':
+            ok = dispatches_js(name, txt)
+        else:
+            ok = dispatches_shell(name, strip_line_comments(txt))
+        if ok:
+            hits.append(r)
+    return hits
+
+# ── DECLARATIONS ──────────────────────────────────────────────────────────────────────────────
+# Format, deliberately the dumbest thing that carries a reason:
+#
+#     exempt:
+#       - scripts/foo.sh   # why this legitimately has no caller
+#     baseline:
+#       - scripts/bar.sh   # what it is waiting on
+#
+# The reason is a CHANNEL check, in this repo's sense: the gate asserts a property of the record
+# (present · attributable · non-vacuous), never that the reason is a good one. A reason that is
+# missing or under 12 characters is an instrument error, not a pass — an entry you cannot write a
+# sentence for probably belongs in a runner instead of in this file.
+exempt, baseline, decl_lines = {}, {}, 0
+if os.path.isfile(BASELINE_FILE):
+    sect = None
+    for i, raw in enumerate(read(BASELINE_FILE).split('\n'), 1):
+        s = raw.rstrip()
+        if not s.strip() or s.lstrip().startswith('#'):
+            continue
+        m = re.match(r'^([A-Za-z_]+):\s*$', s)
+        if m:
+            sect = m.group(1)
+            if sect not in ('exempt', 'baseline'):
+                err.append(f"{BASELINE_FILE}:{i}: unknown section '{sect}' (expected exempt/baseline)")
+            continue
+        m = re.match(r'^\s+-\s+(\S+)\s*(?:#\s*(.*))?$', s)
+        if not m:
+            err.append(f"{BASELINE_FILE}:{i}: unparseable line: {s.strip()[:60]}")
+            continue
+        if sect is None:
+            err.append(f"{BASELINE_FILE}:{i}: entry before any section header")
+            continue
+        path, reason = m.group(1), (m.group(2) or '').strip()
+        if len(reason) < 12:
+            err.append(f"{BASELINE_FILE}:{i}: '{path}' has no substantive reason "
+                       f"(needs a trailing `# <why>` of 12+ chars; got {len(reason)})")
+            continue
+        if path in exempt or path in baseline:
+            err.append(f"{BASELINE_FILE}:{i}: '{path}' declared twice — ambiguous")
+            continue
+        (exempt if sect == 'exempt' else baseline)[path] = reason
+        decl_lines += 1
+elif MODE != 'emit':
+    err.append(f"{BASELINE_FILE} not found. Bootstrap it with --print-baseline, then write a "
+               f"reason on every line. A MISSING baseline is UNMEASURED, not empty.")
+
+# ── CONTROLS — the instrument proves it can separate a known pair before it judges anything ────
+# Not a substitute for the fixture lanes in scripts/test_script_caller_ratchet_lanes.sh; this is the
+# in-process floor that stops a silently-dead predicate from reporting a clean tree.
+ctrl = []
+_pos = 'scripts/zzz_known_positive.sh'
+if has_caller(_pos, runners):
+    ctrl.append('known-negative control FAILED: a script that does not exist reports a caller')
+if not dispatches_shell('alpha.sh', 'bash scripts/alpha.sh --quiet\n'):
+    ctrl.append('known-positive control FAILED: a literal `bash scripts/alpha.sh` is not seen')
+# 🟥 This control drives the SAME COMPOSITION the real call site uses — dispatches_shell over
+# strip_line_comments(...) — not dispatches_shell alone. The first draft called the predicate bare
+# and failed, correctly: comment-stripping lives one level up, so a control that skips it is
+# measuring a pipeline that no caller runs. Keep the composition here identical to has_caller's.
+if dispatches_shell('alpha.sh', strip_line_comments('#   bash scripts/alpha.sh   <- usage, not a caller\n')):
+    ctrl.append('known-negative control FAILED: a commented usage line counts as a caller')
+if not dispatches_shell('a.sh', 'source "$D/scripts/a.sh"\n'):
+    ctrl.append('known-positive control FAILED: `source` is not read as a dispatch verb')
+if not dispatches_shell('a.sh', 'V="$R/scripts/a.sh"\nbash "$V" --quiet\n'):
+    ctrl.append('known-positive control FAILED: assign-then-dispatch (shape 3) not seen')
+if dispatches_shell('a.sh', 'V="$R/scripts/a.sh"\ncp "$V" "$d/scripts/"\n'):
+    ctrl.append('known-negative control FAILED: copying a script counts as dispatching it')
+if not dispatches_plist('a.sh', '<string>/x/scripts/a.sh</string>'):
+    ctrl.append('known-positive control FAILED: plist <string> dispatch not seen')
+if dispatches_plist('a.sh', '<!-- point this at scripts/a.sh instead --><string>/x/b.sh</string>'):
+    ctrl.append('known-negative control FAILED: an XML-commented plist path counts as a caller')
+# ── boundary controls (added 2026-08-22 for the substring defect) ─────────────────────────────
+# Each blocking direction gets its known-negative AND its known-positive twin, because a boundary
+# that is too tight silently converts wired scripts into UNDECLARED — an over-block on a
+# merge-blocking gate, which trains the override and disarms the neighbouring hooks with it.
+if dispatches_shell('a.sh', 'bash scripts/a.sh.bak --quiet\n'):
+    ctrl.append('known-negative control FAILED: a `.bak` suffix path certifies the base name')
+if dispatches_shell('a.sh', 'bash scripts/mya.sh --quiet\n'):
+    ctrl.append('known-negative control FAILED: a longer basename certifies its suffix')
+if dispatches_shell('a.sh', 'V="$R/scripts/a.sh.bak"\nbash "$V"\n'):
+    ctrl.append('known-negative control FAILED: shape 3 over a suffixed path certifies the base name')
+if not dispatches_shell('a.sh', 'bash ' + chr(34) + '$D/scripts/a.sh' + chr(34) + ' --quiet\n'):
+    ctrl.append('known-positive control FAILED: boundary over-tightened — a quoted path no longer dispatches')
+if not dispatches_shell('a.sh', 'bash scripts/a.sh\n'):
+    ctrl.append('known-positive control FAILED: boundary over-tightened — end-of-line dispatch lost')
+if dispatches_plist('a.sh', '<string>/path/to/repo/scripts/a.sh</string>'):
+    ctrl.append('known-negative control FAILED: a /path/to/ placeholder plist path counts as a caller')
+if not dispatches_plist('a.sh', '<string>/opt/ci/projects/repo/scripts/a.sh</string>'):
+    ctrl.append('known-positive control FAILED: placeholder filter over-blocks a real absolute path')
+# ── unexpanded-variable plist paths (added 2026-08-22, cross-family reproduction) ─────────────
+# launchd execs ProgramArguments literally — no shell expansion — so each of these is a path that
+# cannot run. The known-positive twin directly above is what stops this from over-blocking.
+for _ph in ('$HOME/projects/repo/scripts/a.sh',
+            '${HOME}/projects/repo/scripts/a.sh',
+            '~/projects/repo/scripts/a.sh',
+            '~someone/projects/repo/scripts/a.sh'):
+    if dispatches_plist('a.sh', '<string>' + _ph + '</string>'):
+        ctrl.append('known-negative control FAILED: an unexpanded plist path counts as a caller: ' + _ph)
+if dispatches_js('a.sh', "path.join(__dirname, 'scripts', 'a.sh.bak')"):
+    ctrl.append('known-negative control FAILED: bin/*.js suffix path certifies the base name')
+if not dispatches_js('a.sh', "path.join(__dirname, '..', 'scripts', 'a.sh')"):
+    ctrl.append('known-positive control FAILED: bin/*.js path.join dispatch not seen')
+
+# ── CLASSIFY ──────────────────────────────────────────────────────────────────────────────────
+wired, callerless, test_only, local_only = {}, [], [], []
+LANE_RE = re.compile(r'^(test_.*|.*_lanes)\.sh$')
+for p in population:
+    hits = has_caller(p, runners)
+    if hits:
+        wired[p] = hits
+        if all(LANE_RE.match(os.path.basename(h)) for h in hits):
+            test_only.append(p)          # advisory: only a lane suite calls it
+    else:
+        callerless.append(p)
+        if has_caller(p, LOCAL_ONLY_SURFACES):
+            local_only.append(p)
+
+undeclared = [p for p in callerless if p not in exempt and p not in baseline]
+resolved   = sorted(p for p in baseline if p in wired)
+ghost      = sorted(p for p in list(exempt) + list(baseline) if not os.path.isfile(p))
+
+print(json.dumps({
+    'mode': MODE, 'list': LIST,
+    'n_pop': len(population), 'n_runners': len(runners), 'n_decl': decl_lines,
+    'wired': {k: v for k, v in wired.items()},
+    'callerless': callerless, 'undeclared': undeclared,
+    'exempt': sorted(p for p in callerless if p in exempt),
+    'baseline': sorted(p for p in callerless if p in baseline),
+    'test_only': sorted(test_only), 'local_only': sorted(local_only),
+    'resolved': resolved, 'ghost': ghost,
+    'placeholder': sorted(set(plist_placeholder_hits)),
+    'err': err, 'ctrl': ctrl,
+}))
+PY
+)
+rc=$?
+if [ "$rc" -ne 0 ] || [ -z "$out" ]; then
+  echo "FAIL  caller-ratchet: the scan itself did not run (python3 exit $rc)."
+  echo "      An instrument that did not run is UNMEASURED — this is not a pass."
+  exit 2
+fi
+
+# Rendering is bash-side so the judgment above stays one pure function of the tree.
+_j() { printf '%s' "$out" | python3 -c "import json,sys;d=json.load(sys.stdin);print(d[sys.argv[1]] if not isinstance(d[sys.argv[1]],(list,dict)) else '\n'.join(d[sys.argv[1]]) if isinstance(d[sys.argv[1]],list) else '\n'.join(sorted(d[sys.argv[1]])))" "$1"; }
+
+CTRL="$(_j ctrl)"
+if [ -n "$CTRL" ]; then
+  echo "FAIL  caller-ratchet: the instrument's own known pair collapsed —"
+  printf '%s\n' "$CTRL" | sed 's/^/        · /'
+  echo "      A scan that cannot separate a case whose answer is known is generating, not measuring."
+  exit 2
+fi
+
+ERRS="$(_j err)"
+if [ -n "$ERRS" ]; then
+  echo "FAIL  caller-ratchet: declarations could not be read as declarations —"
+  printf '%s\n' "$ERRS" | sed 's/^/        · /'
+  exit 2
+fi
+
+N_POP="$(_j n_pop)"; N_RUN="$(_j n_runners)"
+if [ "$N_POP" -eq 0 ] || [ "$N_RUN" -eq 0 ]; then
+  echo "FAIL  caller-ratchet: scanned $N_POP scripts against $N_RUN runners under $ROOT."
+  echo "      Zero is an instrument failure, not a clean tree."
+  exit 2
+fi
+
+if [ "$MODE" = "emit" ]; then
+  echo "# scripts/caller_zero_baseline.txt — generated by --print-baseline on $(date +%Y-%m-%d)."
+  echo "# 🟥 EVERY LINE BELOW IS A DRAFT. Move it to exempt: (legitimately callerless) or leave it"
+  echo "#    under baseline: (debt), and WRITE THE REASON. A line without one is rejected."
+  echo "exempt:"
+  echo "baseline:"
+  printf '%s\n' "$(_j callerless)" | sed 's|^|  - |;s|$|   # TODO reason|'
+  exit 0
+fi
+
+echo "      caller-ratchet: $N_POP non-lane scripts · $N_RUN runner surfaces · $(_j n_decl) declarations"
+echo "      caller-ratchet: WIRED $(printf '%s' "$out" | python3 -c 'import json,sys;print(len(json.load(sys.stdin)["wired"]))') · EXEMPT $(_j exempt | grep -c . || true) · BASELINE $(_j baseline | grep -c . || true) · UNDECLARED $(_j undeclared | grep -c . || true)"
+
+TESTONLY="$(_j test_only)"
+[ -n "$TESTONLY" ] && { echo "      ⚠️  called ONLY by a lane suite — an anchor exists, production wiring does not:"; printf '%s\n' "$TESTONLY" | sed 's/^/           /'; }
+LOCALONLY="$(_j local_only)"
+[ -n "$LOCALONLY" ] && { echo "      ⚠️  dispatched ONLY from the gitignored .claude/settings.json — wired on this machine,"; echo "          callerless for CI and for every consumer:"; printf '%s\n' "$LOCALONLY" | sed 's/^/           /'; }
+RESOLVED="$(_j resolved)"
+[ -n "$RESOLVED" ] && { echo "      ⚠️  baseline entry now WIRED — the list is shrink-only, delete these lines:"; printf '%s\n' "$RESOLVED" | sed 's/^/           /'; }
+GHOST="$(_j ghost)"
+[ -n "$GHOST" ] && { echo "      ⚠️  declared but the file does not exist (renamed/deleted?):"; printf '%s\n' "$GHOST" | sed 's/^/           /'; }
+PLACEHOLDER="$(_j placeholder)"
+[ -n "$PLACEHOLDER" ] && { echo "      ⚠️  a plist NAMES this script but on a PLACEHOLDER path launchd cannot execute —"; echo "          the name is present, the dispatch is not:"; printf '%s\n' "$PLACEHOLDER" | sed 's/^/           /'; }
+
+if [ "$LIST" -eq 1 ]; then
+  echo "      -- callerless, declared --"
+  printf '%s\n' "$(_j exempt)" | sed '/^$/d;s/^/         EXEMPT   /'
+  printf '%s\n' "$(_j baseline)" | sed '/^$/d;s/^/         BASELINE /'
+fi
+
+# ── SHRINK-ONLY ENFORCEMENT ON `baseline:` ────────────────────────────────────────────────────
+# Three-valued on purpose. "I could not compare" and "I compared and found nothing" are different
+# facts, and collapsing the first into the second is how a gate reports a clean tree while blind
+# ([[feedback_not_found_is_not_zero_family]]). The state is printed on EVERY run, including in the
+# PASS line, so an UNMEASURED run can never be quoted as evidence that the list did not grow.
+# 🟥 FOUR-VALUED, and WORKTREE_ONLY is the value a cross-family review had to add.
+#   ENFORCED       compared against a commit that is NOT HEAD — full power over committed changes
+#   WORKTREE_ONLY  the base resolved to HEAD itself. The diff then compares HEAD against the WORKING
+#                  TREE, so it still catches an uncommitted new `baseline:` line (that is the
+#                  pre-commit / developer case, and it is genuinely useful) but it has ZERO power
+#                  over anything already committed — against a clean tree it is vacuous, because
+#                  "nothing was added relative to myself" is true by construction.
+#   BOOTSTRAP      the baseline file does not exist at the base — this change introduces it
+#   UNMEASURED     no base at all
+# Reproduced 2026-08-22 (cross-family, codex/gpt-5.5) on the surface that matters: a `push` to main
+# leaves GITHUB_BASE_REF unset, `origin/main` resolves to the checked-out HEAD, and a commit carrying
+# BOTH a new callerless script AND its new `baseline:` line exited 0 while printing
+# "shrink-only ENFORCED". The word ENFORCED was doing the damage: the run had measured nothing and
+# said it had. Same shape on a detached or shallow checkout.
+SHRINK_STATE="UNMEASURED"
+SHRINK_WHY="not determined"
+SHRINK_ADDED=""
+SELF_COMPARE=0
+
+_resolve_base() {
+  # Ordered by how specific the signal is. GITHUB_BASE_REF is set only on pull_request events and
+  # names the branch being merged INTO, which is exactly the comparison this gate wants.
+  for _cand in ${GITHUB_BASE_REF:+"origin/$GITHUB_BASE_REF" "$GITHUB_BASE_REF"} origin/main main origin/master master; do
+    _o=$(git -C "$ROOT" merge-base HEAD "$_cand" 2>/dev/null)
+    _r=$?
+    if [ "$_r" -eq 0 ] && [ -n "$_o" ]; then printf '%s' "$_o"; return 0; fi
+  done
+  return 1
+}
+
+if ! git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+  SHRINK_WHY="$ROOT is not a git work tree, so there is no previous state to diff against"
+else
+  # 🟥 `out=$(...)` then `rc=$?` on its own line — an empty HEAD_SHA must stay empty rather than
+  # being papered over by a fallback, because an empty HEAD_SHA would make the `=` test below
+  # false and silently restore the ENFORCED label this whole block exists to withhold.
+  HEAD_SHA=$(git -C "$ROOT" rev-parse --verify --quiet 'HEAD^{commit}')
+  _rh=$?
+  [ "$_rh" -eq 0 ] || HEAD_SHA=""
+  if [ -n "${FH_RATCHET_BASE_REF:-}" ]; then
+    # 🟥 An explicitly named base that does not resolve is exit 2 — NEVER a silent fall-through to
+    # auto-detection, and never a labelled UNMEASURED. The caller stated which comparison they
+    # wanted; quietly substituting a different one (or none) would hand back a verdict about a
+    # question nobody asked, which is the failure mode where an instrument answers confidently
+    # about the wrong target.
+    BASE_SHA=$(git -C "$ROOT" rev-parse --verify --quiet "${FH_RATCHET_BASE_REF}^{commit}")
+    _rb=$?
+    if [ "$_rb" -ne 0 ] || [ -z "$BASE_SHA" ]; then
+      echo "FAIL  caller-ratchet: --base / FH_RATCHET_BASE_REF names '${FH_RATCHET_BASE_REF}',"
+      echo "      which does not resolve to a commit in $ROOT. An explicitly requested comparison"
+      echo "      that could not be made is an instrument error, not a pass."
+      exit 2
+    fi
+  else
+    BASE_SHA="$(_resolve_base)"
+    _rb=$?
+  fi
+  if [ "$_rb" -ne 0 ] || [ -z "$BASE_SHA" ]; then
+    SHRINK_WHY="no base commit resolvable (tried FH_RATCHET_BASE_REF, \$GITHUB_BASE_REF, origin/main, main, origin/master, master — a depth-1 clone has none)"
+  else
+    # The self-comparison test, computed BEFORE the diff so it labels every branch below —
+    # including BOOTSTRAP, where "the file is absent at base" and "the base is myself" can be true
+    # at once (an untracked baseline file) and the pair of them is not a measurement either.
+    if [ -n "$HEAD_SHA" ] && [ "$BASE_SHA" = "$HEAD_SHA" ]; then
+      SELF_COMPARE=1
+    fi
+    BASE_TMP="$(mktemp)"
+    git -C "$ROOT" show "$BASE_SHA:$BASELINE_FILE" > "$BASE_TMP" 2>/dev/null
+    _rs=$?
+    if [ "$_rs" -ne 0 ]; then
+      SHRINK_STATE="BOOTSTRAP"
+      SHRINK_WHY="$BASELINE_FILE does not exist at base ${BASE_SHA} — this is the change that introduces it"
+    else
+      # Same line grammar as the declaration parser above, deliberately duplicated in ONE place
+      # (here) rather than shared through a third file: two normalizers with different leniency is
+      # a logged defect in this repo, so the rule is that if this grammar ever diverges from the
+      # parser above, lane L15b (an entry the main parser accepts) goes red and names it.
+      SHRINK_ADDED=$(python3 - "$BASE_TMP" "$BASELINE_FILE" <<'PY'
+import re, sys
+
+def baseline_paths(path):
+    try:
+        txt = open(path, encoding='utf-8', errors='replace').read()
+    except OSError:
+        return None
+    sect, out = None, set()
+    for raw in txt.split('\n'):
+        s = raw.rstrip()
+        if not s.strip() or s.lstrip().startswith('#'):
+            continue
+        m = re.match(r'^([A-Za-z_]+):\s*$', s)
+        if m:
+            sect = m.group(1)
+            continue
+        m = re.match(r'^\s+-\s+(\S+)', s)
+        if m and sect == 'baseline':
+            out.add(m.group(1))
+    return out
+
+base = baseline_paths(sys.argv[1])
+cur = baseline_paths(sys.argv[2])
+if base is None or cur is None:
+    sys.exit(3)
+for p in sorted(cur - base):
+    print(p)
+PY
+)
+      _rp=$?
+      if [ "$_rp" -ne 0 ]; then
+        rm -f "$BASE_TMP"
+        echo "FAIL  caller-ratchet: the shrink-only diff itself did not run (python3 exit $_rp)."
+        echo "      An instrument that did not run is UNMEASURED — this is not a pass."
+        exit 2
+      fi
+      if [ "$SELF_COMPARE" -eq 1 ]; then
+        SHRINK_STATE="WORKTREE_ONLY"
+        SHRINK_WHY="the resolved base IS HEAD (${BASE_SHA}); only UNCOMMITTED edits to $BASELINE_FILE are visible"
+      else
+        SHRINK_STATE="ENFORCED"
+        SHRINK_WHY="base ${BASE_SHA}"
+      fi
+    fi
+    rm -f "$BASE_TMP"
+  fi
+fi
+
+FAILED=0
+
+# ── DEGRADE-CLOSED CHECK, BEFORE ANY VERDICT IS ISSUED ────────────────────────────────────────
+# 🟥 Ordered first on purpose. If the comparison could not be made, or was made against HEAD
+# itself, the run must not go on to publish a verdict about it — a verdict from a base nobody can
+# trust is the "instrument answers confidently about the wrong target" failure, and exit 2
+# (instrument error) is the honest code for it, not exit 0 and not exit 1.
+# SELF_COMPARE is checked independently of the state so that a BOOTSTRAP-at-HEAD (an UNTRACKED
+# baseline file in CI) is caught by the same line rather than slipping through the state name.
+if [ "${FH_RATCHET_REQUIRE_BASE:-0}" = "1" ] && \
+   { [ "$SHRINK_STATE" = "UNMEASURED" ] || [ "$SELF_COMPARE" -eq 1 ]; }; then
+  echo "FAIL  caller-ratchet: FH_RATCHET_REQUIRE_BASE=1 and the base is not a usable comparison"
+  echo "      (state: $SHRINK_STATE) — $SHRINK_WHY"
+  echo "      This surface degrades CLOSED. Comparing a commit against ITSELF can never show growth,"
+  echo "      so a pass from it would be vacuous. Fetch history (actions/checkout fetch-depth: 0) and"
+  echo "      name an IMMUTABLE base via --base / FH_RATCHET_BASE_REF:"
+  echo "        pull_request  ->  github.event.pull_request.base.sha"
+  echo "        push          ->  github.event.before   (or HEAD~1 when that is all-zeros)"
+  exit 2
+fi
+
+case "$SHRINK_STATE" in
+  ENFORCED|WORKTREE_ONLY)
+    if [ -n "$SHRINK_ADDED" ]; then
+      echo "FAIL  caller-ratchet: NEW entries under \`baseline:\` — that section is SHRINK-ONLY —"
+      printf '%s\n' "$SHRINK_ADDED" | sed 's/^/        · /'
+      echo "      Compared against $SHRINK_WHY."
+      echo "      baseline: is grandfathered debt, measured once. A path that was not already there"
+      echo "      is regrowth, and stopping regrowth is the entire purpose of this ratchet. Legal:"
+      echo "        ① wire it · ② move it to exempt: with the reason it needs no caller · ③ delete it"
+      echo "      Deleting a baseline: line, or moving one from baseline: to exempt:, always passes."
+      FAILED=1
+    elif [ "$SHRINK_STATE" = "ENFORCED" ]; then
+      echo "      caller-ratchet: shrink-only ENFORCED — no new \`baseline:\` entry vs $SHRINK_WHY"
+    else
+      # 🟥 NOT the word ENFORCED, and not merely a softer adjective on the same sentence. A run
+      # that compared HEAD with itself found nothing because there was nothing it COULD find.
+      echo "      ⚠️  caller-ratchet: shrink-only WORKTREE_ONLY — $SHRINK_WHY"
+      echo "          A baseline: entry that is already COMMITTED would NOT be caught by this run."
+      echo "          At a merge boundary set FH_RATCHET_REQUIRE_BASE=1 and name a real base."
+    fi
+    ;;
+  BOOTSTRAP)
+    echo "      ⚠️  caller-ratchet: shrink-only NOT JUDGED — $SHRINK_WHY"
+    ;;
+  *)
+    echo "      ⚠️  caller-ratchet: shrink-only UNMEASURED — $SHRINK_WHY"
+    echo "          A new \`baseline:\` entry would NOT be caught by this run. Unmeasured is not zero."
+    # The FH_RATCHET_REQUIRE_BASE=1 exit for this state used to live HERE. It was moved above the
+    # case (and widened to cover WORKTREE_ONLY / SELF_COMPARE) and DELETED from here rather than
+    # left in place: two copies of one degrade rule is a place for them to diverge in silence, and
+    # the second copy is unreachable, so it would diverge without anything going red.
+    ;;
+esac
+
+UNDECL="$(_j undeclared)"
+if [ -n "$UNDECL" ]; then
+  echo "FAIL  caller-ratchet: script(s) with ZERO callers and no declaration —"
+  printf '%s\n' "$UNDECL" | sed 's/^/        · /'
+  echo "      Fix by ONE of:"
+  echo "        ① wire it — a runner surface must dispatch it (script · git hook · CI workflow ·"
+  echo "           package.json · bin/*.js · a tracked templates/ settings snippet)"
+  echo "        ② declare it EXEMPT in $BASELINE_FILE with the reason it needs no caller"
+  echo "        ③ delete it — an unwired script is a claim the repo cannot honour"
+  echo "      Adding it under baseline: is NOT one of the options — and as of 2026-08-22 that is"
+  echo "      enforced, not merely written here: the section is diffed against the base commit."
+  FAILED=1
+fi
+
+[ "$FAILED" -eq 0 ] || exit 1
+
+if [ "$SHRINK_STATE" = "ENFORCED" ]; then
+  echo "PASS  caller-ratchet: no undeclared zero-caller script; \`baseline:\` did not grow."
+else
+  echo "PASS  caller-ratchet: no undeclared zero-caller script (shrink-only: $SHRINK_STATE)."
+fi
+exit 0

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -531,6 +531,14 @@ fi
 # test_capability_entrypoint_shipping.sh pins two (degrade_probe_capability.sh and
 # psa_probe_capability.sh); degrade is named here as the sentinel — the suite itself checks both and
 # fails if either is gone, so nothing is lost by not listing both in this table.
+# test_script_caller_ratchet_lanes.sh is the second of that shape: it pins BOTH
+# scripts/script_caller_ratchet.sh (the checker) and scripts/ratchet_base_resolve.sh (the base
+# resolver its L24–L26 lanes execute), and it hard-exits 1 naming the missing file if either is
+# gone. The checker is the sentinel because it is the one whose absence means the gate itself is
+# gone; the resolver's absence is a narrower failure the suite still reports by name. Neither
+# script ships — both, and this anchor, are declared in package_coverage_check.sh ACCEPTED_ABSENT.
+# On a consumer install the SUBJECT arm fires first and `_ships_per_files` returns 1, so the row
+# resolves to "SKIP (subject not in files[], and absent)" — the anchor arm is never reached.
 _LANE_TO=""; command -v timeout >/dev/null 2>&1 && _LANE_TO="timeout 300"
 for _pair in \
   "scripts/degrade_probe_capability.sh|scripts/test_capability_entrypoint_shipping.sh" \
@@ -552,7 +560,8 @@ for _pair in \
   "scripts/reviewer_capability_corpus.tsv|scripts/test_reviewer_capability_conformance.sh" \
   "scripts/field_canon_preload.sh|scripts/test_field_canon_lanes.sh" \
   "scripts/stale_clone_guard.sh|scripts/test_stale_clone_guard_lanes.sh" \
-  "plugins/fh-commons/skills/ko-tech-writer/SKILL.md|scripts/test_ko_tech_writer_lanes.sh"
+  "plugins/fh-commons/skills/ko-tech-writer/SKILL.md|scripts/test_ko_tech_writer_lanes.sh" \
+  "scripts/script_caller_ratchet.sh|scripts/test_script_caller_ratchet_lanes.sh"
 do
   _subj="${_pair%%|*}"; _anc="${_pair##*|}"; _lbl="${_anc##*/}"
   if [ ! -f "$_subj" ]; then

--- a/scripts/test_script_caller_ratchet_lanes.sh
+++ b/scripts/test_script_caller_ratchet_lanes.sh
@@ -1,0 +1,749 @@
+#!/usr/bin/env bash
+# test_script_caller_ratchet_lanes.sh — behavioural known-pair lanes for scripts/script_caller_ratchet.sh
+#
+# 🟥 EVERY LANE RUNS AGAINST A FIXTURE ROOT, NEVER AGAINST THIS REPO.
+# The checker takes `--root DIR` for exactly this reason. A lane that scanned the real tree would
+# pass or fail on whatever the tree happens to contain today, which is a lane that measures the
+# repo instead of the instrument — a trap this repo has fallen into before. Lane L0 is the control
+# that proves the swap actually took: it asserts the fixture's own population size, so if `--root`
+# were ignored and the real repo were scanned, L0 goes red instead of everything silently passing.
+#
+# The pairs are deliberate: every blocking lane has a known-negative twin, because "it blocked" is
+# not the same claim as "it blocked for the right reason", and an over-blocking gate trains the
+# override into muscle memory.
+#
+# Usage: bash scripts/test_script_caller_ratchet_lanes.sh
+# Exit:  0 = all lanes pass · 1 = a lane failed
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# The override exists for the REVERT PROBE: point the lanes at a deliberately neutered copy of the
+# checker and confirm that exactly the lanes covering the removed behaviour go red. An anchor that
+# stays green when its subject is disabled is decorative, and the only way to know which one you
+# have is to disable it on purpose. Default is the real checker; CI never sets this.
+CHECK="${FH_CALLER_RATCHET_BIN:-$ROOT/scripts/script_caller_ratchet.sh}"
+[ -f "$CHECK" ] || { echo "FAIL  harness: $CHECK not found"; exit 1; }
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf 'PASS  %s\n' "$1"; }
+no()  { fail=$((fail+1)); printf 'FAIL  %s\n' "$1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; }
+
+# 🟥 ONE TEMP ROOT FOR THE WHOLE SUITE, and every fixture is a child of it.
+# Two reasons, both measured in this repo rather than assumed:
+#   · a sibling lane suite leaked fixture writes into the real tree, so "the fixtures are under
+#     mktemp" has to be a property of a single named root that can be printed and removed as a unit,
+#     not of N independent mktemp calls scattered through the file.
+#   · the trap removes the root on ANY exit path, including a lane that dies mid-fixture. The old
+#     per-lane `rm -rf "$d"` runs only when the lane reaches its own last line.
+# The per-lane `rm -rf "$d"` calls below are KEPT: they bound peak disk during the run, and a
+# belt-and-braces cleanup is not a duplicate normalizer — neither one changes any verdict.
+FIXROOT="$(mktemp -d)"
+trap 'rm -rf "$FIXROOT"' EXIT INT TERM
+newfix() { mktemp -d "$FIXROOT/fix.XXXXXX"; }
+
+# Each fixture is a throwaway root with its own scripts/ — no inheritance from this repo.
+# 🟥 THE RUNNER LIVES IN .github/workflows/, NOT IN scripts/. First draft put it at
+# scripts/runner.sh and eight lanes went red for a reason that had nothing to do with the lane: the
+# runner is itself a non-lane script under scripts/, so it entered its own population with no caller
+# and every fixture blocked on IT. The fixture, not the checker, was wrong — and it is worth keeping
+# written down, because a green version of that fixture would have been the worse outcome.
+mkfix() {
+  d="$(newfix)"
+  mkdir -p "$d/scripts" "$d/.github/workflows"
+  printf '%s\n' '#!/usr/bin/env bash' 'echo alpha' > "$d/scripts/alpha.sh"
+  printf 'exempt:\nbaseline:\n' > "$d/scripts/caller_zero_baseline.txt"
+  printf 'run: bash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
+  echo "$d"
+}
+run()  { bash "$CHECK" --root "$1" 2>&1; }
+rcof() { bash "$CHECK" --root "$1" >/dev/null 2>&1; echo $?; }
+# Variants that forward extra flags/env (--base, FH_RATCHET_REQUIRE_BASE) to the checker.
+runx()  { _d="$1"; shift; bash "$CHECK" --root "$_d" "$@" 2>&1; }
+rcofx() { _d="$1"; shift; bash "$CHECK" --root "$_d" "$@" >/dev/null 2>&1; echo $?; }
+
+# A fixture that is a REAL git repo with one commit, so the shrink-only half has a base to diff.
+# 🟥 `git init` here touches ONLY a throwaway mktemp directory — never the repo under test. The
+# add is by explicit path rather than `-A` to keep that habit intact even where it is harmless.
+# hooksPath is pointed at a directory that does not exist and every commit is --no-verify, so a
+# global core.hooksPath (this repo installs one) cannot make the FIXTURE run the real gates.
+gitfix() {
+  _d="$(mkfix)"
+  git -C "$_d" -c init.defaultBranch=main init -q >/dev/null 2>&1
+  git -C "$_d" add scripts .github >/dev/null 2>&1
+  git -C "$_d" -c user.email=lane@example.invalid -c user.name=lane \
+      -c core.hooksPath=/nonexistent-fixture-hooks \
+      commit -q --no-verify -m base >/dev/null 2>&1
+  echo "$_d"
+}
+
+# ── L0 CONTROL — the root swap took effect ────────────────────────────────────────────────────
+d="$(mkfix)"
+printf '#!/usr/bin/env bash\necho beta\n' > "$d/scripts/beta.sh"
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\nbash scripts/beta.sh\n' > "$d/.github/workflows/ci.yml"
+o="$(run "$d")"
+# TWO assertions, because either alone is weak: the population size pins the fixture, and the
+# absence of a name that exists only in the real repo pins that the real tree was not reached.
+if printf '%s' "$o" | grep -q '2 non-lane scripts' && ! printf '%s' "$o" | grep -q 'selfcheck'; then
+  ok "L0 fixture isolation — the fixture's 2 scripts are the population, not this repo's"
+else
+  no "L0 fixture isolation — --root did not take; the lanes below would be measuring the real repo" "$o"
+fi
+rm -rf "$d"
+
+# ── L1 known-POSITIVE — a callerless, undeclared script BLOCKS ────────────────────────────────
+d="$(mkfix)"
+printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/orphan.sh"
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
+rc="$(rcof "$d")"; o="$(run "$d")"
+if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q 'scripts/orphan.sh'; then
+  ok "L1 known-positive — undeclared zero-caller blocks (exit 1) and is NAMED"
+else
+  no "L1 known-positive — expected exit 1 naming orphan.sh, got exit $rc" "$o"
+fi
+rm -rf "$d"
+
+# ── L2 known-NEGATIVE — a properly wired script PASSES ────────────────────────────────────────
+d="$(mkfix)"
+printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/wired.sh"
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\nbash scripts/wired.sh\n' > "$d/.github/workflows/ci.yml"
+rc="$(rcof "$d")"
+[ "$rc" = "0" ] && ok "L2 known-negative — a dispatched script passes (exit 0)" \
+                || no "L2 known-negative — a wired script was blocked (over-block), exit $rc" "$(run "$d")"
+rm -rf "$d"
+
+# ── L3 THE RATCHET IS BY IDENTITY, NOT BY COUNT ───────────────────────────────────────────────
+# The scenario a count-keyed gate passes and an identity-keyed gate must not: the baseline holds ONE
+# entry, that entry gets WIRED, and a DIFFERENT script goes callerless. The total is unchanged at 1.
+d="$(mkfix)"
+printf '#!/usr/bin/env bash\necho old\n' > "$d/scripts/olddebt.sh"
+printf '#!/usr/bin/env bash\necho new\n' > "$d/scripts/newdebt.sh"
+printf 'exempt:\nbaseline:\n  - scripts/olddebt.sh   # grandfathered measured debt\n' > "$d/scripts/caller_zero_baseline.txt"
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\nbash scripts/olddebt.sh\n' > "$d/.github/workflows/ci.yml"
+rc="$(rcof "$d")"; o="$(run "$d")"
+if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q 'scripts/newdebt.sh' \
+   && ! printf '%s' "$o" | grep -q 'FAIL.*olddebt'; then
+  ok "L3 identity-keyed — count unchanged (1→1) yet the NEW callerless script blocks"
+else
+  no "L3 identity-keyed — a count-keyed gate would have passed here; exit $rc" "$o"
+fi
+# ── L3b twin — the same tree with the new script wired passes ────────────────────────────────
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\nbash scripts/olddebt.sh\nbash scripts/newdebt.sh\n' > "$d/.github/workflows/ci.yml"
+rc="$(rcof "$d")"
+[ "$rc" = "0" ] && ok "L3b twin — wiring the new script clears the block (not a permanent red)" \
+                || no "L3b twin — still blocking after the script was wired, exit $rc" "$(run "$d")"
+rm -rf "$d"
+
+# ── L4 a declaration without a substantive reason is an INSTRUMENT ERROR, not a pass ──────────
+d="$(mkfix)"
+printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/orphan.sh"
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
+printf 'exempt:\n  - scripts/orphan.sh\n' > "$d/scripts/caller_zero_baseline.txt"
+rc="$(rcof "$d")"
+[ "$rc" = "2" ] && ok "L4 reason required — a bare declaration is exit 2 (channel check), never a silent pass" \
+                || no "L4 reason required — expected exit 2, got $rc" "$(run "$d")"
+# twin: the same line WITH a reason is accepted
+printf 'exempt:\n  - scripts/orphan.sh   # operator-run tool, no caller owed\n' > "$d/scripts/caller_zero_baseline.txt"
+rc="$(rcof "$d")"
+[ "$rc" = "0" ] && ok "L4b twin — the same entry with a written reason is accepted" \
+                || no "L4b twin — a reasoned declaration was rejected, exit $rc" "$(run "$d")"
+rm -rf "$d"
+
+# ── L5 a MISSING baseline is UNMEASURED, not empty ────────────────────────────────────────────
+d="$(mkfix)"
+rm -f "$d/scripts/caller_zero_baseline.txt"
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
+rc="$(rcof "$d")"
+[ "$rc" = "2" ] && ok "L5 missing baseline — exit 2 (not-found is not zero)" \
+                || no "L5 missing baseline — expected exit 2, got $rc" "$(run "$d")"
+rm -rf "$d"
+
+# ── L6 an empty population is an instrument failure, not a clean tree ─────────────────────────
+d="$(newfix)"; mkdir -p "$d/scripts"
+printf 'exempt:\nbaseline:\n' > "$d/scripts/caller_zero_baseline.txt"
+rc="$(rcof "$d")"
+[ "$rc" = "2" ] && ok "L6 zero population — exit 2, a scan that found nothing did not pass" \
+                || no "L6 zero population — expected exit 2, got $rc" "$(run "$d")"
+rm -rf "$d"
+
+# ── L7 lane suites are DELEGATED to lane_runner_check.sh, not judged twice ────────────────────
+d="$(mkfix)"
+printf '#!/usr/bin/env bash\necho lane\n' > "$d/scripts/test_something_lanes.sh"
+printf '#!/usr/bin/env bash\necho lane\n' > "$d/scripts/test_other.sh"
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
+rc="$(rcof "$d")"
+[ "$rc" = "0" ] && ok "L7 delegation — callerless lane suites are out of population (no double judgment)" \
+                || no "L7 delegation — a lane suite was judged by this ratchet, exit $rc" "$(run "$d")"
+rm -rf "$d"
+
+# ── L8 a MENTION is not an invocation ─────────────────────────────────────────────────────────
+d="$(mkfix)"
+printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/orphan.sh"
+printf '#!/usr/bin/env bash\n#   bash scripts/orphan.sh   <- usage example\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
+rc="$(rcof "$d")"; o="$(run "$d")"
+if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q 'scripts/orphan.sh'; then
+  ok "L8 mention≠invocation — a commented usage line does not certify a caller"
+else
+  no "L8 mention≠invocation — a comment counted as wiring, exit $rc" "$o"
+fi
+rm -rf "$d"
+
+# ── L9 dot-source counts as a dispatch (a library is CALLED by being sourced) ─────────────────
+# The shape that broke the first draft: ` . "$LIB"` has no word boundary before the dot.
+d="$(mkfix)"
+printf '#!/usr/bin/env bash\necho lib\n' > "$d/scripts/somelib.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'L="$(dirname "$0")/somelib.sh"' 'if [ -f "$L" ]; then . "$L"; fi' 'bash scripts/alpha.sh' > "$d/.github/workflows/ci.yml"
+rc="$(rcof "$d")"
+[ "$rc" = "0" ] && ok "L9 dot-source — a sourced library is wired, not callerless" \
+                || no "L9 dot-source — a sourced library read as callerless, exit $rc" "$(run "$d")"
+rm -rf "$d"
+
+# ── L10 assign-then-dispatch counts / a COPY does not ─────────────────────────────────────────
+d="$(mkfix)"
+printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/assigned.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'JC="$R/scripts/assigned.sh"' 'bash "$JC" --quiet' 'bash scripts/alpha.sh' > "$d/.github/workflows/ci.yml"
+rc="$(rcof "$d")"
+[ "$rc" = "0" ] && ok "L10 assign-then-dispatch — the dominant hook idiom is seen as wiring" \
+                || no "L10 assign-then-dispatch — missed, exit $rc" "$(run "$d")"
+printf '%s\n' '#!/usr/bin/env bash' 'JC="$R/scripts/assigned.sh"' 'cp "$JC" "$T/scripts/"' 'bash scripts/alpha.sh' > "$d/.github/workflows/ci.yml"
+rc="$(rcof "$d")"
+[ "$rc" = "1" ] && ok "L10b twin — COPYING a script is not dispatching it (no free pass for fixtures)" \
+                || no "L10b twin — a cp was read as a caller, exit $rc" "$(run "$d")"
+rm -rf "$d"
+
+# ── L11 plist: <string> is a dispatch, an XML comment is not ─────────────────────────────────
+d="$(mkfix)"
+printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/daily.sh"
+printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/autopilot.sh"
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
+printf '%s\n' '<plist>' '<!-- point this at scripts/daily.sh instead -->' '<string>/x/scripts/autopilot.sh</string>' '</plist>' > "$d/scripts/x.plist"
+rc="$(rcof "$d")"; o="$(run "$d")"
+if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q 'scripts/daily.sh' \
+   && ! printf '%s' "$o" | grep -q '· scripts/autopilot.sh'; then
+  ok "L11 plist — <string> dispatch wires autopilot, an XML-commented path does NOT wire daily"
+else
+  no "L11 plist — comment/dispatch not separated, exit $rc" "$o"
+fi
+rm -rf "$d"
+
+# ── L12 bin/*.js path.join reaches its script ────────────────────────────────────────────────
+d="$(mkfix)"; mkdir -p "$d/bin"
+printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/gate.sh"
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
+printf "%s\n" "path.join(__dirname, '..', 'scripts', 'gate.sh')," > "$d/bin/fh-gate.js"
+rc="$(rcof "$d")"
+[ "$rc" = "0" ] && ok "L12 bin/*.js — a node entry point's path.join counts as a caller" \
+                || no "L12 bin/*.js — missed, exit $rc" "$(run "$d")"
+rm -rf "$d"
+
+# ── L13 a baseline entry that is now WIRED warns but does not block ──────────────────────────
+# Shrink-only hygiene must never punish the person who did the wiring — that is how a ratchet
+# becomes something people route around.
+d="$(mkfix)"
+printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/fixed.sh"
+printf 'exempt:\nbaseline:\n  - scripts/fixed.sh   # was debt, wired since\n' > "$d/scripts/caller_zero_baseline.txt"
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\nbash scripts/fixed.sh\n' > "$d/.github/workflows/ci.yml"
+rc="$(rcof "$d")"; o="$(run "$d")"
+# 🟥 The grep is 'now WIRED', not 'shrink-only'. When the shrink-only ENFORCEMENT lanes below were
+# added, the checker started printing a `shrink-only: UNMEASURED` line on every non-git fixture —
+# which contains the substring 'shrink-only' and would have kept THIS lane green even if the
+# resolved-entry warning were deleted. The anchor would have gone decorative at the moment a
+# neighbouring feature landed, with nothing red to say so.
+if [ "$rc" = "0" ] && printf '%s' "$o" | grep -q 'now WIRED'; then
+  ok "L13 shrink-only — a resolved baseline entry warns (visible) and passes (not punished)"
+else
+  no "L13 shrink-only — expected exit 0 plus a warning, got $rc" "$o"
+fi
+rm -rf "$d"
+
+# ── L14 an entry naming a file that does not exist is surfaced ───────────────────────────────
+d="$(mkfix)"
+printf 'exempt:\n  - scripts/renamed_away.sh   # stale entry, file is gone\nbaseline:\n' > "$d/scripts/caller_zero_baseline.txt"
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
+o="$(run "$d")"
+printf '%s' "$o" | grep -q 'does not exist' \
+  && ok "L14 ghost entry — a declaration for a missing file is named, not silently honoured" \
+  || no "L14 ghost entry — stale declaration passed unnoticed" "$o"
+rm -rf "$d"
+
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+# L15–L17 — SHRINK-ONLY ENFORCEMENT ON `baseline:`
+# The defect these anchor: the checker's own FAIL message said "Adding it under baseline: is NOT
+# one of the options … a new entry there is the regrowth this ratchet exists to stop", and the code
+# permitted exactly that. Reproduced by the governor 2026-08-22: a new callerless script plus a new
+# baseline: line in the same change exited 0. The rule was true in prose and false in machinery.
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+
+# ── L15 known-POSITIVE — a NEW baseline: entry blocks even though it is "declared" ────────────
+d="$(gitfix)"
+printf '#!/usr/bin/env bash\necho new\n' > "$d/scripts/newdebt.sh"
+printf 'exempt:\nbaseline:\n  - scripts/newdebt.sh   # freshly added debt, the illegal move\n' > "$d/scripts/caller_zero_baseline.txt"
+rc="$(rcof "$d")"; o="$(run "$d")"
+if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q 'SHRINK-ONLY' \
+   && printf '%s' "$o" | grep -q 'scripts/newdebt.sh'; then
+  ok "L15 shrink-only — a NEW baseline: entry blocks (exit 1) and is NAMED"
+else
+  no "L15 shrink-only — the governor's reproduction still passes; exit $rc" "$o"
+fi
+
+# ── L15b known-NEGATIVE twin — the SAME script declared under exempt: passes ──────────────────
+# Without this twin, L15 would also be green if the checker simply blocked all declarations. The
+# claim under test is narrow: growth of `baseline:` specifically, not declaring a script at all.
+printf 'exempt:\n  - scripts/newdebt.sh   # entry point, no caller owed\nbaseline:\n' > "$d/scripts/caller_zero_baseline.txt"
+rc="$(rcof "$d")"
+[ "$rc" = "0" ] && ok "L15b twin — the same new script under exempt: is a legal move (exit 0)" \
+                || no "L15b twin — exempt: additions were blocked too (over-block), exit $rc" "$(run "$d")"
+
+# ── L15c known-NEGATIVE twin — an UNCHANGED baseline: passes, and NAMES what it compared to ───
+# 🟥 This lane used to assert the word ENFORCED and it was WRONG to. `gitfix` has exactly one
+# commit, so the auto-resolved base IS HEAD and the comparison is HEAD-vs-working-tree: real power
+# over the uncommitted edit these lanes make, zero power over anything committed. The checker now
+# calls that WORKTREE_ONLY, and this lane asserts the honest label — plus, explicitly, that the
+# misleading one is ABSENT. Asserting only the new string would have left the lane green if both
+# labels were printed.
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\nbash scripts/newdebt.sh\n' > "$d/.github/workflows/ci.yml"
+printf 'exempt:\nbaseline:\n' > "$d/scripts/caller_zero_baseline.txt"
+rc="$(rcof "$d")"; o="$(run "$d")"
+if [ "$rc" = "0" ] && printf '%s' "$o" | grep -q 'shrink-only WORKTREE_ONLY' \
+   && ! printf '%s' "$o" | grep -q 'ENFORCED'; then
+  ok "L15c twin — an unchanged baseline: passes, labelled WORKTREE_ONLY (never ENFORCED vs HEAD)"
+else
+  no "L15c twin — expected exit 0 plus WORKTREE_ONLY and no ENFORCED, got $rc" "$o"
+fi
+rm -rf "$d"
+
+# ── L16 REMOVAL and baseline:→exempt: MIGRATION are always legal ──────────────────────────────
+# A ratchet that punished the person who paid down the debt is a ratchet people route around.
+d="$(mkfix)"
+printf '#!/usr/bin/env bash\necho old\n' > "$d/scripts/olddebt.sh"
+printf 'exempt:\nbaseline:\n  - scripts/olddebt.sh   # grandfathered measured debt\n' > "$d/scripts/caller_zero_baseline.txt"
+d="$(cd "$d" && pwd)"
+git -C "$d" -c init.defaultBranch=main init -q >/dev/null 2>&1
+git -C "$d" add scripts .github >/dev/null 2>&1
+git -C "$d" -c user.email=lane@example.invalid -c user.name=lane \
+    -c core.hooksPath=/nonexistent-fixture-hooks commit -q --no-verify -m base >/dev/null 2>&1
+# (a) wire it and delete the line
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\nbash scripts/olddebt.sh\n' > "$d/.github/workflows/ci.yml"
+printf 'exempt:\nbaseline:\n' > "$d/scripts/caller_zero_baseline.txt"
+rc="$(rcof "$d")"
+[ "$rc" = "0" ] && ok "L16 shrink — deleting a paid-off baseline: line passes (exit 0)" \
+                || no "L16 shrink — paying down debt was punished, exit $rc" "$(run "$d")"
+# (b) move it to exempt: without wiring it
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
+printf 'exempt:\n  - scripts/olddebt.sh   # reclassified: operator-run tool\nbaseline:\n' > "$d/scripts/caller_zero_baseline.txt"
+rc="$(rcof "$d")"
+[ "$rc" = "0" ] && ok "L16b migration — baseline: → exempt: is a legal move (exit 0)" \
+                || no "L16b migration — a reclassification was blocked, exit $rc" "$(run "$d")"
+rm -rf "$d"
+
+# ── L17 DEGRADE DIRECTION — unmeasurable base is LABELLED, and closes only where told to ──────
+# 🟥 Three-valued on purpose. "could not compare" must never render as "compared, nothing found".
+d="$(mkfix)"          # deliberately NOT a git repo
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
+rc="$(rcof "$d")"; o="$(run "$d")"
+if [ "$rc" = "0" ] && printf '%s' "$o" | grep -q 'shrink-only UNMEASURED' \
+   && printf '%s' "$o" | grep -q 'shrink-only: UNMEASURED'; then
+  ok "L17 degrade — no base: labelled UNMEASURED in BOTH the body and the PASS line, non-blocking"
+else
+  no "L17 degrade — an unmeasurable base was rendered as a clean pass, exit $rc" "$o"
+fi
+# twin: the merge-boundary setting turns the same state into an instrument error
+rc="$(FH_RATCHET_REQUIRE_BASE=1 rcof "$d")"
+[ "$rc" = "2" ] && ok "L17b degrade-closed — FH_RATCHET_REQUIRE_BASE=1 makes UNMEASURED exit 2" \
+                || no "L17b degrade-closed — CI setting did not fail closed, exit $rc" "$(FH_RATCHET_REQUIRE_BASE=1 run "$d")"
+rm -rf "$d"
+
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+# L18 — SUBSTRING vs PATH TOKEN
+# The defect: `bash scripts/foo.sh.bak` in a runner certified scripts/foo.sh as WIRED, exit 0.
+# The FP always lands on the PASS side, which is the direction that makes a gate decorative.
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+
+# ── L18 known-POSITIVE — a SUFFIXED path does not certify the base name ───────────────────────
+d="$(mkfix)"
+printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/foo.sh"
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\nbash scripts/foo.sh.bak --quiet\n' > "$d/.github/workflows/ci.yml"
+rc="$(rcof "$d")"; o="$(run "$d")"
+if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q 'scripts/foo.sh$'; then
+  ok "L18 token boundary — a .bak suffix does NOT wire foo.sh (blocks, exit 1)"
+else
+  no "L18 token boundary — a suffixed path certified the base name, exit $rc" "$o"
+fi
+# twin: the unsuffixed dispatch of the same name still counts (no over-tightening)
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\nbash scripts/foo.sh --quiet\n' > "$d/.github/workflows/ci.yml"
+rc="$(rcof "$d")"
+[ "$rc" = "0" ] && ok "L18b twin — the real dispatch of foo.sh still passes (boundary not over-tight)" \
+                || no "L18b twin — the boundary broke a legitimate dispatch, exit $rc" "$(run "$d")"
+rm -rf "$d"
+
+# ── L18c the LEADING end of the same hole — a LONGER basename must not certify its suffix ─────
+d="$(mkfix)"
+printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/foo.sh"
+printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/myfoo.sh"
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\nbash scripts/myfoo.sh\n' > "$d/.github/workflows/ci.yml"
+rc="$(rcof "$d")"; o="$(run "$d")"
+if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q '· scripts/foo.sh' \
+   && ! printf '%s' "$o" | grep -q '· scripts/myfoo.sh'; then
+  ok "L18c token boundary — myfoo.sh is wired, foo.sh is not; the longer name does not cover it"
+else
+  no "L18c token boundary — leading end of the substring hole is open, exit $rc" "$o"
+fi
+rm -rf "$d"
+
+# ── L18d shape 3 through a suffixed path ─────────────────────────────────────────────────────
+# The assign-then-dispatch idiom re-opened the same hole one level down: a variable assigned
+# `.../foo.sh.bak` and later run as "$VAR" certified foo.sh, because the shape-3 prefilter was a
+# bare substring test even after the direct-match regex had been given boundaries.
+d="$(mkfix)"
+printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/foo.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'V="$R/scripts/foo.sh.bak"' 'bash "$V"' 'bash scripts/alpha.sh' > "$d/.github/workflows/ci.yml"
+rc="$(rcof "$d")"
+[ "$rc" = "1" ] && ok "L18d token boundary — shape 3 over a suffixed path does not wire foo.sh" \
+                || no "L18d token boundary — assign-then-dispatch bypassed the boundary, exit $rc" "$(run "$d")"
+# twin: shape 3 over the REAL path still wires it
+printf '%s\n' '#!/usr/bin/env bash' 'V="$R/scripts/foo.sh"' 'bash "$V"' 'bash scripts/alpha.sh' > "$d/.github/workflows/ci.yml"
+rc="$(rcof "$d")"
+[ "$rc" = "0" ] && ok "L18e twin — shape 3 over the real path still wires it" \
+                || no "L18e twin — the boundary broke the dominant hook idiom, exit $rc" "$(run "$d")"
+rm -rf "$d"
+
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+# L19 — A PLACEHOLDER PLIST PATH IS NOT A DISPATCH
+# The defect, found by the governor with a known pair: scripts/frontier_digest_autopilot.sh read
+# as WIRED on the strength of `<string>/path/to/forge-harness/scripts/...</string>` — a path
+# launchd cannot execute, and one that ship_readiness_gate.md had ALREADY recorded as an
+# identity-④ defect. The gate was passing over a defect its own repo had written down.
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+d="$(mkfix)"
+printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/daily.sh"
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
+printf '%s\n' '<plist>' '<string>/path/to/forge-harness/scripts/daily.sh</string>' '</plist>' > "$d/scripts/x.plist"
+rc="$(rcof "$d")"; o="$(run "$d")"
+if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q '· scripts/daily.sh' \
+   && printf '%s' "$o" | grep -q 'PLACEHOLDER path'; then
+  ok "L19 placeholder plist — /path/to/ does not wire, and the run SAYS why (named, not silent)"
+else
+  no "L19 placeholder plist — a template path certified a dispatch, exit $rc" "$o"
+fi
+# 🟥 twin, and it is the one that matters for portability: a CORRECT plist hardcodes the author's
+# own absolute path, which does not exist on the CI runner. The naive repair (does this path
+# resolve on disk?) would go green on macOS and red on Linux for a plist with nothing wrong with
+# it. This twin is what forbids that repair from ever being substituted in.
+printf '%s\n' '<plist>' '<string>/opt/ci/projects/forge-harness/scripts/daily.sh</string>' '</plist>' > "$d/scripts/x.plist"
+rc="$(rcof "$d")"
+[ "$rc" = "0" ] && ok "L19b twin — a real absolute path wires it, on any OS, resolvable or not" \
+                || no "L19b twin — the placeholder filter over-blocks a legitimate plist, exit $rc" "$(run "$d")"
+rm -rf "$d"
+
+# ── L20 the EXPLICIT --base ref is honoured, and an unresolvable one is exit 2 ────────────────
+# L15–L17 exercise the AUTO resolver, which is the path CI and developers actually take (nobody
+# types --base). That left the flag itself with zero anchors — a checker option nothing exercises
+# is the built-but-not-wired shape, inside the very gate that hunts it. These two close it.
+d="$(gitfix)"
+printf '#!/usr/bin/env bash\necho new\n' > "$d/scripts/newdebt.sh"
+printf 'exempt:\nbaseline:\n  - scripts/newdebt.sh   # freshly added debt, the illegal move\n' > "$d/scripts/caller_zero_baseline.txt"
+rc="$(rcofx "$d" --base HEAD)"; o="$(runx "$d" --base HEAD)"
+if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q 'SHRINK-ONLY'; then
+  ok "L20 explicit --base — the named ref is used and the new baseline: entry blocks"
+else
+  no "L20 explicit --base — the flag did not drive the comparison, exit $rc" "$o"
+fi
+# 🟥 twin: a --base that does not resolve must be exit 2, NOT a silent fall-through to
+# auto-detection and NOT a labelled UNMEASURED. Substituting a different comparison for the one
+# that was asked for is how an instrument answers confidently about the wrong target.
+rc="$(rcofx "$d" --base no-such-ref-xyz)"
+[ "$rc" = "2" ] && ok "L20b twin — an unresolvable --base is an instrument error (exit 2), not a fallback" \
+                || no "L20b twin — a bad --base silently fell back, exit $rc" "$(runx "$d" --base no-such-ref-xyz)"
+# 🟥 twin: and it must still block via the ENV twin of the flag, since CI sets env not argv.
+rc="$(FH_RATCHET_BASE_REF=HEAD rcof "$d")"
+[ "$rc" = "1" ] && ok "L20c twin — FH_RATCHET_BASE_REF drives the same path as --base" \
+                || no "L20c twin — the env twin of --base is dead, exit $rc" "$(FH_RATCHET_BASE_REF=HEAD run "$d")"
+rm -rf "$d"
+
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+# L21–L22 — THE BASE MUST NOT BE HEAD
+# The defect (cross-family reproduction, codex/gpt-5.5, 2026-08-22): on a `push` to main
+# GITHUB_BASE_REF is unset and `origin/main` resolves to the checked-out HEAD. A commit carrying
+# BOTH scripts/newdebt.sh and its new `baseline:` line — the exact illegal move the ratchet exists
+# to stop — exited 0 and printed "shrink-only ENFORCED". Comparing a commit with itself makes
+# "nothing was added" true by construction. Detached and shallow checkouts have the same shape.
+# Reproduced against the pre-fix checker before these lanes were written; the fail-before output is
+# recorded in the repair note rather than paraphrased here.
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+
+# A two-commit git fixture: `base` holds the starting tree, then a second commit lands whatever the
+# lane wants COMMITTED (clean working tree — that is what CI checks out, and a dirty tree is what
+# masked this defect in every earlier lane).
+gitfix2() {
+  _d="$(gitfix)"
+  printf '#!/usr/bin/env bash\necho new\n' > "$_d/scripts/newdebt.sh"
+  printf 'exempt:\nbaseline:\n  - scripts/newdebt.sh   # freshly added debt, the illegal move\n' \
+      > "$_d/scripts/caller_zero_baseline.txt"
+  git -C "$_d" add scripts >/dev/null 2>&1
+  git -C "$_d" -c user.email=lane@example.invalid -c user.name=lane \
+      -c core.hooksPath=/nonexistent-fixture-hooks \
+      commit -q --no-verify -m illegal >/dev/null 2>&1
+  echo "$_d"
+}
+
+# ── L21 known-POSITIVE — the CI reproduction: clean tree, base auto-resolves to HEAD ──────────
+d="$(gitfix2)"
+# control first: the tree really is clean, so this lane is testing the committed case and not
+# accidentally re-testing the worktree case that already had power.
+st="$(git -C "$d" status --short)"
+[ -z "$st" ] || no "L21 SETUP — fixture tree is not clean, the lane would measure the wrong thing" "$st"
+rc="$(FH_RATCHET_REQUIRE_BASE=1 rcof "$d")"; o="$(FH_RATCHET_REQUIRE_BASE=1 run "$d")"
+if [ "$rc" = "2" ] && printf '%s' "$o" | grep -q 'not a usable comparison'; then
+  ok "L21 base≠HEAD — a self-comparison under CI settings is exit 2, not a vacuous pass"
+else
+  no "L21 base≠HEAD — the governor/codex reproduction still passes; exit $rc" "$o"
+fi
+
+# ── L21b known-NEGATIVE twin — the SAME tree with a REAL base actually CATCHES it ─────────────
+# 🟥 Without this twin L21 would also be green if the fix simply made CI always exit 2. The claim
+# under test is that naming an immutable base RESTORES the verdict, not that it suppresses it.
+rc="$(FH_RATCHET_BASE_REF=HEAD~1 FH_RATCHET_REQUIRE_BASE=1 rcof "$d")"
+o="$(FH_RATCHET_BASE_REF=HEAD~1 FH_RATCHET_REQUIRE_BASE=1 run "$d")"
+if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q 'SHRINK-ONLY' \
+   && printf '%s' "$o" | grep -q 'scripts/newdebt.sh'; then
+  ok "L21b twin — with an immutable base the committed illegal move BLOCKS and is NAMED"
+else
+  no "L21b twin — a real base did not restore the catch, exit $rc" "$o"
+fi
+
+# ── L21c known-NEGATIVE twin — a LEGAL commit under the same CI settings still passes ─────────
+# The over-block guard for the whole L21 family: CI must not go red on every push.
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\nbash scripts/newdebt.sh\n' > "$d/.github/workflows/ci.yml"
+printf 'exempt:\nbaseline:\n' > "$d/scripts/caller_zero_baseline.txt"
+git -C "$d" add scripts .github >/dev/null 2>&1
+git -C "$d" -c user.email=lane@example.invalid -c user.name=lane \
+    -c core.hooksPath=/nonexistent-fixture-hooks commit -q --no-verify -m legal >/dev/null 2>&1
+rc="$(FH_RATCHET_BASE_REF=HEAD~1 FH_RATCHET_REQUIRE_BASE=1 rcof "$d")"
+o="$(FH_RATCHET_BASE_REF=HEAD~1 FH_RATCHET_REQUIRE_BASE=1 run "$d")"
+if [ "$rc" = "0" ] && printf '%s' "$o" | grep -q 'shrink-only ENFORCED'; then
+  ok "L21c twin — a legal commit with a real base passes, and the run says ENFORCED for real"
+else
+  no "L21c twin — the CI configuration over-blocks a legal change, exit $rc" "$o"
+fi
+rm -rf "$d"
+
+# ── L22 the LOCAL degrade direction — self-comparison is labelled, not blocked ────────────────
+# Without FH_RATCHET_REQUIRE_BASE (a developer's machine, a pre-commit hook) the same state must
+# stay non-blocking: an over-blocking local gate trains `--no-verify` and disarms its neighbours.
+# But it must NOT be able to print the word a CI log would be quoted from.
+d="$(gitfix2)"
+rc="$(rcof "$d")"; o="$(run "$d")"
+if [ "$rc" = "0" ] && printf '%s' "$o" | grep -q 'shrink-only WORKTREE_ONLY' \
+   && ! printf '%s' "$o" | grep -q 'ENFORCED'; then
+  ok "L22 degrade — locally a self-comparison passes but is LABELLED, never called ENFORCED"
+else
+  no "L22 degrade — a self-comparison was rendered as a real comparison, exit $rc" "$o"
+fi
+rm -rf "$d"
+
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+# L23 — AN UNEXPANDED VARIABLE IN A PLIST PATH IS NOT A DISPATCH
+# launchd execs ProgramArguments literally; it performs no shell expansion. `$HOME/...` is
+# therefore exactly as unexecutable as `/path/to/...`. Cross-family reproduction 2026-08-22:
+# `<string>$HOME/projects/forge-harness/scripts/daily.sh</string>` counted as a caller, exit 0.
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+for _form in '$HOME/projects/repo/scripts/daily.sh' \
+             '${HOME}/projects/repo/scripts/daily.sh' \
+             '~/projects/repo/scripts/daily.sh'; do
+  d="$(mkfix)"
+  printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/daily.sh"
+  printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
+  printf '%s\n' '<plist>' "<string>$_form</string>" '</plist>' > "$d/scripts/x.plist"
+  rc="$(rcof "$d")"; o="$(run "$d")"
+  if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q '· scripts/daily.sh' \
+     && printf '%s' "$o" | grep -q 'PLACEHOLDER path'; then
+    ok "L23 unexpanded plist path — '$_form' does NOT wire, and the run SAYS why"
+  else
+    no "L23 unexpanded plist path — '$_form' certified a dispatch, exit $rc" "$o"
+  fi
+  rm -rf "$d"
+done
+
+# ── L23b known-NEGATIVE twin — an absolute path in the SAME fixture shape still wires ─────────
+# 🟥 The over-block twin has to live next to the block, in the same fixture shape. L19b proves the
+# `/path/to/` filter does not over-block; it says nothing about the three forms just added, and a
+# `$`/`~` class written one character too wide would eat real paths silently on the PASS side.
+d="$(mkfix)"
+printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/daily.sh"
+printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
+printf '%s\n' '<plist>' '<string>/opt/ci/projects/repo/scripts/daily.sh</string>' '</plist>' \
+    > "$d/scripts/x.plist"
+rc="$(rcof "$d")"
+[ "$rc" = "0" ] && ok "L23b twin — a real absolute path still wires (the \$/~ class did not over-reach)" \
+                || no "L23b twin — the added placeholder forms over-block a real path, exit $rc" "$(run "$d")"
+rm -rf "$d"
+
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+# L24–L26 — THE BASE RESOLVER MUST NOT SUBSTITUTE A DIFFERENT COMPARISON
+# The defect (reproduced 2026-08-22, on a three-commit fixture, before scripts/ratchet_base_resolve.sh
+# existed): the workflow tested its candidate with `git cat-file -e`, and on failure set B="" and
+# fell through to HEAD~1. A base NAMED by the event but force-pushed away therefore became a
+# SILENT, NARROWER comparison — and the checker printed "shrink-only ENFORCED" over the exact
+# illegal move (a callerless script plus its new `baseline:` line) landed one commit earlier.
+#
+# 🟥 These lanes could not exist before the extraction. The logic lived in a `run:` block, and no
+# lane can execute YAML — which is why an A-grade fail-open survived three adversarial rounds in
+# the one component that decides whether this gate measures anything at all.
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+RESOLVE="${FH_RATCHET_BASE_RESOLVE_BIN:-$ROOT/scripts/ratchet_base_resolve.sh}"
+[ -f "$RESOLVE" ] || { echo "FAIL  harness: $RESOLVE not found"; exit 1; }
+
+# 🟥 THE FIXTURE'S UNREACHABLE BASE IS A WELL-FORMED 40-HEX SHA, NOT `no-such-ref`.
+# A malformed ref name is the EASY spelling: almost any sloppy check rejects it. What a force-push
+# actually leaves behind is a syntactically perfect object id that is simply no longer in the
+# object store, and that is the spelling that has to be in the fixture
+# ([[feedback_fixture_must_use_the_breaking_spelling]]). `no-such-ref-xyz` is kept as a second,
+# weaker case in L24d so the easy spelling is covered too — not as a replacement for this one.
+GONE_SHA=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+
+# Three commits: A (clean base) · B (the illegal move, COMMITTED) · C (an unrelated later commit).
+# HEAD~1 is therefore B, which already contains the growth — so a HEAD~1 substitution reports a
+# clean diff. That is the whole shape of the defect, and it needs three commits to exist at all.
+gitfix3() {
+  _d="$(gitfix)"
+  printf '#!/usr/bin/env bash\necho new\n' > "$_d/scripts/newdebt.sh"
+  printf 'exempt:\nbaseline:\n  - scripts/newdebt.sh   # freshly added debt, the illegal move\n' \
+      > "$_d/scripts/caller_zero_baseline.txt"
+  git -C "$_d" add scripts >/dev/null 2>&1
+  git -C "$_d" -c user.email=lane@example.invalid -c user.name=lane \
+      -c core.hooksPath=/nonexistent-fixture-hooks commit -q --no-verify -m illegal >/dev/null 2>&1
+  printf '#!/usr/bin/env bash\necho alpha2\n' > "$_d/scripts/alpha.sh"
+  git -C "$_d" add scripts >/dev/null 2>&1
+  git -C "$_d" -c user.email=lane@example.invalid -c user.name=lane \
+      -c core.hooksPath=/nonexistent-fixture-hooks commit -q --no-verify -m later >/dev/null 2>&1
+  echo "$_d"
+}
+# Drive the resolver the way the workflow does: event vars in, base=/require= out to a FILE.
+# RATCHET_OUTPUT is always set explicitly so a real $GITHUB_OUTPUT in the ambient environment can
+# never be appended to by a lane.
+RESOUT="$FIXROOT/resolver.out"
+resolve() {   # resolve <root> [VAR=VAL ...] -> rc; writes base=/require= to $RESOUT
+  _d="$1"; shift
+  : > "$RESOUT"
+  env -u GITHUB_OUTPUT BASE_BRANCH="" PR_BASE_SHA="" PUSH_BEFORE="" RATCHET_OUTPUT="$RESOUT" "$@" \
+      bash "$RESOLVE" --root "$_d" >"$FIXROOT/resolver.log" 2>&1
+  echo $?
+}
+rget() { grep "^$1=" "$RESOUT" | tail -1 | cut -d= -f2-; }
+rlog() { cat "$FIXROOT/resolver.log"; }
+
+# ── L24 known-POSITIVE — a NAMED base that is unreachable is exit 3, with NO substitution ──────
+d="$(gitfix3)"
+A="$(git -C "$d" rev-parse HEAD~2)"
+rc="$(resolve "$d" PUSH_BEFORE="$GONE_SHA")"
+b="$(rget base)"; req="$(rget require)"
+# THREE assertions, because "it exited nonzero" is not the claim. The claim is that it refused AND
+# published nothing usable: a resolver that exited 3 while still writing base=HEAD~1 would leave
+# the substitution live for any caller that ignores the exit code.
+if [ "$rc" = "3" ] && [ -z "$b" ] && [ -z "$req" ] && rlog | grep -q 'does not resolve in this checkout'; then
+  ok "L24 named-but-gone — exit 3, no base emitted, and the run SAYS the comparison was refused"
+else
+  no "L24 named-but-gone — the force-push shape still substitutes; exit $rc base='$b' require='$req'" "$(rlog)"
+fi
+
+# ── L24b known-NEGATIVE twin — the SAME event with a REACHABLE base resolves normally ──────────
+# 🟥 Without this twin L24 would also be green if the resolver simply refused every push event.
+# The claim under test is narrow: refusal is keyed on the base being GONE, not on it being named.
+rc="$(resolve "$d" PUSH_BEFORE="$A")"
+b="$(rget base)"; req="$(rget require)"
+if [ "$rc" = "0" ] && [ "$b" = "$A" ] && [ "$req" = "1" ]; then
+  ok "L24b twin — a reachable named base resolves to itself, require=1 (refusal is not blanket)"
+else
+  no "L24b twin — a legitimate push event was refused (over-block); exit $rc base='$b'" "$(rlog)"
+fi
+
+# ── L24c THE END-TO-END ARM — resolver + checker, the pair the CI job actually runs ────────────
+# L24/L24b test the resolver in isolation. This one closes the loop the defect actually lived in:
+# under the OLD code this pair printed "shrink-only ENFORCED" and exited 0 over the illegal move.
+# The control runs first so the checker is proven live on this very fixture before the arm's
+# non-verdict is read as anything.
+ctl_rc="$(FH_RATCHET_BASE_REF="$A" FH_RATCHET_REQUIRE_BASE=1 rcof "$d")"
+ctl_o="$(FH_RATCHET_BASE_REF="$A" FH_RATCHET_REQUIRE_BASE=1 run "$d")"
+if [ "$ctl_rc" = "1" ] && printf '%s' "$ctl_o" | grep -q 'scripts/newdebt.sh'; then
+  ok "L24c CONTROL — with the true base the checker catches the illegal move on this fixture"
+else
+  no "L24c CONTROL — the checker is not live on this fixture; the arm below would prove nothing" "$ctl_o"
+fi
+# the arm: the resolver refuses, so the checker is never reached with a substituted base
+rc="$(resolve "$d" PUSH_BEFORE="$GONE_SHA")"
+h1="$(git -C "$d" rev-parse HEAD~1)"
+if [ "$rc" = "3" ] && ! grep -q "$h1" "$RESOUT"; then
+  ok "L24c ARM — the gone-base run stops at the resolver; HEAD~1 is never handed to the checker"
+else
+  no "L24c ARM — HEAD~1 reached the checker as a substitute base; exit $rc" "$(cat "$RESOUT"; rlog)"
+fi
+
+# ── L24d the easy spelling too — a MALFORMED named ref is also a refusal, not a fallback ──────
+rc="$(resolve "$d" PUSH_BEFORE=no-such-ref-xyz)"
+[ "$rc" = "3" ] && ok "L24d named-but-gone — a malformed named ref refuses as well (both spellings)" \
+                || no "L24d named-but-gone — a malformed ref fell through, exit $rc" "$(rlog)"
+
+# ── L24e the PR shape — a base BRANCH that does not exist here refuses too ────────────────────
+# github.base_ref names a branch, not a sha, and takes a different code path (merge-base). A fix
+# applied to only the sha path would leave this one open and every lane above would stay green.
+rc="$(resolve "$d" BASE_BRANCH=no-such-branch)"
+[ "$rc" = "3" ] && ok "L24e PR shape — an unresolvable base BRANCH refuses (the merge-base path too)" \
+                || no "L24e PR shape — the branch path still falls through, exit $rc" "$(rlog)"
+rm -rf "$d"
+
+# ── L25 NOTHING NAMED — HEAD~1 is used, and the one-commit window is ANNOUNCED ────────────────
+# This half is unchanged from the YAML it replaces: nothing was requested, so nothing is being
+# substituted. What it owes is honesty about the width of the window.
+d="$(gitfix3)"
+h1="$(git -C "$d" rev-parse HEAD~1)"
+rc="$(resolve "$d")"
+b="$(rget base)"; req="$(rget require)"
+if [ "$rc" = "0" ] && [ "$b" = "$h1" ] && [ "$req" = "1" ] && rlog | grep -q 'ONE-COMMIT window'; then
+  ok "L25 nothing named — HEAD~1 is used and the narrow window is stated, not implied"
+else
+  no "L25 nothing named — expected HEAD~1 plus an announcement; exit $rc base='$b'" "$(rlog)"
+fi
+rm -rf "$d"
+
+# ── L26 EMPTY INPUT — a one-commit repo emits require=0, NEVER require=1 with an empty base ───
+# 🟥 The empty-set question asked on its own. `require=1` beside an empty base would reach the
+# checker as "compare against nothing, and refuse to accept nothing" — exit 2 for a repo whose
+# only sin is having one commit, i.e. a gate no author action can satisfy.
+d="$(gitfix)"
+rc="$(resolve "$d")"
+b="$(rget base)"; req="$(rget require)"
+if [ "$rc" = "0" ] && [ -z "$b" ] && [ "$req" = "0" ] && rlog | grep -q 'BOOTSTRAP'; then
+  ok "L26 empty input — one commit gives base='' require=0 (bootstrap), not a satisfiable-by-nobody gate"
+else
+  no "L26 empty input — expected an empty base with require=0; exit $rc base='$b' require='$req'" "$(rlog)"
+fi
+# twin: and that bootstrap really is non-blocking end to end
+rc="$(FH_RATCHET_REQUIRE_BASE=0 rcof "$d")"
+[ "$rc" = "0" ] && ok "L26b twin — the bootstrap answer does not block the checker" \
+                || no "L26b twin — bootstrap blocked, exit $rc" "$(run "$d")"
+rm -rf "$d"
+
+# ── L26c a NON-REPO root is an instrument error (exit 2), distinct from bootstrap (exit 0) ────
+# Two different facts, two different codes. Collapsing them would let "the step ran in the wrong
+# directory" render as "this repo has no history yet".
+d="$(mkfix)"          # deliberately not a git repo
+rc="$(resolve "$d")"
+[ "$rc" = "2" ] && ok "L26c non-repo — exit 2 (instrument error), not exit 0 bootstrap" \
+                || no "L26c non-repo — a non-repo root was read as a bootstrap, exit $rc" "$(rlog)"
+rm -rf "$d"
+
+# ── L27 WIRING — the workflow calls the resolver, not an inline copy of it ────────────────────
+# 🟥 A static grep, and it is labelled as one. It cannot prove the step RUNS; what it does prove is
+# that the extracted logic has not been silently re-inlined beside it, which is the way this repair
+# would rot. The behavioural claim is carried by L24–L26, which execute the real file.
+WF="$ROOT/.github/workflows/caller-zero-ratchet.yml"
+if [ -f "$WF" ] && grep -q 'ratchet_base_resolve.sh' "$WF" \
+   && ! grep -q "rev-parse --verify --quiet 'HEAD~1" "$WF"; then
+  ok "L27 wiring — the workflow dispatches the resolver and carries no inline HEAD~1 fallback"
+else
+  no "L27 wiring — the workflow does not call the resolver, or an inline fallback came back" \
+     "$(grep -n 'HEAD~1\|ratchet_base_resolve' "$WF" 2>&1)"
+fi
+
+echo "-- caller-ratchet lanes: PASS $pass · FAIL $fail --"
+[ "$fail" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
`built_but_not_wired` 회귀 라쳇. 호출자 0인 스크립트 집합이 기준선 대비 **늘지 못하게**
한다(shrink-only). 타계열 3라운드 R3 이 `not converged` + *"land one gate at a time"* 을
냈고, 그 판정에 따라 **셋 중 둘째**를 착지시킨다(#503 이 첫째, new-code-anchor 는 미착지).

## 🟥 A급이 적대검증 3라운드를 살아남은 이유

결함은 체커가 아니라 **워크플로 YAML 의 인라인 `run:` 블록**에 있었다.
**`run:` 블록은 어떤 레인도 실행할 수 없다** — 그래서 게이트가 «무엇과 비교할지»를 정하는
유일한 부품에 앵커가 0개였다. 스크립트 쪽 앵커를 아무리 촘촘히 붙여도 그 칸은 검증 밖이다.

그리고 체커 자신의 헤더가 이미 이렇게 적고 있었다 —
*"An explicitly named base that does not resolve is exit 2 — NEVER a silent fall-through"*.
**규칙이 체커에선 참이고, 그것을 구동하는 워크플로에선 거짓이었다.**

재현(그 `run:` 본문을 축자 복사, 3커밋 픽스처):
```
CONTROL  PUSH_BEFORE=실재 SHA   → rc=1 · FAIL 「NEW entries under baseline:」
ARM      PUSH_BEFORE=deadbeef…  → base 를 HEAD~1 로 무음 치환 · rc=0 · PASS 「ENFORCED」
```
성질 둘이 겹친다 — 치환이 **무음**이고(요청한 비교를 못 했다는 말이 어디에도 없다), 치환된
base 가 **더 좁은데**(1커밋) 이 게이트에서 가장 센 단어를 찍는다.

## 수리

base 결정 로직을 YAML 밖(`ratchet_base_resolve.sh`)으로 꺼낸 것이 수리의 절반이다.
판별을 「해석됐나」에서 **「이벤트가 지목했나」**로 바꾸고 부재를 네 값으로 갈랐다:
지목됐는데 도달 불가 → **exit 3, 치환 없음**(degrade CLOSED) · 아무것도 안 지목 → HEAD~1
+ **창 폭 명시** · 선행 커밋 없음 → BOOTSTRAP 비차단 · git 트리 아님 → exit 2.
옛 코드는 뒤의 둘을 접었다(「엉뚱한 디렉터리」가 「이력이 없다」로 렌더됐다).

`require=1 + 빈 base` 는 절대 안 낸다 — 죄가 「커밋이 하나뿐」인 레포에 exit 2 를 내는
게이트는 아무도 만족시키지 못하고, 그건 override 훈련기다.

## 검증

fail-before: 옛 로직을 같은 레인에 물려 **48 PASS · 6 FAIL** → 수리 후 **54/54**.
🟥 정직한 축소 — 그 6 중 L24b·L26 은 pre-fix 에서도 초록이었다. 옛 코드가 그 성질은 이미
옳게 했으므로 **그 둘은 이 수리의 앵커가 아니라 회귀 앵커**이고, 수리를 박는 것은 넷이다.

되돌림 2레그(리졸버 · 워크플로 배선) — 후자는 옛 인라인 블록을 되살린 사본에 레인을 돌려
**정확히 L27 하나만** 적색. WIRED 판정은 주장이 아니라 known-pair 로 확인했다(워크플로
있음/제거 두 arm 이 갈렸다). 범위 밖 델타 독립성도 격리 사본으로 통제(85→84).

selfcheck rc=0 · count_check rc=0 · package_coverage rc=0 · lane_runner rc=0
`67 suites — 67 wired · 0 debt` · 레인 54/54. 전부 `out=$(cmd 2>&1); rc=$?`.
🟥 배선 증거는 표에 이름이 있는 게 아니라, selfcheck 로그에 레인 출력이 pair 루프 **안에**
찍히는 것이다.

## 출하 안 한다 — 판정 근거가 실측이다

체커의 `RUNNER_GLOBS` 에 `.github/workflows/*.yml` 이 있는데 **`.github/` 는 `files[]` 에
없다**(197개 중 0). 소비자 트리에선 워크플로에서만 디스패치되는 스크립트가 전부 caller 0 →
UNDECLARED → exit 1 — **모든 신선한 설치에서 100% 적색**이다. 그래서 `ACCEPTED_ABSENT` 에
등재했다. 그 목록의 뜻은 「아직 안 실었다」가 아니라 **「싣는 것이 틀렸다」**다.

## 곁가지 — 기밀 스캔이 이 커밋을 한 번 막았다

픽스처의 launchd plist 경로가 `/Users/someone/...` 였다. **가짜 경로인데 스캐너가 홈 경로
«모양»을 잡았다.** 스캐너가 옳다 — 진짜와 가짜를 구분할 수 없는 게 정상이고, 그래서 그
모양을 아예 안 쓰는 쪽으로 고쳤다(`/opt/ci/...`). 고친 뒤 레인 54/54 유지 — 픽스처 위력은
안 깎였다.

## 잔여 — 마커에 값으로

🟥 **CI 에서 이 워크플로가 돈 적이 없다.** 레인은 리졸버를 실행하지만 Actions 배관
(`$GITHUB_OUTPUT` 왕복 · `env:` 전달)은 미실행이고 **로컬에서 못 닫는다.** 이 게이트가 막으려는
사고와 **같은 축**이라, 첫 PR 에서 그 잡 로그를 눈으로 읽어야 한다.
그 외: 타계열은 설계를 봤지 **이 수리는 다시 안 봤다** · B급 1건은 내용이 없어 못 닫았다
(라벨만 남은 블로커의 실사례) · HEAD~1 창 1커밋 폭 존속 · required check 아님.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ5j1CS87eUQALCWfaxy2F