### PR TITLE
docs(ethos): "harness" 라는 낱말에 대한 한 문단

### DIFF
--- a/docs/ETHOS.md
+++ b/docs/ETHOS.md
@@ -9,6 +9,11 @@ optimizes for *whether the work holds up*, not how fast it leaves the building. 
 asks "how quickly can the agent ship?", FH asks "what survives a cold, independent pass?" — and makes
 running that pass routine instead of a chore you skip.
 
+A note on the word: "harness" is also used, commonly and correctly, for the *runtime
+substrate* — prompts, tools, the agentic loop, the adapter across models. FH uses it for
+what that substrate is **for**: turning intent into machinery you can hold someone to.
+The substrate sense is a layer FH sits on, not a rival definition.
+
 Everything below is **copyable**. None of it is a secret. The principles are the product.
 
 ---


### PR DESCRIPTION
frontier-digest 2026-08-24 적용 후보 1. `docs/ETHOS.md` 첫 문단 뒤에 네 줄.

다른 흔한 용법(런타임 substrate)을 **틀렸다고 하지 않고**, FH 가 그 위에 앉는 층이라고 관계를 준다. naming-territory 다툼이 아니다.

## 🟥 넣기 전에 쟀고, 계측은 「넣지 마라」였다

```
플로어 티어(sonnet) 블라인드 · 레포 밖 cwd 헤드리스(CLAUDE.md 미상속)
ETHOS 단독 대상 · ARM/CONTROL · reps=3 · 사전등록 봉인 후 실행

  CONTROL (문장 없음)  3/3 BOTH   — 확신에 찬 오답 0건
  ARM     (문장 있음)  3/3 BOTH
```

문장 **없이도** 셋 다 두 뜻을 스스로 알았다 — *"보통 test harness(자동화된 테스트 실행 환경)를 가리키는 게 더 흔하다"* · *"LLM 쪽에서는 에이전트 하네스(모델을 감싸는 도구/프롬프트/제어 로직 레이어)"*. 정확히 이 문단이 막으려던 오해다.

ARM 과의 차이는 **답이 아니라 출처**였다 — ARM 은 *"문서도 이걸 인정하며"* 라고 문서를 인용할 뿐 결론이 같다. ⇒ 이 문단은 **새로 가르치는 게 아니라 이미 아는 것에 출처를 준다.**

**운영자가 그 위에서 넣기로 판정했다.** taste 층이고 최종은 운영자 것이다. 이 PR 이 계측을 근거로 삼지 않는다는 걸 분명히 하려고 숫자를 그대로 싣는다.

원자료: `tracks/_audit/ablation_2026-08-24_ethos-harness-term/` (사전등록 + 6런 전문, gitignored)

## 🟥 같은 sim 이 찾은 진짜 혼란은 따로 있다 (이 PR 은 안 건드린다)

**6/6 전원**이 같은 지점을 지목했다:
> *"`steel-quench`, `phantom-quench` 처럼 quench 라 붙어있음에도 temper 역할을 함(문서도 이 불일치를 자인함). 은유와 실제 스킬명이 어긋나서 처음엔 매핑이 헷갈렸음"*

문서가 그 불일치를 **자인하고 있는데 그 자인이 오히려 혼란을 만든다.** 한 런은 «이름 바꾸는 게 더 비싼 거짓말» 이라는 설명을 *"다소 추상적이라 실무적으로 헷갈림"* 이라고 적었다. 별건.

## 안 한 것
README 히어로에는 넣지 않았다 — 그쪽은 **미측정**이고, 2026-08-22 에 문 부제로 한 번 물린 자리다. 잰 범위를 넘어 주장하지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjarhjdUatimG2P8qR8gNK