### PR TITLE
feat(gate): files[] 선언이 실물과 tarball 둘 다에 닿는지 검사 — 형제가 blind 하던 자리

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prepare": "chmod +x bin/fh-gate.js bin/fh-run.js bin/fh-goal.js bin/fh-codex-doctor.js scripts/fh-gate.sh scripts/fh-run.sh scripts/fh-goal.sh",
     "postinstall": "node scripts/postinstall_notice.js",
     "test": "bash scripts/selfcheck.sh",
-    "prepublishOnly": "bash scripts/prepublish_scope_note.sh && bash scripts/publish_freshness_check.sh && bash scripts/version_lockstep_check.sh && bash scripts/package_coverage_check.sh --vs-tarball && bash scripts/public_surface_scan_files.sh",
+    "prepublishOnly": "bash scripts/prepublish_scope_note.sh && bash scripts/publish_freshness_check.sh && bash scripts/version_lockstep_check.sh && bash scripts/package_coverage_check.sh --vs-tarball && bash scripts/files_manifest_shipping_check.sh --vs-tarball && bash scripts/public_surface_scan_files.sh",
     "release": "bash scripts/public_surface_scan_files.sh && npm publish"
   },
   "engines": {
@@ -73,6 +73,8 @@
     "scripts/test_lane_runner_lanes.sh",
     "scripts/test_version_lockstep_lanes.sh",
     "scripts/package_coverage_check.sh",
+    "scripts/files_manifest_shipping_check.sh",
+    "scripts/test_files_manifest_shipping_lanes.sh",
     "scripts/test_ko_tech_writer_lanes.sh",
     "scripts/ko_tech_writer_calibrate.py",
     "plugins/fh-commons/skills/ko-tech-writer/fixtures/known_positive.md",

--- a/scripts/files_manifest_shipping_check.sh
+++ b/scripts/files_manifest_shipping_check.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+# files_manifest_shipping_check.sh — every path package.json declares in files[] must actually
+# exist on disk AND actually land in the real npm tarball.
+#
+# WHY THIS EXISTS (gap named but not closed elsewhere, found 2026-08-23):
+# `package_coverage_check.sh` walks REFERENCES — a shipped doc names a path, does that path ship —
+# but it never iterates package.json's files[] array itself. `selfcheck.sh` (~:1065) says so in its
+# own comment: "measured 2026-08-09, package_coverage_check.sh returns PASS on a files[] entry whose
+# file does not exist, so a deleted subject would be green on every surface (SKIP here + PASS there
+# + npm silently omitting it)." selfcheck.sh works around this for a HANDFUL of hand-picked subjects
+# (branch_claim.sh, marker axes lanes, sidecar_calibrate.sh, ...), each guarded by its own
+# `if [ ! -f ... ]` block, and its own comment names the remainder as a residual: "the sibling blocks
+# above carry the same hole for their own shipped subjects. Fixing them is a separate change."
+# This script is that separate change, done ONCE for the full 200+-entry list instead of per-subject.
+#
+# TWO FAILURE SHAPES THIS CATCHES, NEITHER CAUGHT ELSEWHERE:
+#   (a) a files[] entry whose file was deleted (rename, cleanup, a stale exception) but the
+#       declaration was never removed — package_coverage_check.sh reads files[] as a coverage
+#       ORACLE, so an entry naming nothing is invisible to it by construction.
+#   (b) a files[] entry that exists on disk but does not actually pack — .npmignore precedence,
+#       a directory that npm's own default-ignore rules (e.g. nested .git, node_modules) hollow
+#       out, or a git-tracked file under a declared DIRECTORY that silently fails to tar. This is
+#       the disk-vs-declaration gap the tarball oracle in package_coverage_check.sh was built to
+#       close for referenced paths; this script applies the same tarball oracle to files[] itself.
+#
+# SCOPE (deliberately narrow — see cross-family review 2026-08-23): this checks LITERAL paths only.
+# It does NOT resolve npm glob patterns (`dist/*.js`) or normalize a leading `./` beyond a literal
+# strip — an entry containing glob metacharacters is reported as OUT-OF-SCOPE, never as phantom or
+# unpacked, because this script cannot know what a glob resolves to without re-implementing npm's
+# own pattern matcher. Widening to real glob support is a scope increase, not a bug fix; it is
+# deliberately left undone rather than guessed at.
+#
+# Usage:  bash scripts/files_manifest_shipping_check.sh              # disk-existence only, offline
+#         bash scripts/files_manifest_shipping_check.sh --vs-tarball # + real `npm pack` check
+# Exit:   0 = every files[] entry exists on disk (and, with --vs-tarball, ships in the real
+#             tarball); 1 = at least one entry is a phantom declaration or an oracle failure.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || { echo "FAIL: cannot cd to repo root"; exit 1; }
+
+# Argument validation FIRST, before anything else can silently downgrade behavior. An unrecognized
+# argument (e.g. a `--vs-tarbll` typo) used to fall through to the declaration-mode default, which
+# on the publish path (the ONLY caller of --vs-tarball, see prepublishOnly) means "I asked for the
+# strict tarball oracle and silently got the weak one instead" — a false PASS on exactly the surface
+# this script exists to guard. Unrecognized input is now a hard error, not a silent mode switch.
+if [ -n "${1:-}" ] && [ "${1:-}" != "--vs-tarball" ]; then
+  echo "FAIL  files-manifest-shipping: unrecognized argument '${1}' — did you mean --vs-tarball?"
+  echo "      Refusing to silently fall back to a weaker check mode."
+  exit 1
+fi
+MODE="declaration"
+if [ "${1:-}" = "--vs-tarball" ]; then
+  MODE="tarball"
+fi
+
+if [ ! -f package.json ]; then
+  echo "FAIL  files-manifest-shipping: no package.json at repo root — declared coverage is"
+  echo "      UNMEASURED, not clean"
+  exit 1
+fi
+command -v node >/dev/null 2>&1 || {
+  echo "FAIL  files-manifest-shipping: node unavailable — files[] cannot be read"; exit 1; }
+
+# Source-tree predicate, same idea package_coverage_check.sh uses: an installed package has no
+# comparable files[] to self-audit against (it IS the audited output, not the declaration).
+#
+# BUT the degrade direction differs BY MODE, and that split is deliberate (cross-family review
+# 2026-08-23, S1). `--vs-tarball` has exactly one caller in this repo: prepublishOnly. There is no
+# legitimate "installed package" scenario on that path — `npm publish`/`npm pack` only make sense
+# run from the source checkout that IS being published, so a missing `.git` there means the
+# environment is not what the publish path expects, not that the check has nothing to do. Per the
+# Irreversibility Surface-Class Degrade Invariant (CLAUDE.md): an irreversible surface (publish)
+# fails CLOSED when its tooling/environment is off-shape, it does not get a free skip. Declaration
+# mode keeps the original SKIP — it runs from more places (e.g. a routine sweep against an
+# installed/vendored copy) where "no .git" genuinely does mean "nothing comparable to check".
+if [ ! -d .git ] && [ ! -f .git ]; then
+  if [ "$MODE" = "tarball" ]; then
+    echo "FAIL  files-manifest-shipping (--vs-tarball): no .git at repo root on the publish path —"
+    echo "      this check has exactly one caller (prepublishOnly) and it always runs from the"
+    echo "      source checkout being published. Fail-closed: an off-shape publish environment is"
+    echo "      not a legitimate reason to skip an irreversible-surface check."
+    exit 1
+  fi
+  echo "SKIP  files-manifest-shipping (no .git — looks like an installed package, not a source checkout)"
+  exit 0
+fi
+
+echo "files-manifest shipping check ($MODE)"
+
+if [ "$MODE" = "tarball" ]; then
+  command -v npm >/dev/null 2>&1 || {
+    echo "FAIL  files-manifest-shipping (--vs-tarball): npm is not on PATH — the tarball oracle is"
+    echo "      UNAVAILABLE. Fail-closed: this is an irreversible-surface check (publish path), and"
+    echo "      an unreadable oracle must never render as pass."
+    exit 1
+  }
+  # git is also required for the tarball-mode directory walk (walkTracked, below, via `git
+  # ls-files`). Checked here rather than left to fail mid-walk so a missing binary renders as an
+  # explicit instrument-unavailable FAIL, not as a per-directory "zero tracked files" phantom
+  # (cross-family review 2026-08-23, A4: a `git ls-files` failure must never be reported as if the
+  # TARGET were empty — it means the INSTRUMENT could not look).
+  command -v git >/dev/null 2>&1 || {
+    echo "FAIL  files-manifest-shipping (--vs-tarball): git is not on PATH — the declared-directory"
+    echo "      tracked-file walk is UNAVAILABLE. Fail-closed, same reasoning as the npm check above."
+    exit 1
+  }
+fi
+
+# Scratch directory, not a predictable /tmp/*.$$ filename. A predictable per-PID temp path is
+# guessable and writable by any other local process before this one gets to read it back (cross-
+# family review 2026-08-23, A2). `mktemp -d` gives a directory only this process's owner can see
+# (mode 0700 by default on both GNU and BSD mktemp), and every write into it below is check-marked —
+# a write that silently failed used to be indistinguishable from "nothing to report".
+FMSC_DIR="$(mktemp -d "${TMPDIR:-/tmp}/fmsc.XXXXXXXX")" || {
+  echo "FAIL  files-manifest-shipping: mktemp -d failed — cannot allocate a private scratch dir"
+  exit 1
+}
+trap 'rm -rf "$FMSC_DIR"' EXIT
+FMSC_JS="$FMSC_DIR/check.js"
+FMSC_PACK_JSON="$FMSC_DIR/pack.json"
+FMSC_PACK_ERR="$FMSC_DIR/pack.err"
+
+if [ "$MODE" = "tarball" ]; then
+  PACK_JSON=$(npm pack --dry-run --json 2>"$FMSC_PACK_ERR")
+  PACK_RC=$?
+  if [ "$PACK_RC" -ne 0 ] || [ -z "$PACK_JSON" ]; then
+    echo "FAIL  files-manifest-shipping (--vs-tarball): npm pack exited $PACK_RC — tarball UNKNOWN"
+    sed 's/^/      /' "$FMSC_PACK_ERR" 2>/dev/null
+    exit 1
+  fi
+  printf '%s' "$PACK_JSON" > "$FMSC_PACK_JSON" || {
+    echo "FAIL  files-manifest-shipping (--vs-tarball): could not write pack output to scratch dir"
+    exit 1
+  }
+fi
+
+# bash 3.2 (macOS system bash) has a documented heredoc-inside-command-substitution bug: a quoted
+# heredoc (`<<'NODE'`) body containing single quotes can still desync `$( ... )`'s own quote count,
+# producing a false "unexpected EOF" parse error even though the heredoc itself is syntactically
+# correct. Writing the JS to a real file and invoking it by path sidesteps the bug entirely.
+cat > "$FMSC_JS" <<'NODE'
+const fs = require('fs');
+
+const mode = process.argv[2];
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+
+// Malformed `files` field must FAIL, not silently coerce to an empty/single-entry list (cross-
+// family review 2026-08-23, A1: `pkg.files || []` let `"files": "."` pass as "1 entry checked").
+// npm's own contract is that `files` is an array of path/glob strings; anything else is an invalid
+// manifest, and an invalid manifest is not a clean result.
+if (pkg.files !== undefined && !Array.isArray(pkg.files)) {
+  console.log(`FAIL\tpackage.json files[] is not an array (got ${typeof pkg.files}) — invalid`
+    + ' manifest, not a clean result');
+  process.exit(1);
+}
+const declared = pkg.files || [];
+
+if (declared.length === 0) {
+  console.log('FAIL\tpackage.json files[] is EMPTY or missing — that is not a clean result, it is an\n\tinstrument that found nothing to check');
+  process.exit(1);
+}
+
+// Line-protocol sanitizer: every string emitted below goes through this first. Without it, a path
+// containing a literal newline (attacker-controlled files[] entry, or a corrupted manifest) can
+// inject a line that itself starts with "PASS" or another verdict token, which a naive human or
+// grep-based reader downstream could mistake for the real verdict (cross-family review 2026-08-23,
+// A3). JSON.stringify turns any control character, including \n and \t, into a visible escape and
+// wraps the value in quotes, so an injected line can never masquerade as line-protocol output.
+function safe(s) { return JSON.stringify(s); }
+
+// SCOPE GUARD (cross-family review 2026-08-23, B1/B2): this script checks LITERAL paths only. An
+// entry containing npm glob metacharacters cannot be resolved to a real filesystem path without
+// re-implementing npm's own matcher, so treating a glob as a literal-and-missing path is a false
+// PHANTOM, not a scope limitation being honest about itself. `./`-prefixed entries are npm's own
+// documented way of writing a literal (npm strips the prefix when building the tarball), so THAT
+// case is safe to normalize rather than punt out of scope.
+const GLOB_RE = /[*?{}\[\]]/;
+function normalizeLiteral(entry) {
+  return entry.startsWith('./') ? entry.slice(2) : entry;
+}
+
+let tarballSet = null;
+if (mode === 'tarball') {
+  const packPath = process.argv[3];
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(packPath, 'utf8'));
+  } catch (e) {
+    console.log(`FAIL\tnpm pack --json did not parse (${e.constructor.name}) — tarball UNKNOWN`);
+    process.exit(1);
+  }
+  const entry = Array.isArray(parsed) ? parsed[0] : null;
+  const list = entry && Array.isArray(entry.files) ? entry.files : null;
+  if (!list || list.length === 0) {
+    // Impossible-zero guard, same rule package_coverage_check.sh applies to this same oracle:
+    // a genuinely empty tarball means the instrument broke, not that the package shrank to nothing.
+    console.log(`FAIL\tnpm pack reported ${list ? list.length : 0} files — implausible, oracle UNAVAILABLE`);
+    process.exit(1);
+  }
+  // Below-threshold is now an ADVISORY, not an automatic FAIL (cross-family review 2026-08-23, B3:
+  // a legitimately tiny package — package.json + README + LICENSE + one file — used to hard-fail on
+  // count alone). A near-empty tarball is still worth a human's eyes, so it is surfaced as its own
+  // line-protocol kind rather than silently accepted, but it no longer blocks by itself; only the
+  // phantom/unpacked findings computed below can still FAIL the run.
+  if (list.length < 10) {
+    console.log(`ADVISORY\tnpm pack reported only ${list.length} files — small package, or a`
+      + ' shrunk oracle. Not auto-failed; verify by eye if this package is not meant to be tiny.');
+  }
+  tarballSet = new Set(list.map(f => normalizeLiteral(f.path)));
+}
+
+function walkTracked(dir) {
+  // git-tracked descendants only — untracked/gitignored files under a declared directory are not
+  // this check's business (they are correctly absent from both git and the tarball).
+  //
+  // INSTRUMENT FAILURE vs TARGET EMPTY (cross-family review 2026-08-23, A4): the git binary itself
+  // is checked for availability before this function is ever called (bash side, above), so an error
+  // reaching here means `git ls-files` itself failed against a directory that IS tracked in git
+  // (the .git-presence check upstream already established this is a real git checkout) — a
+  // corrupted index, a pathspec git rejects, or similar. That is the INSTRUMENT breaking, not the
+  // target having zero files, so it must not be folded into "zero tracked files" and reported as a
+  // phantom declared-directory. It throws instead, and the caller renders it as its own kind.
+  const { execFileSync } = require('child_process');
+  return execFileSync('git', ['ls-files', '--', dir], { encoding: 'utf8' })
+    .split('\n').filter(Boolean);
+}
+
+const phantoms = [];    // declared, absent on disk
+const unpacked = [];    // exists on disk, declared, but did not make the real tarball (tarball mode only)
+const outOfScope = [];  // glob entry — this checker does not resolve glob patterns
+const instrumentErrors = []; // the oracle itself failed while examining a specific entry
+
+for (const rawEntry of declared) {
+  if (typeof rawEntry !== 'string') {
+    instrumentErrors.push(`non-string files[] entry: ${safe(rawEntry)}`);
+    continue;
+  }
+  if (GLOB_RE.test(rawEntry)) {
+    outOfScope.push(rawEntry);
+    continue;
+  }
+  const entry = normalizeLiteral(rawEntry);
+  let stat;
+  try {
+    stat = fs.statSync(entry);
+  } catch (e) {
+    phantoms.push(rawEntry);
+    continue;
+  }
+  if (mode !== 'tarball') continue;
+
+  if (stat.isDirectory()) {
+    let tracked;
+    try {
+      tracked = walkTracked(entry);
+    } catch (e) {
+      instrumentErrors.push(`git ls-files failed for declared dir '${rawEntry}': ${e.message}`);
+      continue;
+    }
+    if (tracked.length === 0) {
+      // A declared directory with zero git-tracked files under it is its own phantom shape —
+      // shipping an empty directory declaration gives the consumer nothing either way. This is
+      // reached only when `git ls-files` itself SUCCEEDED and reported nothing, so it is a real
+      // target finding, not an instrument failure (see walkTracked's comment above).
+      phantoms.push(rawEntry + '/ (declared directory, zero git-tracked files under it)');
+      continue;
+    }
+    for (const t of tracked) {
+      if (!tarballSet.has(normalizeLiteral(t))) unpacked.push(t + '  (under declared dir ' + rawEntry + ')');
+    }
+  } else {
+    if (!tarballSet.has(entry)) unpacked.push(rawEntry);
+  }
+}
+
+const hasFailure = phantoms.length > 0 || unpacked.length > 0 || instrumentErrors.length > 0;
+
+if (!hasFailure) {
+  const scopeNote = outOfScope.length > 0 ? `, ${outOfScope.length} out-of-scope (glob)` : '';
+  console.log(`PASS\t${declared.length} files[] entries checked, 0 phantom, 0 unpacked${scopeNote}`);
+  process.exit(0);
+}
+
+for (const s of outOfScope) console.log('SCOPE\t' + safe(s));
+for (const p of phantoms) console.log('PHANTOM\t' + safe(p));
+for (const u of unpacked) console.log('UNPACKED\t' + safe(u));
+for (const ie of instrumentErrors) console.log('INSTRUMENT-ERROR\t' + ie);
+console.log(`FAIL\t${phantoms.length} phantom declaration(s), ${unpacked.length} declared-but-unpacked`
+  + ` path(s), ${instrumentErrors.length} instrument error(s)`);
+process.exit(1)
+NODE
+
+if [ "$MODE" = "tarball" ]; then
+  RESULT=$(node "$FMSC_JS" "$MODE" "$FMSC_PACK_JSON")
+else
+  RESULT=$(node "$FMSC_JS" "$MODE")
+fi
+RC=$?
+
+echo "$RESULT" | while IFS=$'\t' read -r kind detail; do
+  case "$kind" in
+    PASS)             echo "PASS  files-manifest-shipping: $detail" ;;
+    ADVISORY)         echo "  ⚠️  $detail" ;;
+    FAIL)             printf 'FAIL  files-manifest-shipping: %s\n' "$detail" ;;
+    SCOPE)            echo "  ⏭️  out of scope (glob pattern, not resolved): $detail" ;;
+    PHANTOM)          echo "  ❌ declared in files[] but ABSENT on disk: $detail" ;;
+    UNPACKED)         echo "  ❌ declared, present on disk, but NOT in the real npm tarball: $detail" ;;
+    INSTRUMENT-ERROR) echo "  🛑 instrument failure examining this entry (target unproven, not clean): $detail" ;;
+    *)                echo "$kind	$detail" ;;
+  esac
+done
+
+exit "$RC"

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -463,6 +463,34 @@ else
   fail=1
 fi
 
