### PR TITLE
feat(identity4): 빌드-시점 격발 채널을 처음으로 세운다 — 하중선은 스크립트가 아니라 등록이다

### DIFF
--- a/scripts/prior_art_prompt.sh
+++ b/scripts/prior_art_prompt.sh
@@ -129,9 +129,56 @@ esac
 #    날짜로 degrade(침묵이 아니라 «덜 자주» 쪽).
 _SID_SAFE=$(printf '%s' "${SID:-}" | tr -cd 'A-Za-z0-9_-')
 STAMP="${CLAUDE_PROJECT_DIR:-.}/.claude/.prior_art_prompted_${_SID_SAFE:-$(date +%Y%m%d)}"
-[ -f "$STAMP" ] && exit 0
+
+# ③-b 🟥 **세션당 1회로는 T2 를 구조적으로 못 잡는다** (실측 2026-08-22, 한 세션 전수 재생).
+# 이 훅의 존재 이유는 이 파일 머리가 적어둔 «T2 = 컨텍스트가 길어진 뒤 **또** 새로 빌드업할 때» 인데,
+# 스탬프가 세션 스코프면 그 «또» 가 영원히 억제된다. 한 세션(08:29~13:33)에서 새 메커니즘 3건이
+# 08:38 · 13:06 · 13:07 에 났고, 세션당 1회는 **첫 건만** 띄웠다 — 억제된 둘이 정확히 T2 다.
+# ⇒ 시간 재무장으로 바꾼다. 마지막 **발화** 시각에서 N초가 지나면 다시 무장한다.
+#
+# 🟥 N 은 임의로 골랐다. 이 값은 데이터가 정한 것이 아니다 — 같은 실측에서 **N=1h·2h·4h 가 전부
+#    같은 결과(2 발화)** 를 냈다. 즉 **데이터가 N 을 판별하지 않았다**, n=1 세션이고, 그 세션의
+#    간극이 4.5시간이라 임계에 둔감했을 뿐이다. §Mechanization Boundary 의 «오늘의 판단을 내일의
+#    천장으로 굳히지 마라» 에 걸리는 자리라, 상수를 박는 대신 **아래 로그를 남겨서 다음 세션들이
+#    실제 분포를 쌓게 한다.** N 재정은 그 로그 위에서만 해라 — 이 주석을 지우지 말고.
+# 왜 «대상 파일당 1회» 가 아닌가: 같은 실측에서 13:06 `mapped_tracks.sh` 와 13:07 그 레인 스위트는
+#    **한 메커니즘**이다. 파일당이면 13:07 이 같은 메커니즘을 재질문하는 **오발화**가 된다. 이 파일
+#    머리가 «오발화는 미발화보다 훨씬 비싸다(소음 = 자기무력화 경로)» 라고 못박은 방향과 반대다.
+PRIOR_ART_REARM_SECONDS="${PRIOR_ART_REARM_SECONDS:-7200}"   # 2h — 위 단락이 이 값의 출처이자 한계다
+
+# 시계는 주입 가능하다 — 픽스처가 4.5시간을 실시간으로 기다릴 수는 없다. 테스트 시임일 뿐이고
+# 억제를 **끄지는** 못한다(값을 넣어도 아래 산술을 그대로 통과해야 한다).
+_NOW="${PRIOR_ART_NOW:-$(date +%s)}"
+case "$_NOW" in ''|*[!0-9]*) _NOW=$(date +%s) ;; esac
+
+_LAST=""
+if [ -f "$STAMP" ]; then
+  _LAST=$(cat "$STAMP" 2>/dev/null | tr -cd '0-9')
+fi
+
+# 로그. 🟥 발화만이 아니라 **억제도** 남긴다 — 「몇 건 억제」만 세면 그것이 옳은 억제였는지 못
+# 가른다. 그래서 무엇을(파일명) · 직전 발화로부터 얼마나(초) 를 같이 적는다.
+# 실패해도 판정은 안 바뀐다(로깅은 게이트가 아니다).
+_PA_LOG="${CLAUDE_PROJECT_DIR:-.}/.claude/.prior_art_events.tsv"
+_pa_log() { # $1=FIRE|SUPPRESS  $2=elapsed-or-dash
+  mkdir -p "$(dirname "$_PA_LOG")" 2>/dev/null || true
+  printf '%s\t%s\t%s\t%s\t%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" "$1" "${_SID_SAFE:-nosid}" "$2" "$FILE" \
+    >> "$_PA_LOG" 2>/dev/null || true
+}
+
+if [ -n "$_LAST" ]; then
+  _ELAPSED=$(( _NOW - _LAST ))
+  if [ "$_ELAPSED" -lt "$PRIOR_ART_REARM_SECONDS" ]; then
+    _pa_log SUPPRESS "$_ELAPSED"
+    exit 0
+  fi
+  _pa_log FIRE "$_ELAPSED"
+else
+  _pa_log FIRE -
+fi
 mkdir -p "$(dirname "$STAMP")" 2>/dev/null || true
