### PR TITLE
fix(chamber): 인큐베이션 큐가 한글 후보의 절반을 조용히 삼키고 있었다

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "plugins/fh-meta/CHANGELOG.md",
     "knowledge/shared/learnings/subagent_invocations_log.yaml",
     "scripts/chamber_candidate_collect.sh",
+    "scripts/test_chamber_sig_lanes.sh",
     "scripts/chamber_witness.sh",
     "scripts/digest_landing_check.sh",
     "scripts/relay_channel.sh",

--- a/scripts/chamber_candidate_collect.sh
+++ b/scripts/chamber_candidate_collect.sh
@@ -88,13 +88,64 @@ fi
 
 # --- keyword signature per candidate (for dedup) ---
 STOP='^(that|this|from|into|over|when|what|will|your|there|their|then|than|with|chamber|candidate|skill|agent|tool|does|done|after|before|which|about|through)$'
-_sig() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9가-힣' ' ' | tr -s ' ' '\n' \
-         | awk 'length($0)>=4' | grep -vE "$STOP" | sort -u; }
+#
+# 🟥 EVERY STAGE IS PINNED TO LC_ALL=C, AND THAT IS THE WHOLE REPAIR (2026-08-22 — known-pair
+# calibration lives in scripts/test_chamber_sig_lanes.sh, which is where the measurements below
+# are reproducible). The signature pipeline used to run under the ambient locale, and in a UTF-8
+# locale THREE of its stages silently mis-handle Hangul:
+#   · `sort -u`  — Hangul syllables collate as EQUAL to one another. Measured: 8 distinct Korean
+#     tokens → 2 survivors on macOS/BSD sort (grouped by syllable count, input-order dependent),
+#     → 1 survivor on GNU coreutils 9.7. The signature is not shortened, it is DELETED.
+#   · `comm -12` — inherits the same collation, so two entirely different Korean tokens are
+#     reported as a common line. Measured: comm -12 <(레인) <(발주) prints a line. The jaccard
+#     numerator was measuring a collation, not an overlap.
+#   · `awk length()` — BYTES on BSD awk, CHARACTERS on gawk in a UTF-8 locale. The same 2-syllable
+#     token passes the old `>=4` on macOS (6 bytes) and is DROPPED on Linux (2 chars): the two
+#     platforms did not even agree on the token set before comparing it.
+# Live effect on this repo's 64-marker corpus: unrelated candidates folded into clusters of 11, 7,
+# 7, 4 and 3, only each cluster's first member reached the queue, and the run still printed a
+# healthy "deduped candidates: 31". A silent fold rendered as a clean number
+# ([[feedback_not_found_is_not_zero_family]]).
+#
+# ⚠️ The threshold (MINJ) was NOT touched. The signatures were shredded; a threshold moved to
+# compensate would have papered over the shredding and mis-scored the corpus in a new way.
+#
+# Tokenizer: one POSIX-awk pass over BYTES, no locale-sensitive character classes anywhere.
+#   _HANLEAD = UTF-8 lead bytes EA-ED  → U+A000..U+DFFF, which contains the Hangul syllable block
+#              (U+AC00-D7A3). Deliberately a byte range and not `[가-힣]`: BSD tr reads that range
+#              as characters and GNU tr reads it as bytes 0x80-0xED, so the same pattern keeps the
+#              em-dash on Linux and drops it on macOS (measured, both).
+#   _HANCONT = UTF-8 continuation bytes 80-BF.
+# Because the alternation matches ASCII-alnum runs and Hangul runs separately, every other byte —
+# «»「」·—→…, CJK punctuation, fullwidth forms — is a SEPARATOR by construction, with no
+# hand-maintained punctuation vocabulary to drift.
+# Length is then counted in CHARACTERS on both platforms without asking awk about encoding: an
+# ASCII run is 1 byte/char, a Hangul run is exactly 3.
+# Thresholds preserve the pre-repair BSD semantics on purpose (ASCII ≥4 chars, Hangul ≥2 syllables
+# for _sig; ≥2 / ≥1 for _ksig) — this commit fixes the collation, it does not re-tune the filter.
+#
+# Portability, ARGUED AND THEN MEASURED (not asserted): the awk program uses only match/substr/
+# length/tolower and dynamic regexes built from -v byte ranges, all of which are byte-semantic in
+# the C locale on every awk. Run on the same input: BSD awk 20200816 (macOS), mawk 1.3.4 and
+# gawk 5 (debian:stable-slim, via docker) → BYTE-IDENTICAL token sets.
+_HANLEAD=$(printf '\352-\355')
+_HANCONT=$(printf '\200-\277')
+_tok() { # $1=text  $2=min ASCII chars  $3=min Hangul syllables → sorted unique token list
+  printf '%s' "$1" | LC_ALL=C awk -v L="$_HANLEAD" -v C="$_HANCONT" -v MA="$2" -v MH="$3" '
+    { s = tolower($0); pat = "[a-z0-9]+|([" L "][" C "][" C "])+"
+      while (match(s, pat)) {
+        t = substr(s, RSTART, RLENGTH)
+        if (t ~ ("^[" L "]")) { if (length(t) / 3 >= MH) print t }
+        else                  { if (length(t)     >= MA) print t }
+        s = substr(s, RSTART + RLENGTH)
+      } }' \
+  | LC_ALL=C grep -vE "$STOP" | LC_ALL=C sort -u
+}
+_sig() { _tok "$1" 4 2; }
 # kill-side signature for the seen-filter: keeps 2+ char tokens (a slug's meaningful short tokens like
 # "qa"/"ui" are dropped by _sig's ≥4 filter → an all-short slug yields an EMPTY sig → kkn=0 → the old
 # match never fired → a KILLed candidate re-entered the queue SILENTLY, Axis-2 MED-3b). Drops stopwords only.