+# files-manifest-shipping — sibling of package-coverage, DIFFERENT question. That check walks
+# REFERENCES (a shipped doc names a path, does the path ship); this one walks package.json's files[]
+# ARRAY ITSELF and asks whether every declared entry exists on disk. selfcheck.sh's own branch_claim
+# block (below) names the exact gap this closes: "measured 2026-08-09, package_coverage_check.sh
+# returns PASS on a files[] entry whose file does not exist, so a deleted subject would be green on
+# every surface" — that comment calls fixing it, for every subject and not just branch_claim.sh, "a
+# separate change with its own verification". This is that change.
+if [ ! -f scripts/files_manifest_shipping_check.sh ]; then
+  _absent_subject_verdict "test_files_manifest_shipping_lanes.sh" "scripts/files_manifest_shipping_check.sh" || fail=1
+elif [ -f scripts/test_files_manifest_shipping_lanes.sh ]; then
+  if ! bash scripts/test_files_manifest_shipping_lanes.sh; then
+    fail=1
+  fi
+  # Same applicability guard as package-coverage directly above, same reason: a repo with no npm
+  # surface has no files[] to audit, and that is NOT-APPLICABLE, not a red.
+  if [ -f package.json ] || [ -d bin ]; then
+    if ! bash scripts/files_manifest_shipping_check.sh; then
+      fail=1
+    fi
+  else
+    echo "SKIP  files-manifest-shipping — NOT APPLICABLE: this repo ships no npm surface"
+    echo "      (checked mechanically: package.json absent, bin/ absent — not a claim, a test)"
+  fi
+else
+  echo "FAIL  test_files_manifest_shipping_lanes.sh: files_manifest_shipping_check.sh present but its anchor is missing"
+  fail=1
+fi
+
 # lane-runner — sibling of package-coverage one level up: that one asks "does the CONSUMER get the
 # file a shipped doc names", this one asks "does ANYTHING execute the lane suite we wrote". Measured
 # 2026-08-12 (reship axis, card §🔱⑮ A): 12 of 43 suites under scripts/ had no runner in selfcheck,