-: > "$STAMP" 2>/dev/null || true
+printf '%s\n' "$_NOW" > "$STAMP" 2>/dev/null || true
 
 MSG="🔎 새 메커니즘을 쓰려는 참이다 ($(basename "$FILE")). 짓기 전에 **책장부터, 없으면 도서관** —
 안 했으면 지금 하고, 했으면 이 줄은 무시해라.

--- a/scripts/test_prior_art_prompt_lanes.sh
+++ b/scripts/test_prior_art_prompt_lanes.sh
@@ -123,6 +123,54 @@ chk "C1 입력이 JSON 이 아니면 무음 exit 0" \
     "$(printf 'not json' | bash "$H" >/dev/null 2>&1; echo $?)" 0
 chk "C2 file_path 없으면 무음" "$(printf '{"tool_input":{}}' | bash "$H" 2>/dev/null | wc -c | tr -d ' ')" 0
 
+echo "── T2 재무장 (2026-08-22): 세션당 1회가 T2 를 구조적으로 못 잡던 자리 ──"
+# 🟥 실측 기반 픽스처다. 한 세션에서 새 메커니즘 3건이 08:38 · 13:06 · 13:07 에 났고, 세션당 1회는
+# 첫 건만 띄웠다. 뒤의 둘이 정확히 이 훅이 존재 이유로 적어둔 T2 다. 시각은 주입한다 —
+# 4.5시간을 실시간으로 기다리는 앵커는 아무도 안 돌린다.
+_T1=1787387902   # 08:38:22Z
+_T2=1787404013   # 13:06:53Z  (+16111s = 4h28m)
+_T3=1787404067   # 13:07:47Z  (+54s — T2 와 **같은 메커니즘**: 스크립트와 그 레인 스위트)
+DT=$(mktemp -d); export CLAUDE_PROJECT_DIR="$DT"
+_fire() { # $1=NOW $2=name → 발화면 1
+  printf '{"session_id":"t2rearm","tool_input":{"file_path":"%s/scripts/%s"}}' "$DT" "$2" \
+    | PRIOR_ART_NOW="$1" bash "$H" 2>/dev/null | grep -c additionalContext | tr -d ' '
+}
+chk "T2-1 첫 메커니즘 → 발화"                       "$(_fire $_T1 m1.sh)" 1
+chk "T2-2 4h28m 뒤 새 메커니즘 → **재발화** (이 수리의 요점)" "$(_fire $_T2 m2.sh)" 1
+chk "T2-3 54초 뒤 같은 메커니즘의 레인 → 억제 (과발화 방지)"  "$(_fire $_T3 m3.sh)" 0
+# 과차단 컨트롤 — 메커니즘 하나짜리 평범한 세션에서 발화가 1회를 넘지 않는다.
+rm -f "$DT/.claude/.prior_art_prompted_"* "$DT/.claude/.prior_art_events.tsv"
+_n=$(( $(_fire $_T1 solo.sh) + $(_fire $((_T1+60)) solo_b.sh) + $(_fire $((_T1+120)) solo_c.sh) ))
+chk "T2-4 과차단 컨트롤: 한 버스트(2분 내 3파일) → 발화 총 1회" "$_n" 1
+# 로그가 실제로 남는가 — 이 상수(N)를 다음에 재정할 유일한 근거다.
+rm -f "$DT/.claude/.prior_art_prompted_"* "$DT/.claude/.prior_art_events.tsv"
+_fire $_T2 g1.sh >/dev/null; _fire $_T3 g2.sh >/dev/null   # T2→T3 = 54s, 억제 구간
+chk "T2-5 로그에 FIRE 와 SUPPRESS 가 둘 다 남는다" \
+    "$(awk -F'\t' '{print $2}' "$DT/.claude/.prior_art_events.tsv" 2>/dev/null | sort -u | tr '\n' ',' )" "FIRE,SUPPRESS,"
+chk "T2-6 억제 로그가 경과초와 파일명을 같이 싣는다 (옳은 억제였는지 가르려면 필요)" \
+    "$(awk -F'\t' '$2=="SUPPRESS" && $4 ~ /^[0-9]+$/ && $5 ~ /g2\.sh$/ {n++} END{print n+0}' "$DT/.claude/.prior_art_events.tsv" 2>/dev/null)" 1
+unset CLAUDE_PROJECT_DIR; rm -rf "$DT"
+
+echo "── 특성화: 인용부호 안 텍스트를 빌드로 읽는다 (오발화 5번째 얼굴) ──"
+# 🟥 2026-08-22 실측: 훅을 시험하려고 `echo` 인자 **안에** 픽스처 문자열을 넣은 호출에서 발화했다.
+# 이 파일 머리가 센 cross-family 오발화 4종(tee 경계 · `2>` · 리포트가 .sh · 미확장 변수)의 **5번째**다.
+# 🟥 이 레인은 «현재 동작»을 박는 특성화 레인이고, **수리됐다는 주장이 아니다.** 지금은 의도적으로
+#    미수리다 — 인용 문맥을 정규식으로 가르는 것은 비싸고 표본이 1이다.
+#    ⚠️ 다음 사람에게: 정규식을 **넓히면** 이 클래스가 더 나빠진다. 이 줄이 그때 걸린다.
+#       그리고 이 오발화를 실제로 **고쳤다면** 기대값을 1 → 0 으로 뒤집고 이 주석을 지워라.
+# 픽스처는 실물에서 왔다 — 초판은 이스케이프가 뭉개져 «침묵» 이 나왔고, 그건 결함이 사라진 게
+# 아니라 **재현을 못 한 것**이었다. 그래서 heredoc 으로 원문 그대로 넣는다.
+# 🟥 자기 CLAUDE_PROJECT_DIR 를 반드시 준다. 초판은 안 줘서 스탬프가 **레포 안**에 쌓였고,
+#    2회차부터 «침묵» 이 나왔다 — 탐지기가 아니라 스탬프가 억제한 것이라 결함이 사라진 것처럼
+#    보였다. 계기가 자기 부작용에 오염되는 형태이고, 레인이 idempotent 하지 않다는 뜻이다.
+_QD=$(mktemp -d)
+_QJ=$(mktemp); cat > "$_QJ" <<'QEOF'
+{"session_id":"q1","tool_input":{"command":"echo \"cat > scripts/not_real.sh <<EOF\""}}
+QEOF
+chk "Q1 [특성화·미수리] 인용문 안 텍스트에 발화한다" \
+    "$(CLAUDE_PROJECT_DIR="$_QD" bash "$H" < "$_QJ" 2>/dev/null | grep -c additionalContext | tr -d ' ')" 1
+rm -f "$_QJ"; rm -rf "$_QD"
+
 echo
 if [ "$FAIL" -eq 0 ]; then echo "════ prior-art-prompt lanes: $PASS passed · 0 failed ════"; exit 0
 else echo "🟥 prior-art-prompt lanes: $FAIL 실패 / $((PASS+FAIL))"; exit 1; fi