-_ksig() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9가-힣' ' ' | tr -s ' ' '\n' \
-          | awk 'length($0)>=2' | grep -vE "$STOP" | sort -u; }
+_ksig() { _tok "$1" 2 1; }
 
 # --- LAYER 2: dedup by greedy jaccard clustering ---
 # cluster files: $WORK/cluster.N holds "source<TAB>desc" lines; $WORK/sig.N holds the union keyword sig.
@@ -106,12 +157,17 @@ while IFS=$'\t' read -r label desc; do
   merged=0
   c=1
   while [ "$c" -le "$NC" ]; do
-    inter=$(comm -12 "$WORK/sig.$c" "$WORK/candsig.$idx" 2>/dev/null | grep -c . || true)
-    union=$(sort -u "$WORK/sig.$c" "$WORK/candsig.$idx" 2>/dev/null | grep -c . || true)
+    # LC_ALL=C on BOTH: `comm` requires its inputs sorted in the SAME collation it compares with,
+    # and _tok already emits C-collated lines. Under a UTF-8 locale this pair reported different
+    # Korean tokens as common (see the _sig header) — the numerator, not just the token list.
+    inter=$(LC_ALL=C comm -12 "$WORK/sig.$c" "$WORK/candsig.$idx" 2>/dev/null | grep -c . || true)
+    union=$(LC_ALL=C sort -u "$WORK/sig.$c" "$WORK/candsig.$idx" 2>/dev/null | grep -c . || true)
     jac=0; [ "${union:-0}" -gt 0 ] && jac=$(( inter * 100 / union ))
     if [ "$jac" -ge "$MINJ" ]; then
       printf '%s\t%s\n' "$label" "$desc" >> "$WORK/cluster.$c"
