### PR TITLE
fix(readme): star 배지 제거 — 정보가 아니라 사회적 증거 위젯이다

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -8,7 +8,6 @@
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
   <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-22c55e.svg" alt="MIT License"></a>
-  <a href="https://github.com/chrono-meta/forge-harness/stargazers"><img src="https://img.shields.io/github/stars/chrono-meta/forge-harness?style=social" alt="GitHub stars"></a>
 </p>
 
 <p align="center">

--- a/README.ko.md
+++ b/README.ko.md
@@ -8,7 +8,6 @@
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
   <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-22c55e.svg" alt="MIT License"></a>
-  <a href="https://github.com/chrono-meta/forge-harness/stargazers"><img src="https://img.shields.io/github/stars/chrono-meta/forge-harness?style=social" alt="GitHub stars"></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
   <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-22c55e.svg" alt="MIT License"></a>
-  <a href="https://github.com/chrono-meta/forge-harness/stargazers"><img src="https://img.shields.io/github/stars/chrono-meta/forge-harness?style=social" alt="GitHub stars"></a>
 </p>
 
 <p align="center">

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,7 +8,6 @@
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
   <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-22c55e.svg" alt="MIT License"></a>
-  <a href="https://github.com/chrono-meta/forge-harness/stargazers"><img src="https://img.shields.io/github/stars/chrono-meta/forge-harness?style=social" alt="GitHub stars"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
별 7 · 14일 uniques 30 인 상태에서 배지 줄이 배너 바로 아래 있어, **방문자가 첫 스크롤 안에서 「★ 7」을 정면으로 본다.** 그 값은 제품에 대해 아무것도 안 알려준다.

## 판별자 — 주장인가 위젯인가

| 남긴다 | 뺀다 |
|---|---|
| npm 버전 · 라이선스 · awesome 등재 · Claude Code 호환 | `shields.io/github/stars` |
| 방문자가 **쓸지 말지를 정하는 데 쓰는 정보** | **사회적 증거 위젯** |

🟥 **은폐가 아니다** — GitHub 이 레포 상단과 stargazers 페이지에 같은 숫자를 항상 표시한다. 우리가 가릴 수 없고 가리지도 않는다. **강조하지 않기로 한 것**이다.

## 컨트롤

4개 언어판 전수 처리 후 같은 실행에서 **npm 배지 4파일 · 라이선스 배지 4파일 생존** 확인 — 정규식이 배지 줄을 통째로 지운 게 아니라 **대상 하나만** 제거했다는 증거. 패턴 불일치 시 파일을 안 건드리도록 짰고, 4파일 전부 「제거」가 출력됐다.

```
diff        4 files changed, 4 deletions(-)
잔존 star   0
selfcheck   SELFCHECK: PASS · FAIL 0줄
```

## 잔여

- 🟥 **효과 미측정** — 배지 제거가 전환을 올린다는 근거가 없다. **판단이지 측정이 아니다.**
- 되돌리기 쉽다. 별이 의미 있는 수가 되면 다시 달면 되고, 그 시점 판단은 미정이다.