### PR TITLE
docs(agents): ablation 요약이 «가장 거짓 CUT 을 내기 쉬운 함정»을 안 싣고 있었다

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,3 +253,8 @@ The constraint above is not.
 > pass `bash scripts/ablation_calibrate.sh` (exit 0), and verdicts are recorded in
 > `.claude/regression/ablation_verdicts.md`. Worth knowing before you propose a cut: a section whose
 > removal makes a reader answer *confidently wrong* counts as load-bearing, not as safe to drop.
+> **And the trap that produces a wrong CUT most easily**: when both arms score the *same*, that is
+> equally consistent with the section being redundant and with the scorer never having moved. The
+> two are indistinguishable from the outcome alone. Before writing a CUT on equal scores, name an arm
+> that MUST score differently and show the metric moved on *that* pair; if it did not, the verdict is
+> `INSTRUMENT-UNCONFIRMED`, not `CUT` (added to the script header 2026-08-23, §7).


### PR DESCRIPTION
## 무엇이 빠져 있었나

오늘 `probe_scope_check.sh` 헤더에 **§7** 을 넣었다 — 두 팔이 **동점**일 때 그것은 「절이 중복이다」와 「채점기가 안 움직였다」 **둘 다와 똑같이 일치**하고, 결과만으로는 구분되지 않는다.

`AGENTS.md:249-255` 는 그 헤더를 **가리키면서 함정을 요약해 싣는다** — 두 팔 · `reps>=3` · 사전등록 질문셋 · 「확신-오답은 load-bearing」. **넷 중 셋만 있었다.**

🟥 **포인터는 안 깨져 있었다** — §7 은 그 헤더 안에 있으니 포인터를 따라간 에이전트는 읽는다. 깨진 것은 **요약의 완전성**이고, 그 요약이 존재하는 이유가 바로 **함정을 나르는 것**이다(기존 넷째 항목 「확신-오답」이 그 성격을 이미 보인다).

## 🟥 이건 오늘 내 답습의 반쪽-픽스다

frozen-replay 답습을 착지시키며 **「두 자리에 넣었다」**고 적었다 — 계기-판별력 표 + probe 헤더. **그 둘은 전부 Claude 세션이 읽는 자리다.** 비-Claude 진입점이라는 **세 번째 행위자 자리**를 안 봤고, 하필 `AGENTS.md` 가 그 스크립트를 이름으로 가리키고 있었다.

**자력 적발 0** — `session_close_check` ④-b 가 드리프트 후보를 표면화했고, 그 판정을 하려고 파일을 열어서야 걸렸다. `[[feedback_half_fix_propagation_boundary]]` 정확히 그 형태.

## 드리프트 판정 — 넷 중 하나만 참이었다

④-b 는 자기 규격에 «grep 이 깃발을 들 뿐 parity 는 **판단**» 이라 적는다. 판단 결과:

| 토큰 | 판정 | 근거 |
|---|---|---|
| `files_manifest_shipping` | ❌ 아님 | AGENTS.md 는 게이트를 **전수 열거하지 않는다** — `selfcheck.sh`·`package_coverage_check.sh` 도 없다. 비-Claude 가 「해야 할 것」만 적는 문서다 |
| `n+12` / `frozen-replay` | ❌ 아님 | 계기-판별력 표는 knowledge 층이고 AGENTS.md 가 가리키는 대상이 아니다 |
| `INSTRUMENT-UNCONFIRMED` | 🟥 **맞음** | AGENTS.md 가 `probe_scope_check.sh`·`ablation_calibrate.sh` 를 **이름으로** 가리키고 그 함정들을 요약해 싣기 때문이다 |

**컨트롤 동반**: 네 토큰을 CC 층 / `AGENTS.md` / `docs/codex-compat.md` 세 곳에 각각 grep 하고, **양쪽에 확실히 있는 토큰(`axes-run`)** 을 같은 실행에 넣어 `AGENTS.md=2` 를 확인했다 — 0 이 계기 사망이 아니라 실제 부재임을 갈랐다.

## 잔여 — 이름으로

- 🟥 **「비-Claude 가 이 줄을 읽고 따르나」는 미측정** — codex 블라인드 sim 을 안 돌렸다. **이 델타의 목적축인데 안 쟀다.**
- 🟥 `crossfamily: DEGRADED_PANEL_UNUSED` — **가장 아이러니한 미검사 축이다.** 이 줄의 독자가 바로 타계열 사이드카이고, 「이 요약이 그들에게 충분한가」는 그들에게 물어야 안다. **값이 클 자리를 알면서 안 돌렸다.**
- **나머지 셋의 「드리프트 아님」은 판단이다** — AGENTS.md 의 범위 해석에 근거하지 측정이 아니다. 해석이 틀렸으면 셋 다 드리프트다.
- `docs/codex-compat.md` 는 `axes-run` 히트 0 을 근거로 「마커 어휘를 안 나르는 문서」로 판단했는데, **그 판단도 토큰 하나에 근거한다.**