-      sort -u "$WORK/sig.$c" "$WORK/candsig.$idx" > "$WORK/sig.$c.tmp" && mv "$WORK/sig.$c.tmp" "$WORK/sig.$c"
+      # C-collated too: this file is a `comm` input on the next iteration. A UTF-8 sort here would
+      # re-break the ordering precondition one merge after it was established.
+      LC_ALL=C sort -u "$WORK/sig.$c" "$WORK/candsig.$idx" > "$WORK/sig.$c.tmp" && mv "$WORK/sig.$c.tmp" "$WORK/sig.$c"
       merged=1; break
     fi
     c=$((c+1))
@@ -146,8 +202,8 @@ RANKED="$WORK/ranked"; : > "$RANKED"
 c=1
 while [ "$c" -le "$NC" ]; do
   freq=$(grep -c . "$WORK/cluster.$c" 2>/dev/null); freq=${freq:-0}
-  ndiv=$(cut -f1 "$WORK/cluster.$c" | sort -u | grep -c . || true)
-  srcs=$(cut -f1 "$WORK/cluster.$c" | sort -u | paste -sd, -)
+  ndiv=$(cut -f1 "$WORK/cluster.$c" | LC_ALL=C sort -u | grep -c . || true)
+  srcs=$(cut -f1 "$WORK/cluster.$c" | LC_ALL=C sort -u | paste -sd, -)
   rep=$(head -1 "$WORK/cluster.$c" | cut -f2-)
   score=$(( ndiv * 2 + freq ))
   # seen-filter: does this candidate match an already-KILLed ledger entry? Two decorrelated tests, either
@@ -159,15 +215,17 @@ while [ "$c" -le "$NC" ]; do
   # catches a wrong match), whereas silent re-entry was invisible. Visible-imprecise ≻ silent-miss.
   if [ "$NKILL" -gt 0 ]; then
     _ksig "$rep" > "$WORK/repsig"