### PR DESCRIPTION

정체성 ④(프런티어 답습)의 **ⓐ 빌드-시점 격발 표면**. 새 메커니즘을 짓기 직전에
«책장 먼저, 없으면 도서관»을 띄운다. (b) 시간 재무장 N=2h + 로깅. 레인 **43 passed · 0 failed**.

## 🟥 이 자산은 2026-08-21 부터 «있는데 한 번도 안 돈» 상태였다

이유가 스크립트가 아니었다. **이 스니펫만 `project_settings_json` 래퍼 없이 출하되고 있었고**,
install-wizard 의 머지 코드는 그 키가 없으면 `SKIP (no project_settings_json)` 로 **조용히
건너뛴다.** 즉 「아직 안 돌렸다」가 아니라 **「돌려도 항상 스킵돼서 한 번도 등록된 적이 없다」**
였다. 래퍼 수리는 이미 들어갔고, 이 커밋이 **그 수리 이후 첫 실제 등록**이다.

## 등록 실측 (컨트롤 동반)

```
등록 전   grep -c prior_art_prompt ~/.claude/settings.json .claude/settings.json  → 0 / 0
등록 후   프로젝트 쪽 1
컨트롤    zzz_nonexistent_hook → 0   ·   compaction_probe → 2
매처      ['Bash','Write']  →  ['Bash','Write','Write|Bash']
```

🟥 **«같은 커밋»은 구조적으로 불가능하다** — `.claude/settings*.json` 은 전부 gitignored 라
훅 등록을 tracked 로 둘 수 없다. 그래서 합의사항 「등록은 수리와 같은 커밋」을 **「같은 행동」**
으로 읽었고, 그 재해석을 마커에 적었다. 조용히 완화한 게 아니다.

## 🟥 이 커밋이 ④ 를 완주시키지 «않는다»

완주 판정은 *사람이 안 시켰는데* «물어볼까?»가 뜨고, 그 표본이 **플로어 티어에서 났을 때만**
계상한다. 이 델타는 **표본이 발생 가능한 상태**를 만들 뿐이다. 자발성은 무대에 못 올린다 —
등급표가 스스로 그렇게 적고, 그래서 이 다리는 만들어내지 않고 자연발생을 기다린다.

## 안 닫은 것

**채널이 «섰다»는 확인했고 «뜬다»는 안 확인했다** — 실제 발화는 미관측이고 다음 세션의 첫
확인거리다. ⓑ 대화-시점 표면은 여전히 기계 없음(그리고 그건 의도된 자리다). N=2h 창이 맞는지
미측정. 소비자 위치 install-wizard 머지 미실행.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ5j1CS87eUQALCWfaxy2F