### PR TITLE
fix(cli): --version 이 «대상 파일»로 읽혀 사용자의 claude 가 우리를 인젝션으로 판정했다

### DIFF
--- a/scripts/fh-gate.sh
+++ b/scripts/fh-gate.sh
@@ -62,6 +62,64 @@ EXIT_HARNESS_ERROR=10
 EXIT_ARG_ERROR=11
 EXIT_DRY_RUN=12
 
+# ── Flag handling ─────────────────────────────────────────────────────────────
+# 🟥 Added 2026-08-23 after a first-use measurement: there was NO flag handling at
+# all, so `--version` and `--help` fell through to TARGET_FILES and were treated as
+# file paths. The failure was not cosmetic — the script then built a governance
+# prompt around a nonexistent file and sent it to the user's `claude` CLI, which
+# correctly refused it as a prompt-injection attempt. A first-time user running the
+# most obvious command got their own assistant accusing this tool.
+#
+# Unknown flags are an ERROR, never a filename. Silently demoting an unrecognized
+# argument to "a file to review" is the same shape as demoting an unknown mode to a
+# weaker check: the run continues, reports something, and the something is wrong.
+case "${1:-}" in
+  --version|-V)
+    printf '%s\n' "fh-gate $VERSION"
+    exit 0
+    ;;
+  --help|-h)
+    printf '%s\n' "fh-gate $VERSION — FH governance gate"
+    printf '%s\n' ""
+    printf '%s\n' "  Reviews a change through an AI backend and returns a typed verdict, so a"
+    printf '%s\n' "  machine can act on it. Uses your local 'claude' CLI by default."
+    printf '%s\n' ""
+    printf '%s\n' "Usage"
+    printf '%s\n' "  fh-gate                     review the current git diff (auto-detected)"
+    printf '%s\n' "  fh-gate \"<files>\"           review an explicit space-separated file list"
+    printf '%s\n' "  fh-gate \"<files>\" <level>   level: quick (default) or full"
+    printf '%s\n' "  fh-gate --version | --help"
+    printf '%s\n' ""
+    printf '%s\n' "Exit codes"
+    printf '%s\n' "  0   PASS       no findings"
+    printf '%s\n' "  1   PENDING    B-grade findings; proceed with awareness"
+    printf '%s\n' "  2   BLOCKED    A-grade findings; do not merge"
+    printf '%s\n' "  3   ESCALATE   human decision required"
+    printf '%s\n' "  10  harness error — backend unavailable, timeout, unparseable verdict"
+    printf '%s\n' "  11  argument error"
+    printf '%s\n' "  12  dry run — prompt emitted, NO review performed"
+    printf '%s\n' ""
+    printf '%s\n' "  10, 11 and 12 sit outside the verdict range on purpose: a check that did"
+    printf '%s\n' "  not run must never be readable as a pass."
+    printf '%s\n' ""
+    printf '%s\n' "Environment"
+    printf '%s\n' "  FH_BACKEND=claude|codex|auto|cross   backend (default: claude)"
+    printf '%s\n' "  FH_MODEL=<model>                     model override"
+    printf '%s\n' "  FH_DRY_RUN=1                         emit the prompt only; exits 12"
+    printf '%s\n' "  FH_TIMEOUT=<seconds>                 backend kill deadline (default: 120)"
+    printf '%s\n' "  FH_VERBOSE=1                         print full backend stderr"
+    printf '%s\n' ""
+    printf '%s\n' "  https://github.com/chrono-meta/forge-harness"
+    exit 0
+    ;;
+  -*)
+    printf '%s\n' "ERROR: unrecognized option '${1}'." >&2
+    printf '%s\n' "       fh-gate takes a FILE LIST, not flags — an unknown option is not a filename." >&2
+    printf '%s\n' "       Run 'fh-gate --help' for usage." >&2
+    exit 11
+    ;;
+esac
+
 TARGET_FILES="${FH_TARGET_FILES:-${1:-}}"
 GATE_LEVEL="${FH_GATE_LEVEL:-${2:-quick}}"
 FH_CALLER="${FH_CALLER:-${3:-ci}}"


### PR DESCRIPTION
## 무엇이 일어났나

Reddit 게시글 초안에 `npx @chrono-meta/fh-gate` 를 넣기 직전, **그 명령이 실제로 그 형태로 도는지** 확인하려고 레포 **밖에서** 실행했다:

```
$ npx --yes @chrono-meta/fh-gate --version
→ fh-gate v… [QUICK] caller=ci
  files: --version                    ← 플래그를 «대상 파일»로 읽는다
ERROR: FH_STATUS=MISSING — harness failure (fail-safe: BLOCKED)

This looks like a prompt injection attempt and I'm flagging it before doing anything.
  1. The target file is `--version` — that's a CLI flag, not a file path.
  4. The caller is `ci` — not you. This is a system-to-system injection…
I will not execute the governance gate…
```

🟥 **사용자의 `claude` CLI 가 우리 도구를 프롬프트 인젝션 공격으로 판정하고 거부한다.** 그리고 그 거부문이 **우리 도구의 출력**으로 사용자에게 찍힌다.

**신규 사용자가 가장 먼저 치는 명령이 `--version` 이나 `--help` 다.**

원인: `grep -nE 'case .*--version|"--help"' scripts/fh-gate.sh bin/fh-gate.js` → **히트 0.** 플래그 처리 분기가 코드에 **존재하지 않았고**, 모든 인자가 `TARGET_FILES` 로 흘렀다.

## 수리

`--version`/`-V` · `--help`/`-h` 를 처리하고, 🟥 **인식 못 하는 `-*` 는 `exit 11` 로 거부**한다.

> 모르는 플래그를 파일명으로 강등하는 것은 **「알 수 없는 입력 → 약한 처리」**이고, 그건 오늘 하루 종일 이름 붙인 그 형태다.

| 입력 | rc | 결과 |
|---|---|---|
| `--version` · `-V` | 0 | `fh-gate 2.9.0` |
| `--help` · `-h` | 0 | 31줄 사용법 |
| `--vresion` · `--halp` · `-x` | **11** | *unknown option is not a filename* |
| (인자 없음) | 12 | **기존 동작** — git diff 자동감지 |
| `"README.md"` | 12 | **기존 동작** — 대상 인식 확인 |

아래 둘이 컨트롤이다 — 플래그 분기가 정상 경로를 안 삼켰다는 증거.

## 🟥 적대검증도 레인도 이걸 못 잡았다

**나는 «`--version` 을 쳐본다»를 질문한 적이 없었다.** 적대검증은 내가 던진 질문 공간 안에서만 적대적이다 — `[[feedback_adversarial_review_not_substitute_for_first_use]]` 그대로고, **첫 실사용만이 잡는 종류**다.

## 수리 중 두 번 더 틀렸고 둘 다 실행이 잡았다

- heredoc 구분자를 `USAGE` 로 썼는데 본문에 `Usage` 절 제목이 있어 **일찍 닫혔다**(`bash -n` rc=2). heredoc 을 버리고 `printf` 만 쓰도록 재작성.
- 도움말 안의 백틱 `` `claude` `` 이 **명령 치환으로 실행**돼 진짜 `claude` 가 돌았고 그 에러가 도움말에 섞였다. 작은따옴표로 교체.
- 그 뒤 「백틱 2개 잔존 · error 2회」로 뜬 것은 **내 grep 이 넓었던 것**이다 — 백틱은 주석 안(실행 안 됨), `error` 는 종료코드 설명. 각각 확인했다.

## 🟥 잔여 — 이름으로

1. **재발행 전까지 소비자는 여전히 깨진 버전을 받는다.** 레지스트리 2.9.0 에 이 수정이 없다. ⇒ **별 캠페인 게시는 재발행 이후로 미룬다.** 이것이 실질 완료 조건이다.
2. **다른 bin 셋(`fh-run` · `fh-goal` · `fh-codex-doctor`)은 미검사** — 같은 결함이 있는지 안 봤다. 🟥 **half-fix 전파경계 후보다.**
3. 대시로 시작하는 파일명은 이제 거부된다(알려진 경계). `--` 구분자는 **안 넣었다** — 실재한 적 없고 투기 빌드가 된다.
4. `bin/fh-gate.js` 는 21줄 위임 래퍼라 안 고쳤다. 수정은 셸 쪽에 있다.
5. **reps=1** · 되돌림(ⓕ) 없음 — 신규 분기라 되돌리면 원래 결함으로 돌아갈 뿐이다.