### PR TITLE
docs(readme): awesome-agent-skills 등재 뱃지 + mermaid LR→TD (컨트롤 가림 수정)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -353,7 +353,7 @@ Project B  ──→  CLAUDE.md でハブを接続
 **3段工程** — これはメニューではなく*投資の順序*です:
 
 ```mermaid
-flowchart LR
+flowchart TD
   S["① 判断回路<br/>設計の前に"]
   P["② 並列脱相関<br/>中間で"]
   B["③ 焼き切る<br/>6つの軸で"]
@@ -597,7 +597,7 @@ forge-harness はプロジェクトを鋼のように扱い、この比喩は装
 > 高くつく嘘なので、名前は残し、役割だけをここで正します。
 
 ```mermaid
-flowchart LR
+flowchart TD
   F["鍛え<br/>① 魂"] --> Q["焼き入れ<br/>② 並列脱相関"] --> T["焼き戻し<br/>③ 6軸"] --> A(["⟹ 加速"])
   style A fill:#0f766e,stroke:#0f766e,color:#fff
 ```

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,6 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/walkinglabs/awesome-harness-engineering#coding-agent-harnesses"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Harness Engineering"></a>
+  <a href="https://github.com/VoltAgent/awesome-agent-skills#community-skills"><img src="https://img.shields.io/badge/listed_in-awesome--agent--skills-0ea5e9.svg" alt="Listed in awesome-agent-skills"></a>
   <img src="https://img.shields.io/badge/Claude_Code-compatible-a855f7.svg" alt="Claude Code">
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
   <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -348,7 +348,7 @@ Project B  ──→  CLAUDE.md에서 허브 연결
 **3단 공정** — 이것은 메뉴가 아니라 *투자의 순서*입니다:
 
 ```mermaid
-flowchart LR
+flowchart TD
   S["① 설계 전에<br/>판단 회로"]
   P["② 중간은<br/>병렬 탈상관"]
   B["③ 마무리<br/>6축 태우기"]
@@ -633,7 +633,7 @@ forge-harness는 프로젝트를 강철처럼 다루고, 이 은유는 장식이
 > 은유를 맞추자고 출하된 스킬 이름을 바꾸는 게 더 비싼 거짓말이라, 이름은 두고 역할만 여기 바로잡습니다.
 
 ```mermaid
-flowchart LR
+flowchart TD
   F["벼림 Forge<br/>① 영혼"] --> Q["담금질 Quench<br/>② 병렬 탈상관"] --> T["뜨임 Temper<br/>③ 6축"] --> A(["⟹ 가속"])
   style A fill:#0f766e,stroke:#0f766e,color:#fff
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -4,6 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/walkinglabs/awesome-harness-engineering#coding-agent-harnesses"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Harness Engineering"></a>
+  <a href="https://github.com/VoltAgent/awesome-agent-skills#community-skills"><img src="https://img.shields.io/badge/listed_in-awesome--agent--skills-0ea5e9.svg" alt="Listed in awesome-agent-skills"></a>
   <img src="https://img.shields.io/badge/Claude_Code-compatible-a855f7.svg" alt="Claude Code">
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
   <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ harness is actually used.
 **The three-stage process** — this is an *order of investment*, not a menu:
 
 ```mermaid
-flowchart LR
+flowchart TD
   S["① Circuit<br/>before design"]
   P["② Parallel decorrelation<br/>in the middle"]
   B["③ Burn it down<br/>on six axes"]