--- a/scripts/test_files_manifest_shipping_lanes.sh
+++ b/scripts/test_files_manifest_shipping_lanes.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# test_files_manifest_shipping_lanes.sh — regression anchor for
+# scripts/files_manifest_shipping_check.sh.
+#
+# Known-pair calibration (CLAUDE.md §Instrument-Calibration): a phantom files[] entry (declared,
+# absent on disk) must FAIL; the real, unmodified package.json must PASS. Both lanes exercise the
+# actual script against a real npm invocation via a scratch package.json copy — not a stub — so a
+# regression in the node extraction logic (the bash-3.2 heredoc-in-$(...) class this script was
+# rewritten to avoid, see the subject's own header) shows up here.
+#
+# Usage:  bash scripts/test_files_manifest_shipping_lanes.sh
+# Exit:   0 = no lane failed. 1 = a regression.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SUBJECT="$REPO_ROOT/scripts/files_manifest_shipping_check.sh"
+[ -f "$SUBJECT" ] || { echo "FAIL: $SUBJECT not found"; exit 1; }
+cd "$REPO_ROOT" || exit 1
+
+pass=0; fail=0
+ok()  { printf '  \xe2\x9c\x85 %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  \xe2\x9d\x8c %s\n' "$1"; fail=$((fail+1)); }
+
+echo "files-manifest-shipping lane suite"
+
+# Lane 1 — real tree, declaration mode: must PASS. This is the everyday run, offline, no npm.
+if bash "$SUBJECT" >/tmp/fmsc_lane1.$$.out 2>&1; then
+  ok "lane 1: real package.json (declaration mode) PASSes"
+else
+  bad "lane 1: real package.json (declaration mode) unexpectedly FAILed"
+  sed 's/^/      /' /tmp/fmsc_lane1.$$.out
+fi
+rm -f /tmp/fmsc_lane1.$$.out
+
+# Lane 2 — known-negative → known-positive pair, same tree, one flipped field. Inject a phantom
+# entry into a SCRATCH copy of package.json (never mutate the real one in place — a failure mid-lane
+# must not leave the repo's actual manifest corrupted), point the subject at it via a temp cwd copy.
+LANE2_DIR="$(mktemp -d)"
+trap 'rm -rf "$LANE2_DIR"' EXIT
+
+# The check does `cd` to its own repo root via BASH_SOURCE, so exercising it against a modified
+# manifest means running it FROM a copy of the tree — cheapest correct way: symlink everything the
+# check might touch (package.json, .git, scripts/) into the scratch dir is fragile across
+# filesystems, so instead we run the REAL subject in the REAL tree but swap package.json out and
+# back atomically, exactly as the manual known-pair check that authored this suite did.
+cp package.json "$LANE2_DIR/package.json.orig"
+node -e '
+  const fs = require("fs");
+  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  pkg.files.push("scripts/__test_fixture_does_not_exist__.sh");
+  fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+'
+restore_pkg() { cp "$LANE2_DIR/package.json.orig" package.json; }
+
+if bash "$SUBJECT" >/tmp/fmsc_lane2.$$.out 2>&1; then
+  bad "lane 2 (known-positive: phantom files[] entry): expected FAIL, got PASS — the detector is blind"
+  sed 's/^/      /' /tmp/fmsc_lane2.$$.out
+  restore_pkg
+else
+  if grep -q "scripts/__test_fixture_does_not_exist__.sh" /tmp/fmsc_lane2.$$.out; then
+    ok "lane 2: injected phantom files[] entry correctly FAILs and is named"
+  else
+    bad "lane 2: FAILed, but did not name the injected phantom — wrong reason"
+    sed 's/^/      /' /tmp/fmsc_lane2.$$.out
+  fi
+  restore_pkg
+fi
+rm -f /tmp/fmsc_lane2.$$.out
+
+# Lane 3 — restore integrity check: the real package.json must be back and byte-identical, and the
+# subject must PASS again on it. If lane 2's restore silently failed, this is where it surfaces
+# instead of leaking a broken manifest out of the test.
+if diff -q "$LANE2_DIR/package.json.orig" package.json >/dev/null 2>&1; then
+  ok "lane 3: package.json restored byte-identical after lane 2"
+else
+  bad "lane 3: package.json was NOT restored — repo manifest is corrupted, fix immediately"
+fi
+if bash "$SUBJECT" >/tmp/fmsc_lane3.$$.out 2>&1; then
+  ok "lane 3: subject PASSes again on the restored real manifest"
+else
+  bad "lane 3: subject FAILed on the restored manifest (should be identical to lane 1)"
+  sed 's/^/      /' /tmp/fmsc_lane3.$$.out
+fi
+rm -f /tmp/fmsc_lane3.$$.out
+
+# ─────────────────────────────────────────────────────────────────────────────────────────────
+# Lanes 4+ — cross-family review fixes (2026-08-23). Each lane exercises an axis the REPAIR itself
+# did NOT touch as its detection vocabulary (CLAUDE.md feedback_lane_vocabulary_blind_to_its_own_fix
+# — a lane written in the same words as the fix can pass while the defect survives). These build
+# throwaway fixture trees (script copy + package.json + optional .git) the same way lane 2 does, so
+# the SUBJECT is exercised for real, never stubbed.
+
+fixture_dir() {
+  local d; d="$(mktemp -d)"
+  mkdir -p "$d/scripts"
+  cp "$SUBJECT" "$d/scripts/files_manifest_shipping_check.sh"
+  printf '%s' "$d"
+}
+
+# Lane 4 — S2: an unrecognized argument (typo'd flag) must FAIL, never silently downgrade to the
+# weaker declaration-mode default. Real package.json, real repo — only the argument is wrong.
+if out=$(bash "$SUBJECT" --vs-tarbll 2>&1); rc=$?; [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "unrecognized argument"; then
+  ok "lane 4: typo'd --vs-tarbll argument FAILs loudly, does not downgrade to declaration mode"
+else
+  bad "lane 4: typo'd argument should FAIL and name itself — got rc=$rc"
+  printf '%s\n' "$out" | sed 's/^/      /'
+fi
+
+# Lane 5 — S1: no .git must degrade DIFFERENTLY by mode. Declaration mode: SKIP rc=0 (an installed
+# package legitimately has nothing comparable to check). Tarball mode: FAIL rc=1, fail-closed — the
+# ONLY caller of --vs-tarball is the publish path, which always runs from a real source checkout, so
+# "no .git" there means the environment is off-shape, not that the check has nothing to do.
+D5="$(fixture_dir)"
+cp package.json "$D5/package.json"
+if out=$(bash "$D5/scripts/files_manifest_shipping_check.sh" 2>&1); rc=$?; [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q "^SKIP"; then
+  ok "lane 5a: no .git, declaration mode: SKIPs rc=0"
+else
+  bad "lane 5a: no .git, declaration mode: expected SKIP rc=0, got rc=$rc"
+  printf '%s\n' "$out" | sed 's/^/      /'
+fi
+if out=$(bash "$D5/scripts/files_manifest_shipping_check.sh" --vs-tarball 2>&1); rc=$?; [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "^FAIL"; then
+  ok "lane 5b: no .git, --vs-tarball mode: FAILs rc=1 (fail-closed on the publish surface)"
+else
+  bad "lane 5b: no .git, --vs-tarball mode: expected FAIL rc!=0, got rc=$rc"
+  printf '%s\n' "$out" | sed 's/^/      /'
+fi
+rm -rf "$D5"
+
+# Lane 6 — A1: files[] declared as a non-array (e.g. a bare string) must FAIL as an invalid
+# manifest, never silently coerce and report "1 entry checked".
+D6="$(fixture_dir)"
+mkdir -p "$D6/.git"
+node -e '
+  const fs = require("fs");
+  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  pkg.files = ".";
+  fs.writeFileSync(process.argv[1], JSON.stringify(pkg, null, 2) + "\n");
+' "$D6/package.json"
+if out=$(bash "$D6/scripts/files_manifest_shipping_check.sh" 2>&1); rc=$?; [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "not an array"; then
+  ok "lane 6: files[] as a non-array (string) FAILs as an invalid manifest"
+else
+  bad "lane 6: malformed files[] type should FAIL — got rc=$rc"
+  printf '%s\n' "$out" | sed 's/^/      /'
+fi
+rm -rf "$D6"
+
+# Lane 7 — A3: a files[] entry containing a literal newline (and a forged verdict token) must never
+# render a bare, unescaped "PASS" line — the injected content must stay visibly inside a quoted,
+# escaped value so no downstream grep/human reader can mistake it for the real verdict. The run must
+# still exit 1 (it IS a phantom entry).
+D7="$(fixture_dir)"
+mkdir -p "$D7/.git"
+node -e '
+  const fs = require("fs");
+  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  pkg.files.push("missing\nPASS\\t999 entries checked, 0 phantom, 0 unpacked");
+  fs.writeFileSync(process.argv[1], JSON.stringify(pkg, null, 2) + "\n");
+' "$D7/package.json"
+out=$(bash "$D7/scripts/files_manifest_shipping_check.sh" 2>&1); rc=$?
+if [ "$rc" -ne 0 ] && ! printf '%s' "$out" | grep -qE '^PASS( |$)'; then
+  ok "lane 7: newline-injected phantom entry FAILs and never renders a bare PASS line"
+else
+  bad "lane 7: newline injection should FAIL without a bare PASS line — got rc=$rc"
+  printf '%s\n' "$out" | sed 's/^/      /'
+fi
+rm -rf "$D7"
+
+# Lane 8 — A4: when `git ls-files` itself fails against a declared directory (corrupted index,
+# rejected pathspec, or similar — simulated here with a shim, since actually uninstalling git would
+# also break this SUITE'S own tooling), the finding must render as an INSTRUMENT failure, never as
+# "declared directory, zero git-tracked files" — the latter says the TARGET is empty, which was not
+# established; the git oracle itself did not run.
+D8="$(fixture_dir)"
+mkdir -p "$D8/.git" "$D8/scripts_dummy"
+echo x > "$D8/scripts_dummy/foo.sh"
+node -e '
+  const fs = require("fs");
+  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  pkg.files = ["scripts_dummy"];
+  delete pkg.scripts.prepare;
+  delete pkg.scripts.prepublishOnly;
+  fs.writeFileSync(process.argv[1], JSON.stringify(pkg, null, 2) + "\n");
+' "$D8/package.json"
+FAKEBIN8="$(mktemp -d)"
+REALGIT="$(command -v git)"
+cat > "$FAKEBIN8/git" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "ls-files" ]; then
+  echo "fatal: simulated git ls-files failure" >&2
+  exit 128
+fi
+exec "$REALGIT" "\$@"
+EOF
+chmod +x "$FAKEBIN8/git"
+out=$(PATH="$FAKEBIN8:$PATH" bash "$D8/scripts/files_manifest_shipping_check.sh" --vs-tarball 2>&1); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "instrument failure" && ! printf '%s' "$out" | grep -q "zero git-tracked files"; then
+  ok "lane 8: git ls-files failure renders as INSTRUMENT failure, not a phantom empty directory"
+else
+  bad "lane 8: git ls-files failure should render as instrument failure, not target-empty — got rc=$rc"
+  printf '%s\n' "$out" | sed 's/^/      /'
+fi
+rm -rf "$D8" "$FAKEBIN8"
+
+# Lane 9 — B1/B2: a glob entry (`dist/*.js`) is out-of-scope, never a false PHANTOM; a `./`-prefixed
+# entry is npm's own literal notation and must match normally in tarball mode, never a false
+# UNPACKED. Both in one small real repo (git init'd for real, so npm pack sees real tracked files).
+D9="$(mktemp -d)"
+mkdir -p "$D9/scripts" "$D9/dist"
+cp "$SUBJECT" "$D9/scripts/files_manifest_shipping_check.sh"
+echo 'console.log("hi");' > "$D9/dist/index.js"
+echo 'console.log("hi");' > "$D9/index.js"
+cat > "$D9/package.json" <<'EOF'
+{
+  "name": "fmsc-lane9-fixture",
+  "version": "1.0.0",
+  "files": ["dist/*.js", "./index.js"]
+}
+EOF
+( cd "$D9" && git init -q && git -c user.email=t@t -c user.name=t add -A && git -c user.email=t@t -c user.name=t commit -q -m init )
+if out=$(bash "$D9/scripts/files_manifest_shipping_check.sh" 2>&1); rc=$?; [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q "out-of-scope"; then
+  ok "lane 9a: glob entry (dist/*.js) reported out-of-scope, not phantom (declaration mode PASSes)"
+else
+  bad "lane 9a: glob entry should be out-of-scope, not phantom — got rc=$rc"
+  printf '%s\n' "$out" | sed 's/^/      /'
+fi
+if out=$(bash "$D9/scripts/files_manifest_shipping_check.sh" --vs-tarball 2>&1); rc=$?; [ "$rc" -eq 0 ] && ! printf '%s' "$out" | grep -q "UNPACKED"; then
+  ok "lane 9b: ./-prefixed entry matches the real tarball, no false UNPACKED (tarball mode PASSes)"
+else
+  bad "lane 9b: ./index.js should match normally in tarball mode — got rc=$rc"
+  printf '%s\n' "$out" | sed 's/^/      /'
+fi
+rm -rf "$D9"
+
+# Lane 10 — B3: a legitimately tiny tarball (< 10 files) must be an ADVISORY, not an automatic FAIL.
+# Reuses lane 9's fixture repo, which packs 3 files (package.json + dist/index.js + index.js).
+D10="$(mktemp -d)"
+mkdir -p "$D10/scripts" "$D10/dist"
+cp "$SUBJECT" "$D10/scripts/files_manifest_shipping_check.sh"
+echo 'console.log("hi");' > "$D10/dist/index.js"
+cat > "$D10/package.json" <<'EOF'
+{
+  "name": "fmsc-lane10-fixture",
+  "version": "1.0.0",
+  "files": ["dist/index.js"]
+}
+EOF
+( cd "$D10" && git init -q && git -c user.email=t@t -c user.name=t add -A && git -c user.email=t@t -c user.name=t commit -q -m init )
+if out=$(bash "$D10/scripts/files_manifest_shipping_check.sh" --vs-tarball 2>&1); rc=$?; [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q "ADVISORY\|small package"; then
+  ok "lane 10: tiny (<10-file) tarball PASSes with an advisory, not an automatic FAIL"
+else
+  bad "lane 10: tiny valid tarball should PASS with advisory, not hard-fail on count — got rc=$rc"
+  printf '%s\n' "$out" | sed 's/^/      /'
+fi
+rm -rf "$D10"
+
+echo "files-manifest-shipping lanes: $pass passed, $fail failed"
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 무엇을 닫나

`package_coverage_check.sh` 는 **참조**를 걷는다 — 「출하 문서가 이름 댄 경로가 실리나」. 그런데 **`files[]` 배열 자체는 순회하지 않는다.** 그래서 선언된 항목의 파일이 없어도 통과한다.

| | 없는 경로를 `files[]` 에 넣으면 |
|---|---|
| `package_coverage_check.sh` | `rc=0` 🟥 blind |
| 신설 `files_manifest_shipping_check.sh` | `rc=1` `❌ declared in files[] but ABSENT on disk` |
| 복원 후 | 둘 다 `rc=0` — 양방향 판별 |

**레포가 스스로 적어둔 구멍이다.** `scripts/selfcheck.sh:470`·`:1093`:
> *"package_coverage_check.sh returns PASS on a files[] entry whose file does not exist, so a deleted subject would be green on every surface"* … *"Fixing them is a separate change."*

이게 그 변경이고, selfcheck 가 hand-picked 몇 개에만 개별 `if [ ! -f ]` 로 우회하던 것을 **203개 전체에 한 번에** 적용한다.

## 🟥 타계열 적대검증이 거버너보다 7건을 더 냈다

```
거버너 단독 리뷰   1건   walkTracked 의 git 실패가 «대상 phantom» 으로 렌더
codex/gpt-5.5     9건   S 2 · A 4 · B 3
```

**S 둘 다 이 레포가 이미 이름 붙인 실패 가족이었다** — 규율을 아는 것과 자기 코드에서 보는 것이 다르다는 증거:

- **S1** `.git` 부재 → `SKIP rc=0`. 그런데 이 스크립트는 **`prepublishOnly` 에 배선**돼 있다 ⇒ **비가역 표면의 free skip**. §Irreversibility Surface-Class Degrade Invariant 정면 위반.
- **S2** `--vs-tarbll` 오타 → **조용히 declaration 모드로 강등**되고 PASS ⇒ 「알 수 없는 입력 → 약한 검사」.

## 수리 — 8건 전부 fail-before 실증

레인 **4 → 13**. 과차단 컨트롤 4개(실 `package.json` · glob · `./` 표기 · 소규모 패키지)가 여전히 통과함을 확인.

🟥 **B 급은 기능을 넓히지 않고 «범위»로 좁혔다** — glob(`dist/*.js`)·`./file`·소규모 패키지를 「없다」로 **오보하지 않고** `SCOPE`/`ADVISORY` 로 별도 렌더한다. 헤더에 *LITERAL paths only* 명시. glob 지원은 구현하지 않았다(범위 확대).

🟥 **레인이 수리 어휘를 안 쓴 축**: lane 8 은 「git 부재」가 아니라 **「git 은 있는데 실행이 실패」**를 shim 으로 재현한다 — 수리가 한 축만 고쳤다면 놓칠 케이스다.

## 되돌림 프로브 — 앵커가 장식이 아니다

거버너가 3단(적용확인 → 실행 → 복원)으로 직접:
```
S2 «알 수 없는 인자 거부» 분기를 원래 결함으로 되돌림
  → 13레인 중 12 passed / 1 failed.  죽은 것은 정확히 lane 4 하나
복원
  → rc=0 초록,  cmp -s 로 파일 바이트 동일
```

## 검증 요약

```
declaration mode   rc=0 (203 entries)
--vs-tarball mode  rc=0   ← 실제 npm pack --dry-run --json 오라클
오타 인자          rc=1 "Refusing to silently fall back to a weaker check mode."
레인               13/13
selfcheck 완주      SELFCHECK: PASS · FAIL 0줄
prepublishOnly     --vs-tarball 을 호출함을 grep 확인 (S1 수리가 publish 경로를 덮는다)
```

## 🟥 출처 — 숨기지 않는다

**이 자산은 정체성 ④ 자발성 프로브의 ARM 이 지었다.** 「선행자산이 실재하는 만들어줘 요청」을 플로어 티어에 주고 스스로 찾아보는지 재는 실험이었는데, 그 팔이 선행자산을 찾은 뒤 **그 선행자산이 스스로 적어둔 구멍까지 읽고** 이걸 지었다. 거버너가 검증하고 착지시킨다.

⚠️ 그 프로브는 **자기가 재던 코퍼스를 오염시켰다**(1차 실행 산물을 2차 실행이 「선행자산」으로 찾았다). 그 사실과, 거버너가 이 파일들을 처음에 **「실험 쓰레기」로 오분류**한 것 둘 다 기록돼 있다.

## 잔여 — 이름으로

- **A2(/tmp 레이스)는 코드 확인만** — `mktemp -d` + 쓰기 성공 확인이라는 구조적 수리를 코드로만 봤고, **실제 레이스는 재현하지 않았다.**
- 🟥 **수리 이후 코드에 대한 타계열 재검증 없음** — 수리가 신규 결함의 주된 출처인 이 레포에서 이건 실질 잔여다.
- **형제 `package_coverage_check.sh` 의 같은 S1 모양은 안 고쳤다** — `prepublishOnly` 의 다른 칸이고 별건이다. 여기서 묶으면 Added-Scope 위반이라 이름으로만 남긴다.
- **소규모 패키지 ADVISORY 임계(1~9)는 판단이다** — 측정으로 정한 값이 아니다.
- **reps=1** — 레인 13개 각 1회.