### PR TITLE
fix(npm): homepage·bugs 부재로 npm 페이지가 레포로 안 보내고 있었다

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@chrono-meta/fh-gate",
   "version": "2.9.0",
   "description": "FH runtime adapters — run FH governance, skills, and agents via Claude or Codex with machine-parseable gates.",
+  "homepage": "https://github.com/chrono-meta/forge-harness#readme",
+  "bugs": {
+    "url": "https://github.com/chrono-meta/forge-harness/issues"
+  },
   "license": "MIT",
   "keywords": [
     "ai-governance",

--- a/scripts/postinstall_notice.js
+++ b/scripts/postinstall_notice.js
@@ -24,8 +24,15 @@ if (process.env.CI || process.env.FH_NO_BANNER || process.env.CONTINUOUS_INTEGRA
 }
 try {
   process.stderr.write(
-    '\n⭐ forge-harness (fh-gate) — if this is useful, a star helps others find it:\n' +
-    '   https://github.com/chrono-meta/forge-harness\n' +
+    '\n✓ fh-gate installed — a governance gate for AI-written changes.\n' +
+    '\n' +
+    '  Try it on a change you already have:\n' +
+    '      npx fh-gate            # reviews your git diff, returns a typed verdict\n' +
+    '                             # PASS 0 · PENDING 1 · BLOCKED 2 · ESCALATE 3\n' +
+    '  Runs through your local `claude` CLI. Nothing staged? Stage something first —\n' +
+    '  with an empty diff it has nothing to review.\n' +
+    '\n' +
+    '⭐ Useful? A star helps others find it: https://github.com/chrono-meta/forge-harness\n' +
     '   (set FH_NO_BANNER=1 to silence this message)\n\n'
   );
 } catch (_) {


### PR DESCRIPTION
## 실측 (2026-08-23, GitHub traffic API)

```
npm 주간 다운로드   2465        →   14일간 레포 유입  uniq 1명
유입 경로 전체       github.com 10 · linkedin 2 · npmjs 1 · (그 외 없음)
stars 7 · forks 1 · watchers 0 · 14일 uniques 30
```

**우리가 통제할 수 있는 표면 중 가장 크게 새는 곳이다.** 원인이 실물로 보인다 — `package.json` 에 `homepage` 가 없으면 npmjs.com 패키지 페이지에서 레포 링크가 눈에 띄는 자리에 안 걸린다. `bugs` 도 없어서 이슈로 가는 경로가 없었다.

## 왜 레포를 homepage 로

`eslint`→`eslint.org` · `prettier`→`prettier.io` · `vitest`→`vitest.dev` — 셋 다 **자체 사이트가 있을 때의 관행**이다. 우리는 없으므로 레포 README 가 맞다.

## ⚠️ 이건 «막는» 수리지 «채우는» 것이 아니다

- 다운로드 2465 중 몇 %가 사람인지 **미측정**.
- clone 지표(2889 / uniq 529)는 **미귀속** — 일별 분포가 55~132로 매일 평평해서 봇·미러 신호에 가깝다. 플러그인 설치도 clone 을 쓰지만(우리 install 에 `gitCommitSha` 존재) **둘을 가를 계기가 없다.** 「사용자 529명」으로 읽지 마라.

## 게이트

```
version_lockstep_check        rc=0  (4 surfaces @ 2.9.0 — 버전 무변경)
files_manifest_shipping_check rc=0  (203 entries, 0 phantom)
package_coverage_check        rc=0
JSON 유효 · diff = 4 insertions / 0 deletions (포맷 보존)
```

## 별건 — `postinstall_notice.js` 는 운영자 판정 대기

현재 문구는 **「⭐ 유용하면 별이 도움됩니다」 한 줄**이고, **이게 무엇을 하는 물건인지는 0글자**다. 설치한 사람이 본 유일한 우리 메시지인데 **별을 부탁하기 전에 이유를 안 준다.** 문구 신설은 운영자 판정 사항이라 이 PR 에 넣지 않았다.