### PR TITLE
초록이 clone 을 못 넘었다 — new-code-anchor 배선 + 러너 표면 index 전환

### DIFF
--- a/.github/workflows/new-code-anchor.yml
+++ b/.github/workflows/new-code-anchor.yml
@@ -1,0 +1,85 @@
+name: New-code anchor
+
+# WHAT THIS GATES, in one sentence: a NEWLY ADDED executable must not ship with zero lanes that
+# actually run it. Transplanted from qasp's `new-code-anchor` job via the door-④ synergy scan
+# (tracks/_meta/synergy_scan_2026-08-22.md, pair T3). Origin incident there: 123 tests green, and
+# none of them touched the file the PR added — the aggregate was green, the new file was unmeasured.
+#
+# 🟥 A SEPARATE WORKFLOW ON PURPOSE, not a step inside validate.yml. Two reasons, both about the
+# reader: (a) this gate needs `fetch-depth: 0` and a base ref, which validate.yml does not, and
+# folding it in would quietly change that job's checkout semantics for every other step in it;
+# (b) when it blocks, the CI UI must name THIS gate — a failure buried inside a 100-line selfcheck
+# log gets diagnosed as "selfcheck is red again". Same reasoning validate.yml states for keeping
+# the count-consistency step separate from the selfcheck step that also runs it.
+#
+# ⚠️ NOT A REQUIRED CHECK unless someone makes it one. Branch protection on this repo lists
+# `validate` and nothing else, so as shipped this job REPORTS and does not gate the merge button.
+# That is stated rather than implied: CLAUDE.md's §FH-Improvement-4-Axis-Auto-Gate already had to
+# correct a stale claim about which checks are required, and a workflow that describes itself as a
+# floor it is not is the same defect. Promoting it is an operator decision.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: ['**']
+    # NAMED RESIDUAL: on a push to main itself, merge-base(origin/main, HEAD) IS HEAD, so the
+    # added-file set is empty and the job passes vacuously. That is correct — the change already
+    # merged, and this gate's binding point is pre-merge — but it means a green run on main is not
+    # evidence about anything ([[feedback_gate_binding_point_not_check_point]]).
+
+jobs:
+  new-code-anchor:
+    runs-on: ubuntu-latest
+    steps:
+      # fetch-depth: 0 is load-bearing, not hygiene. The default shallow checkout has no
+      # merge-base with the base ref, and the checker's response to that is exit 10 (UNMEASURED),
+      # not a green — so a shallow checkout turns this job red for an instrument reason. Correct
+      # direction, wrong diagnosis for whoever reads it; giving it the full history avoids the
+      # question entirely.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # The lane suite FIRST, and that ordering is the point of this step existing here at all.
+      # If the calibration is broken, the gate's verdict below proves nothing — a gate whose
+      # known-pair has never executed is exactly the fail-open this repo spent 2026-08-11/12
+      # closing, one file at a time. It also gives the suite a runner: scripts/lane_runner_check.sh
+      # enumerates `.github/workflows/*.yml` as one of its three runner surfaces, so this line is
+      # what keeps test_new_code_anchor_lanes.sh out of its DEBT list.
+      - name: Calibrate the gate (known-pair lanes)
+        run: |
+          bash scripts/test_new_code_anchor_lanes.sh
+
+      - name: New-code anchor gate
+        env:
+          # On a PR, diff against the base the PR actually targets — NOT against origin/main's tip,
+          # which moves under the PR and would attribute other people's merged files to this
+          # change. On a push there is no such field, so the checker's own auto-resolution
+          # (origin/main → main → …) runs; an empty value is treated as unset by the checker.
+          NEW_CODE_ANCHOR_BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # `set +e` around the call, NOT `cmd || rc=$?`. GitHub runs steps under `bash -e`, so an
+          # unguarded non-zero exit kills the step before `rc=$?` is ever read and the case block
+          # below becomes unreachable decoration — the routing would look present and never run.
+          # The `||` form works too but this repo has logged what that idiom degrades into when it
+          # spreads ([[feedback_pipefail_fallback_disarms_guard]]); the explicit form says what it
+          # is doing.
+          set +e
+          bash scripts/new_code_anchor_check.sh
+          rc=$?
+          set -e
+          # Routed explicitly rather than left to the step's implicit exit-code handling, because
+          # the three values mean different things and a reader must not have to guess which one
+          # produced the red X. 10 is NOT a pass and NOT a lane failure: the instrument could not
+          # measure, so nothing below it is evidence either way
+          # ([[feedback_not_found_is_not_zero_family]]).
+          case "$rc" in
+            0)  echo "PASS — every added executable is exercised by a lane" ;;
+            1)  echo "FAIL — an added executable ships with no working anchor (see above)"; exit 1 ;;
+            # 10 also covers a MALFORMED EXEMPT ENTRY (a `path|reason` line whose reason is missing
+            # or vacuous). That is deliberately not a code verdict: the checker's own configuration
+            # is broken, so neither a pass nor a block would be evidence about the diff.
+            10) echo "HARNESS ERROR — the gate could not measure (base/git/python3/EXEMPT). Not a pass."; exit 1 ;;
+            *)  echo "HARNESS ERROR — undeclared exit code $rc; the contract is 0/1/10."; exit 1 ;;
+          esac

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,8 @@ outputs/
 # deep-clarify spec documents — user goals, constraints, and "must not touch" lists.
 # Written per-task in a working project; keep off the tracked surface.
 .claude/specs/
+
+# prior-art hook runtime sentinels — per-session state written by the hook itself.
+# Never a commit target; without this they dirty `git status` every session.
+.claude/.prior_art_events.tsv
+.claude/.prior_art_prompted_*

--- a/scripts/lane_runner_check.sh
+++ b/scripts/lane_runner_check.sh
@@ -270,8 +270,97 @@ fi
 # treats an EMPTY array's expansion as an unbound variable and aborts. DEBT is now empty by design,
 # which is exactly the state the plain form cannot survive — measured here 2026-08-13, and it
 # aborted so early that the script still printed PASS (see the rc routing further down).