@@ -649,7 +649,7 @@ hardened by attack, and only then does it ship faster, for having survived.
 > the names stay and the roles are stated correctly here.
 
 ```mermaid
-flowchart LR
+flowchart TD
   F["Forge<br/>① circuit"] --> Q["Quench<br/>② parallel"] --> T["Temper<br/>③ six axes"] --> A(["⟹ Accelerate"])
   style A fill:#0f766e,stroke:#0f766e,color:#fff
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/walkinglabs/awesome-harness-engineering#coding-agent-harnesses"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Harness Engineering"></a>
+  <a href="https://github.com/VoltAgent/awesome-agent-skills#community-skills"><img src="https://img.shields.io/badge/listed_in-awesome--agent--skills-0ea5e9.svg" alt="Listed in awesome-agent-skills"></a>
   <img src="https://img.shields.io/badge/Claude_Code-compatible-a855f7.svg" alt="Claude Code">
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
   <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -4,6 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/walkinglabs/awesome-harness-engineering#coding-agent-harnesses"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Harness Engineering"></a>
+  <a href="https://github.com/VoltAgent/awesome-agent-skills#community-skills"><img src="https://img.shields.io/badge/listed_in-awesome--agent--skills-0ea5e9.svg" alt="Listed in awesome-agent-skills"></a>
   <img src="https://img.shields.io/badge/Claude_Code-compatible-a855f7.svg" alt="Claude Code">
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
   <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -328,7 +328,7 @@ Project B  ──→  在 CLAUDE.md 中连接中枢
 **三段工序** —— 这是一个 *投入的顺序*，不是一份菜单：
 
 ```mermaid
-flowchart LR
+flowchart TD
   S["① 立坐标系<br/>设计之前"]
   P["② 并行去相关<br/>中段"]
   B["③ 烧一遍<br/>六条轴上"]
@@ -561,7 +561,7 @@ forge-harness 把项目当作钢来对待，而这个隐喻是字面的，不是
 > 是更昂贵的谎言；因此名字留着，只在这里把角色说清楚。
 
 ```mermaid
-flowchart LR
+flowchart TD
   F["锻造 Forge<br/>① 回路"] --> Q["淬火 Quench<br/>② 并行去相关"] --> T["回火 Temper<br/>③ 六轴"] --> A(["⟹ 加速 Accelerate"])
   style A fill:#0f766e,stroke:#0f766e,color:#fff
 ```


### PR DESCRIPTION
## 무엇

`VoltAgent/awesome-agent-skills` (★31,029) 의 **Community Skills** 에
`plugins/fh-meta/skills/context-doctor` 가 등재됐다 (그쪽 PR #928, 2026-08-23 머지, 수정 요청 0건).
뱃지를 하나 **추가**한다 — README 4종 전부(en/ko/ja/zh).

## 🟥 왜 «교체»가 아닌가

기존 `awesome.re` 뱃지(walkinglabs/awesome-harness-engineering, ★3,904)와 **다른 것을 주장한다**:

| | 무엇이 등재됐나 |
|---|---|
| walkinglabs | 이 하네스 **본체**가 «coding-agent-harnesses» 에 |
| VoltAgent | 우리 **스킬 하나**가 «Community Skills» 220개 중 하나로 |

별 수는 8배지만 주장은 약한 쪽이다. 별 수를 이유로 바꾸면 **더 센 주장을 버리는 것**이 된다.
같은 이유로 문구를 `listed in` 으로 좁혔다 — 「3만 레포에 FH 가 등재」로 읽히면 질문 하나에 무너진다.

## 실측 (전부 컨트롤 동반)

| 항목 | 결과 |
|---|---|
| 뱃지 URL | `http=200` · `aria-label="listed in: awesome-agent-skills"` |
| ↳ known-negative | 잘못된 badge 경로 → `"404: badge not found"` — **계기가 판별한다** |
| 앵커 | 그쪽 `README:1664` `### Community Skills` 실재 · 우리 항목 `:1858` |
| 링크 대상 | `plugins/fh-meta/skills/context-doctor` 실재 (control: 없는 스킬은 부재로 나옴) |
| 줄 너비 | 뱃지 6개 합 696px + 간격 20 = **716px** < 본문단 ≈830px → 한 줄 유지 |

## ⚠️ 이름으로 남기는 잔여

- 배너(680px)보다 **36px 넓다.** 같은 날 「리드미 못생겼다」 지적이 있었던 자리라, 눈으로 볼 값을
  숫자로 남긴다. 좁히려면 라벨 `listed_in` → `in` (670px, 배너 안에 들어옴).
- **렌더 스크린샷은 안 찍었다** — 폭은 SVG width 합산으로 계산한 값이고 실제 렌더 관측이 아니다.
- 등재 목록의 우리 항목 설명문은 **그쪽이 쓴 것**이고 우리가 통제하지 않는다.