### PR TITLE
docs(ethos): README 첫 줄이 «왜 그 문장인지» — 기각된 두 대안을 기록한다

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
   <b>English</b> · <a href="README.ko.md">한국어</a> · <a href="README.zh.md">中文</a> · <a href="README.ja.md">日本語</a>
 </p>
 
+<!-- This line was chosen, not drafted. Before rewriting it, read docs/ETHOS.md
+     §"Who this line is for" — two rejected alternatives are recorded there with why. -->
 <p align="center">
   <b>Quality gates that catch you, not just your agent.</b>
 </p>

--- a/docs/ETHOS.md
+++ b/docs/ETHOS.md
@@ -116,3 +116,38 @@ forward), so the harness audits itself and the learnings compound session over s
   question, and an isolated reviewer also adds false positives you must triage.
 
 The honesty is not a disclaimer bolted on at the end. It *is* the positioning.
+
+---
+
+## Who this line is for
+
+> **Quality gates that catch you, not just your agent.**
+
+That sentence is the first thing on the README, and it was **chosen against two alternatives**. Both
+rejections are recorded because a line with no recorded reason gets rewritten by whoever edits next,
+and the reason is the part that does not survive in the artifact.
+
+**Rejected — "a reliable ally when you're unsure before opening a PR."** It names a *feeling*, and a
+feeling cannot be checked. What FH actually does is a set of things you can name and run: it blocks a
+commit, it refuses a publish, it makes an absent measurement say `UNMEASURED` instead of `0`. A
+first line should say **what you can do with it**, because that is the only half a reader can verify
+before installing. Warmth that outruns the verifiable is the same defect this file's §"What FH does
+not claim" exists to prevent — one register up.
+
+**Rejected — the solo-developer framing.** An earlier draft aimed the line at "a solo developer, before
+they open a PR". It reads narrower than the thing is. FH's gates fire the same way for one person and
+for a team; nothing in the machinery keys on team size. Naming an audience the machinery does not
+distinguish trades reach for nothing, and it invites the reader who *is* on a team to conclude the
+tool is not theirs.
+
+**And the surviving half is deliberately awkward: "catch *you*."** The natural sentence is "catches
+your agent" — that is what a reader expects and what most tools in this space promise. It is also the
+easier claim, and FH's own record refutes it as sufficient: on the day this line was written, the
+gates blocked the *author* seven times with **zero** self-catches ([`GATE_DAY.md`](GATE_DAY.md)). The
+person driving the agent is inside the surface being gated, and a first line that omits them is
+describing a smaller tool than the one that ships.
+
+⚠️ **Scope of this record.** These are positioning decisions, not measurements. The `GATE_DAY.md`
+figure is measured; "which sentence reads better" is not, and no reader study was run. What is being
+preserved here is *why the choice was made*, so a future rewrite argues with the reason rather than
+rediscovering it.


### PR DESCRIPTION
**공개 카피는 안 바꾼다.** 늘어난 것은 그 문장이 왜 그 문장인지다.

## 왜 필요했나

오늘 운영자 발화 착지 검증(`utterance_landing_check.sh`, `--self-test` PASS · CONTROL 3/3 생존)에서 **미착지 5건 중 둘이 이것**이었다. 손검증으로 재확인 — README/knowledge 의 `solo dev` 히트는 전부 다른 화제(청중 표 · 인큐베이터 교리)였다.

**산출물은 착지했는데 결정은 안 착지한 형태**다. 사유 없는 줄은 다음 편집자가 다시 쓴다 — `[[feedback_regenerated_asset_loses_committed_intent]]`.

## 기록한 셋

**① 「a reliable ally when you're unsure」 기각** — *느낌*을 말하는데 느낌은 검증이 안 된다. FH 가 실제로 하는 건 이름 대고 돌릴 수 있는 것들이다: 커밋을 막고, 발행을 거부하고, 없는 측정을 `0` 이 아니라 `UNMEASURED` 로 말하게 한다. 첫 줄은 **설치 전에 독자가 확인할 수 있는 절반**을 말해야 한다.

**② 1인개발자 프레이밍 기각** — 게이트는 팀 크기를 **구분하지 않는다.** 기계가 구분하지 않는 청중을 이름 대면 도달을 공짜로 버리고, 팀에 속한 독자에게 「내 것이 아니다」를 준다.

**③ 🟥 «catch *you*» 는 의도적으로 어색하다** — 자연스러운 문장은 `"catches your agent"` 이고, 그게 이 바닥이 대체로 약속하는 것이자 **더 쉬운 주장**이다. 그리고 같은 날 우리 기록이 그걸 반증한다: 게이트가 **저자를 7회** 막았고 **자력 적발 0**([`GATE_DAY.md`](../docs/GATE_DAY.md)). 에이전트를 모는 사람이 게이트 대상 안에 있고, 그를 빼면 실제보다 작은 도구를 묘사하게 된다.

## 🟥 gate-locality — 기록만으로는 반쪽이다

`docs/ETHOS.md` 에만 적으면 **이 줄을 고칠 사람이 그 파일을 열 이유가 없다.** 그래서 `README.md:18` 에 편집자용 HTML 주석 포인터를 같이 넣었다 — 렌더에는 안 보이고 편집자에게는 보인다.

```html
<!-- This line was chosen, not drafted. Before rewriting it, read docs/ETHOS.md
     §"Who this line is for" — two rejected alternatives are recorded there with why. -->
```

**참조 무결 확인(컨트롤 동반)**: 포인터가 이름 댄 절이 `ETHOS.md:122` 에 실재(1건) · 존재하지 않는 절 문자열은 0건 · `GATE_DAY.md` 링크 대상 실재.

## 잔여 — 이름으로

- 🟥 **「다음 편집자가 이 주석을 읽나」는 미측정** — 이 델타의 목적이 바로 그건데 블라인드 sim 을 안 돌렸다. HTML 주석은 렌더에 안 보이므로 **못 볼 가능성이 실재**한다. 다음 README 편집이 첫 실사용이다.
- **README 에 HTML 주석 관행이 0건이었다** — 신설이다. 하나뿐인 관행은 다음 사람이 「관행」으로 못 읽을 수 있다.
- **다국어판(ko/ja/zh)에는 안 넣었다** — 각 번역의 문맥 확인이 필요하다. **안 한 것이지 못 한 것이 아니다.**
- **판단이지 측정이 아니다** — 「어느 문장이 더 읽히나」는 독자 연구를 안 돌렸고, 그 사실을 절 안에 명시했다. `GATE_DAY.md` 수치만 측정값이다.