+# -- RUNNER SURFACE = THE GIT INDEX, NOT THE WORKING TREE (D-5, 2026-08-24) --------------------
+# An UNTRACKED file must never certify anything as WIRED. Until this fix the RUNNER globs below
+# were resolved against the DISK, so a workflow / hook / script that existed only in this working
+# copy counted as a caller -- and the tree read green on wiring that disappears on `git clone`.
+#
+# The POPULATION globs (what gets CHECKED) stay on DISK on purpose. There an untracked file must
+# be SEEN, so a new uncommitted script goes red instead of slipping through. Only the RUNNER
+# surface moves to the index; moving both would trade one silent pass for another.
+#
+# 🟥 "NOT A REPOSITORY" AND "GIT FAILED" ARE DIFFERENT FACTS AND MUST NOT SHARE A BRANCH.
+# The first draft of this block folded EVERY non-zero `git ls-files` exit into "no index here, use
+# the disk". Cross-family review (codex/gpt-5.5, 2026-08-24) executed the consequence: a fake `git`
+# that exits 1 for everything produced a warning line and then a PASS. A missing binary, a locked
+# or corrupt index, and a permission failure all landed on the SAME branch as an unpacked npm
+# tarball -- so the repair against "green that a clone deletes" had installed a fresh green of its
+# own. That is [[feedback_not_found_is_not_zero_family]] wearing this file's colours, and the
+# asymmetry was backwards: an EMPTY result was routed to UNMEASURED while a FAILED one was routed
+# to a pass.
+#
+# So the state is resolved by POSITIVE questions, in order, and only the answers that are actually
+# established are allowed to reach the disk fallback:
+#   git absent / `git --version` non-zero        -> UNMEASURED  (the instrument, not the tree)
+#   rev-parse fails AND a .git exists up-chain   -> UNMEASURED  (git broke inside a repo)
+#   rev-parse fails AND no .git anywhere up-chain-> nongit      (an unpacked tarball: disk is right)
+#   inside a git dir with no work tree           -> nongit
+#   in a work tree, `git ls-files` non-zero      -> UNMEASURED  (locked/corrupt index, permissions)
+#   in a work tree, ls-files empty, cwd ignored  -> outside-index (a package unpacked INSIDE some
+#                                                   other repo -- the index cannot answer for it,
+#                                                   and blocking every such install would just
+#                                                   train the override)
+#   in a work tree, ls-files empty, cwd tracked  -> UNMEASURED  (an empty index is not zero runners)
+#   otherwise                                    -> index
+# 🟥 The discriminator can itself fail, and when it does the answer is UNMEASURED -- never "not a
+# repository". That is why the .git walk-up exists: it is a filesystem fact that needs no working
+# git, so "git could not tell us" and "there is genuinely nothing here" stay separable.
+#
+# 🟥 `git ls-files` into a file, then `$?` on its OWN line. No pipe, no `|| true`: a fallback would
+# hand an empty list to the scan and the scan would render it as "no runners".
+_fh_has_dotgit_upchain() {
+  local _d; _d="$(pwd -P)"
+  while : ; do
+    [ -e "$_d/.git" ] && return 0
+    [ "$_d" = "/" ] && return 1
+    _d="$(dirname "$_d")"
+  done
+}
+FH_INDEX_STATE="UNMEASURED"; FH_INDEX_WHY="not determined"; FH_INDEX_FILE_LIST=""
+if ! command -v git >/dev/null 2>&1; then
+  FH_INDEX_WHY="git is not on PATH -- the index could not be read at all"
+else
+  _fh_gv="$(git --version 2>/dev/null)"; _fh_gvrc=$?
+  if [ "$_fh_gvrc" -ne 0 ] || [ -z "$_fh_gv" ]; then
+    FH_INDEX_WHY="\`git --version\` exited $_fh_gvrc -- the git binary is unusable, so nothing below was measured"
+  else
+    _fh_wt="$(git rev-parse --is-inside-work-tree 2>/dev/null)"; _fh_wtrc=$?
+    if [ "$_fh_wtrc" -ne 0 ]; then
+      if _fh_has_dotgit_upchain; then
+        FH_INDEX_WHY="git works but \`rev-parse --is-inside-work-tree\` exited $_fh_wtrc while a .git exists above this directory -- git failed, this is not a plain directory"
+      else
+        FH_INDEX_STATE="nongit"; FH_INDEX_WHY="no repository here and no .git anywhere above -- an unpacked tarball"
+      fi
+    elif [ "$_fh_wt" != "true" ]; then
+      FH_INDEX_STATE="nongit"; FH_INDEX_WHY="inside a git dir with no work tree (bare repository)"
+    else
+      # 🟥 NUL ALL THE WAY. An earlier draft piped this through `tr '\0' '\n'` into an env var,
+      # which un-did the whole point of `-z`: a path containing a NEWLINE was split into two paths
+      # before python ever saw it. Env vars cannot carry NUL, so the list travels as a FILE and the
+      # separator is never translated. Cross-family review, 2026-08-24, round 3.
+      _fh_tmp="$(mktemp)"
+      git ls-files -z >"$_fh_tmp" 2>/dev/null
+      _fh_lrc=$?
+      FH_INDEX_FILE_LIST="$_fh_tmp"
+      if [ "$_fh_lrc" -ne 0 ]; then
+        FH_INDEX_WHY="inside a work tree, but \`git ls-files\` exited $_fh_lrc -- a locked or corrupt index, or a permission failure. NOT an absence of runners"
+      elif [ -s "$_fh_tmp" ]; then
+        FH_INDEX_STATE="index"; FH_INDEX_WHY="the git index"
+      else
+        git check-ignore -q . 2>/dev/null; _fh_ci=$?
+        if [ "$_fh_ci" -eq 0 ]; then
+          FH_INDEX_STATE="outside-index"; FH_INDEX_WHY="this directory is IGNORED by the surrounding repository, so its index cannot answer for these files"
+        else
+          FH_INDEX_WHY="\`git ls-files\` exited 0 and returned NOTHING while this directory is tracked territory -- an empty index is not zero runners"
+        fi
+      fi
+    fi
+  fi
+fi
+export FH_INDEX_STATE FH_INDEX_WHY FH_INDEX_FILE_LIST
+
 out=$(python3 - "${#EXEMPT[@]}" "${EXEMPT[@]+"${EXEMPT[@]}"}" "${DEBT[@]+"${DEBT[@]}"}" <<'PY'
-import os, re, sys, glob, json
+import os, re, sys, glob, json, subprocess
 
 n_exempt = int(sys.argv[1])
 exempt = set(sys.argv[2:2 + n_exempt])
@@ -287,13 +376,160 @@ suites = sorted({os.path.basename(f) for f in glob.glob('scripts/*.sh')
 # Runner surfaces, enumerated rather than assumed. All three were checked by hand when this file was
 # written: CI runs `bash scripts/selfcheck.sh` + count_check + the plugin validators and nothing else.
 SELF = os.path.basename(__file__) if '__file__' in dir() else 'lane_runner_check.sh'
-runners = []
-for pat in ('scripts/*.sh', 'templates/.git-hooks/*', '.github/workflows/*.yml'):
-    runners += [p for p in glob.glob(pat) if os.path.isfile(p)]
+RUNNER_GLOBS = ('scripts/*.sh', 'templates/.git-hooks/*', '.github/workflows/*.yml')
+
+# -- INDEX-vs-DISK enumeration, RUNNER surfaces ONLY. State resolved in the bash preamble above. -
+INDEX_MODE = os.environ.get('FH_INDEX_STATE', '')
+INDEX_WHY = os.environ.get('FH_INDEX_WHY', 'the preamble did not run')
+_idx_path = os.environ.get('FH_INDEX_FILE_LIST', '')
+_idx_raw = b''
+if _idx_path:
+    try:
+        _idx_raw = open(_idx_path, 'rb').read()
+    except OSError:
+        _idx_raw = b''
+INDEX_FILES = [_b.decode('utf-8', 'replace') for _b in _idx_raw.split(b'\0') if _b]
+# Fail-closed on anything this file does not recognise, including the empty string a caller that
+# skipped the preamble would leave behind. A mode nobody set is not a mode that means "use disk".
+if INDEX_MODE not in ('index', 'nongit', 'outside-index'):
+    INDEX_MODE = 'UNMEASURED'
+if INDEX_MODE == 'index' and not INDEX_FILES:
+    INDEX_MODE = 'UNMEASURED'
+    INDEX_WHY = 'state said index and the file list is empty -- the two disagree'
+
+def _glob_rx(pat):
+    # glob semantics, NOT fnmatch, and that includes the DOTFILE rule.
+    # `*` -> `[^/]*` alone is WIDER than the `glob.glob()` it replaced: fnmatch translates `*` to
+    # `.*`, which also crosses `/`, and neither form hides dotfiles. `glob.glob('scripts/*.sh')`
+    # does NOT return `scripts/.x.sh`; a regex without the guard below DOES, so a hidden tracked
+    # file would certify a caller that the old surface never contained. Cross-family review,
+    # 2026-08-24. The guard is per SEGMENT and keys on a leading `*`/`?` in that segment -- a dot
+    # in a literal segment (`templates/.git-hooks/`) is a directory name and is unaffected; what
+    # glob hides is a leading dot in the matched BASENAME.
+    _segs = []
+    for _seg in pat.split('/'):
+        _s = ''
+        if _seg[:1] in ('*', '?'):
+            _s += '(?!\\.)'
+        for _c in _seg:
+            _s += '[^/]*' if _c == '*' else '[^/]' if _c == '?' else re.escape(_c)
+        _segs.append(_s)
+    return re.compile('^' + '/'.join(_segs) + '$')
+
+def enumerate_runners(patterns):
+    # index: the candidate runners are what `git ls-files` says is TRACKED.
+    # nongit / outside-index: no index can answer here, so disk is the correct surface -- and the
+    # run says which of the two it is out loud. UNMEASURED never reaches this function.
+    if INDEX_MODE == 'index':
+        # 🟥 NO os.path.isfile HERE. Filtering the INDEX list by what happens to be on disk lets the
+        # working tree decide the population of an index-grounded judgment -- a tracked runner the
+        # worktree has deleted would silently become "not a runner" instead of "read its blob",
+        # which also skips the completeness check below. The index blob exists regardless of the
+        # working tree; that is the whole reason to read it. Cross-family review, round 3.
+        # The disk branch on the next line KEEPS isfile, and so do LOCAL_ONLY_SURFACES: there the
+        # working tree IS the surface, and a name with no file behind it is genuinely nothing.
+        _rx = [_glob_rx(_p) for _p in patterns]
+        return [_p for _p in INDEX_FILES if any(_r.match(_p) for _r in _rx)]
+    return [_p for _pat in patterns for _p in glob.glob(_pat) if os.path.isfile(_p)]
+
+if INDEX_MODE == 'UNMEASURED':
+    print('CONTROL_FAILED\tthe runner surface is UNMEASURED, not zero runners: ' + INDEX_WHY)
+    raise SystemExit(2)
+print('INDEX_MODE\t' + INDEX_MODE + '\t' + INDEX_WHY)
+
+runners = enumerate_runners(RUNNER_GLOBS)
 # This file names every DEBT and EXEMPT suite in its own arrays. Scanning itself would read each of
 # those declarations as evidence the suite is run — the check would certify its own todo list as
 # done. Caught by the known-negative control below on the first execution.
 runners = [r for r in runners if os.path.basename(r) != 'lane_runner_check.sh']
+
+# -- RUNNER CONTENT = THE INDEX BLOB, NOT THE WORKING TREE FILE -------------------------------
+# 🟥 THE OTHER HALF OF D-5. Moving the runner FILE LIST to the index closed "is this runner in the
+# clone"; it did NOT close "does that runner call this lane in the clone". The names came from
+# `git ls-files` while the bodies were still read with `open()`, so ONE UNSTAGED LINE added to an
+# already-tracked runner certified a wiring that exists in nobody's checkout but this one -- the
+# same defect wearing the other half of its face. Cross-family review, 2026-08-24, round 2.
+# Claiming "the surface is index-grounded" while half of it was not is exactly
+# [[feedback_half_fix_propagation_boundary]] / "measured scope != claimed scope".
+#
+# ONE process, not one per runner: there are ~185 runner surfaces here, and `git show` per file
+# would be ~185 forks. `git cat-file --batch` reads them all from one stdin stream.
+#
+# 🟥 EVERY FAILURE PATH IS UNMEASURED, NEVER AN EMPTY BODY. A missing blob, a short read, a
+# non-blob object, a git that will not start -- each of them, read as "" , renders the runner as
+# calling nothing, which is the fold this whole file exists to refuse. They collect in _BLOB_ERR
+# and route to the same UNMEASURED exit as a broken index does.
+# In `nongit` / `outside-index` there is no blob to read and that is already decided policy
+# (protection off, labelled) -- the loader is simply not run, and the disk reader stays in place.
+# No new state value.
+_BLOBS = {}
+_BLOB_ERR = []
+
+def _load_index_blobs(paths):
+    if INDEX_MODE != 'index' or not paths:
+        return
+    # `git cat-file --batch` reads NEWLINE-delimited input, so a path containing one cannot be
+    # asked for safely. Refuse to guess: that is UNMEASURED, not "this runner calls nothing".
+    for _p in paths:
+        if '\n' in _p:
+            _BLOB_ERR.append('a runner path contains a newline and cannot be batched: ' + repr(_p))
+    if _BLOB_ERR:
+        return
+    _inp = ''.join(':' + _p + '\n' for _p in paths)
+    try:
+        _pr = subprocess.run(['git', 'cat-file', '--batch'], input=_inp.encode('utf-8'), stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    except OSError as _e:
+        _BLOB_ERR.append('git cat-file could not be started: ' + str(_e))
+        return
+    if _pr.returncode != 0:
+        _BLOB_ERR.append('git cat-file --batch exited ' + str(_pr.returncode))
+        return
+    _buf = _pr.stdout
+    _pos = 0
+    for _p in paths:
+        _nl = _buf.find(b'\n', _pos)
+        if _nl < 0:
+            _BLOB_ERR.append('git cat-file output ended early at ' + _p)
+            return
+        _hdr = _buf[_pos:_nl].decode('utf-8', 'replace').split()
+        _pos = _nl + 1
+        if len(_hdr) != 3 or _hdr[1] != 'blob':
+            _BLOB_ERR.append('no blob in the index for ' + _p + ': ' + ' '.join(_hdr))
+            return
+        _sz = int(_hdr[2])
+        _end = _pos + _sz
+        if _end > len(_buf):
+            _BLOB_ERR.append('git cat-file returned a short body for ' + _p)
+            return
+        _BLOBS[_p] = _buf[_pos:_end].decode('utf-8', 'replace')
+        _pos = _end + 1
+    # Completeness, checked rather than assumed, and INSIDE the loader so that the loader is a
+    # single switch: this is what makes the disk fallback in read_runner unreachable for a runner
+    # in index mode. Without it a silently missing key would fall through to the working tree and
+    # rebuild the defect one path at a time.
+    for _p in paths:
+        if _p not in _BLOBS:
+            _BLOB_ERR.append('the index blob for ' + _p + ' was never read')
+
+_load_index_blobs(runners)
+
+def _read_disk(path):
+    try:
+        return open(path, encoding='utf-8', errors='replace').read()
+    except OSError:
+        return ''
+
+def read_runner(path):
+    # index mode: every runner is in _BLOBS (asserted above), so the disk branch is reachable only
+    # for surfaces that are deliberately NOT index-backed -- the gitignored local settings file --
+    # and for the nongit / outside-index states.
+    if path in _BLOBS:
+        return _BLOBS[path]
+    return _read_disk(path)
+
+if _BLOB_ERR:
+    print('CONTROL_FAILED\tthe runner CONTENT is UNMEASURED, not empty: ' + ' - '.join(_BLOB_ERR))
+    raise SystemExit(2)
 
 # An invocation is `bash <path-ending-in-suite>`, not a mention of the name. The bounded `.{0,60}?`
 # spans wrappers like `exec bash "$(dirname "$0")/x.sh"` (which contains a space inside the command
@@ -314,10 +550,7 @@ def has_runner(suite):
     for r in runners:
         if os.path.basename(r) == suite:
             continue
-        try:
-            txt = open(r, encoding='utf-8', errors='replace').read()
-        except OSError:
-            continue
+        txt = read_runner(r)
         if runner_dispatches(suite, txt):
             return True
     return False
@@ -470,7 +703,7 @@ def has_selftest_runner(bare_name):
     # added at the same time and for the same reason — without it this line is a repair no control
     # drives, which is the failure mode this file exists to name.
     _own = bare_name + '.sh'
-    return any(selftest_dispatched(bare_name, _read(r)) for r in runners if os.path.basename(r) != _own)
+    return any(selftest_dispatched(bare_name, read_runner(r)) for r in runners if os.path.basename(r) != _own)
 
 selftest_wired = {s for s in selftest_subjects if has_selftest_runner(s)}
 selftest_undeclared = sorted(s for s in selftest_subjects if s not in selftest_wired)
@@ -602,6 +835,7 @@ for s in selftest_undeclared:
 PY
 )
 rc=$?
+[ -n "${FH_INDEX_FILE_LIST:-}" ] && rm -f "$FH_INDEX_FILE_LIST"
 
 if [ "$rc" -eq 2 ]; then
   echo "FAIL  lane-runner: the instrument broke, it did not pass"
@@ -687,6 +921,20 @@ if [ -n "$SELFTEST_UNDECLARED" ]; then
   echo "    substring match. Require the terminal verdict AS A WHOLE LINE, with a non-zero count"
   echo "    in it, or exit 0 will certify a suite that ran nothing."
 fi
+
+INDEX_MODE=$(printf '%s\n' "$out" | awk -F'\t' '$1=="INDEX_MODE"{print $2}')
+INDEX_WHY=$(printf '%s\n' "$out" | awk -F'\t' '$1=="INDEX_MODE"{print $3}')
+# Labelled, never silent, and the two disk-fallback states are NOT merged. `nongit` is an
+# unpacked tarball; `outside-index` is this tree sitting inside some OTHER repo that ignores it.
+# Both are correct places to read the disk, and neither may appear inside a normal checkout --
+# if one does, the WIRED count is not index-grounded and the reader has to know that.
+case "$INDEX_MODE" in
+  nongit|outside-index)
+    echo "⚠️  lane-runner: runner surface enumerated from DISK, not the index ($INDEX_MODE)."
+    echo "    $INDEX_WHY"
+    echo "    Correct outside a checkout; WRONG inside one. It is not zero runners either way."
+    ;;
+esac
 
 echo "PASS  lane-runner: ${TOTAL} suites — ${WIRED} wired · ${N_EXEMPT} exempt · ${N_DEBT} declared debt" \
      "· self-test: ${ST_WIRED}/${ST_TOTAL} wired"

--- a/scripts/new_code_anchor_check.sh
+++ b/scripts/new_code_anchor_check.sh
@@ -1,0 +1,726 @@
+#!/usr/bin/env bash
+# new_code_anchor_check.sh — a NEWLY ADDED executable must not ship with zero lanes exercising it.
+#
+# provenance: transplanted 2026-08-22 from qasp's `new-code-anchor` CI job via the door-④ synergy
+#   scan (`tracks/_meta/synergy_scan_2026-08-22.md`, pair T3). Origin incident there: 123 tests
+#   green, and not one of them touched the file the PR added. The aggregate was green; the new file
+#   was unmeasured. FH has named that failure class for itself ever since
+#   [[feedback_anchor_can_be_decorative]] — «앵커가 장식일 수 있다» — but had no gate on it.
+#   The outward pass (Step 3-c) found the mainstream name for the shape: **diff / patch coverage**.
+#   This is that pattern, spelled for a shell-centric repo where "test" means a lane suite.
+#
+# ── WHAT THIS IS NOT — the bookshelf, checked before building (no-reinvention) ────────────────
+#   scripts/lane_runner_check.sh   asks the INVERSE question: "does anything RUN this lane suite?"
+#       (subject = the lane; it globs `test_*.sh` / `*_lanes.sh` and looks for a runner). A brand
+#       new `scripts/foo.sh` with no lane at all is invisible to it — there is no suite to be
+#       unwired. The two checks are mirror images and neither substitutes for the other.
+#   scripts/selfcheck.sh           carries a `subject|anchor` pair table — the right DIRECTION, but
+#       HAND-CURATED. Adding a new script does not add a row, so nothing goes red. This check is
+#       what makes that table's omissions visible; it does not replace it.
+#   scripts/package_coverage_check.sh  is SHIPPING coverage (does a referenced path make the
+#       tarball), not test coverage.
+#   scripts/gate_anchor_check.sh   is a known-pair harness for the git HOOKS specifically.
+#   .github/workflows/regression-guard.yml  is Axis 1, `paths:`-filtered to docs/rules.
+#   ⇒ Nothing in the repo asked "is this NEW executable exercised by anything". That is the hole.
+#
+# ── THE TRAP THIS FILE IS BUILT AROUND: anchor EXISTENCE ≠ anchor OPERATION ───────────────────
+# The cheap version of this check greps the lane corpus for the new file's name and passes on a
+# hit. That version certifies its own decoration: a name inside a comment, inside a grep PATTERN,
+# inside an echoed string, or inside `bash -n` (a SYNTAX check — this repo has measured that
+# `bash -n` passes a runtime bad-substitution that leaves the gate fail-open,
+# [[feedback_gate_verification_must_execute]]) all satisfy "the name appears" and none of them
+# execute one line of the subject. So a mention is reported as its own verdict, MENTION_ONLY, and
+# MENTION_ONLY BLOCKS — loudly, and by a different name than "no anchor at all", because the two
+# send a reader to different places.
+# 🟥 HONEST CEILING, stated here rather than implied: this scans LINES, it does not parse shell.
+# See §NAMED RESIDUALS at the bottom. It is strictly stronger than a name grep and strictly weaker
+# than execution tracing, and it says so instead of claiming the strong form.
+#
+# ── SCOPE: the diff, not the repo ────────────────────────────────────────────────────────────
+# Only files ADDED between the base ref and HEAD are in scope. Everything already in the tree is
+# grandfathered on purpose: a gate that opens red on 80 pre-existing files is not a strict gate,
+# it is a bypass trainer (this repo has logged that trade — [[feedback_overblock_traded_for_failopen]]).
+#
+# Usage:  bash scripts/new_code_anchor_check.sh [--list-exempt]
+# Env:    NEW_CODE_ANCHOR_BASE=<ref|sha>   base to diff against (CI passes the PR base sha)
+#         NEW_CODE_ANCHOR_OK=1             explicit, LOGGED operator override
+# Exit:   0 = every added in-scope file is anchored, exempt, or there were none
+#         1 = an added file ships with no working anchor (NO_ANCHOR or MENTION_ONLY)
+#        10 = the instrument could not measure (no resolvable base, git unavailable, no python3).
+#             10 IS NOT A PASS. Unmeasured is not zero — [[feedback_not_found_is_not_zero_family]].
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT" || exit 10
+
+# ── EXEMPT — an added file that legitimately CANNOT have a lane, with the reason ──────────────
+# Same discipline as package_coverage_check.sh's ACCEPTED_ABSENT and lane_runner_check.sh's EXEMPT:
+# if you cannot write the sentence, the file probably needs a lane instead of an entry here. The
+# array lives in the CHECKER, not in the exempted file, on purpose — a self-declared exemption is
+# a permission slip the beneficiary writes ([[feedback_declared_side_effect_is_unverified]]);
+# putting it here forces the exemption into the checker's own diff, where a reviewer meets it.
+#
+# 🟥 FORMAT IS `path|reason`, AND THE REASON IS ENFORCED, NOT REQUESTED.
+# The first version of this array was a bare string set whose comment said "with the reason" — the
+# reason had no channel to live in, so the very first user would have satisfied a documented bar by
+# typing a path, and the gate's own lane suite asserted a pass on an entry labelled "with a reason"
+# that carried none. That is a rule lying about its own machinery
+# ([[feedback_rule_misdescribes_its_own_machine]]), and it was found by cross-family review
+# (codex, 2026-08-22), not here. A malformed entry now REFUSES to run — exit 10, HARNESS ERROR —
+# rather than blocking or passing the code, because a checker configured wrong is not evidence in
+# either direction ([[feedback_not_found_is_not_zero_family]]).
+#   "scripts/foo.sh|generated by build.sh; running it rewrites the tree"     ← valid
+#   "scripts/foo.sh"            ← refused, no reason channel used
+#   "scripts/foo.sh|n/a"        ← refused, vacuous (MIN_REASON_CHARS below)
+#   "foo.sh|<any reason>"       ← refused, BARE BASENAME (see below)
+#
+# 🟥 THE PATH IS A REPO-RELATIVE PATH, NOT A BASENAME — AND THAT IS ENFORCED (codex, 2026-08-22).
+# The first version matched `subj in exempt or name in exempt`, so a bare-basename entry exempted
+# EVERY file with that name in any directory: with `"fixture_subject.sh|<reason>"` declared, a newly
+# added `scripts/nested/fixture_subject.sh` with zero anchors — and an EMPTY lane corpus — exited 0
+# (reproduced here before the fix). That is a false PASS on a blocking gate reached by writing one
+# plausible-looking config line.
+# It was also DIVERGENT LENIENCY against the sibling gate: scripts/script_caller_ratchet.sh matches
+# `path in exempt` exactly and additionally reports ghost entries, so one and the same file was
+# exempt here and blocked there ([[feedback_divergent_leniency_duplicate_normalizers]] — two
+# normalizers for one judgment means the input that only one of them accepts drops silently).
+# A basename entry is now REFUSED (exit 10) rather than ignored: with the leniency removed it would
+# otherwise become an inert line that the author reads as an active exemption.
+#
+# 🟥 WHICH HALF IS LOAD-BEARING — MEASURED BY REVERT PROBE, NOT ASSERTED. Two guards went in
+# (exact-path matching at the classify site, and the refusal here), and reverting them one at a time
+# says they are not equals:
+#   · revert BOTH                      → lane X3 exits 0 — the original false PASS is back
+#   · revert only the FATAL            → X3 exits 1: the file is correctly blocked, but the reader is
+#                                        told "add a lane" about a config line that is the real fault
+#   · revert only `name in exempt`     → NO lane changes (42/42 either way)
+# So exact-path matching is what closes the false PASS, the refusal is what makes the diagnosis
+# right, and the `or name in exempt` removal is unreachable belt-and-braces once the refusal stands —
+# no lane can distinguish it, and this comment says so rather than letting a future reader assume the
+# green covers it ([[feedback_anchor_can_be_decorative]]).
+# The 12-character floor matches the sibling gate scripts/script_caller_ratchet.sh, deliberately:
+# two thresholds for the same judgment in one repo is a coin-flip for whoever writes the next entry.
+#
+# EMPTY AT SHIP, and that is a measurement, not an oversight: this gate is diff-scoped, so on the
+# commit that introduces it the in-scope set is only the files that commit adds.
+EXEMPT=(
+)
+
+if [ "${1:-}" = "--list-exempt" ]; then
+  printf '%s\n' "${EXEMPT[@]+"${EXEMPT[@]}"}"
+  exit 0
+fi
+
+command -v git     >/dev/null 2>&1 || { echo "⛔ UNMEASURED: git not available"; exit 10; }
+command -v python3 >/dev/null 2>&1 || { echo "⛔ UNMEASURED: python3 not available"; exit 10; }
+git rev-parse --git-dir >/dev/null 2>&1 || { echo "⛔ UNMEASURED: not inside a git work tree"; exit 10; }
+
+# ── BASE RESOLUTION — and the failure arm is 10, never "assume nothing was added" ─────────────
+# An unresolvable base yields an EMPTY added-file set from `git diff`, which is byte-identical to
+# "this change added nothing". Folding those together is the single most dangerous thing this
+# script could do: every future PR would pass for the reason that the instrument was blind.
+BASE=""
+_base_src=""
+if [ -n "${NEW_CODE_ANCHOR_BASE:-}" ]; then
+  if git rev-parse --verify --quiet "${NEW_CODE_ANCHOR_BASE}^{commit}" >/dev/null; then
+    BASE="$NEW_CODE_ANCHOR_BASE"; _base_src="NEW_CODE_ANCHOR_BASE"
+  else
+    echo "⛔ UNMEASURED: NEW_CODE_ANCHOR_BASE='${NEW_CODE_ANCHOR_BASE}' does not resolve to a commit."
+    echo "   Refusing to fall back to a default base — a silently-substituted base measures a"
+    echo "   different change than the one you asked about."
+    exit 10
+  fi
+else
+  for _cand in origin/main main origin/master master; do
+    if git rev-parse --verify --quiet "${_cand}^{commit}" >/dev/null; then
+      BASE="$_cand"; _base_src="auto:${_cand}"; break
+    fi
+  done
+fi
+if [ -z "$BASE" ]; then
+  echo "⛔ UNMEASURED: no base ref resolved (tried NEW_CODE_ANCHOR_BASE, origin/main, main,"
+  echo "   origin/master, master). Set NEW_CODE_ANCHOR_BASE=<ref> explicitly."
+  echo "   This is exit 10, NOT a pass: an unresolvable base and an empty diff look identical."
+  exit 10
+fi
+
+# merge-base, so a stale local main does not report every commit on main since your branch as
+# "added by you". `--fork-point` is deliberately NOT used — it consults the reflog, which is empty
+# on a CI checkout, so it answers differently on the two surfaces this gate runs on.
+MB="$(git merge-base "$BASE" HEAD 2>/dev/null || true)"
+if [ -z "$MB" ]; then
+  echo "⛔ UNMEASURED: no merge-base between '$BASE' and HEAD (unrelated histories / shallow clone)."
+  echo "   On CI use actions/checkout with fetch-depth: 0."
+  exit 10
+fi
+
+ADDED="$(git diff --diff-filter=A --name-only "$MB" HEAD 2>/dev/null)"
+_diff_rc=$?
+if [ "$_diff_rc" -ne 0 ]; then
+  echo "⛔ UNMEASURED: git diff failed (rc=$_diff_rc) against base '$BASE' ($MB)."
+  exit 10
+fi
+
+# ── THE SCAN ─────────────────────────────────────────────────────────────────────────────────
+# python3, not grep, and that is a portability decision with a measured precedent in this repo:
+# a BRE `\t` means a literal `t` to GNU grep and a tab to BSD grep, which made a sibling check's
+# fail-closed arm silently dead on the platform that gates merges (lane_runner_check.sh, 2026-08-13).
+# This gate must answer identically on macOS (BSD, where it is authored) and Linux (GNU, where CI
+# runs it), so the predicate lives somewhere that has one spelling.
+#
+# 🟥 THE HEREDOC BELOW IS **NOT** INSIDE A COMMAND SUBSTITUTION, AND THAT IS LOAD-BEARING.
+# Measured here 2026-08-22 while writing this file: with the scan written as
+# `out="$(... <<'PY' ... PY)"`, bash's close-paren-matching scan for the `$( )` wrapper is not
+# fully heredoc-blind, so an ordinary unbalanced paren inside a PYTHON COMMENT broke the parse of
+# the whole file — `bash -n` reported the failure ~270 lines later at an unrelated-looking spot.
+# scripts/lane_runner_check.sh carries a paragraph on the identical trap (2026-08-14), which is
+# how it was diagnosed in one step instead of by bisection. Redirecting to a temp file instead of
+# capturing means no wrapper is scanning for a paren, so python comments can contain whatever they
+# need to. Do not "simplify" this back into a `$(...)`.
+#
+# 🟥 THE FILE LIST GOES THROUGH THE ENVIRONMENT, NOT THROUGH A PIPE. `python3 -` reads the PROGRAM
+# from stdin, so `printf … | python3 - <<'PY'` hands python the heredoc and leaves `sys.stdin.read()`
+# empty — the scan then sees ZERO added files and prints a confident green. Measured here
+# 2026-08-22: every known-positive lane passed the exit code but reported "added in scope: 0",
+# i.e. the instrument was dead in the PASS direction while looking perfectly healthy. The lanes
+# caught it because they assert the VERDICT LABEL and not only the exit code — asserting rc alone
+# would have shipped this ([[feedback_broken_parser_reports_a_verdict]]).
+_scan_out="$(mktemp 2>/dev/null)" || { echo "⛔ UNMEASURED: mktemp failed"; exit 10; }
+NCA_ADDED="$ADDED" python3 - "${EXEMPT[@]+"${EXEMPT[@]}"}" > "$_scan_out" <<'PY'
+import os, re, sys, glob
+
+MIN_REASON_CHARS = 12
+
+# ── EXEMPT PARSING — a malformed entry stops the run, it does not degrade to "not exempt" ──────
+# Degrading to "not exempt" would look safe (the file blocks) and would be wrong for the reader:
+# the author WOULD see a red gate, would read it as "my lane is missing", and would go add a
+# decoration instead of fixing the entry. Refusing names the actual fault.
+exempt = set()
+_bad_exempt = []
+for _e in sys.argv[1:]:
+    if '|' not in _e:
+        _bad_exempt.append((_e, 'no `|reason` — the entry names a path and no reason at all'))
+        continue
+    _p, _r = _e.split('|', 1)
+    _p, _r = _p.strip(), _r.strip()
+    if not _p:
+        _bad_exempt.append((_e, 'empty path'))
+    elif '/' not in _p:
+        _bad_exempt.append((_e, 'bare basename — EXEMPT takes a repo-relative PATH. A basename '
+                                'would exempt every file with that name in ANY directory, and the '
+                                'sibling gate script_caller_ratchet.sh would still block it'))
+    elif len(_r) < MIN_REASON_CHARS:
+        _bad_exempt.append((_e, 'reason is %d chars, under the %d-char floor — write the sentence'
+                                % (len(_r), MIN_REASON_CHARS)))
+    else:
+        exempt.add(_p)
+if _bad_exempt:
+    for _e, _why in _bad_exempt:
+        print('FATAL_EXEMPT\t%s\t%s' % (_e, _why))
+    sys.exit(4)
+
+if 'NCA_ADDED' not in os.environ:
+    # Fail LOUD, never silently empty. An absent variable and an empty change set are the same
+    # bytes to `.get(…, '')`, and the empty one prints a green.
+    print('FATAL\tNCA_ADDED unset — the file list never reached the scan')
+    sys.exit(3)
+added = [l.strip() for l in os.environ['NCA_ADDED'].split('\n') if l.strip()]
+
+LANE_NAME = re.compile(r'^(test_.*|.*_lanes)\.(sh|py)$')
+
+def is_lane(path):
+    return LANE_NAME.match(os.path.basename(path)) is not None
+
+# ── IN-SCOPE: what counts as "code" for this repo ─────────────────────────────────────────────
+# Shell and python under scripts/, plus the git hooks in templates/. Deliberately NOT every
+# executable in the tree: a scope claim wider than what the anchor corpus can actually cover would
+# report coverage it does not have. Anything outside is reported as OUT_OF_SCOPE, by name, so a
+# reader can see what the gate declined to judge rather than inferring a clean sheet from silence.
+def in_scope(path):
+    if is_lane(path):
+        return False          # a lane IS an anchor; whether anything runs IT is lane_runner_check's question
+    if path.startswith('scripts/') and path.endswith(('.sh', '.py')):
+        return True
+    if path.startswith('templates/.git-hooks/'):
+        return True
+    return False
+
+subjects = [p for p in added if in_scope(p)]
+skipped  = [p for p in added if not in_scope(p)]
+
+# ── ANCHOR CORPUS ─────────────────────────────────────────────────────────────────────────────
+lanes = sorted({p for p in glob.glob('scripts/**/*.sh', recursive=True) if is_lane(p)} |
+               {p for p in glob.glob('scripts/**/*.py', recursive=True) if is_lane(p)})
+
+# Runner surfaces — the same three lane_runner_check.sh enumerates, and enumerated for the same
+# reason: they were checked by hand rather than assumed.
+# 🟥 BOTH WORKFLOW SPELLINGS. GitHub accepts `.yml` and `.yaml`; this repo happens to use only
+# `.yml`, which is exactly the condition under which the omission stays invisible here and blocks
+# somebody else's PR ([[feedback_candidate_list_completeness]] — "we can't tell them apart" is not
+# the same claim as "the candidate list is complete"). Found by cross-family review (agy, 2026-08-22).
+runner_surfaces = []
+for pat in ('scripts/*.sh', 'templates/.git-hooks/*',
+            '.github/workflows/*.yml', '.github/workflows/*.yaml'):
+    runner_surfaces += [p for p in glob.glob(pat) if os.path.isfile(p)]
+
+def read(path):
+    try:
+        return open(path, encoding='utf-8', errors='replace').read()
+    except OSError:
+        return ''
+
+# ── DEAD BRANCHES — a dispatch that provably never runs is not an anchor ──────────────────────
+# 🟥 CROSS-FAMILY FINDING (codex, 2026-08-22). A lane containing
+#     CHECK="scripts/foo.sh"; if false; then bash "$CHECK"; fi
+# scored `EXECUTED(via var)` and exited 0. The subject runs ZERO times. Reproduced here before the
+# fix in THREE spellings, not the one reported — the multi-line `if false` block, the one-liner, and
+# the DIRECT form `if false; then bash scripts/foo.sh; fi`, which has the identical hole and was not
+# in the report. Fixing only the arm that was demonstrated would have left the twin open
+# ([[feedback_half_fix_propagation_boundary]]), so the mask is applied to every predicate at once
+# rather than inside the variable resolver.
+#
+# 🟥 THE PREDICATE IS "SYNTACTICALLY CONSTANT-FALSE", NOT "CONDITIONAL", AND THE DIFFERENCE IS THE
+# WHOLE DESIGN. `if [ -f "$CHECK" ]; then bash "$CHECK"; fi` is an ordinary, correct guard and the
+# commonest real spelling in this repo's own lanes; treating every guarded dispatch as unproven
+# would block most legitimate anchors and train the override into muscle memory, which is how the
+# channel gets disarmed ([[feedback_overblock_traded_for_failopen]]). So only a condition that is a
+# literal constant — `false`, `[ 1 -eq 0 ]` and its spellings — is judged dead. That is decidable by
+# reading the line; anything requiring a value is not, and is deliberately left live (see residual 3c).
+#
+# EVERY AMBIGUITY RESOLVES TOWARD *LIVE*, i.e. toward the current behaviour, never toward a new
+# block: a nested block inside the branch body abandons the marking entirely, and an `else` arm
+# (one-line or multi-line) leaves the construct untouched because that arm does run.
+_FALSE_COND = (r'(?:false'
+               r'|\[\[?\s*1\s*-eq\s*0\s*\]\]?'
+               r'|\[\[?\s*0\s*-eq\s*1\s*\]\]?'
+               r'|\[\[?\s*0\s*-ne\s*0\s*\]\]?)')
+# One-liner, at ANY position on the line — `CHECK=x.sh; if false; then bash "$CHECK"; fi` does not
+# start with `if`, and anchoring at line start is exactly how the first draft of this fix missed it.
+_DEAD_INLINE = re.compile(
+    r'((?:^|[;&|]\s*)(?:if|while)\s+' + _FALSE_COND + r'\s*;\s*(?:then|do)\b)(.*?)(;\s*(?:fi|done)\b)')
+# Multi-line opener: nothing but `then`/`do` after the constant, since every closed-on-one-line form
+# is already handled above.
+_DEAD_OPEN  = re.compile(r'^\s*(?:if|while)\s+' + _FALSE_COND + r'\s*;?\s*(?:then|do)\s*$')
+_BLOCK_OPEN = re.compile(r'(?:^|[;&|]\s*|\bthen\s+|\bdo\s+)(?:if|while|until|for|case)\b')
+_BLOCK_END  = re.compile(r'^\s*(?:fi|done|esac|else\b|elif\b)')
+
+def _scrub_inline(ln):
+    def rep(m):
+        if re.search(r'(?:^|[;&\s])(?:else|elif)\b', m.group(2)):
+            return m.group(0)          # the else arm is live — leave the line alone
+        return m.group(1) + ' ' + m.group(3)
+    return _DEAD_INLINE.sub(rep, ln)
+
+def live_text(txt):
+    """`txt` with the bodies of provably-dead branches blanked. Line COUNT and line INDICES are
+    preserved, because assigned_then_invoked() reasons about `after` and `before the next
+    assignment` by index — collapsing the lines would silently re-order that analysis."""
+    lines = [_scrub_inline(l) for l in txt.split('\n')]
+    n = len(lines)
+    mask = [False] * n
+    i = 0
+    while i < n:
+        if not _DEAD_OPEN.match(lines[i]):
+            i += 1
+            continue
+        j, body, closed = i + 1, [], False
+        while j < n:
+            if _BLOCK_END.match(lines[j]):
+                closed = True
+                break
+            if _BLOCK_OPEN.search(lines[j]):
+                break              # nested block — abandon, mark nothing, stay live
+            body.append(j)
+            j += 1
+        if closed:
+            mask[i] = True
+            for b in body:
+                mask[b] = True
+            i = j + 1
+        else:
+            i += 1
+    return '\n'.join('' if mask[k] else lines[k] for k in range(n))
+
+# ── THE EXECUTION PREDICATE — the whole point of the file ─────────────────────────────────────
+# A line EXECUTES the subject if it invokes it. It does NOT execute the subject if it merely names
+# it. The four spellings that make a naive grep certify a decoration are each excluded by name:
+#
+#   1. line comment            `# scripts/foo.sh does the thing`
+#   2. syntax check            `bash -n scripts/foo.sh`    ← runs zero lines of foo.sh
+#   3. grep / search pattern   `grep -q 'scripts/foo.sh' scripts/selfcheck.sh`
+#   4. echoed prose            `echo "next: bash scripts/foo.sh"`
+#
+# 🟥 (2) is the sharpest and is the one this repo has already been burned by: `bash -n` passes a
+# runtime bad-substitution, so a hook in that state ABORTS and exits 0 — every push allowed. A
+# check that scored `bash -n` as coverage would be certifying the exact instrument this repo
+# already ruled is not one.
+#
+# The `-n` exclusion is spelled as "any short-flag cluster containing n", not as the literal
+# `-n`, because `bash -en`, `bash -nu` and `sh -n` are the same non-execution.
+INVOKERS = r'(?:exec\s+)?(?:bash|sh|zsh|python3?|source|\.)'
+FLAGS    = r'(?:\s+-[A-Za-z]+)*'
+
+# ── 🟥 THE NAME IS A TOKEN, NOT A SUBSTRING ───────────────────────────────────────────────────
+# `re.escape(name)` alone matched `foo.sh` inside `foo.sh.bak`, `foo.sh2` and `xfoo.sh`, so a lane
+# that runs a NEIGHBOURING file scored the subject EXECUTED and the gate exited 0 — a false PASS on
+# a blocking gate, found by cross-family review (codex, 2026-08-22), not by the then-green 17-lane
+# known-pair set ([[feedback_control_presence_is_not_discrimination]]).
+#
+# The boundary is spelled as "not adjacent to a word char, dot or dash" rather than "followed by
+# whitespace", and the difference is the whole repair: whitespace would have rejected the two
+# commonest real spellings, `bash "…/foo.sh"` and `$(bash …/foo.sh)`, turning a false-pass into a
+# false-block. Both directions are pinned by lanes (P10–P12 positive, N13–N14 negative).
+def _name_pat(name):
+    return r'(?<![\w.-])' + re.escape(name) + r'(?![\w.-])'
+
+def mentions(name, text):
+    return re.search(_name_pat(name), text) is not None
+
+def _flags_have_n(seg):
+    return any('n' in f for f in re.findall(r'-([A-Za-z]+)', seg))
+
+def executes(name, line):
+    """Does THIS line run the subject? `name` is the basename; the path may be spelled with any
+    prefix (scripts/, $REPO_ROOT/scripts/, ./scripts/, "$ROOT"/scripts/)."""
+    stripped = line.strip()
+    if stripped.startswith('#'):
+        return False                                  # (1)
+    npat = _name_pat(name)
+    if not re.search(npat, line):
+        return False
+    # (4) echoed prose — the name lives inside an echo/printf argument
+    if re.search(r'\b(?:echo|printf)\b[^;&|]*' + npat, line):
+        return False
+    # (3) the name is the ARGUMENT of a search tool, i.e. a pattern, not a command
+    if re.search(r'\b(?:grep|egrep|fgrep|rg|ag|sed|awk)\b[^;&|]*' + npat, line):
+        return False
+    # (2) + the direct invocation form
+    for m in re.finditer(INVOKERS + r'(' + FLAGS + r')\s+[^\s;&|]{0,80}?' + npat, line):
+        if _flags_have_n(m.group(1)):
+            continue                                  # (2) syntax check only
+        return True
+    # command-position form:  ./scripts/foo.sh   |   "$ROOT/scripts/foo.sh" --flag
+    if re.search(r'(?:^|[;&|]|\$\(|\bthen\b|\bdo\b|\bif\s+!?\s*)\s*"?\$?[\w{}/$.-]*' +
+                 npat + r'"?(?:\s|$|")', line):
+        return True
+    return False
+
+# ── ASSIGNED, THEN INVOKED — the spelling nearly every real lane in this repo uses ────────────
+#     CHECK="$ROOT/scripts/foo.sh"
+#     ...
+#     bash "$CHECK" --quiet
+# 🟥 THIS WAS A MEASURED FALSE POSITIVE, not a foreseen case. The first version of this file had
+# only the direct and heuristic-list predicates, and on its first run against real work in progress
+# it called a peer's freshly-written lane suite MENTION_ONLY — a suite that does execute its
+# subject, through exactly this two-line form. Hand-checking that one case is what found it
+# (CLAUDE.md §Instrument-Calibration, hand-verify-one-sample); the 17-lane known-pair set was green
+# and could not have found it, because every fixture in it used a spelling the predicate already
+# knew ([[feedback_control_presence_is_not_discrimination]] — a control measures whether there are
+# false positives, not which KINDS exist).
+#
+# This resolves the variable rather than guessing: the assignment must name the subject AND that
+# same variable must be invoked. The `-n` exclusion is applied at the invocation site too, so
+# `CHECK=…; bash -n "$CHECK"` is still MENTION_ONLY — a syntax check does not become an execution
+# by being routed through a variable.
+#
+# 🟥 REASSIGNMENT IS RESOLVED, NOT DOCUMENTED AWAY (codex, 2026-08-22). The first version asked
+# "does SOME line assign it and SOME line invoke that variable", with a residual note calling the
+# result "flow-insensitive". It was worse than imprecise: on
+#     CHECK="scripts/foo.sh"; CHECK="scripts/bar.sh"; bash "$CHECK"
+# it scored foo.sh — a file that runs zero times — as EXECUTED and exited 0. An imprecision that
+# manufactures a false PASS on a blocking gate is a hole; writing the ceiling down does not close
+# it, and "I declared the limitation" is not a reason to pass a file with no anchor.
+#
+# What replaces it is a REACHING-DEFINITION check over line order: an assignment that names the
+# subject counts only if the variable is invoked AFTER it and BEFORE the next assignment to that
+# same variable. That is what makes both twins land correctly, which a blunter fix does not:
+#   P9  assign foo → reassign bar → invoke   ⇒ foo never reaches the invocation  → MENTION_ONLY
+#   N11 assign foo → reassign foo → invoke   ⇒ still reaches                     → EXECUTED
+#   N12 assign foo → invoke → assign bar → invoke ⇒ foo reaches its own invoke   → EXECUTED
+# "any reassignment ⇒ MENTION_ONLY" fails N11+N12 and "last assignment wins" fails N12 — both would
+# be false blocks, which is not the safe direction here ([[feedback_overblock_traded_for_failopen]]).
+def assigned_then_invoked(name, txt):
+    npat = _name_pat(name)
+    ASSIGN = re.compile(
+        r'\s*(?:local\s+|export\s+|declare\s+(?:-\w+\s+)?|readonly\s+)?([A-Za-z_]\w*)=')
+    # (index, text, assignment-match-or-None) for every non-comment line, index preserved so
+    # "after" and "before the next assignment" are answerable at all.
+    body = []
+    for i, ln in enumerate(txt.split('\n')):
+        if ln.strip().startswith('#'):
+            continue
+        body.append((i, ln, ASSIGN.match(ln)))
+
+    assigns = {}       # var -> [(line index, does this assignment name the subject, match end)]
+    for i, ln, m in body:
+        if m:
+            assigns.setdefault(m.group(1), []).append(
+                (i, re.search(npat, ln) is not None, m.end()))
+
+    def invoked_in(seg, v):
+        ref = r'"?\$\{?' + re.escape(v) + r'\}?"?'
+        for m in re.finditer(INVOKERS + r'(' + FLAGS + r')\s+' + ref, seg):
+            if not _flags_have_n(m.group(1)):
+                return True
+        return re.search(r'(?:^|[;&|]|\$\(|\bthen\b|\bdo\b|\bif\s+!?\s*)\s*' + ref + r'(?:\s|$)',
+                         seg) is not None
+
+    for v, alist in assigns.items():
+        for pos, (i, names_subject, end) in enumerate(alist):
+            if not names_subject:
+                continue
+            nxt = alist[pos + 1][0] if pos + 1 < len(alist) else None
+            # the remainder of the assignment's OWN line first: `CHECK=x.sh; bash "$CHECK"`
+            own = [ln for (j, ln, _m) in body if j == i]
+            if own and invoked_in(own[0][end:], v):
+                return True
+            for j, ln, _m in body:
+                if j <= i:
+                    continue
+                if nxt is not None and j >= nxt:
+                    break
+                if invoked_in(ln, v):
+                    return True
+    return False
+
+# INDIRECT dispatch: `for f in scripts/a.sh scripts/b.sh; do bash "$f"; done`. The literal name is
+# in a list; the invocation goes through a variable, so the direct predicate structurally cannot
+# see it. Mirrors lane_runner_check.sh's `indirect_dispatch`, including its gate — the file must
+# actually invoke SOMETHING through a variable, so a prose mention in a file that never dispatches
+# indirectly gets no free pass. Reported under its own label so it is never mistaken for a
+# hand-verified direct call.
+def indirect(name, txt):
+    lines = txt.split('\n')
+    if not any(re.search(r'\b(?:exec\s+)?(?:bash|sh|zsh|python3?)\s+"?\$', ln)
+               for ln in lines if not ln.strip().startswith('#')):
+        return False
+    for ln in lines:
+        if not mentions(name, ln) or ln.strip().startswith('#'):
+            continue
+        if re.match(r'\s*(?:for\s+\w+\s+in\b|["\']?\S*\|)', ln):
+            return True
+        if re.match(r'\s*"?[\w./$-]*' + re.escape(name) + r'"?\s*$', ln):   # bare array element
+            return True
+    return False
+
+# ── EMBEDDED --self-test: an anchor that is not a separate file ───────────────────────────────
+# A subject may carry its own known-pair behind `--self-test`. That counts as an anchor ONLY if a
+# runner surface actually dispatches it — otherwise it is a lane suite nobody runs, which is
+# precisely the decoration this whole check is about. Two propositions, kept separate.
+_CP = chr(41)
+SELFTEST_FORMS = ('"--self-test"', '--self-test' + _CP)
+
+def selftest_wired(path):
+    txt = read(path)
+    if not any(f in txt for f in SELFTEST_FORMS):
+        return False
+    name = os.path.basename(path)
+    for r in runner_surfaces:
+        if os.path.abspath(r) == os.path.abspath(path):
+            continue
+        rt = live_text(read(r))     # a --self-test dispatch inside `if false` is not a dispatch
+        for ln in rt.split('\n'):
+            if mentions(name, ln) and '--self-test' in ln and executes(name, ln):
+                return True
+    return False
+
+# ── CLASSIFY ──────────────────────────────────────────────────────────────────────────────────
+verdicts = []
+for subj in subjects:
+    name = os.path.basename(subj)
+    if subj in exempt:          # EXACT repo-relative path only — see the EXEMPT header block
+        verdicts.append(('EXEMPT', subj, 'declared in the checker EXEMPT array'))
+        continue
+    hit_exec, hit_var, hit_indirect, hit_mention = [], [], [], []
+    for lane in lanes:
+        if os.path.abspath(lane) == os.path.abspath(subj):
+            continue
+        txt = read(lane)
+        # The MENTION test runs on the raw text and the EXECUTION tests on the live text, on
+        # purpose: a dispatch buried in a dead branch is still a mention of the file, so it lands as
+        # MENTION_ONLY ("named but never executed") rather than NO_ANCHOR ("no lane names it at
+        # all"). Both block; they send the reader to different places.
+        if not mentions(name, txt):
+            continue
+        ltxt = live_text(txt)
+        if any(executes(name, ln) for ln in ltxt.split('\n')):
+            hit_exec.append(lane)
+        elif assigned_then_invoked(name, ltxt):
+            hit_var.append(lane)
+        elif indirect(name, ltxt):
+            hit_indirect.append(lane)
+        else:
+            hit_mention.append(lane)
+    if hit_exec:
+        verdicts.append(('EXECUTED', subj, 'run by ' + ', '.join(hit_exec[:3])))
+    elif hit_var:
+        verdicts.append(('EXECUTED_VIA_VAR', subj,
+                         'assigned to a variable and that variable is invoked, in ' +
+                         ', '.join(hit_var[:3])))
+    elif hit_indirect:
+        verdicts.append(('EXECUTED_INDIRECT', subj,
+                         'dispatched through a variable by ' + ', '.join(hit_indirect[:3]) +
+                         ' — weaker evidence than a direct call, verify by hand once'))
+    elif selftest_wired(subj):
+        verdicts.append(('SELFTEST_WIRED', subj, 'embedded --self-test, dispatched by a runner surface'))
+    elif hit_mention:
+        verdicts.append(('MENTION_ONLY', subj,
+                         'named but never executed in ' + ', '.join(hit_mention[:3]) +
+                         ' (comment / grep pattern / echoed string / `bash -n`)'))
+    else:
+        verdicts.append(('NO_ANCHOR', subj, 'no lane suite names it at all'))
+
+# ── REPORT ────────────────────────────────────────────────────────────────────────────────────
+# The corpus size is printed unconditionally. A zero-lane corpus makes every subject NO_ANCHOR for
+# a reason that is about the instrument, not about the subject, and the reader has to be able to
+# see that from the output alone.
+print(f'CORPUS\t{len(lanes)}')
+print(f'SCOPE\t{len(subjects)}\t{len(skipped)}')
+for p in skipped:
+    print(f'OUT_OF_SCOPE\t{p}\tnot scripts/*.{{sh,py}} or templates/.git-hooks/* (or is itself a lane)')
+for v, p, why in verdicts:
+    print(f'{v}\t{p}\t{why}')
+PY
+_py_rc=$?
+out="$(cat "$_scan_out")"
+rm -f "$_scan_out"
+if [ "$_py_rc" -eq 4 ]; then
+  # A malformed EXEMPT entry. Reported under its own message because the fix is in THIS file's
+  # array, not in anybody's lane — routing it through the generic "the scan failed" text would send
+  # the reader to look for a python bug that is not there.
+  echo "⛔ HARNESS ERROR: the EXEMPT array in this checker is malformed. Not a pass, and not a"
+  echo "   verdict about your code — the gate refused to run with a broken configuration."
+  printf '%s\n' "$out" | awk -F'\t' '$1=="FATAL_EXEMPT"{printf "   ✗ %s — %s\n", $2, $3}'
+  echo "   Required form:  \"repo/relative/path.sh|reason\"  — a repo-relative path (not a bare"
+  echo "   basename), and the reason must be a real sentence (12+ chars)."
+  exit 10
+fi
+if [ "$_py_rc" -ne 0 ]; then
+  echo "⛔ UNMEASURED: the scan itself failed (python3 rc=$_py_rc). Not a pass."
+  printf '%s\n' "$out"
+  exit 10
+fi
+
+echo "── new-code-anchor ─────────────────────────────────────────────────────────────"
+echo "   base: $BASE ($_base_src) · merge-base: ${MB:0:12}"
+
+_corpus="$(printf '%s\n' "$out" | awk -F'\t' '$1=="CORPUS"{print $2}')"
+_nsubj="$(printf '%s\n'  "$out" | awk -F'\t' '$1=="SCOPE"{print $2}')"
+_nskip="$(printf '%s\n'  "$out" | awk -F'\t' '$1=="SCOPE"{print $3}')"
+echo "   lane corpus: ${_corpus:-?} suites · added in scope: ${_nsubj:-?} · added out of scope: ${_nskip:-?}"
+
+if [ "${_corpus:-0}" = "0" ] && [ "${_nsubj:-0}" != "0" ]; then
+  echo "   🟥 the lane corpus is EMPTY — every verdict below is about the instrument, not the code."
+fi
+
+printf '%s\n' "$out" | awk -F'\t' '
+  $1=="OUT_OF_SCOPE"      { printf "   ·  %-18s %s\n", "out-of-scope", $2 }
+  $1=="EXEMPT"            { printf "   ✅ %-18s %s — %s\n", "EXEMPT", $2, $3 }
+  $1=="EXECUTED"          { printf "   ✅ %-18s %s — %s\n", "EXECUTED", $2, $3 }
+  $1=="EXECUTED_VIA_VAR"  { printf "   ✅ %-18s %s — %s\n", "EXECUTED(via var)", $2, $3 }
+  $1=="EXECUTED_INDIRECT" { printf "   ⚠️  %-18s %s — %s\n", "EXECUTED(indirect)", $2, $3 }
+  $1=="SELFTEST_WIRED"    { printf "   ✅ %-18s %s — %s\n", "SELFTEST_WIRED", $2, $3 }
+  $1=="MENTION_ONLY"      { printf "   ❌ %-18s %s — %s\n", "MENTION_ONLY", $2, $3 }
+  $1=="NO_ANCHOR"         { printf "   ❌ %-18s %s — %s\n", "NO_ANCHOR", $2, $3 }
+'
+
+# `grep -c` returns 1 on zero matches, which under a naive `$(...)` capture is indistinguishable
+# from a broken pipeline. Counted with awk so the empty case is a real 0 and not a swallowed error
+# ([[feedback_pipefail_fallback_disarms_guard]] — the question is not "did I add a fallback" but
+# "does this print an empty string when it fails").
+_bad="$(printf '%s\n' "$out" | awk -F'\t' '$1=="MENTION_ONLY" || $1=="NO_ANCHOR"' | grep -c . || true)"
+_bad="${_bad//[!0-9]/}"; _bad="${_bad:-0}"
+
+if [ "${_nsubj:-0}" = "0" ]; then
+  echo "   SCANNED, and the in-scope set is genuinely empty — this change adds no scripts/ executable."
+  echo "   (That is a measured zero, not an unrun scan: the base resolved and the diff succeeded.)"
+  echo "✅ new-code-anchor: PASS (0 in scope)"
+  exit 0
+fi
+
+if [ "$_bad" -eq 0 ]; then
+  echo "✅ new-code-anchor: PASS — every added executable has a lane that RUNS it."
+  exit 0
+fi
+
+echo ""
+echo "❌ new-code-anchor: $_bad added file(s) ship with no working anchor."
+echo "   A green suite total does not mean these files were verified — it can mean nothing touched them."
+echo "   Fix (in order of preference):"
+echo "     1. add lanes to scripts/test_<name>_lanes.sh that actually EXECUTE the file"
+echo "     2. if the file carries its own --self-test, wire that dispatch into a runner surface"
+echo "        (scripts/selfcheck.sh · .github/workflows/*.yml|*.yaml · templates/.git-hooks/*)"
+echo "     3. if it genuinely cannot be exercised, add it to EXEMPT in this file as"
+echo "        \"path|reason\" — the reason is enforced (12+ chars), not merely requested"
+echo "   🟥 MENTION_ONLY means a lane NAMES the file without running it. Adding another mention"
+echo "      does not clear it — that is the decoration this gate exists to catch."
+
+if [ "${NEW_CODE_ANCHOR_OK:-}" = "1" ]; then
+  echo ""
+  echo "⚠️  OVERRIDE ACCEPTED — NEW_CODE_ANCHOR_OK=1 was set. The findings above STAND; they were"
+  echo "    acknowledged, not resolved. Recording this line is the point of the channel."
+  exit 0
+fi
+exit 1
+
+# ── NAMED RESIDUALS — what this instrument does NOT establish ─────────────────────────────────
+# Written here rather than omitted, because silence in a checker reads as coverage.
+#
+# 1. LINE SCANNING, NOT SHELL PARSING. A dispatch line inside a heredoc body still counts as a
+#    live call, and a `#`-comment is only detected at line PREFIX (a trailing comment on a real
+#    command line is correctly ignored, but `foo && bash x.sh # note` is judged on the whole line).
+#    Symmetric with lane_runner_check.sh, which carries the identical limit. Closing it means
+#    parsing shell — the Grep-Collision Treadmill this repo has already logged. Fix on the first
+#    case that actually bites, not before.
+# 2. "A LANE RUNS IT" ≠ "A LANE VERIFIES IT". A lane that invokes the subject once and asserts
+#    nothing scores EXECUTED. This gate closes the ZERO-coverage hole, which is the one the origin
+#    incident was about; it does not measure assertion quality, and nothing here should be cited
+#    as if it did.
+# 3. EXECUTED_INDIRECT is heuristic. It exists because the strict predicate provably under-reports
+#    (measured in the sibling check, 2026-08-12: two genuinely-run suites called UNWIRED). It is
+#    labelled ⚠️ rather than ✅ so the weaker evidence is visible in the output.
+# 3c. DEAD BRANCHES ARE CLOSED ONLY FOR *CONSTANT* CONDITIONS. `if false; then bash x.sh; fi` no
+#    longer counts as an execution, in the direct, variable and --self-test arms alike (lanes
+#    P13–P15). What is still scored as an execution is a branch that is dead for a reason a reader
+#    cannot get from the line — `if [ "$NEVER_SET" = 1 ]; then bash x.sh; fi`. That is not a
+#    documented-away version of the same hole: closing it means evaluating conditions, i.e. constant
+#    propagation over shell, which is undecidable in general and would have to guess. The line drawn
+#    here is "decidable by reading the line", and the guessing side is left LIVE so the gate never
+#    blocks a legitimate guard (N18–N20 pin that direction).
+#    Two known-narrow spots in the marking itself, both failing toward live: a nested block inside a
+#    dead branch abandons the marking, and a one-line `if false; then A; else B; fi` is left entirely
+#    alone rather than risking B.
+# 3b. VARIABLE RESOLUTION IS SINGLE-FILE, ORDER-AWARE, BRANCH-BLIND. Since 2026-08-22 it is a
+#    reaching-definition check over line order: an assignment naming the subject counts only if the
+#    variable is invoked after it and before the next assignment to that variable (lanes P9 / N11 /
+#    N12). What remains open, and is NOT a false-pass direction:
+#      · branches — `if …; then CHECK=other.sh; fi; bash "$CHECK"` treats the branch body as a
+#        plain reassignment, so the earlier subject is judged unreached. That direction BLOCKS;
+#        the author clears it by adding a lane, not by arguing with the parser. (The opposite
+#        direction — a branch that never runs being scored as an execution — was a false PASS, not
+#        an over-block, and is closed for constant conditions; see 3c.)
+#      · one-liners with two assignments to the same variable on a single line: only the first is
+#        seen (`ASSIGN` anchors at line start), so the rest of that line is attributed to it.
+#      · cross-file — a variable assigned in a sourced helper is invisible.
+#    The previous version of this note said the resolution was flow-insensitive and left it there.
+#    That was not an honest ceiling but a hole with a label on it: it produced a false PASS on a
+#    blocking gate, and cross-family review (codex) found it by writing the two-line fixture the
+#    note itself described. A stated limitation does not become acceptable by being stated.
+# 4. RENAMES. `--diff-filter=A` sees a renamed file as added when git does not detect the rename
+#    (it defaults to detecting them for `--name-only`, so this is a partial, not a total, gap).
+#    A rename of an already-anchored file whose lane still names the OLD path will surface as
+#    NO_ANCHOR — which is the correct direction (the lane is now stale), but the message will say
+#    "new file" about something that is not new.
+# 5. UNCOMMITTED WORK IS OUT OF SCOPE. The diff is base..HEAD. A file added but not yet committed
+#    is not judged. This gate's binding point is CI/pre-merge, not the working tree
+#    ([[feedback_gate_binding_point_not_check_point]]).
+# 6b. THE NAME BOUNDARY IS LEXICAL. `foo.sh` no longer matches inside `foo.sh.bak` / `foo.sh2` /
+#    `xfoo.sh`, but two DIFFERENT files with the SAME basename in different directories are still
+#    one token to this scan — `a/run.sh` and `b/run.sh` are indistinguishable, and a lane running
+#    either anchors both. Basename matching is what lets the four legitimate path spellings
+#    (bare, ./, $ROOT/, "$VAR") work at all; narrowing it to full paths would trade this
+#    false-pass for a large false-block. Named, not closed.
+# 6. SCOPE IS scripts/ + templates/.git-hooks/. A new executable elsewhere (e.g. a plugin hook,
+#    .github/scripts/) is reported OUT_OF_SCOPE by name and judged by nobody. Widening the scope
+#    without widening what the lane corpus can reach would be a coverage claim this cannot back
+#    ([[feedback_scope_widening_needs_grounding]]).

--- a/scripts/package_coverage_check.sh
+++ b/scripts/package_coverage_check.sh
@@ -183,6 +183,12 @@ ACCEPTED_ABSENT=(
   "scripts/script_caller_ratchet.sh"
   "scripts/ratchet_base_resolve.sh"
   "scripts/test_script_caller_ratchet_lanes.sh"
+  # ── D-5 runner-surface known pair, 2026-08-24 — 같은 사유로 미출하 ────────────────────────
+  # test_runner_surface_index_lanes.sh 는 주체가 **둘**이다: lane_runner_check.sh(출하됨)와
+  # script_caller_ratchet.sh(미출하). 후자가 없는 트리에서는 파일 상단 가드가 exit 2 로 죽으므로
+  # 소비자에게 실으면 **모든 설치에서 계기 오류**가 된다. selfcheck 의 짝 표에서도 sentinel 주체를
+  # script_caller_ratchet.sh 로 잡아, 소비자 트리에서는 주체 팔이 먼저 발화해 SKIP 으로 끝난다.
+  "scripts/test_runner_surface_index_lanes.sh"
   # ── The two settings destinations, surfaced 2026-08-13 by fixing this file's own extractor ────
   # These were invisible until the `js|json` alternation below was corrected: every `.json`
   # reference in every shipped doc was being truncated to `.js`, a path that exists nowhere, so

--- a/scripts/script_caller_ratchet.sh
+++ b/scripts/script_caller_ratchet.sh
@@ -117,8 +117,97 @@ BASELINE_FILE="scripts/caller_zero_baseline.txt"
 # 🟥 `out=$(...)` then `rc=$?` on its OWN line — never `cmd | tail` and never `|| echo 0`.
 # A fallback operator here would hand a broken instrument's empty stdout to the parser and the
 # parser would render it as "no violations" ([[feedback_pipefail_fallback_disarms_guard]]).
+# -- RUNNER SURFACE = THE GIT INDEX, NOT THE WORKING TREE (D-5, 2026-08-24) --------------------
+# An UNTRACKED file must never certify anything as WIRED. Until this fix the RUNNER globs below
+# were resolved against the DISK, so a workflow / hook / script that existed only in this working
+# copy counted as a caller -- and the tree read green on wiring that disappears on `git clone`.
+#
+# The POPULATION globs (what gets CHECKED) stay on DISK on purpose. There an untracked file must
+# be SEEN, so a new uncommitted script goes red instead of slipping through. Only the RUNNER
+# surface moves to the index; moving both would trade one silent pass for another.
+#
+# 🟥 "NOT A REPOSITORY" AND "GIT FAILED" ARE DIFFERENT FACTS AND MUST NOT SHARE A BRANCH.
+# The first draft of this block folded EVERY non-zero `git ls-files` exit into "no index here, use
+# the disk". Cross-family review (codex/gpt-5.5, 2026-08-24) executed the consequence: a fake `git`
+# that exits 1 for everything produced a warning line and then a PASS. A missing binary, a locked
+# or corrupt index, and a permission failure all landed on the SAME branch as an unpacked npm
+# tarball -- so the repair against "green that a clone deletes" had installed a fresh green of its
+# own. That is [[feedback_not_found_is_not_zero_family]] wearing this file's colours, and the
+# asymmetry was backwards: an EMPTY result was routed to UNMEASURED while a FAILED one was routed
+# to a pass.
+#
+# So the state is resolved by POSITIVE questions, in order, and only the answers that are actually
+# established are allowed to reach the disk fallback:
+#   git absent / `git --version` non-zero        -> UNMEASURED  (the instrument, not the tree)
+#   rev-parse fails AND a .git exists up-chain   -> UNMEASURED  (git broke inside a repo)
+#   rev-parse fails AND no .git anywhere up-chain-> nongit      (an unpacked tarball: disk is right)
+#   inside a git dir with no work tree           -> nongit
+#   in a work tree, `git ls-files` non-zero      -> UNMEASURED  (locked/corrupt index, permissions)
+#   in a work tree, ls-files empty, cwd ignored  -> outside-index (a package unpacked INSIDE some
+#                                                   other repo -- the index cannot answer for it,
+#                                                   and blocking every such install would just
+#                                                   train the override)
+#   in a work tree, ls-files empty, cwd tracked  -> UNMEASURED  (an empty index is not zero runners)
+#   otherwise                                    -> index
+# 🟥 The discriminator can itself fail, and when it does the answer is UNMEASURED -- never "not a
+# repository". That is why the .git walk-up exists: it is a filesystem fact that needs no working
+# git, so "git could not tell us" and "there is genuinely nothing here" stay separable.
+#
+# 🟥 `git ls-files` into a file, then `$?` on its OWN line. No pipe, no `|| true`: a fallback would
+# hand an empty list to the scan and the scan would render it as "no runners".
+_fh_has_dotgit_upchain() {
+  local _d; _d="$(pwd -P)"
+  while : ; do
+    [ -e "$_d/.git" ] && return 0
+    [ "$_d" = "/" ] && return 1
+    _d="$(dirname "$_d")"
+  done
+}
+FH_INDEX_STATE="UNMEASURED"; FH_INDEX_WHY="not determined"; FH_INDEX_FILE_LIST=""
+if ! command -v git >/dev/null 2>&1; then
+  FH_INDEX_WHY="git is not on PATH -- the index could not be read at all"
+else
+  _fh_gv="$(git --version 2>/dev/null)"; _fh_gvrc=$?
+  if [ "$_fh_gvrc" -ne 0 ] || [ -z "$_fh_gv" ]; then
+    FH_INDEX_WHY="\`git --version\` exited $_fh_gvrc -- the git binary is unusable, so nothing below was measured"
+  else
+    _fh_wt="$(git rev-parse --is-inside-work-tree 2>/dev/null)"; _fh_wtrc=$?
+    if [ "$_fh_wtrc" -ne 0 ]; then
+      if _fh_has_dotgit_upchain; then
+        FH_INDEX_WHY="git works but \`rev-parse --is-inside-work-tree\` exited $_fh_wtrc while a .git exists above this directory -- git failed, this is not a plain directory"
+      else
+        FH_INDEX_STATE="nongit"; FH_INDEX_WHY="no repository here and no .git anywhere above -- an unpacked tarball"
+      fi
+    elif [ "$_fh_wt" != "true" ]; then
+      FH_INDEX_STATE="nongit"; FH_INDEX_WHY="inside a git dir with no work tree (bare repository)"
+    else
+      # 🟥 NUL ALL THE WAY. An earlier draft piped this through `tr '\0' '\n'` into an env var,
+      # which un-did the whole point of `-z`: a path containing a NEWLINE was split into two paths
+      # before python ever saw it. Env vars cannot carry NUL, so the list travels as a FILE and the
+      # separator is never translated. Cross-family review, 2026-08-24, round 3.
+      _fh_tmp="$(mktemp)"
+      git ls-files -z >"$_fh_tmp" 2>/dev/null
+      _fh_lrc=$?
+      FH_INDEX_FILE_LIST="$_fh_tmp"
+      if [ "$_fh_lrc" -ne 0 ]; then
+        FH_INDEX_WHY="inside a work tree, but \`git ls-files\` exited $_fh_lrc -- a locked or corrupt index, or a permission failure. NOT an absence of runners"
+      elif [ -s "$_fh_tmp" ]; then
+        FH_INDEX_STATE="index"; FH_INDEX_WHY="the git index"
+      else
+        git check-ignore -q . 2>/dev/null; _fh_ci=$?
+        if [ "$_fh_ci" -eq 0 ]; then
+          FH_INDEX_STATE="outside-index"; FH_INDEX_WHY="this directory is IGNORED by the surrounding repository, so its index cannot answer for these files"
+        else
+          FH_INDEX_WHY="\`git ls-files\` exited 0 and returned NOTHING while this directory is tracked territory -- an empty index is not zero runners"
+        fi
+      fi
+    fi
+  fi
+fi
+export FH_INDEX_STATE FH_INDEX_WHY FH_INDEX_FILE_LIST
+
 out=$(python3 - "$BASELINE_FILE" "$MODE" "$LIST" <<'PY'
-import os, re, sys, glob, json
+import os, re, sys, glob, json, subprocess
 
 BASELINE_FILE, MODE, LIST = sys.argv[1], sys.argv[2], sys.argv[3] == '1'
 SELF = 'script_caller_ratchet.sh'
@@ -159,12 +248,157 @@ RUNNER_GLOBS = (
     # Extending the SURFACE list is the correct repair; an exemption would have been a false record.
     '.claude/capabilities/*.cap', '.claude/capabilities/adapters/*.cap',
 )
-runners = []
-for pat in RUNNER_GLOBS:
-    runners += [p for p in glob.glob(pat) if os.path.isfile(p)]
+
+# -- INDEX-vs-DISK enumeration, RUNNER surfaces ONLY. State resolved in the bash preamble above. -
+INDEX_MODE = os.environ.get('FH_INDEX_STATE', '')
+INDEX_WHY = os.environ.get('FH_INDEX_WHY', 'the preamble did not run')
+_idx_path = os.environ.get('FH_INDEX_FILE_LIST', '')
+_idx_raw = b''
+if _idx_path:
+    try:
+        _idx_raw = open(_idx_path, 'rb').read()
+    except OSError:
+        _idx_raw = b''
+INDEX_FILES = [_b.decode('utf-8', 'replace') for _b in _idx_raw.split(b'\0') if _b]
+# Fail-closed on anything this file does not recognise, including the empty string a caller that
+# skipped the preamble would leave behind. A mode nobody set is not a mode that means "use disk".
+if INDEX_MODE not in ('index', 'nongit', 'outside-index'):
+    INDEX_MODE = 'UNMEASURED'
+if INDEX_MODE == 'index' and not INDEX_FILES:
+    INDEX_MODE = 'UNMEASURED'
+    INDEX_WHY = 'state said index and the file list is empty -- the two disagree'
+
+def _glob_rx(pat):
+    # glob semantics, NOT fnmatch, and that includes the DOTFILE rule.
+    # `*` -> `[^/]*` alone is WIDER than the `glob.glob()` it replaced: fnmatch translates `*` to
+    # `.*`, which also crosses `/`, and neither form hides dotfiles. `glob.glob('scripts/*.sh')`
+    # does NOT return `scripts/.x.sh`; a regex without the guard below DOES, so a hidden tracked
+    # file would certify a caller that the old surface never contained. Cross-family review,
+    # 2026-08-24. The guard is per SEGMENT and keys on a leading `*`/`?` in that segment -- a dot
+    # in a literal segment (`templates/.git-hooks/`) is a directory name and is unaffected; what
+    # glob hides is a leading dot in the matched BASENAME.
+    _segs = []
+    for _seg in pat.split('/'):
+        _s = ''
+        if _seg[:1] in ('*', '?'):
+            _s += '(?!\\.)'
+        for _c in _seg:
+            _s += '[^/]*' if _c == '*' else '[^/]' if _c == '?' else re.escape(_c)
+        _segs.append(_s)
+    return re.compile('^' + '/'.join(_segs) + '$')
+
+def enumerate_runners(patterns):
+    # index: the candidate runners are what `git ls-files` says is TRACKED.
+    # nongit / outside-index: no index can answer here, so disk is the correct surface -- and the
+    # run says which of the two it is out loud. UNMEASURED never reaches this function.
+    if INDEX_MODE == 'index':
+        # 🟥 NO os.path.isfile HERE. Filtering the INDEX list by what happens to be on disk lets the
+        # working tree decide the population of an index-grounded judgment -- a tracked runner the
+        # worktree has deleted would silently become "not a runner" instead of "read its blob",
+        # which also skips the completeness check below. The index blob exists regardless of the
+        # working tree; that is the whole reason to read it. Cross-family review, round 3.
+        # The disk branch on the next line KEEPS isfile, and so do LOCAL_ONLY_SURFACES: there the
+        # working tree IS the surface, and a name with no file behind it is genuinely nothing.
+        _rx = [_glob_rx(_p) for _p in patterns]
+        return [_p for _p in INDEX_FILES if any(_r.match(_p) for _r in _rx)]
+    return [_p for _pat in patterns for _p in glob.glob(_pat) if os.path.isfile(_p)]
+
+if INDEX_MODE == 'UNMEASURED':
+    err.append('the runner surface is UNMEASURED, not zero runners: ' + INDEX_WHY)
+
+runners = enumerate_runners(RUNNER_GLOBS)
 # This file names every EXEMPT and BASELINE entry (in the file it reads, not in itself) and prints
 # script paths in its own report. Scanning itself would let the report certify its own todo list.
 runners = [r for r in runners if os.path.basename(r) != SELF]
+
+# -- RUNNER CONTENT = THE INDEX BLOB, NOT THE WORKING TREE FILE -------------------------------
+# 🟥 THE OTHER HALF OF D-5. Moving the runner FILE LIST to the index closed "is this runner in the
+# clone"; it did NOT close "does that runner call this lane in the clone". The names came from
+# `git ls-files` while the bodies were still read with `open()`, so ONE UNSTAGED LINE added to an
+# already-tracked runner certified a wiring that exists in nobody's checkout but this one -- the
+# same defect wearing the other half of its face. Cross-family review, 2026-08-24, round 2.
+# Claiming "the surface is index-grounded" while half of it was not is exactly
+# [[feedback_half_fix_propagation_boundary]] / "measured scope != claimed scope".
+#
+# ONE process, not one per runner: there are ~185 runner surfaces here, and `git show` per file
+# would be ~185 forks. `git cat-file --batch` reads them all from one stdin stream.
+#
+# 🟥 EVERY FAILURE PATH IS UNMEASURED, NEVER AN EMPTY BODY. A missing blob, a short read, a
+# non-blob object, a git that will not start -- each of them, read as "" , renders the runner as
+# calling nothing, which is the fold this whole file exists to refuse. They collect in _BLOB_ERR
+# and route to the same UNMEASURED exit as a broken index does.
+# In `nongit` / `outside-index` there is no blob to read and that is already decided policy
+# (protection off, labelled) -- the loader is simply not run, and the disk reader stays in place.
+# No new state value.
+_BLOBS = {}
+_BLOB_ERR = []
+
+def _load_index_blobs(paths):
+    if INDEX_MODE != 'index' or not paths:
+        return
+    # `git cat-file --batch` reads NEWLINE-delimited input, so a path containing one cannot be
+    # asked for safely. Refuse to guess: that is UNMEASURED, not "this runner calls nothing".
+    for _p in paths:
+        if '\n' in _p:
+            _BLOB_ERR.append('a runner path contains a newline and cannot be batched: ' + repr(_p))
+    if _BLOB_ERR:
+        return
+    _inp = ''.join(':' + _p + '\n' for _p in paths)
+    try:
+        _pr = subprocess.run(['git', 'cat-file', '--batch'], input=_inp.encode('utf-8'), stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    except OSError as _e:
+        _BLOB_ERR.append('git cat-file could not be started: ' + str(_e))
+        return
+    if _pr.returncode != 0:
+        _BLOB_ERR.append('git cat-file --batch exited ' + str(_pr.returncode))
+        return
+    _buf = _pr.stdout
+    _pos = 0
+    for _p in paths:
+        _nl = _buf.find(b'\n', _pos)
+        if _nl < 0:
+            _BLOB_ERR.append('git cat-file output ended early at ' + _p)
+            return
+        _hdr = _buf[_pos:_nl].decode('utf-8', 'replace').split()
+        _pos = _nl + 1
+        if len(_hdr) != 3 or _hdr[1] != 'blob':
+            _BLOB_ERR.append('no blob in the index for ' + _p + ': ' + ' '.join(_hdr))
+            return
+        _sz = int(_hdr[2])
+        _end = _pos + _sz
+        if _end > len(_buf):
+            _BLOB_ERR.append('git cat-file returned a short body for ' + _p)
+            return
+        _BLOBS[_p] = _buf[_pos:_end].decode('utf-8', 'replace')
+        _pos = _end + 1
+    # Completeness, checked rather than assumed, and INSIDE the loader so that the loader is a
+    # single switch: this is what makes the disk fallback in read_runner unreachable for a runner
+    # in index mode. Without it a silently missing key would fall through to the working tree and
+    # rebuild the defect one path at a time.
+    for _p in paths:
+        if _p not in _BLOBS:
+            _BLOB_ERR.append('the index blob for ' + _p + ' was never read')
+
+_load_index_blobs(runners)
+
+def _read_disk(path):
+    try:
+        return open(path, encoding='utf-8', errors='replace').read()
+    except OSError:
+        return ''
+
+def read_runner(path):
+    # index mode: every runner is in _BLOBS (asserted above), so the disk branch is reachable only
+    # for surfaces that are deliberately NOT index-backed -- the gitignored local settings file --
+    # and for the nongit / outside-index states.
+    if path in _BLOBS:
+        return _BLOBS[path]
+    return _read_disk(path)
+
+if _BLOB_ERR:
+    INDEX_MODE = 'UNMEASURED'
+    INDEX_WHY = 'the runner CONTENT is UNMEASURED, not empty: ' + ' - '.join(_BLOB_ERR)
+    err.append(INDEX_WHY)
 
 # Read but NOT counted as a caller — see the header. Kept as its own surface so the state is a
 # labelled value rather than an invisible zero.
@@ -352,7 +586,7 @@ def has_caller(path, surfaces):
     for r in surfaces:
         if os.path.abspath(r) == os.path.abspath(path):
             continue                       # a script does not wire itself
-        txt = read(r)
+        txt = read_runner(r)
         if name not in txt:
             continue
         ext = os.path.splitext(r)[1]
@@ -489,6 +723,7 @@ ghost      = sorted(p for p in list(exempt) + list(baseline) if not os.path.isfi
 
 print(json.dumps({
     'mode': MODE, 'list': LIST,
+    'index_mode': INDEX_MODE, 'index_why': INDEX_WHY,
     'n_pop': len(population), 'n_runners': len(runners), 'n_decl': decl_lines,
     'wired': {k: v for k, v in wired.items()},
     'callerless': callerless, 'undeclared': undeclared,
@@ -502,6 +737,7 @@ print(json.dumps({
 PY
 )
 rc=$?
+[ -n "${FH_INDEX_FILE_LIST:-}" ] && rm -f "$FH_INDEX_FILE_LIST"
 if [ "$rc" -ne 0 ] || [ -z "$out" ]; then
   echo "FAIL  caller-ratchet: the scan itself did not run (python3 exit $rc)."
   echo "      An instrument that did not run is UNMEASURED — this is not a pass."
@@ -519,12 +755,34 @@ if [ -n "$CTRL" ]; then
   exit 2
 fi
 
+# 🟥 Ordered BEFORE the generic `err` render so the reason a reader sees is the true one. The
+# state also rides in `err` (fail-closed if this branch is ever moved or deleted), but the err
+# header says "declarations could not be read", which is a wrong diagnosis for a broken index.
+if [ "$(_j index_mode)" = "UNMEASURED" ]; then
+  echo "FAIL  caller-ratchet: the runner surface is UNMEASURED, not empty —"
+  echo "        · $(_j index_why)"
+  echo "      A scan that could not enumerate its own runner surface did not pass."
+  exit 2
+fi
+
 ERRS="$(_j err)"
 if [ -n "$ERRS" ]; then
   echo "FAIL  caller-ratchet: declarations could not be read as declarations —"
   printf '%s\n' "$ERRS" | sed 's/^/        · /'
   exit 2
 fi
+
+# Three-valued, printed rather than folded. `nongit` is CORRECT in an unpacked npm tarball
+# (no index exists there) and WRONG inside a checkout; `empty` is routed through `err` above and
+# has already exited 2 by the time this runs. Neither may ever read as "zero runners".
+IDX_MODE="$(_j index_mode)"
+case "$IDX_MODE" in
+  nongit|outside-index)
+    echo "      ⚠️  caller-ratchet: runner surface enumerated from DISK, not the index ($IDX_MODE)."
+    echo "          $(_j index_why)"
+    echo "          Correct outside a checkout, wrong inside one. Not zero runners either way."
+    ;;
+esac
 
 N_POP="$(_j n_pop)"; N_RUN="$(_j n_runners)"
 if [ "$N_POP" -eq 0 ] || [ "$N_RUN" -eq 0 ]; then

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -592,6 +592,7 @@ for _pair in \
   "scripts/stale_clone_guard.sh|scripts/test_stale_clone_guard_lanes.sh" \
   "plugins/fh-commons/skills/ko-tech-writer/SKILL.md|scripts/test_ko_tech_writer_lanes.sh" \
   "scripts/script_caller_ratchet.sh|scripts/test_script_caller_ratchet_lanes.sh" \
+  "scripts/script_caller_ratchet.sh|scripts/test_runner_surface_index_lanes.sh" \
   "scripts/mapped_tracks.sh|scripts/test_mapped_tracks_lanes.sh"
 do
   _subj="${_pair%%|*}"; _anc="${_pair##*|}"; _lbl="${_anc##*/}"

--- a/scripts/test_new_code_anchor_lanes.sh
+++ b/scripts/test_new_code_anchor_lanes.sh
@@ -1,0 +1,680 @@
+#!/usr/bin/env bash
+# test_new_code_anchor_lanes.sh — known-pair calibration for scripts/new_code_anchor_check.sh.
+#
+# 🟥 EVERY LANE BUILDS A REAL, THROWAWAY GIT REPO UNDER mktemp AND RUNS THE CHECKER THERE.
+# Not one lane scans this repository. That is not tidiness — a fixture that reads the live tree
+# measures whatever the tree happens to look like today, so the lane's verdict drifts with
+# unrelated commits and the known-pair stops being known ([[feedback_audit_target_must_be_frozen]]).
+# It also means the lanes exercise the REAL git path (merge-base, --diff-filter=A) instead of an
+# injected file list, so there is no test-only seam that production does not take.
+#
+# ── HOW THE KNOWN-POSITIVES WERE CHOSEN ───────────────────────────────────────────────────────
+# The trivial positive (a new script no lane mentions at all) is included, but it is NOT the
+# load-bearing one — any name-grep would catch it. The lanes that decide whether this gate is real
+# are P2–P5: the file IS named in a lane suite, in each of the four spellings that satisfy a name
+# grep while executing zero lines of the subject. Those are the "뚫리는 표기"
+# ([[feedback_fixture_must_use_the_breaking_spelling]]): if the fixture only used the easiest
+# positive, a checker that greps for the name would score 100% here and ship as a decoration.
+#   P2 comment · P3 grep pattern · P4 `bash -n` (syntax check) · P5 echoed string
+#   P8 assigned to a variable, then only syntax-checked through it (added after N8's false positive)
+# P4 is the sharpest: this repo has measured that `bash -n` passes a runtime bad-substitution that
+# leaves a hook fail-open, so scoring it as coverage would certify the very instrument FH already
+# ruled is not one ([[feedback_gate_verification_must_execute]]).
+#
+# Exit: 0 = every pair held · 1 = a pair collapsed · 10 = the harness could not set itself up.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SUBJECT="$REPO_ROOT/scripts/new_code_anchor_check.sh"
+
+[ -f "$SUBJECT" ] || { echo "FATAL: subject missing: $SUBJECT"; exit 2; }
+command -v git     >/dev/null 2>&1 || { echo "FATAL: git unavailable";     exit 10; }
+command -v python3 >/dev/null 2>&1 || { echo "FATAL: python3 unavailable"; exit 10; }
+
+TMPROOT="$(mktemp -d 2>/dev/null)" || { echo "FATAL: mktemp failed"; exit 10; }
+cleanup() { [ -n "${TMPROOT:-}" ] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); printf '  ✅ %s\n' "$*"; }
+bad()  { FAIL=$((FAIL+1)); printf '  ❌ %s\n' "$*"; }
+
+# ── fixture builders ──────────────────────────────────────────────────────────────────────────
+# `-c` flags rather than global config writes: this suite must not touch the runner's git identity,
+# and on a shared checkout it must not touch anything outside its own mktemp dir.
+_git() { git -C "$1" -c user.name=fixture -c user.email=fixture@example.invalid \
+                     -c commit.gpgsign=false "${@:2}"; }
+
+new_repo() {  # $1 = name → echoes the repo path
+  local d="$TMPROOT/$1"
+  mkdir -p "$d/scripts" || return 1
+  git init -q "$d" >/dev/null 2>&1 || return 1
+  # symbolic-ref instead of `git init -b main`: -b needs git >= 2.28 and this suite runs on
+  # whatever the CI image and the operator's macOS ship.
+  git -C "$d" symbolic-ref HEAD refs/heads/main >/dev/null 2>&1 || return 1
+  cp "$SUBJECT" "$d/scripts/new_code_anchor_check.sh" || return 1
+  # A pre-existing, UNANCHORED script on the base commit. It is the grandfather control: if it
+  # ever shows up in a verdict, the gate has stopped being diff-scoped and is auditing the tree.
+  printf '#!/usr/bin/env bash\necho legacy\n' > "$d/scripts/legacy_thing.sh"
+  _git "$d" add -A >/dev/null 2>&1 || return 1
+  _git "$d" commit -qm base >/dev/null 2>&1 || return 1
+  printf '%s' "$d"
+}
+
+branch_and_commit() {  # $1 = repo
+  _git "$1" checkout -q -b feat >/dev/null 2>&1 || return 1
+  _git "$1" add -A >/dev/null 2>&1 || return 1
+  _git "$1" commit -qm change >/dev/null 2>&1 || return 1
+}
+
+run_check() {  # $1 = repo  → sets OUT / RC
+  # 🟥 THE FIXTURE-ROOT GUARD IS NOT DEFENSIVE PADDING. `cd ""` is a NO-OP that exits 0, so an empty
+  # or missing fixture path would silently run the checker against the REAL repository — a sibling
+  # lane suite in this repo did exactly that on 2026-08-22 and the suite stayed green while
+  # measuring the live tree ([[feedback_audit_target_must_be_frozen]]). Refuse instead.
+  case "${1:-}" in
+    "$TMPROOT"/*) : ;;
+    *) echo "FATAL: run_check called with a path outside the fixture root: '${1:-}'"; exit 10 ;;
+  esac
+  [ -d "$1/.git" ] || { echo "FATAL: not a fixture repo: '$1'"; exit 10; }
+  OUT="$(cd "$1" && bash scripts/new_code_anchor_check.sh 2>&1)"
+  RC=$?
+}
+
+# The subject file every lane adds. Named distinctly so a stray match against a real repo file is
+# impossible even if a lane were ever mis-rooted.
+NEWSCRIPT='#!/usr/bin/env bash
+echo "fixture subject"
+'
+
+expect() {  # $1 label  $2 expected_rc  $3 expected_marker(regex, "" to skip)
+  if [ "$RC" != "$2" ]; then
+    bad "$1 — expected rc=$2, got rc=$RC"
+    printf '%s\n' "$OUT" | sed 's/^/        /'
+    return
+  fi
+  if [ -n "${3:-}" ] && ! printf '%s' "$OUT" | grep -qE "$3"; then
+    bad "$1 — rc=$2 as expected, but the verdict label did not match /$3/"
+    printf '%s\n' "$OUT" | sed 's/^/        /'
+    return
+  fi
+  ok "$1 (rc=$RC)"
+}
+
+echo "── known-POSITIVES: an added executable with no working anchor must BLOCK ──────────"
+
+# P1 — the trivial positive. No lane names it at all.
+d="$(new_repo p1)" || { echo "FATAL: fixture p1"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+branch_and_commit "$d" || { echo "FATAL: commit p1"; exit 10; }
+run_check "$d"; expect "P1 NO_ANCHOR — nothing names it" 1 'NO_ANCHOR.*fixture_subject\.sh'
+
+# P2 — 🟥 breaking spelling: named in a lane, inside a COMMENT.
+d="$(new_repo p2)" || { echo "FATAL: fixture p2"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+# covers scripts/fixture_subject.sh end to end
+echo "lane ran"
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit p2"; exit 10; }
+run_check "$d"; expect "P2 MENTION_ONLY — comment" 1 'MENTION_ONLY.*fixture_subject\.sh'
+
+# P3 — 🟥 breaking spelling: the name is a GREP PATTERN, not a command.
+d="$(new_repo p3)" || { echo "FATAL: fixture p3"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+if grep -q 'scripts/fixture_subject.sh' scripts/legacy_thing.sh; then
+  echo wired
+fi
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit p3"; exit 10; }
+run_check "$d"; expect "P3 MENTION_ONLY — grep pattern" 1 'MENTION_ONLY.*fixture_subject\.sh'
+
+# P4 — 🟥 the sharpest one: `bash -n` is a SYNTAX check. Zero lines of the subject execute.
+d="$(new_repo p4)" || { echo "FATAL: fixture p4"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+bash -n scripts/fixture_subject.sh || exit 1
+echo "syntax ok"
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit p4"; exit 10; }
+run_check "$d"; expect "P4 MENTION_ONLY — bash -n (syntax check, not execution)" 1 'MENTION_ONLY.*fixture_subject\.sh'
+
+# P5 — 🟥 breaking spelling: the invocation lives inside an ECHOED STRING.
+d="$(new_repo p5)" || { echo "FATAL: fixture p5"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+echo "to reproduce: bash scripts/fixture_subject.sh --verbose"
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit p5"; exit 10; }
+run_check "$d"; expect "P5 MENTION_ONLY — echoed string" 1 'MENTION_ONLY.*fixture_subject\.sh'
+
+# P8 — 🟥 the same two-line form N8 passes on, but with `bash -n` at the invocation site. Routing a
+# syntax check through a variable does not make it an execution. This lane exists because the
+# variable-resolution predicate was added AFTER a measured false positive, and a predicate added
+# under pressure to stop blocking is exactly the one that gets written too permissive
+# ([[feedback_repair_is_the_main_defect_source]]).
+d="$(new_repo p8)" || { echo "FATAL: fixture p8"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CHECK="$ROOT/scripts/fixture_subject.sh"
+bash -n "$CHECK" || exit 1
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit p8"; exit 10; }
+run_check "$d"; expect "P8 MENTION_ONLY — assigned, then only \`bash -n \$VAR\`" 1 'MENTION_ONLY.*fixture_subject\.sh'
+
+# P9 — 🟥 REGRESSION ANCHOR (cross-family finding, codex 2026-08-22): the variable is REASSIGNED
+# before it is ever invoked, so the first path never runs. The first version of this checker scored
+# BOTH paths `EXECUTED(via var)` and exited 0 — i.e. a file with zero anchors shipped green. The
+# residual note said the resolution was "flow-insensitive", which is true and is exactly why this is
+# a defect and not a documented limit: an imprecision that produces a false PASS on a blocking gate
+# is a hole, and writing the ceiling down does not close it.
+d="$(new_repo p9)" || { echo "FATAL: fixture p9"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+CHECK="scripts/fixture_subject.sh"
+CHECK="scripts/legacy_thing.sh"
+bash "$CHECK" || exit 1
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit p9"; exit 10; }
+run_check "$d"; expect "P9 MENTION_ONLY — reassigned before the invocation (never runs)" 1 'MENTION_ONLY.*fixture_subject\.sh'
+
+# P10–P12 — 🟥 REGRESSION ANCHORS (codex 2026-08-22): the predicate matched the basename as a bare
+# SUBSTRING, so a lane naming a NEIGHBOURING file scored the subject as EXECUTED. Three spellings,
+# not one, because a boundary fix that only handles the suffix leaves the prefix open and vice
+# versa ([[feedback_fixture_must_use_the_breaking_spelling]] — the easiest positive proves least):
+#   P10 suffix, punctuation  `fixture_subject.sh.bak`
+#   P11 suffix, word char    `fixture_subject.sh2`   (command position, the other predicate arm)
+#   P12 prefix               `xfixture_subject.sh`
+d="$(new_repo p10)" || { echo "FATAL: fixture p10"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh.bak"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+bash scripts/fixture_subject.sh.bak || exit 1
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit p10"; exit 10; }
+run_check "$d"; expect "P10 substring — .bak neighbour is not the subject" 1 '(NO_ANCHOR|MENTION_ONLY).*fixture_subject\.sh —'
+
+d="$(new_repo p11)" || { echo "FATAL: fixture p11"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh2"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+./scripts/fixture_subject.sh2
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit p11"; exit 10; }
+run_check "$d"; expect "P11 substring — .sh2 neighbour, command position" 1 '(NO_ANCHOR|MENTION_ONLY).*fixture_subject\.sh —'
+
+d="$(new_repo p12)" || { echo "FATAL: fixture p12"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+printf '%s' "$NEWSCRIPT" > "$d/scripts/xfixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+bash scripts/xfixture_subject.sh || exit 1
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit p12"; exit 10; }
+run_check "$d"; expect "P12 substring — x-prefixed neighbour is not the subject" 1 '(NO_ANCHOR|MENTION_ONLY).*fixture_subject\.sh —'
+
+# P13–P15 — 🟥 REGRESSION ANCHORS (cross-family finding, codex 2026-08-22): a dispatch inside a
+# provably DEAD branch was scored as an execution. The reported repro was P13; P14 and P15 are the
+# same hole in spellings the report did not name, and they are here because a repair that only
+# closes the demonstrated arm leaves its twins open ([[feedback_half_fix_propagation_boundary]]).
+#   P13 multi-line `if false` block, variable dispatch   → was EXECUTED(via var), rc=0
+#   P14 the same collapsed onto ONE line, NOT at line start (a line-anchored fix misses this)
+#   P15 DIRECT dispatch in a dead branch                 → was EXECUTED, rc=0
+# All three are false PASSes on a blocking gate: the subject runs zero times.
+d="$(new_repo p13)" || { echo "FATAL: fixture p13"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+CHECK="scripts/fixture_subject.sh"
+if false; then
+  bash "$CHECK"
+fi
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit p13"; exit 10; }
+run_check "$d"; expect "P13 dead branch (\`if false\`), variable dispatch — never runs" 1 'MENTION_ONLY.*fixture_subject\.sh'
+
+d="$(new_repo p14)" || { echo "FATAL: fixture p14"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+CHECK="scripts/fixture_subject.sh"; if false; then bash "$CHECK"; fi
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit p14"; exit 10; }
+run_check "$d"; expect "P14 dead branch on one line, mid-line (not at line start)" 1 'MENTION_ONLY.*fixture_subject\.sh'
+
+d="$(new_repo p15)" || { echo "FATAL: fixture p15"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+if false; then
+  bash scripts/fixture_subject.sh
+fi
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit p15"; exit 10; }
+run_check "$d"; expect "P15 dead branch, DIRECT dispatch (the unreported twin)" 1 'MENTION_ONLY.*fixture_subject\.sh'
+
+# P16 — 🟥 A CONTROL, NOT AN ANCHOR, AND IT IS LABELLED THAT WAY BECAUSE THE REVERT PROBE SAID SO.
+# It was written as the regression anchor for the EXEMPT basename-leniency hole (codex 2026-08-22)
+# and it is not one: reverting the fix leaves this lane GREEN, because the leniency only fires when
+# the ENTRY is a bare basename, and this entry is a full path. A lane that passes with and without
+# the fix measures nothing about it ([[feedback_anchor_can_be_decorative]] — an anchor can be a
+# decoration, and only reverting finds out which). X3 below is the discriminating lane.
+# It is kept because it does pin the intended semantics — one path's exemption does not travel to a
+# same-basename file in another directory, which is also the point on which this gate had diverged
+# from scripts/script_caller_ratchet.sh ([[feedback_divergent_leniency_duplicate_normalizers]]).
+d="$(new_repo p16)" || { echo "FATAL: fixture p16"; exit 10; }
+mkdir -p "$d/scripts/nested"
+printf '%s' "$NEWSCRIPT" > "$d/scripts/nested/fixture_subject.sh"
+python3 - "$d/scripts/new_code_anchor_check.sh" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p, encoding='utf-8').read()
+marker = 'EXEMPT=(\n)'
+assert marker in t, "EXEMPT array shape changed — this lane edits a form that no longer exists"
+open(p, 'w', encoding='utf-8').write(t.replace(
+    marker,
+    'EXEMPT=(\n  "scripts/fixture_subject.sh|fixture-only stub, exercised by the lane harness itself"\n)',
+    1))
+PY
+branch_and_commit "$d" || { echo "FATAL: commit p16"; exit 10; }
+run_check "$d"; expect "P16 same basename, different directory is NOT exempt" 1 'NO_ANCHOR.*nested/fixture_subject\.sh'
+
+# X3 — the bare-basename EXEMPT entry itself. With the leniency removed such an entry would become
+# an inert line the author reads as an active exemption, so it is refused as a harness error (10)
+# rather than ignored ([[feedback_not_found_is_not_zero_family]] — a silently-inert config is the
+# quietest face of "unmeasured rendered as fine").
+d="$(new_repo x3)" || { echo "FATAL: fixture x3"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+python3 - "$d/scripts/new_code_anchor_check.sh" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p, encoding='utf-8').read()
+marker = 'EXEMPT=(\n)'
+assert marker in t
+open(p, 'w', encoding='utf-8').write(t.replace(
+    marker, 'EXEMPT=(\n  "fixture_subject.sh|fixture-only exemption with a real reason"\n)', 1))
+PY
+branch_and_commit "$d" || { echo "FATAL: commit x3"; exit 10; }
+run_check "$d"; expect "X3 bare-basename EXEMPT entry → refused (10), never a silent pass" 10 'bare basename'
+
+# X1 — 🟥 REGRESSION ANCHOR (codex 2026-08-22): the EXEMPT array documented itself as "with the
+# reason" while being a bare string-membership set — the reason had NO CHANNEL to live in, so the
+# first user of the array would have satisfied the documented bar by writing a path. That is the
+# «규칙이 자기 기계에 대해 거짓을 말한다» shape ([[feedback_rule_misdescribes_its_own_machine]]).
+# A reason-less entry must now be REFUSED, and refused as a harness error (10) rather than a code
+# verdict: the checker's own configuration is malformed, so nothing it says about the code is
+# evidence either way.
+d="$(new_repo x1)" || { echo "FATAL: fixture x1"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+python3 - "$d/scripts/new_code_anchor_check.sh" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p, encoding='utf-8').read()
+marker = 'EXEMPT=(\n)'
+assert marker in t, "EXEMPT array shape changed — this lane edits a form that no longer exists"
+open(p, 'w', encoding='utf-8').write(
+    t.replace(marker, 'EXEMPT=(\n  "scripts/fixture_subject.sh"\n)', 1))
+PY
+branch_and_commit "$d" || { echo "FATAL: commit x1"; exit 10; }
+run_check "$d"; expect "X1 EXEMPT without a reason → refused (10), never a silent pass" 10 'EXEMPT'
+
+# X2 — the same refusal for a VACUOUS reason. Without this the fix would be "any character after the
+# pipe", and `foo.sh|x` would clear a bar whose whole content is that someone had to write a sentence.
+d="$(new_repo x2)" || { echo "FATAL: fixture x2"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+python3 - "$d/scripts/new_code_anchor_check.sh" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p, encoding='utf-8').read()
+marker = 'EXEMPT=(\n)'
+assert marker in t
+open(p, 'w', encoding='utf-8').write(
+    t.replace(marker, 'EXEMPT=(\n  "scripts/fixture_subject.sh|n/a"\n)', 1))
+PY
+branch_and_commit "$d" || { echo "FATAL: commit x2"; exit 10; }
+run_check "$d"; expect "X2 EXEMPT with a vacuous reason → refused (10)" 10 'EXEMPT'
+
+# P6 — a python subject, to pin that scope is not shell-only.
+d="$(new_repo p6)" || { echo "FATAL: fixture p6"; exit 10; }
+printf 'print("fixture")\n' > "$d/scripts/fixture_subject.py"
+branch_and_commit "$d" || { echo "FATAL: commit p6"; exit 10; }
+run_check "$d"; expect "P6 NO_ANCHOR — added .py" 1 'NO_ANCHOR.*fixture_subject\.py'
+
+# P7 — a git hook, the other in-scope surface.
+d="$(new_repo p7)" || { echo "FATAL: fixture p7"; exit 10; }
+mkdir -p "$d/templates/.git-hooks"
+printf '%s' "$NEWSCRIPT" > "$d/templates/.git-hooks/pre-merge-commit"
+branch_and_commit "$d" || { echo "FATAL: commit p7"; exit 10; }
+run_check "$d"; expect "P7 NO_ANCHOR — added git hook" 1 'NO_ANCHOR.*pre-merge-commit'
+
+echo ""
+echo "── known-NEGATIVES: an anchored / out-of-scope / pre-existing file must PASS ───────"
+# Without these, the suite measures only "does it block", and an always-block gate would score
+# 7/7 above. Over-blocking is not a safe failure: it trains the override into muscle memory and
+# disarms the channel ([[feedback_overblock_traded_for_failopen]]).
+
+# N1 — a lane that actually runs it, plain spelling.
+d="$(new_repo n1)" || { echo "FATAL: fixture n1"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+bash scripts/fixture_subject.sh || exit 1
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit n1"; exit 10; }
+run_check "$d"; expect "N1 EXECUTED — bash scripts/x.sh" 0 'EXECUTED.*fixture_subject\.sh'
+
+# N2 — run through an absolute-path variable, the way every real lane in this repo spells it.
+d="$(new_repo n2)" || { echo "FATAL: fixture n2"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+bash "$ROOT/scripts/fixture_subject.sh" --quiet
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit n2"; exit 10; }
+run_check "$d"; expect "N2 EXECUTED — bash \"\$ROOT/scripts/x.sh\"" 0 'EXECUTED.*fixture_subject\.sh'
+
+# N3 — command-position invocation.
+d="$(new_repo n3)" || { echo "FATAL: fixture n3"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+./scripts/fixture_subject.sh
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit n3"; exit 10; }
+run_check "$d"; expect "N3 EXECUTED — ./scripts/x.sh" 0 'EXECUTED.*fixture_subject\.sh'
+
+# N8 — 🟥 THE MEASURED FALSE POSITIVE, frozen as a lane. Assign the path to a variable on one line,
+# invoke the variable on another. This is how nearly every real lane suite in scripts/ spells it,
+# and the first version of this checker called it MENTION_ONLY — caught by hand-checking one live
+# case, not by the (then fully green) known-pair set. The fixture reproduces the exact two-line
+# shape rather than a tidied approximation.
+d="$(new_repo n8)" || { echo "FATAL: fixture n8"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CHECK="$ROOT/scripts/fixture_subject.sh"
+bash "$CHECK" --quiet || exit 1
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit n8"; exit 10; }
+run_check "$d"; expect "N8 EXECUTED(via var) — assigned then invoked" 0 'EXECUTED\(via var\).*fixture_subject\.sh'
+
+# N9 — the variable invoked in COMMAND POSITION rather than after `bash`. Same resolution, other
+# spelling; without it the predicate would be pinned to one of its two arms.
+d="$(new_repo n9)" || { echo "FATAL: fixture n9"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+CHECK="scripts/fixture_subject.sh"
+if "$CHECK" --quiet; then echo ok; fi
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit n9"; exit 10; }
+run_check "$d"; expect "N9 EXECUTED(via var) — variable in command position" 0 'EXECUTED\(via var\).*fixture_subject\.sh'
+
+# N10 — 🟥 the OVER-PERMISSIVE direction of the same repair: a variable that is assigned the path
+# and then NEVER invoked must stay MENTION_ONLY. Without this lane, "resolve the variable" could
+# have been implemented as "an assignment counts", which would pass every fixture above while
+# certifying a decoration — the exact thing this gate exists to stop.
+d="$(new_repo n10)" || { echo "FATAL: fixture n10"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+CHECK="scripts/fixture_subject.sh"
+echo "the subject under test is $CHECK"
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit n10"; exit 10; }
+run_check "$d"; expect "N10 assigned but never invoked stays MENTION_ONLY" 1 'MENTION_ONLY.*fixture_subject\.sh'
+
+# N11 — 🟥 THE KNOWN-NEGATIVE TWIN OF P9, and the reason the P9 repair is a reaching-definition
+# check rather than a blunt "any reassignment ⇒ MENTION_ONLY". The variable IS reassigned, but the
+# reassignment names the SAME subject (the conditional-override spelling), so the invocation still
+# runs it. The blunt fix would block this — and an over-blocking gate trains the override into
+# muscle memory, which is how the channel gets disarmed ([[feedback_overblock_traded_for_failopen]]).
+d="$(new_repo n11)" || { echo "FATAL: fixture n11"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+CHECK="scripts/fixture_subject.sh"
+if [ -n "${ALT:-}" ]; then CHECK="./scripts/fixture_subject.sh"; fi
+bash "$CHECK" || exit 1
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit n11"; exit 10; }
+run_check "$d"; expect "N11 reassigned to the SAME subject still EXECUTED(via var)" 0 'EXECUTED\(via var\).*fixture_subject\.sh'
+
+# N12 — the second known-negative twin of P9: the sequential-reuse spelling one variable, two
+# subjects, each invoked after its own assignment. A "last assignment wins" repair would have called
+# the FIRST subject unanchored here, which is a false block on a file that genuinely runs.
+d="$(new_repo n12)" || { echo "FATAL: fixture n12"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+CHECK="scripts/fixture_subject.sh"
+bash "$CHECK" || exit 1
+CHECK="scripts/legacy_thing.sh"
+bash "$CHECK" || exit 1
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit n12"; exit 10; }
+run_check "$d"; expect "N12 sequential reuse — invoked before the reassignment" 0 'EXECUTED\(via var\).*fixture_subject\.sh'
+
+# N13/N14 — 🟥 the known-negative twins of the SUBSTRING repair (P10–P12). A boundary that is drawn
+# too tight breaks the two commonest real spellings, where the character after the name is a closing
+# quote or a closing paren rather than whitespace. Without these, "require a boundary" could ship as
+# "require whitespace" and block most of the repo's own lanes.
+d="$(new_repo n13)" || { echo "FATAL: fixture n13"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+if bash "scripts/fixture_subject.sh"; then echo ok; fi
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit n13"; exit 10; }
+run_check "$d"; expect "N13 quoted path still EXECUTED (boundary = quote)" 0 'EXECUTED.*fixture_subject\.sh'
+
+d="$(new_repo n14)" || { echo "FATAL: fixture n14"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+out="$(bash scripts/fixture_subject.sh)"
+echo "$out"
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit n14"; exit 10; }
+run_check "$d"; expect "N14 command substitution still EXECUTED (boundary = close paren)" 0 'EXECUTED.*fixture_subject\.sh'
+
+# N15 — 🟥 REGRESSION ANCHOR (agy/gemini 2026-08-22): the runner-surface enumeration listed
+# `.github/workflows/*.yml` and NOT `*.yaml`, so a subject whose embedded --self-test is dispatched
+# from a `.yaml` workflow was classified unanchored. GitHub accepts both spellings; this repo
+# happens to use only `.yml`, which is exactly the condition under which the gap stays invisible
+# until it blocks someone else's PR ([[feedback_candidate_list_completeness]]).
+d="$(new_repo n15)" || { echo "FATAL: fixture n15"; exit 10; }
+mkdir -p "$d/.github/workflows"
+cat > "$d/scripts/fixture_selftest.sh" <<'SUBJ'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--self-test" ]; then echo "self-test ok"; exit 0; fi
+echo "normal run"
+SUBJ
+cat > "$d/.github/workflows/anchor.yaml" <<'WF'
+name: anchor
+jobs:
+  t:
+    runs-on: ubuntu-latest
+    steps:
+      - run: bash scripts/fixture_selftest.sh --self-test
+WF
+branch_and_commit "$d" || { echo "FATAL: commit n15"; exit 10; }
+run_check "$d"; expect "N15 SELFTEST_WIRED — dispatched from a .yaml workflow" 0 'SELFTEST_WIRED.*fixture_selftest\.sh'
+
+# N16 — the `.yml` control for N15. It pins that the fix ADDED a spelling rather than swapping one
+# for the other — a repair that moves the hole instead of closing it would still score N15 green.
+d="$(new_repo n16)" || { echo "FATAL: fixture n16"; exit 10; }
+mkdir -p "$d/.github/workflows"
+cat > "$d/scripts/fixture_selftest.sh" <<'SUBJ'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--self-test" ]; then echo "self-test ok"; exit 0; fi
+echo "normal run"
+SUBJ
+cat > "$d/.github/workflows/anchor.yml" <<'WF'
+name: anchor
+jobs:
+  t:
+    runs-on: ubuntu-latest
+    steps:
+      - run: bash scripts/fixture_selftest.sh --self-test
+WF
+branch_and_commit "$d" || { echo "FATAL: commit n16"; exit 10; }
+run_check "$d"; expect "N16 SELFTEST_WIRED — .yml control for N15" 0 'SELFTEST_WIRED.*fixture_selftest\.sh'
+
+# N17 — the known-negative twin of X1/X2: an EXEMPT entry that DOES carry a substantive reason must
+# still pass. Refusing everything would be the same defect wearing the other sign.
+d="$(new_repo n17)" || { echo "FATAL: fixture n17"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+python3 - "$d/scripts/new_code_anchor_check.sh" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p, encoding='utf-8').read()
+marker = 'EXEMPT=(\n)'
+assert marker in t, "EXEMPT array shape changed — this lane edits a form that no longer exists"
+open(p, 'w', encoding='utf-8').write(t.replace(
+    marker,
+    'EXEMPT=(\n  "scripts/fixture_subject.sh|fixture-only stub, exercised by the lane harness itself"\n)',
+    1))
+PY
+branch_and_commit "$d" || { echo "FATAL: commit n17"; exit 10; }
+run_check "$d"; expect "N17 EXEMPT with a substantive reason passes" 0 'EXEMPT.*fixture_subject\.sh'
+
+# N18–N21 — 🟥 THE KNOWN-NEGATIVE TWINS OF P13–P15, and the reason the repair keys on
+# "syntactically constant-false" rather than on "conditional". A guarded dispatch is the commonest
+# real spelling in this repo's own lanes; a fix that treated every branch body as unproven would
+# score P13–P15 green while blocking most legitimate anchors, and an over-blocking gate trains the
+# override into muscle memory ([[feedback_overblock_traded_for_failopen]]). Each of these four ran
+# GREEN before the repair too — that is the point: they pin that the repair moved nothing else.
+#   N18 the ordinary `[ -f … ]` guard      N19 `if true` — a CONSTANT condition that is not false,
+#   so the discriminator is falseness and not constant-ness (without it, "any literal condition is
+#   suspect" would pass every positive above)
+#   N20/N21 a dead `then` arm with a LIVE `else` arm — the dispatch in the else runs, multi-line and
+#   one-line. A masker that killed the whole construct would false-block both.
+d="$(new_repo n18)" || { echo "FATAL: fixture n18"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+CHECK="scripts/fixture_subject.sh"
+if [ -f "$CHECK" ]; then
+  bash "$CHECK"
+fi
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit n18"; exit 10; }
+run_check "$d"; expect "N18 ordinary [ -f ] guard is still EXECUTED (no over-block)" 0 'EXECUTED\(via var\).*fixture_subject\.sh'
+
+d="$(new_repo n19)" || { echo "FATAL: fixture n19"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+if true; then
+  bash scripts/fixture_subject.sh
+fi
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit n19"; exit 10; }
+run_check "$d"; expect "N19 \`if true\` — constant but not false, still EXECUTED" 0 'EXECUTED.*fixture_subject\.sh'
+
+d="$(new_repo n20)" || { echo "FATAL: fixture n20"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+if false; then
+  bash scripts/legacy_thing.sh
+else
+  bash scripts/fixture_subject.sh
+fi
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit n20"; exit 10; }
+run_check "$d"; expect "N20 dead then-arm, LIVE else-arm (multi-line) still EXECUTED" 0 'EXECUTED.*fixture_subject\.sh'
+
+d="$(new_repo n21)" || { echo "FATAL: fixture n21"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+cat > "$d/scripts/test_fixture_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+if false; then bash scripts/legacy_thing.sh; else bash scripts/fixture_subject.sh; fi
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit n21"; exit 10; }
+run_check "$d"; expect "N21 dead then-arm, LIVE else-arm (one line) still EXECUTED" 0 'EXECUTED.*fixture_subject\.sh'
+
+# N4 — GRANDFATHER control. A pre-existing unanchored script is MODIFIED, not added. If this ever
+# blocks, the gate has silently become a whole-tree audit and the diff scope is a fiction.
+d="$(new_repo n4)" || { echo "FATAL: fixture n4"; exit 10; }
+printf '#!/usr/bin/env bash\necho legacy v2\n' > "$d/scripts/legacy_thing.sh"
+branch_and_commit "$d" || { echo "FATAL: commit n4"; exit 10; }
+run_check "$d"; expect "N4 grandfathered — modified-not-added stays out of scope" 0 'PASS \(0 in scope\)'
+
+# N5 — EMPTY INPUT, asked as its own question. `all()` over an empty set is True and every
+# aggregate predicate passes vacuously ([[feedback_not_found_is_not_zero_family]]), so the lane
+# pins that the output SAYS the set was measured-and-empty rather than printing a bare green.
+d="$(new_repo n5)" || { echo "FATAL: fixture n5"; exit 10; }
+printf 'unrelated\n' > "$d/README.md"
+branch_and_commit "$d" || { echo "FATAL: commit n5"; exit 10; }
+run_check "$d"; expect "N5 empty scope — measured zero, labelled as such" 0 'measured zero, not an unrun scan'
+
+# N6 — an added LANE FILE is not a subject. Whether anything runs IT is lane_runner_check.sh's
+# question; double-owning it here would make the two checks disagree on the same file.
+d="$(new_repo n6)" || { echo "FATAL: fixture n6"; exit 10; }
+cat > "$d/scripts/test_orphan_lanes.sh" <<'LANE'
+#!/usr/bin/env bash
+echo "a lane nobody runs"
+LANE
+branch_and_commit "$d" || { echo "FATAL: commit n6"; exit 10; }
+run_check "$d"; expect "N6 added lane file is out of subject scope" 0 'PASS \(0 in scope\)'
+
+# N7 was the EXEMPT arm. It injected a BARE PATH and asserted a pass while its own label claimed
+# "declared with a reason" — the lane was itself the evidence that the reason had no channel
+# (codex, 2026-08-22). It is superseded by X1/X2 (reason-less and vacuous entries are refused) and
+# N17 (a substantive reason passes), and is not kept as a duplicate.
+
+echo ""
+echo "── instrument-death lanes: could-not-measure must be 10, never 0 ───────────────────"
+# The failure this repo keeps re-finding: an unresolvable base yields an empty diff, which is
+# byte-identical to "nothing was added". If that folded to PASS, every future run would be green
+# for the reason that the instrument was blind.
+
+# E1 — an explicitly-set base that does not resolve.
+d="$(new_repo e1)" || { echo "FATAL: fixture e1"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+branch_and_commit "$d" || { echo "FATAL: commit e1"; exit 10; }
+OUT="$(cd "$d" && NEW_CODE_ANCHOR_BASE=no-such-ref bash scripts/new_code_anchor_check.sh 2>&1)"; RC=$?
+expect "E1 unresolvable base → UNMEASURED, not PASS" 10 'UNMEASURED'
+
+# E2 — no main/master at all. Same principle, reached by a different road.
+d="$(new_repo e2)" || { echo "FATAL: fixture e2"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+branch_and_commit "$d" || { echo "FATAL: commit e2"; exit 10; }
+git -C "$d" branch -m main not-a-default-name >/dev/null 2>&1
+run_check "$d"; expect "E2 no resolvable default base → UNMEASURED" 10 'no base ref resolved'
+
+echo ""
+echo "── override channel: acknowledged is not resolved ──────────────────────────────────"
+# The override must exit 0 AND still print the findings. An override that silences the output
+# converts an acknowledgment into an erasure.
+d="$(new_repo o1)" || { echo "FATAL: fixture o1"; exit 10; }
+printf '%s' "$NEWSCRIPT" > "$d/scripts/fixture_subject.sh"
+branch_and_commit "$d" || { echo "FATAL: commit o1"; exit 10; }
+OUT="$(cd "$d" && NEW_CODE_ANCHOR_OK=1 bash scripts/new_code_anchor_check.sh 2>&1)"; RC=$?
+if [ "$RC" = "0" ] && printf '%s' "$OUT" | grep -q 'NO_ANCHOR' && \
+   printf '%s' "$OUT" | grep -q 'OVERRIDE ACCEPTED'; then
+  ok "O1 override exits 0 but the findings still print"
+else
+  bad "O1 override arm — rc=$RC, or the findings/ack line were missing"
+  printf '%s\n' "$OUT" | sed 's/^/        /'
+fi
+
+echo ""
+echo "──────────────────────────────────────────────────────────────────────────────────"
+echo "new-code-anchor lanes: PASS $PASS · FAIL $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/scripts/test_runner_surface_index_lanes.sh
+++ b/scripts/test_runner_surface_index_lanes.sh
@@ -1,0 +1,634 @@
+#!/usr/bin/env bash
+# test_runner_surface_index_lanes.sh — the known pair for defect D-5 and for the two defects the
+# first repair of D-5 introduced.
+#
+# WHAT D-5 WAS. `scripts/lane_runner_check.sh` and `scripts/script_caller_ratchet.sh` both answer
+# "is this thing WIRED?" by looking for a caller among a list of RUNNER SURFACES. Both enumerated
+# that surface with `glob.glob`, i.e. against the WORKING TREE. So a file that existed only in
+# this working copy counted as a caller. It was green that `git clone` would have deleted.
+#
+# WHAT THE FIX IS, AND WHAT IT DELIBERATELY IS NOT. Only the RUNNER surface moved to the git index.
+# The POPULATION globs (which files get CHECKED) stay on disk on purpose: there an untracked file
+# must be SEEN so a new uncommitted script goes red. Moving both would trade one silent pass for
+# another, so this suite pins BOTH directions — the tracked-runner lanes below are the over-block
+# control and are as load-bearing as the untracked ones.
+#
+# 🟥 THE FIRST REPAIR SHIPPED TWO DEFECTS OF ITS OWN. Cross-family review (codex/gpt-5.5, diff
+# axis, 2026-08-24) found them and executed the first:
+#   S  every non-zero `git ls-files` exit was folded into "no index, use the disk". A fake `git`
+#      that exits 1 for everything printed a warning and then PASSED. A missing binary, a corrupt
+#      or locked index and a permission failure all shared a branch with an unpacked tarball, so
+#      the repair against "green a clone deletes" installed a fresh green of its own — and the
+#      asymmetry was backwards, since an EMPTY result was already routed to UNMEASURED.
+#      L12–L15 pin the split; L16–L17 execute the fail-before.
+#   ①  `*` -> `[^/]*` is WIDER than the `glob.glob()` it replaced: glob hides dotfiles, the regex
+#      did not, so a hidden TRACKED file would certify a caller the old surface never contained.
+#      L18–L20 pin it, on BOTH dot spellings, L21–L22 execute the fail-before.
+#
+# 🟥 WHY THIS SUITE EXISTS AT ALL. On the day of the fix the behaviour change was ZERO: every
+# runner surface in this tree happened to be tracked. "It still passes" is therefore not evidence
+# of anything. The only evidence available is a FAIL-BEFORE executed on the pre-fix code — the
+# lanes marked "fail-before" do exactly that, by mechanically reverting ONE named line in a
+# scratch copy and asserting the defect reproduces there. Each revert self-confirms (the anchor
+# must appear exactly once, and the rewritten copy is re-read to prove the swap landed); if an
+# anchor ever stops matching, those lanes go red as WRONG-TARGET rather than passing on an
+# unmodified copy.
+#
+# Fixtures are materialised as real files in a real throwaway `git init` repo, never as strings
+# handed to a re-implementation of the predicate: a test double would measure the double.
+#
+# 🟥 FIXTURE SPELLING. Untracked runners are planted in `.github/workflows/*.yml`, in
+# `templates/.git-hooks/*` and in `scripts/*.sh`; the broken-git arm is spelled BOTH as "git is
+# entirely unusable" AND as "git works but `ls-files` alone fails" (a repair that only probed
+# `git --version` would pass the first and fail the second); the dotfile arm is spelled in a plain
+# directory AND inside the `.git-hooks` dot-directory. A partial repair goes red.
+#
+# Exit: 0 = every lane passed · 1 = a lane failed · 2 = the harness itself could not run.
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SELF_DIR/.." && pwd)"
+LRC="$ROOT/scripts/lane_runner_check.sh"
+RAT="$ROOT/scripts/script_caller_ratchet.sh"
+for _f in "$LRC" "$RAT"; do
+  [ -f "$_f" ] || { echo "FAIL  runner-surface: subject missing: $_f"; exit 2; }
+done
+REALGIT="$(command -v git 2>/dev/null)"
+[ -n "$REALGIT" ] || { echo "FAIL  runner-surface: git unavailable"; exit 2; }
+command -v python3 >/dev/null 2>&1 || { echo "FAIL  runner-surface: python3 unavailable"; exit 2; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+
+# ── fake-git shims ────────────────────────────────────────────────────────────────────────────
+# Two spellings, because they discriminate two different half-repairs. `allfail` is the shape the
+# cross-family review executed. `lsfail` is the sharper one: `git --version` and `rev-parse` both
+# work, so a repair that probes only "is the binary usable" reads the tree as healthy and then
+# gets an empty answer from a broken index.
+FAKE_ALLFAIL="$WORK/fake_allfail"; mkdir -p "$FAKE_ALLFAIL"
+printf '#!/bin/sh\nexit 1\n' > "$FAKE_ALLFAIL/git"; chmod +x "$FAKE_ALLFAIL/git"
+FAKE_LSFAIL="$WORK/fake_lsfail"; mkdir -p "$FAKE_LSFAIL"
+cat > "$FAKE_LSFAIL/git" <<EOS
+#!/bin/sh
+case "\$1" in
+  ls-files) echo "fatal: index file smaller than expected" >&2; exit 128 ;;
+  *) exec "$REALGIT" "\$@" ;;
+esac
+EOS
+chmod +x "$FAKE_LSFAIL/git"
+
+# ── the mechanical revert anchors ─────────────────────────────────────────────────────────────
+# One named line per defect, so each fail-before is a single deliberate substitution rather than a
+# hand-built "old version" that could drift from what actually shipped.
+#   enum  — D-5 itself: runner enumeration goes back to globbing the disk.
+#   state — the S-class: the initial state goes back to `nongit`, so EVERY unresolved branch falls
+#           through to the disk fallback exactly as the first repair did.
+#   dot   — defect ①: the dotfile guard is removed from the segment translator.
+_revert_copy() {   # $1 = kind (enum|state|dot) · $2 = src · $3 = dst
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys
+kind, src, dst = sys.argv[1:4]
+ANCHORS = {
+    'enum': ('runners = enumerate_runners(RUNNER_GLOBS)',
+             'runners = [p for pat in RUNNER_GLOBS for p in glob.glob(pat) if os.path.isfile(p)]'),
+    'state': ('FH_INDEX_STATE="UNMEASURED"; FH_INDEX_WHY="not determined"; FH_INDEX_FILE_LIST=""',
+              'FH_INDEX_STATE="nongit"; FH_INDEX_WHY="not determined"; FH_INDEX_FILE_LIST=""'),
+    'dot': ("            _s += '(?!\\\\.)'",
+            "            _s += ''  # DOTFILE GUARD REMOVED (fail-before fixture)"),
+    'content': ("    if INDEX_MODE != 'index' or not paths:",
+                '    if True:  # INDEX BLOB LOADER DISABLED (fail-before fixture)'),
+    'isfile': ('        return [_p for _p in INDEX_FILES if any(_r.match(_p) for _r in _rx)]',
+               '        return [_p for _p in INDEX_FILES if any(_r.match(_p) for _r in _rx) and os.path.isfile(_p)]'),
+}
+fixed, prefix = ANCHORS[kind]
+t = open(src, encoding='utf-8').read()
+if t.count(fixed) != 1:
+    print('WRONG-TARGET: the %s anchor appears %d times in %s' % (kind, t.count(fixed), src))
+    raise SystemExit(3)
+open(dst, 'w', encoding='utf-8').write(t.replace(fixed, prefix, 1))
+# step 1 of the control, done mechanically: re-read what was written and prove the swap landed.
+# A copy that was not modified would pass the lane below while proving nothing.
+back = open(dst, encoding='utf-8').read()
+if fixed in back or prefix not in back:
+    print('WRONG-TARGET: the %s revert did not land in %s' % (kind, dst))
+    raise SystemExit(4)
+raise SystemExit(0)
+PY
+}
+
+# ── fixture builders ──────────────────────────────────────────────────────────────────────────
+# `git init` + `git add`, no commit. `git ls-files` reads the INDEX, so staging is enough and the
+# fixture never needs a commit, an identity, or a base ref.
+_new_repo() {
+  local d="$WORK/$1"
+  rm -rf "$d"; mkdir -p "$d/scripts" "$d/.github/workflows" "$d/templates/.git-hooks"
+  git -C "$d" init -q 2>/dev/null || return 2
+  printf '%s' "$d"
+}
+
+_write_workflow() {
+  cat > "$1" <<YML
+name: zz-d5-probe
+on: [push]
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: bash $2
+YML
+}
+_write_hook() {
+  printf '#!/usr/bin/env bash\nbash %s || exit 1\n' "$2" > "$1"
+  chmod +x "$1"
+}
+
+# runner kind -> relative path. `dotwf` and `dothook` are the two dotfile spellings: a hidden file
+# in a plain directory, and a hidden file inside the `.git-hooks` DOT-DIRECTORY. The second is the
+# one that reads as already-covered and is not: what glob hides is a leading dot in the matched
+# BASENAME, never a dot in a literal directory component.
+_runner_path() {
+  case "$1" in
+    workflow) printf '.github/workflows/zz-d5-probe.yml' ;;
+    hook)     printf 'templates/.git-hooks/zz-d5-probe' ;;
+    script)   printf 'scripts/zz_d5_runner.sh' ;;
+    dotwf)    printf '.github/workflows/.zz-d5-hidden.yml' ;;
+    dothook)  printf 'templates/.git-hooks/.zz-d5-hidden' ;;
+  esac
+}
+_write_runner() {  # $1 = kind · $2 = abs path · $3 = dispatch target
+  case "$1" in
+    workflow|dotwf) _write_workflow "$2" "$3" ;;
+    *)              _write_hook     "$2" "$3" ;;
+  esac
+}
+
+# `unstaged` is the sharpest spelling of the second half of D-5: the runner FILE is tracked, its
+# index blob is a real runner, and it even NAMES the target -- in a comment, which is a mention and
+# not an invocation. The only dispatch lives in the working tree and has never been staged. A
+# repair that greps the blob for the name, or that reads the file list from the index and the body
+# from disk, both certify it. Only reading the BODY from the index gets it right.
+_write_unstaged_runner() {  # $1 = abs path · $2 = dispatch target · $3 = repo dir · $4 = rel path
+  {
+    printf 'name: zz-d5-probe\non: [push]\njobs:\n  probe:\n    runs-on: ubuntu-latest\n'
+    printf '    steps:\n      # see %s for the calibration this workflow will run one day\n' "$2"
+    printf '      - run: echo staged-body-dispatches-nothing\n'
+  } > "$1"
+  git -C "$3" add "$4" >/dev/null 2>&1 || return 2
+  printf '      - run: bash %s\n' "$2" >> "$1"     # working tree ONLY -- never staged
+}
+
+PROBE_SUITE='test_zz_d5_probe_lanes.sh'
+PROBE_SUBJ='zz_d5_probe_subject.sh'
+
+_lrc_fixture() {   # $1 = tag · $2 = runner kind (or none) · $3 = track? (1|0)
+  local d; d="$(_new_repo "$1")" || return 2
+  printf '#!/usr/bin/env bash\necho "zz probe lane"\nexit 0\n' > "$d/scripts/$PROBE_SUITE"
+  cp "$LRC" "$d/scripts/lane_runner_check.sh"
+  git -C "$d" add "scripts/$PROBE_SUITE" >/dev/null 2>&1 || return 2
+  if [ "$2" != "none" ]; then
+    local runner; runner="$(_runner_path "$2")"
+    _write_runner "$2" "$d/$runner" "scripts/$PROBE_SUITE"
+    [ "$3" = "1" ] && { git -C "$d" add "$runner" >/dev/null 2>&1 || return 2; }
+  fi
+  printf '%s' "$d"
+}
+_rat_fixture() {   # $1 = tag · $2 = runner kind (or none) · $3 = track?
+  local d; d="$(_new_repo "$1")" || return 2
+  printf '#!/usr/bin/env bash\necho "zz probe subject"\n' > "$d/scripts/$PROBE_SUBJ"
+  printf 'exempt:\nbaseline:\n' > "$d/scripts/caller_zero_baseline.txt"
+  git -C "$d" add "scripts/$PROBE_SUBJ" "scripts/caller_zero_baseline.txt" >/dev/null 2>&1 || return 2
+  if [ "$2" != "none" ]; then
+    local runner; runner="$(_runner_path "$2")"
+    _write_runner "$2" "$d/$runner" "scripts/$PROBE_SUBJ"
+    [ "$3" = "1" ] && { git -C "$d" add "$runner" >/dev/null 2>&1 || return 2; }
+  fi
+  printf '%s' "$d"
+}
+
+_lrc_run() {  # $1 = fixture dir · $2 = script (default: the copy inside) · $3 = PATH prefix
+  local script="${2:-$1/scripts/lane_runner_check.sh}"
+  if [ -n "${3:-}" ]; then ( cd "$1" && PATH="$3:$PATH" bash "$script" 2>&1 )
+  else                     ( cd "$1" && bash "$script" 2>&1 ); fi
+}
+_rat_run() {  # $1 = fixture dir · $2 = script (default: the real one) · $3 = PATH prefix
+  local script="${2:-$RAT}"
+  if [ -n "${3:-}" ]; then PATH="$3:$PATH" bash "$script" --root "$1" 2>&1
+  else                     bash "$script" --root "$1" 2>&1; fi
+}
+
+echo "── D-5 runner surface: lane_runner_check.sh ──────────────────────────────────────────────"
+
+D="$(_lrc_fixture lrc_untracked_wf workflow 0)" || { echo "FAIL harness: fixture build"; exit 2; }
+OUT="$(_lrc_run "$D")"; RC=$?
+if printf '%s' "$OUT" | grep -q "$PROBE_SUITE" && [ "$RC" -ne 0 ]; then
+  ok "L1 untracked .github/workflows runner does NOT certify a suite as WIRED"
+else
+  bad "L1 untracked workflow still certifies the suite (rc=$RC) — D-5 is live"
+fi
+
+D="$(_lrc_fixture lrc_tracked_wf workflow 1)" || { echo "FAIL harness: fixture build"; exit 2; }
+OUT="$(_lrc_run "$D")"; RC=$?
+if [ "$RC" -eq 0 ] && ! printf '%s' "$OUT" | grep -q "no runner and no declaration"; then
+  ok "L2 TRACKED workflow runner still certifies WIRED (no over-block)"
+else
+  bad "L2 over-block: a runner that IS in the index was dropped (rc=$RC)"
+fi
+
+D="$(_lrc_fixture lrc_untracked_hook hook 0)" || { echo "FAIL harness: fixture build"; exit 2; }
+OUT="$(_lrc_run "$D")"; RC=$?
+if printf '%s' "$OUT" | grep -q "$PROBE_SUITE" && [ "$RC" -ne 0 ]; then
+  ok "L3 untracked templates/.git-hooks runner does NOT certify WIRED (second spelling)"
+else
+  bad "L3 the hook glob still resolves against disk — the repair was partial (rc=$RC)"
+fi
+
+D="$(_lrc_fixture lrc_untracked_script script 0)" || { echo "FAIL harness: fixture build"; exit 2; }
+OUT="$(_lrc_run "$D")"; RC=$?
+if printf '%s' "$OUT" | grep -q "$PROBE_SUITE" && [ "$RC" -ne 0 ]; then
+  ok "L4 untracked scripts/*.sh runner does NOT certify WIRED (third spelling)"
+else
+  bad "L4 the scripts glob still resolves against disk (rc=$RC)"
+fi
+
+# ── L5: UNMEASURED is not zero ────────────────────────────────────────────────────────────────
+D="$(_new_repo lrc_empty_index)" || { echo "FAIL harness: fixture build"; exit 2; }
+printf '#!/usr/bin/env bash\nexit 0\n' > "$D/scripts/$PROBE_SUITE"
+cp "$LRC" "$D/scripts/lane_runner_check.sh"
+OUT="$(_lrc_run "$D")"; RC=$?
+if [ "$RC" -ne 0 ] && printf '%s' "$OUT" | grep -qi "UNMEASURED"; then
+  ok "L5 empty index in tracked territory → UNMEASURED, refuses to report zero runners"
+else
+  bad "L5 an empty index was folded into a verdict (rc=$RC)"
+fi
+
+# ── L6: no index at all (an unpacked npm tarball) degrades to disk, LABELLED ──────────────────
+D="$WORK/lrc_nongit"; rm -rf "$D"; mkdir -p "$D/scripts" "$D/.github/workflows"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$D/scripts/$PROBE_SUITE"
+cp "$LRC" "$D/scripts/lane_runner_check.sh"
+_write_workflow "$D/.github/workflows/zz-d5-probe.yml" "scripts/$PROBE_SUITE"
+OUT="$( cd "$D" && bash "$D/scripts/lane_runner_check.sh" 2>&1 )"; RC=$?
+if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | grep -q "nongit"; then
+  ok "L6 no repository and no .git above → disk fallback, and the run SAYS so (not zero)"
+else
+  bad "L6 the non-git degrade is wrong or silent (rc=$RC)"
+  printf '%s\n' "$OUT" | tail -4 | sed 's/^/       /'
+fi
+
+echo "── D-5 runner surface: script_caller_ratchet.sh ──────────────────────────────────────────"
+
+D="$(_rat_fixture rat_untracked_wf workflow 0)" || { echo "FAIL harness: fixture build"; exit 2; }
+OUT="$(_rat_run "$D")"; RC=$?
+if [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q "$PROBE_SUBJ"; then
+  ok "L7 untracked .github/workflows runner does NOT certify a script as having a caller"
+else
+  bad "L7 untracked workflow still counts as a caller (rc=$RC) — D-5 is live"
+fi
+
+D="$(_rat_fixture rat_tracked_wf workflow 1)" || { echo "FAIL harness: fixture build"; exit 2; }
+OUT="$(_rat_run "$D")"; RC=$?
+if [ "$RC" -eq 0 ]; then
+  ok "L8 TRACKED workflow runner still counts as a caller (no over-block)"
+else
+  bad "L8 over-block: a runner that IS in the index was dropped (rc=$RC)"
+fi
+
+D="$(_rat_fixture rat_untracked_hook hook 0)" || { echo "FAIL harness: fixture build"; exit 2; }
+OUT="$(_rat_run "$D")"; RC=$?
+if [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q "$PROBE_SUBJ"; then
+  ok "L9 untracked templates/.git-hooks runner does NOT count as a caller (second spelling)"
+else
+  bad "L9 the hook glob still resolves against disk — the repair was partial (rc=$RC)"
+fi
+
+# ══ FAIL-BEFORE for D-5 itself ════════════════════════════════════════════════════════════════
+echo "── fail-before: D-5 (the pre-fix enumeration, executed) ──────────────────────────────────"
+
+# 🟥 TWO reverts, chained, because the pre-fix code was pre-fix in BOTH halves: it globbed the
+# disk for runner NAMES *and* read their BODIES from disk. Reverting only the enumeration leaves
+# the blob loader in place, which then correctly reports "no blob in the index for <untracked
+# runner>" and goes UNMEASURED — red, but for the wrong reason, and it would not reproduce the
+# original green. Each step self-confirms, so a chain that half-applies is WRONG-TARGET.
+D="$(_lrc_fixture lrc_failbefore workflow 0)" || { echo "FAIL harness: fixture build"; exit 2; }
+MSG="$(_revert_copy enum "$LRC" "$WORK/lrc_enum_step1.sh")" && MSG="$(_revert_copy content "$WORK/lrc_enum_step1.sh" "$D/scripts/lane_runner_check.sh")"; RRC=$?
+if [ "$RRC" -ne 0 ]; then
+  bad "L10 revert control could not apply: $MSG"
+else
+  OUT="$(_lrc_run "$D")"; RC=$?
+  if [ "$RC" -eq 0 ] && ! printf '%s' "$OUT" | grep -q "no runner and no declaration"; then
+    ok "L10 fail-before: pre-fix lane_runner_check reads the UNTRACKED runner as WIRED"
+  else
+    bad "L10 fail-before did NOT reproduce (rc=$RC) — the fixture is not potent, so L1 proves nothing"
+  fi
+fi
+
+D="$(_rat_fixture rat_failbefore workflow 0)" || { echo "FAIL harness: fixture build"; exit 2; }
+PRE="$WORK/rat_enum_prefix.sh"
+MSG="$(_revert_copy enum "$RAT" "$WORK/rat_enum_step1.sh")" && MSG="$(_revert_copy content "$WORK/rat_enum_step1.sh" "$PRE")"; RRC=$?
+if [ "$RRC" -ne 0 ]; then
+  bad "L11 revert control could not apply: $MSG"
+else
+  OUT="$(_rat_run "$D" "$PRE")"; RC=$?
+  if [ "$RC" -eq 0 ]; then
+    ok "L11 fail-before: pre-fix caller-ratchet reads the UNTRACKED runner as a caller"
+  else
+    bad "L11 fail-before did NOT reproduce (rc=$RC) — the fixture is not potent, so L7 proves nothing"
+  fi
+fi
+
+# ══ S-CLASS: "git failed" must never be read as "not a repository" ════════════════════════════
+# The fixture is a HEALTHY tracked repo. Only the git binary is sabotaged, so any verdict other
+# than UNMEASURED means the subject answered a question it could not measure.
+echo "── S-class: broken git ≠ no repository ───────────────────────────────────────────────────"
+
+D="$(_lrc_fixture lrc_gitallfail workflow 1)" || { echo "FAIL harness: fixture build"; exit 2; }
+OUT="$(_lrc_run "$D" "" "$FAKE_ALLFAIL")"; RC=$?
+if [ "$RC" -ne 0 ] && printf '%s' "$OUT" | grep -qi "UNMEASURED"; then
+  ok "L12 lane-runner: a git that fails everything → UNMEASURED, not a disk-fallback PASS"
+else
+  bad "L12 a broken git produced a verdict (rc=$RC) — the S-class hole is open"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
+fi
+
+D="$(_lrc_fixture lrc_gitlsfail workflow 1)" || { echo "FAIL harness: fixture build"; exit 2; }
+OUT="$(_lrc_run "$D" "" "$FAKE_LSFAIL")"; RC=$?
+if [ "$RC" -ne 0 ] && printf '%s' "$OUT" | grep -qi "UNMEASURED"; then
+  ok "L13 lane-runner: git healthy but \`ls-files\` broken → UNMEASURED (the sharper spelling)"
+else
+  bad "L13 a corrupt index passed as a clean tree (rc=$RC) — probing only \`git --version\` is not enough"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
+fi
+
+D="$(_rat_fixture rat_gitallfail workflow 1)" || { echo "FAIL harness: fixture build"; exit 2; }
+OUT="$(_rat_run "$D" "" "$FAKE_ALLFAIL")"; RC=$?
+if [ "$RC" -eq 2 ] && printf '%s' "$OUT" | grep -qi "UNMEASURED"; then
+  ok "L14 caller-ratchet: a git that fails everything → exit 2 UNMEASURED, not a PASS"
+else
+  bad "L14 a broken git produced a verdict (rc=$RC) — the S-class hole is open"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
+fi
+
+D="$(_rat_fixture rat_gitlsfail workflow 1)" || { echo "FAIL harness: fixture build"; exit 2; }
+OUT="$(_rat_run "$D" "" "$FAKE_LSFAIL")"; RC=$?
+if [ "$RC" -eq 2 ] && printf '%s' "$OUT" | grep -qi "UNMEASURED"; then
+  ok "L15 caller-ratchet: git healthy but \`ls-files\` broken → exit 2 UNMEASURED"
+else
+  bad "L15 a corrupt index passed as a clean tree (rc=$RC)"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
+fi
+
+echo "── fail-before: S-class (the first repair's state fold, executed) ────────────────────────"
+# Reverting the initial state to `nongit` restores exactly the first repair's behaviour: every
+# unresolved branch falls through to the disk fallback. The fixture below is a HEALTHY repo with
+# a TRACKED runner, so the pre-fix code must print a warning and then PASS — which is the thing
+# the cross-family review executed and this suite now owns.
+D="$(_lrc_fixture lrc_state_failbefore workflow 1)" || { echo "FAIL harness: fixture build"; exit 2; }
+MSG="$(_revert_copy state "$LRC" "$D/scripts/lane_runner_check.sh")"; RRC=$?
+if [ "$RRC" -ne 0 ]; then
+  bad "L16 revert control could not apply: $MSG"
+else
+  OUT="$(_lrc_run "$D" "" "$FAKE_ALLFAIL")"; RC=$?
+  if [ "$RC" -eq 0 ]; then
+    ok "L16 fail-before: the first repair PASSES with a totally broken git (defect reproduced)"
+  else
+    bad "L16 fail-before did NOT reproduce (rc=$RC) — L12/L13 then prove nothing"
+  fi
+fi
+
+D="$(_rat_fixture rat_state_failbefore workflow 1)" || { echo "FAIL harness: fixture build"; exit 2; }
+PRE="$WORK/rat_state_prefix.sh"
+MSG="$(_revert_copy state "$RAT" "$PRE")"; RRC=$?
+if [ "$RRC" -ne 0 ]; then
+  bad "L17 revert control could not apply: $MSG"
+else
+  OUT="$(_rat_run "$D" "$PRE" "$FAKE_ALLFAIL")"; RC=$?
+  if [ "$RC" -eq 0 ]; then
+    ok "L17 fail-before: the first repair PASSES with a totally broken git (defect reproduced)"
+  else
+    bad "L17 fail-before did NOT reproduce (rc=$RC) — L14/L15 then prove nothing"
+  fi
+fi
+
+# ══ DEFECT ①: dotfile parity with glob.glob ═══════════════════════════════════════════════════
+# The runner here is TRACKED — the index question is satisfied — and hidden. `glob.glob` never
+# returned it, so the index surface must not either, or the repair widened the surface it was
+# supposed to narrow. Both dot spellings, because the `.git-hooks` one reads as already covered.
+echo "── defect ①: dotfile parity with glob.glob ───────────────────────────────────────────────"
+
+D="$(_lrc_fixture lrc_dotwf dotwf 1)" || { echo "FAIL harness: fixture build"; exit 2; }
+OUT="$(_lrc_run "$D")"; RC=$?
+if [ "$RC" -ne 0 ] && printf '%s' "$OUT" | grep -q "$PROBE_SUITE"; then
+  ok "L18 a TRACKED hidden .github/workflows/.x.yml does NOT certify WIRED (glob hides dotfiles)"
+else
+  bad "L18 the index surface is WIDER than the glob.glob it replaced (rc=$RC)"
+fi
+
+D="$(_lrc_fixture lrc_dothook dothook 1)" || { echo "FAIL harness: fixture build"; exit 2; }
+OUT="$(_lrc_run "$D")"; RC=$?
+if [ "$RC" -ne 0 ] && printf '%s' "$OUT" | grep -q "$PROBE_SUITE"; then
+  ok "L19 a TRACKED hidden file inside the .git-hooks DOT-DIRECTORY does NOT certify WIRED"
+else
+  bad "L19 dotfile parity was fixed in one spelling only (rc=$RC)"
+fi
+
+D="$(_rat_fixture rat_dothook dothook 1)" || { echo "FAIL harness: fixture build"; exit 2; }
+OUT="$(_rat_run "$D")"; RC=$?
+if [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q "$PROBE_SUBJ"; then
+  ok "L20 caller-ratchet: a TRACKED hidden runner does NOT count as a caller"
+else
+  bad "L20 caller-ratchet's surface is wider than glob.glob (rc=$RC)"
+fi
+
+echo "── fail-before: dotfile guard (removed, executed) ────────────────────────────────────────"
+D="$(_lrc_fixture lrc_dot_failbefore dotwf 1)" || { echo "FAIL harness: fixture build"; exit 2; }
+MSG="$(_revert_copy dot "$LRC" "$D/scripts/lane_runner_check.sh")"; RRC=$?
+if [ "$RRC" -ne 0 ]; then
+  bad "L21 revert control could not apply: $MSG"
+else
+  OUT="$(_lrc_run "$D")"; RC=$?
+  if [ "$RC" -eq 0 ]; then
+    ok "L21 fail-before: without the guard the hidden runner DOES certify (defect reproduced)"
+  else
+    bad "L21 fail-before did NOT reproduce (rc=$RC) — L18/L19 then prove nothing"
+  fi
+fi
+
+D="$(_rat_fixture rat_dot_failbefore dothook 1)" || { echo "FAIL harness: fixture build"; exit 2; }
+PRE="$WORK/rat_dot_prefix.sh"
+MSG="$(_revert_copy dot "$RAT" "$PRE")"; RRC=$?
+if [ "$RRC" -ne 0 ]; then
+  bad "L22 revert control could not apply: $MSG"
+else
+  OUT="$(_rat_run "$D" "$PRE")"; RC=$?
+  if [ "$RC" -eq 0 ]; then
+    ok "L22 fail-before: without the guard the hidden runner DOES count as a caller"
+  else
+    bad "L22 fail-before did NOT reproduce (rc=$RC) — L20 then proves nothing"
+  fi
+fi
+
+# ── L23: a package unpacked INSIDE a repo that ignores it ─────────────────────────────────────
+# `git ls-files` answers rc=0 and NOTHING here, which is indistinguishable from an empty index by
+# exit code alone. Blocking would red-light every consumer install that lives under a gitignored
+# node_modules, which this repo's own doctrine calls a bypass trainer — so it degrades to disk and
+# says which of the two disk states it is in.
+echo "── outside-index (a package unpacked inside another repo) ────────────────────────────────"
+D="$(_new_repo lrc_outside)" || { echo "FAIL harness: fixture build"; exit 2; }
+printf 'vendor/\n' > "$D/.gitignore"
+git -C "$D" add .gitignore >/dev/null 2>&1
+mkdir -p "$D/vendor/pkg/scripts" "$D/vendor/pkg/.github/workflows"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$D/vendor/pkg/scripts/$PROBE_SUITE"
+cp "$LRC" "$D/vendor/pkg/scripts/lane_runner_check.sh"
+_write_workflow "$D/vendor/pkg/.github/workflows/zz-d5-probe.yml" "scripts/$PROBE_SUITE"
+OUT="$( cd "$D/vendor/pkg" && bash scripts/lane_runner_check.sh 2>&1 )"; RC=$?
+if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | grep -q "outside-index"; then
+  ok "L23 ignored subtree → labelled outside-index disk fallback, not a red gate on every install"
+else
+  bad "L23 an ignored subtree was misrouted (rc=$RC)"
+  printf '%s\n' "$OUT" | tail -4 | sed 's/^/       /'
+fi
+
+# ══ D-5, SECOND HALF: the runner's BODY must come from the index too ══════════════════════════
+echo "── second half: tracked runner + UNSTAGED dispatch line ──────────────────────────────────"
+
+D="$(_lrc_fixture lrc_unstaged none 0)" || { echo "FAIL harness: fixture build"; exit 2; }
+_write_unstaged_runner "$D/.github/workflows/zz-d5-probe.yml" "scripts/$PROBE_SUITE" "$D" ".github/workflows/zz-d5-probe.yml"
+OUT="$(_lrc_run "$D")"; RC=$?
+if [ "$RC" -ne 0 ] && printf '%s' "$OUT" | grep -q "$PROBE_SUITE"; then
+  ok "L24 an UNSTAGED dispatch line in a TRACKED runner does NOT certify WIRED"
+else
+  bad "L24 working-tree-only wiring still counts (rc=$RC) — only half the surface is index-grounded"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
+fi
+
+D="$(_rat_fixture rat_unstaged none 0)" || { echo "FAIL harness: fixture build"; exit 2; }
+_write_unstaged_runner "$D/.github/workflows/zz-d5-probe.yml" "scripts/$PROBE_SUBJ" "$D" ".github/workflows/zz-d5-probe.yml"
+OUT="$(_rat_run "$D")"; RC=$?
+if [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q "$PROBE_SUBJ"; then
+  ok "L25 caller-ratchet: an UNSTAGED dispatch line does NOT count as a caller"
+else
+  bad "L25 working-tree-only wiring still counts as a caller (rc=$RC)"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
+fi
+
+echo "── fail-before: runner body read from disk (executed) ────────────────────────────────────"
+D="$(_lrc_fixture lrc_content_failbefore none 0)" || { echo "FAIL harness: fixture build"; exit 2; }
+_write_unstaged_runner "$D/.github/workflows/zz-d5-probe.yml" "scripts/$PROBE_SUITE" "$D" ".github/workflows/zz-d5-probe.yml"
+MSG="$(_revert_copy content "$LRC" "$D/scripts/lane_runner_check.sh")"; RRC=$?
+if [ "$RRC" -ne 0 ]; then
+  bad "L26 revert control could not apply: $MSG"
+else
+  OUT="$(_lrc_run "$D")"; RC=$?
+  if [ "$RC" -eq 0 ]; then
+    ok "L26 fail-before: reading the body from disk certifies the unstaged line (defect reproduced)"
+  else
+    bad "L26 fail-before did NOT reproduce (rc=$RC) — L24 then proves nothing"
+  fi
+fi
+
+D="$(_rat_fixture rat_content_failbefore none 0)" || { echo "FAIL harness: fixture build"; exit 2; }
+_write_unstaged_runner "$D/.github/workflows/zz-d5-probe.yml" "scripts/$PROBE_SUBJ" "$D" ".github/workflows/zz-d5-probe.yml"
+PRE="$WORK/rat_content_prefix.sh"
+MSG="$(_revert_copy content "$RAT" "$PRE")"; RRC=$?
+if [ "$RRC" -ne 0 ]; then
+  bad "L27 revert control could not apply: $MSG"
+else
+  OUT="$(_rat_run "$D" "$PRE")"; RC=$?
+  if [ "$RC" -eq 0 ]; then
+    ok "L27 fail-before: reading the body from disk certifies the unstaged line (defect reproduced)"
+  else
+    bad "L27 fail-before did NOT reproduce (rc=$RC) — L25 then proves nothing"
+  fi
+fi
+
+# ══ A-CLASS: the working tree must not decide an index-grounded population ════════════════════
+# The runner is TRACKED and its blob dispatches the target; only the working-tree FILE is gone
+# (`rm`, deliberately NOT `git rm` — the index entry survives). In a clone that wiring exists, so
+# WIRED is the correct answer. The pre-fix code filtered the index list by `os.path.isfile` and
+# therefore dropped the runner entirely — a FALSE RED, and worse, it slipped past the completeness
+# check that exists to turn "could not read" into UNMEASURED.
+# 🟥 Recorded divergence: the brief expected the post-fix verdict to be UNMEASURED/red. Measured,
+# it is green, and green is right — the blob is readable, so there is nothing unmeasured. What the
+# fix removes is the working tree's vote, not the runner.
+echo "── A-class: tracked runner deleted from the WORKING TREE only ────────────────────────────"
+
+D="$(_lrc_fixture lrc_wt_deleted workflow 1)" || { echo "FAIL harness: fixture build"; exit 2; }
+rm -f "$D/$(_runner_path workflow)"
+OUT="$(_lrc_run "$D")"; RC=$?
+if [ "$RC" -eq 0 ] && ! printf '%s' "$OUT" | grep -q "no runner and no declaration"; then
+  ok "L28 a TRACKED runner missing from the worktree still counts — the index is the authority"
+else
+  bad "L28 the working tree removed a runner from an index-grounded population (rc=$RC)"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
+fi
+
+D="$(_rat_fixture rat_wt_deleted workflow 1)" || { echo "FAIL harness: fixture build"; exit 2; }
+rm -f "$D/$(_runner_path workflow)"
+OUT="$(_rat_run "$D")"; RC=$?
+if [ "$RC" -eq 0 ]; then
+  ok "L29 caller-ratchet: same — a worktree-deleted tracked runner is still a caller"
+else
+  bad "L29 the working tree removed a runner from an index-grounded population (rc=$RC)"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
+fi
+
+echo "── fail-before: isfile filter over the index list (executed) ─────────────────────────────"
+D="$(_lrc_fixture lrc_isfile_failbefore workflow 1)" || { echo "FAIL harness: fixture build"; exit 2; }
+rm -f "$D/$(_runner_path workflow)"
+MSG="$(_revert_copy isfile "$LRC" "$D/scripts/lane_runner_check.sh")"; RRC=$?
+if [ "$RRC" -ne 0 ]; then
+  bad "L30 revert control could not apply: $MSG"
+else
+  OUT="$(_lrc_run "$D")"; RC=$?
+  if [ "$RC" -ne 0 ] && printf '%s' "$OUT" | grep -q "$PROBE_SUITE"; then
+    ok "L30 fail-before: the isfile filter silently drops the tracked runner (defect reproduced)"
+  else
+    bad "L30 fail-before did NOT reproduce (rc=$RC) — L28 then proves nothing"
+  fi
+fi
+
+D="$(_rat_fixture rat_isfile_failbefore workflow 1)" || { echo "FAIL harness: fixture build"; exit 2; }
+rm -f "$D/$(_runner_path workflow)"
+PRE="$WORK/rat_isfile_prefix.sh"
+MSG="$(_revert_copy isfile "$RAT" "$PRE")"; RRC=$?
+if [ "$RRC" -ne 0 ]; then
+  bad "L31 revert control could not apply: $MSG"
+else
+  OUT="$(_rat_run "$D" "$PRE")"; RC=$?
+  if [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q "$PROBE_SUBJ"; then
+    ok "L31 fail-before: the isfile filter silently drops the tracked runner (defect reproduced)"
+  else
+    bad "L31 fail-before did NOT reproduce (rc=$RC) — L29 then proves nothing"
+  fi
+fi
+
+# ══ B-CLASS: a NEWLINE in a tracked path ══════════════════════════════════════════════════════
+# `git ls-files -z` exists so that such a path survives transport. An earlier draft translated the
+# NULs back to newlines into an env var, which split this fixture into two bogus paths before the
+# scan ever ran. The list now travels as a FILE and is split on NUL; the path then reaches the
+# batch loader, which refuses it (cat-file --batch input is newline-delimited) and routes to
+# UNMEASURED rather than guessing. Not creatable on every filesystem — if it cannot be built here,
+# this lane reports UNMEASURED and neither passes nor fails, which is the honest value.
+echo "── B-class: a newline inside a tracked path ──────────────────────────────────────────────"
+D="$(_lrc_fixture lrc_newline none 0)" || { echo "FAIL harness: fixture build"; exit 2; }
+NLNAME="$(printf 'zz-d5\nnl.yml')"
+if printf 'run: bash scripts/%s\n' "$PROBE_SUITE" > "$D/.github/workflows/$NLNAME" 2>/dev/null \
+   && git -C "$D" add -- ".github/workflows/$NLNAME" >/dev/null 2>&1; then
+  OUT="$(_lrc_run "$D")"; RC=$?
+  if [ "$RC" -ne 0 ] && printf '%s' "$OUT" | grep -q "newline"; then
+    ok "L32 a newline in a tracked runner path → UNMEASURED, never silently split into two paths"
+  else
+    bad "L32 a newline path was mis-handled (rc=$RC)"
+    printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
+  fi
+else
+  echo "  ⬜ L32 UNMEASURED — this filesystem would not accept a newline in a filename, so the"
+  echo "       transport fix is unexercised here. Not a pass and not a failure."
+fi
+
+echo "──────────────────────────────────────────────────────────────────────────────────────────"
+echo "runner-surface-index 캘리브레이션: PASS $PASS · FAIL $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/scripts/test_script_caller_ratchet_lanes.sh
+++ b/scripts/test_script_caller_ratchet_lanes.sh
@@ -55,8 +55,21 @@ mkfix() {
   printf 'run: bash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
   echo "$d"
 }
-run()  { bash "$CHECK" --root "$1" 2>&1; }
-rcof() { bash "$CHECK" --root "$1" >/dev/null 2>&1; echo $?; }
+# 🟥 2026-08-24: the checker now reads a runner's BODY from the git index, not from the working
+# tree (D-5 second half -- an unstaged dispatch line is wiring that exists in nobody's clone). The
+# git-backed fixtures below rewrite .github/workflows/ci.yml AFTER their commit, so their intended
+# wiring was working-tree-only and stopped counting. Staging that one file restores each lane's
+# INTENT -- "this runner dispatches X" -- without weakening anything: it is what an author does
+# before committing, and the non-git fixtures (the majority) are untouched because there is no
+# index there to stage into. Only ci.yml is staged; the baseline file is deliberately left dirty,
+# which is what the shrink-only lanes measure.
+_stage_runner() {
+  git -C "$1" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+  [ -f "$1/.github/workflows/ci.yml" ] || return 0
+  git -C "$1" add .github/workflows/ci.yml >/dev/null 2>&1 || true
+}
+run()  { _stage_runner "$1"; bash "$CHECK" --root "$1" 2>&1; }
+rcof() { _stage_runner "$1"; bash "$CHECK" --root "$1" >/dev/null 2>&1; echo $?; }
 # Variants that forward extra flags/env (--base, FH_RATCHET_REQUIRE_BASE) to the checker.
 runx()  { _d="$1"; shift; bash "$CHECK" --root "$_d" "$@" 2>&1; }
 rcofx() { _d="$1"; shift; bash "$CHECK" --root "$_d" "$@" >/dev/null 2>&1; echo $?; }


### PR DESCRIPTION
커밋 둘이 같은 이야기의 앞뒤다 — **초록이 어디에 기대고 있었나**. 하나는 untracked 파일에, 하나는 워킹트리에. 둘 다 clone 을 못 넘는 초록이었다.

## 20cc210 — new-code-anchor 3종을 tracked 로
레인은 `42/42 PASS`, lane_runner 는 `71/71 wired` 였는데 그 초록이 **디스크에만 있는 파일**에 기대고 있었다.

🟥 `selfcheck.sh` 짝 표에 행을 추가하려다 **철회했다.** 적대검증이 지목하고 실행으로 재현했다 — shipped `selfcheck.sh` 가 `files[]` 밖 경로를 이름대면 `package_coverage_check` 가 phantom 판정을 내고 유일한 필수 체크 `validate` 가 적색이 된다(ARM `rc=1` / 그 행만 제거 `rc=0`). 그리고 그 행은 **애초에 불필요했다**: 워크플로 `:52` 가 레인을 직접 부르고 `:49` 주석이 그 사실을 적고 있다.

`files[]` 에도 `--self-test` 에도 넣지 않았다 — 전자는 `package_coverage_check.sh:138` 철회기록, 후자는 **그 모드가 존재하지 않는다**(`--self-test` 와 `--bogus-flag-xyz` 출력이 바이트 동일).

## 47a5572 — 러너 표면을 index 로
`lane_runner_check` 와 `script_caller_ratchet` 이 러너 표면을 `glob.glob` 으로 잡아 워킹트리에만 있는 파일이 러너로 계상됐다.

🟥 **모집단(검사 대상)은 그대로 뒀다** — 그쪽 디스크 글롭은 untracked 를 *잡는* 안전 방향이고, 함께 바꾸면 새 스크립트가 조용히 모집단에서 빠진다. 위험 방향이 반대인 두 글롭을 갈랐다.

- 러너 **이름과 본문 둘 다** index 기준 (`ls-files` + `cat-file --batch` 단일 프로세스, 185 fork 회피)
- 실패는 전부 **UNMEASURED**: git 없음 · 깨진 index · `ls-files` rc≠0 · blob 아님 · 조기 종료 · 짧은 본문. **빈 결과로 접는 경로 0개**
- 「git 아님」과 「git 실패」를 `.git` 상향 탐색으로 분리 — 판별자 자신의 실패에도 «git 아님»으로 안 접는다
- dotfile parity: 세그먼트 선행 dot 가드 (`.git-hooks` 같은 리터럴 dot **디렉터리**는 무영향)
- `scripts/test_runner_surface_index_lanes.sh` 신규 **32레인**, 되돌림 앵커 **6그룹**

## 검증
```
staged 상태 재검증
  lane_runner_check          rc=0   72 suites · 72 wired · 0 declared debt
  package_coverage_check     rc=0   32 accepted · 30 exercised
  test_runner_surface_index  rc=0   32/0
  script_caller_ratchet      rc=1   ← 기존 원인(별건 untracked 파일), 수리 전후 불변 대조
모집단 무변경 컨트롤          staged diff 에서 삭제된 glob.glob 정확히 2줄(러너 열거만)
```

**cross-family 4라운드, 신규 S/A 벡터 `3 → 1 → 0 → 2 → 0`, 자력 적발 0.**
🟥 R3 에서 벡터가 뒤집힌 것 자체를 마커에 남겼다 — 라운드마다 새 코드가 새 결함을 낳았다. 5라운드는 「안 떨어지면 조이지 말고 줄여라」 규율로 **돌리지 않았다.**

## 잔여 (이름으로)
- `outside-index`(gitignored 트리의 소비자 설치)에서는 이 보호가 꺼진다 — 자기신고 라벨만 붙었다
- `LOCAL_ONLY_SURFACES` 는 계속 디스크 기준(의도)
- `GIT_DIR`/`GIT_WORK_TREE` 명시 배치 미측정 · `check-ignore` 부재는 fail-closed(미측정)
- 새 레인 저자는 `git add` 전까지 적색을 본다(훅 경로 무영향)
- `scripts/audit_marker_axes_completeness.sh` 처분이 별건으로 열려 있다 — `script_caller_ratchet` rc=1 의 원인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjarhjdUatimG2P8qR8gNK