-    repflat=$(printf '%s' "$rep" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9')
+    # C locale: `tr` ranges and case folding are byte-semantic here, so the flattened slug is the
+    # same string on BSD and GNU. Non-ASCII is dropped by design — this is the ASCII-slug fallback.
+    repflat=$(printf '%s' "$rep" | LC_ALL=C tr 'A-Z' 'a-z' | LC_ALL=C tr -cd 'a-z0-9')
     seen_match=""
     while IFS= read -r kname; do
       [ -z "$kname" ] && continue
       _ksig "$kname" > "$WORK/ksig"
       kkn=$(grep -c . "$WORK/ksig" 2>/dev/null || true); kkn=${kkn:-0}
-      matched=0; [ "$kkn" -gt 0 ] && matched=$(comm -12 "$WORK/ksig" "$WORK/repsig" 2>/dev/null | grep -c . || true)
+      matched=0; [ "$kkn" -gt 0 ] && matched=$(LC_ALL=C comm -12 "$WORK/ksig" "$WORK/repsig" 2>/dev/null | grep -c . || true)
       kpct=0; [ "$kkn" -gt 0 ] && kpct=$(( matched * 100 / kkn ))
-      kflat=$(printf '%s' "$kname" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9')
+      kflat=$(printf '%s' "$kname" | LC_ALL=C tr 'A-Z' 'a-z' | LC_ALL=C tr -cd 'a-z0-9')
       if [ "$kkn" -gt 0 ] && [ "$kpct" -ge 60 ]; then seen_match="$kname"; break; fi
       if [ "${#kflat}" -ge 5 ] && printf '%s' "$repflat" | grep -qF "$kflat"; then seen_match="$kname"; break; fi
     done < "$KILLED"
@@ -197,7 +255,7 @@ echo "deduped candidates: $NC (from $NRAW raw markers)"
 echo ""
 printf '%-5s  %-6s  %-24s  %-18s  %s\n' "SCORE" "SRCS" "SOURCES" "REINVENTION" "CANDIDATE"
 printf '%-5s  %-6s  %-24s  %-18s  %s\n' "-----" "------" "------------------------" "------------------" "---------"
-sort -rn "$RANKED" | while IFS=$'\t' read -r score ndiv srcs verdict rep; do
+LC_ALL=C sort -rn "$RANKED" | while IFS=$'\t' read -r score ndiv srcs verdict rep; do
   # drop leading zeros for display
   printf '%-5d  %-6d  %-24s  %-18s  %s\n' "$((10#$score))" "$ndiv" "$srcs" "$verdict" "$rep"
 done

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -543,6 +543,7 @@ _LANE_TO=""; command -v timeout >/dev/null 2>&1 && _LANE_TO="timeout 300"
 for _pair in \
   "scripts/degrade_probe_capability.sh|scripts/test_capability_entrypoint_shipping.sh" \
   "scripts/chamber_run.sh|scripts/test_chamber_run_lanes.sh" \
+  "scripts/chamber_candidate_collect.sh|scripts/test_chamber_sig_lanes.sh" \
   "scripts/destructive_pre_gate.sh|scripts/test_destructive_pre_gate_lanes.sh" \
   "templates/.git-hooks/pre-push|scripts/test_prepush_destructive_lanes.sh" \
   "templates/.git-hooks/pre-push|scripts/test_prepush_destructive_liveness.sh" \

--- a/scripts/test_chamber_sig_lanes.sh
+++ b/scripts/test_chamber_sig_lanes.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# test_chamber_sig_lanes.sh — known-pair calibration for chamber_candidate_collect.sh's LAYER-2
+# dedup signature (`_sig`/`_ksig`) on a NON-ASCII corpus.
+#
+# WHY (measured 2026-08-22, live corpus, this repo):
+#   A freshly-registered candidate was grepped correctly by LAYER 1 and then VANISHED from the
+#   ranked queue. The loss was LAYER 2. Root cause = **locale-dependent collation**, and it is not
+#   one bug but a family, all in the same pipeline:
+#     · `sort -u` in en_US.UTF-8 treats Hangul syllables as EQUAL to one another. Measured on
+#       macOS/BSD sort: 8 distinct Korean tokens → 2 survivors (grouped by syllable count, first
+#       one wins, input-order dependent). Measured on GNU coreutils 9.7 sort: same 8 → **1**.
+#     · `comm -12` inherits that collation, so it reports two COMPLETELY DIFFERENT Korean tokens
+#       as a common line. Measured: comm -12 <(레인) <(발주) → prints a line. The jaccard
+#       numerator is therefore computed against a collation, not against the tokens.
+#     · `awk 'length()>=4'` counts BYTES on BSD awk and CHARACTERS on gawk in a UTF-8 locale. The
+#       same 2-syllable Korean token passes on macOS (6 bytes) and is DROPPED on Linux (2 chars),
+#       so the two platforms disagree about the signature before any comparison happens.
+#   Net effect on the live corpus (64 raw markers): unrelated candidates were folded into clusters
+#   of 11, 7, 7, 4 and 3, and only each cluster's FIRST member reached the output. Everything else
+#   was silently deleted from the queue while the run reported a healthy "deduped candidates: 31".
+#
+#   That is the [[feedback_not_found_is_not_zero_family]] shape — a silent fold rendered as a clean
+#   number — which is why it needs a mechanical anchor rather than a note.
+#
+# WHAT IT PINS (the lanes below, in pairs, because a merge check with only one direction is not a
+# measurement — over-merging and never-merging both produce a "correct" number on half the corpus):
+#   L1 Korean, DIFFERENT   → must NOT merge  (known-positive: the actual live mis-merge)
+#   L2 Korean, SAME        → must merge      (known-negative: the fix must not kill real dedup)
+#   L3 English, DIFFERENT  → must NOT merge  (control: the defect is Hangul-only; if this lane ever
+#                                             goes red the diagnosis above is wrong)
+#   L4 English, SAME       → must merge      (control, other direction)
+#   L5 Korean ×3 unrelated → must stay 3     ("does it collapse a set, not just a pair")
+#   L6 Korean vs English   → must NOT merge  (mixed-script pair)
+#
+# 🟥 EVERY LANE DRIVES THE REAL SCRIPT. Nothing here re-implements `_sig`. A lane suite that carries
+#   its own copy of the logic grades the copy ([[feedback_adversarial_review_not_substitute_for_first_use]]
+#   — "초록의 출처를 물어라: 사본이 통과시키고 있었다").
+#
+# 🟥 FIXTURES ARE SELF-BUILT under mktemp, never this repo's own tracks/ — a suite that reads
+#   repo-specific paths FAILs wholesale once the script is ported (portability_lint P9).
+#
+# Usage:  bash scripts/test_chamber_sig_lanes.sh
+# Exit:   0 = all lanes pass · 1 = a lane failed · 10 = harness error (could not measure)
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+SUBJ="$REPO/scripts/chamber_candidate_collect.sh"
+[ -f "$SUBJ" ] || { echo "HARNESS ERROR: subject missing: $SUBJ"; exit 10; }
+
+TMP="$(mktemp -d 2>/dev/null)" || { echo "HARNESS ERROR: mktemp failed"; exit 10; }
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+lane=0
+
+# Build a throwaway FH root holding exactly the given marker lines, run the REAL collector inside
+# it, and echo "NRAW NDEDUP". The collector locates its own FH root from its dirname, so the copy
+# has to live in <root>/scripts/ — that is also why this cannot be done by calling the repo copy
+# with an env var: the script offers no such knob and inventing one for the test would move the
+# measurement off the shipped path.
+_run() { # $@ = marker descriptions
+  local root="$TMP/fx.$lane"
+  rm -rf "$root"
+  mkdir -p "$root/scripts" "$root/tracks/_meta" "$root/plugins" || return 10
+  cp "$SUBJ" "$root/scripts/" || return 10
+  # NOTE: chamber_candidate_screen.sh is deliberately NOT copied. Its verdict column is irrelevant
+  # here and its absence keeps the fixture independent of this repo's asset tree.
+  local f="$root/tracks/_meta/fh_signal_2000-01-01_fixture.md"
+  : > "$f"
+  local d
+  for d in "$@"; do printf 'CHAMBER-CANDIDATE: %s\n' "$d" >> "$f"; done
+  local out
+  out=$(bash "$root/scripts/chamber_candidate_collect.sh" 2>&1) || true
+  local nraw ndedup
+  nraw=$(printf '%s\n' "$out"   | sed -n 's/.*raw candidate markers found: \([0-9][0-9]*\).*/\1/p' | head -1)
+  ndedup=$(printf '%s\n' "$out" | sed -n 's/^deduped candidates: \([0-9][0-9]*\) .*/\1/p' | head -1)
+  printf '%s %s\n' "${nraw:-X}" "${ndedup:-X}"
+}
+
+# $1=label  $2=expected dedup count  $3..=descriptions
+_lane() {
+  lane=$((lane+1))
+  local label="$1" want="$2"; shift 2
+  local got nraw ndedup
+  got=$(_run "$@")
+  nraw="${got%% *}"; ndedup="${got##* }"
+  # Instrument control BEFORE the verdict: if LAYER 1 did not even see the markers, a "correct"
+  # dedup number would be an accident. `not found` is not a zero.
+  if [ "$nraw" != "$#" ]; then
+    echo "HARNESS ERROR  $label: collector saw $nraw raw markers, fixture planted $# — instrument dead, verdict void"
+    fail=1; return
+  fi
+  if [ "$ndedup" = "$want" ]; then
+    echo "PASS  $label (deduped=$ndedup, expected $want)"
+  else
+    echo "FAIL  $label: deduped=$ndedup, expected $want  ($nraw raw markers)"
+    fail=1
+  fi
+}
+
+echo "── chamber signature lanes (LAYER-2 dedup, non-ASCII corpus) ──"
+
+# L1 — KNOWN-POSITIVE. Both strings are lifted VERBATIM from this repo's live corpus, and this is
+# the exact pair that folded on 2026-08-22: the second was swallowed by the first and never reached
+# the queue. Deliberately NOT a synthetic minimal pair — the punctuation soup («」·—/+()) is the
+# "뚫리는 표기" that a clean two-word fixture would step over.
+# ⚠️ The strings must stay VERBATIM. A first draft of this lane paraphrased six characters of the
+# second string's tail ("행위로 굳힌다" for "행위자가 읽는 곳에.") and the pair stopped folding —
+# the lane went green against the very code it was written to indict. Do not "tidy" these.
+_lane "L1 ko/different (live mis-merge pair)" 2 \
+  '「미사용 자산의 원인 3분할(값어치·배선·계기)」을 tier 전에 강제하는 렌즈 — 처분 tier 가 원인 판정을 앞서지 못하게 한다' \
+  '병렬 레인 발주 계약 — 보고 의무 3줄 + 취향/판정/승인 3축 라우팅 + idle 구독을 카드 안에 박은 형태. 별도 규칙 파일 없이 행위자가 읽는 곳에.'
+
+# L2 — KNOWN-NEGATIVE. Real duplicates must still collapse; a fix that merely stops merging would
+# pass L1 and destroy the feature. Same candidate, re-listed with a trailing qualifier.
+_lane "L2 ko/same (true duplicate must still merge)" 1 \
+  'session-token-ledger — 세션 및 서브에이전트 토큰 실사용을 기계 출처에서 수집해 원장화하고 추정기가 역참조하는 계기' \
+  'session-token-ledger — 세션 및 서브에이전트 토큰 실사용을 기계 출처에서 수집해 원장화하고 추정기가 역참조하는 계기 (동일 건 재등재, 앵커 보강만)'
+
+# L3/L4 — ENGLISH CONTROL. These pin the diagnosis, not the feature: the defect is a Hangul
+# collation defect, so both English lanes must be green BEFORE and AFTER the repair. If L3 or L4
+# is ever red, the cause is somewhere other than where this header says it is.
+_lane "L3 en/different (control)" 2 \
+  'parallel lane dispatch contract — reporting duty condensed into three lines plus an idle subscription card' \
+  'unused asset triage lens — forces value versus wiring versus instrument before any disposal tier is assigned'
+
+_lane "L4 en/same (control)" 1 \
+  'session token ledger — collect subagent token usage from a mechanical source and let the estimator dereference it' \
+  'session token ledger — collect subagent token usage from a mechanical source and let the estimator dereference it, relisted'
+
+# L5 — SET COLLAPSE, not just a pair. The live failure produced clusters of 11; a pairwise-only
+# suite would have called a 3→1 fold "one merge" and moved on.
+_lane "L5 ko/three unrelated" 3 \
+  '낭독 렌즈 — 「소리 내어 읽히는가」를 재는 계기. 문서 린터가 구조적으로 못 보는 축이다' \
+  'fh-router-demotion — salience 상시부하를 플랫폼 네이티브 메커니즘으로 이관하는 대수술' \
+  '인물 시뮬레이터 하네스 — 닫힌 코퍼스 + 그라운딩 게이트 + 페르소나 캐스트를 한 틀로 묶는다'
+
+# L6 — MIXED SCRIPT. A Korean signature that collapses to near-nothing can also collide with an
+# unrelated ASCII one, which is a different failure path from ko↔ko.
+_lane "L6 ko vs en" 2 \
+  '원정 수련 — 세계 강력 레포에서 배워오는 반복 루틴. 탐색 판별 흡수 3단이다' \
+  'entrypoint wiring generator — emit runtime-native hook settings from a single event manifest'
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo "chamber signature lanes: ALL PASS ($lane lanes)"
+else
+  echo "chamber signature lanes: FAILURES PRESENT ($lane lanes run)"
+fi
+exit "$fail"


### PR DESCRIPTION

```
수리 전   raw 64 → dedup 31
수리 후   raw 64 → dedup 61
```
**31 은 정상이 아니라 결함이었다.** dedup 서명이 한글을 뭉개서 서로 무관한 후보가 병합됐다.

## 원인 — 거버너 가설은 기각됐다

넷을 하나씩 켜고 꺼서 갈랐다(입력 = 서로 다른 한글 8토큰):
```
$STOP 만          8/8 생존   무관
tr -c 만          8/8 생존   무관 (단 이식성 결함은 실재)
awk length>=4 만  8/8 생존   무관 (단 이식성 결함은 실재)  ← 거버너가 지목한 것
sort -u (UTF-8)   8 → 2      🟥 원인
sort -u (LC_ALL=C) 8/8       정상
```

🟥 **2차 피해가 더 나쁘다** — `comm -12` 도 같은 collation 을 쓴다. 실측에서 **완전히 다른 두
토큰이 «공통»으로 잡혔다.** 즉 **jaccard 의 분자가 토큰이 아니라 collation 을 재고 있었다.**

`awk`·`tr` 은 원인이 아니지만 **둘 다 실측된 BSD/GNU 분기**라 같이 고쳤다. 안 고치면 리눅스
소비자에서 새 결함이 난다 — 2음절 한글이 macOS 통과(6바이트)·리눅스 탈락(2문자)이라
**두 플랫폼이 비교 전에 토큰 집합부터 다르다.**

## 무엇이 삼켜져 있었나 — 숫자가 아니라 이름으로

n=11 클러스터 하나가 있었다. 대표 하나만 살고 열 건이 사라졌는데 그중에:
- **「세션이 «지금 외부에 물어야 하는 지점»을 스스로 격발하는 층 — ④를 RC 에서…」**
- 「낭독 렌즈 — 소리 내어 읽히는가」 · 「대상 하네스가 자기를 설명하는 프로필」

그 외 n=7 둘 · n=4 · n=3 둘 · n=2 넷. **삼켜진 것 중 하나가 오늘 등재한 줄이었고, 그걸
확인 안 했으면 몰랐다.**

**과수리는 안 났다** — 수리 후 살아남은 병합 3건을 손검증했고 셋 다 진짜 근사중복이다
(「없음 — 기존 스킬 보강이지 새 능력이 아니다」류 상용구).

## 검증

fail-before: 수리 전 코드에 새 레인을 물려 **L1·L5 적색**, 나머지 초록. 수리 후 6/6.
🟥 **영문 대조군은 수리 전에도 초록** — 결함이 한글 전용임이 계기로 확정된다.
되돌림 3단: **정확히 그 레인만, 그 안에서도 정확히 한글 레인만** 빨개졌다(컨트롤 스위트 33레인 rc=0).
이식성은 주장이 아니라 실측 — BSD awk · mawk 1.3.4 · gawk 5 셋에서 **바이트 단위 동일**.
`MINJ=50` 은 **안 건드렸다** — 서명이 갈려나간 게 원인이라 임계 조정은 증상 무마다.

## 🟥 픽스처가 한 번 뚫렸고 그것도 기록한다

L1 초판이 두 번째 문자열 꼬리를 **의역**했더니(`행위자가 읽는 곳에.` → `행위로 굳힌다`)
쌍이 안 합쳐지며 **레인이 초록**이 됐다. **고발 대상 코드에 대고 통과한 것이다.** 축자로
되돌린 뒤에야 적색이 났고, 그 경고를 파일 주석에 박았다.

## 안 닫은 것

🟥 **삼켜져 있던 30건은 이 커밋이 «복구»한 게 아니라 «드러낸» 것이다** — 인큐베이션 가치가
있는지는 별개 판정이고 이 델타는 안 한다. **61 이 옳은 수인지는 부분 검증**(under-merge 방향
전수 손검증 안 함). musl/busybox awk 미측정. 같은 `_sig` 형태를 복사해 쓰는 다른 스크립트가
있는지 안 훑었다(반쪽-픽스 전파경계 미검사).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ5j1CS87eUQALCWfaxy2F