### PR TITLE
fix(close): ⑤-C carry-over 프로브 — 카드 재작성이 «아직 안 온 기한» 을 날렸는가

### DIFF
--- a/scripts/session_close_check.sh
+++ b/scripts/session_close_check.sh
@@ -566,5 +566,93 @@ CARD_LINE_EOF
   [ "$DRIFT_HITS" -eq 0 ] && echo "✅ ⑤-b no card absence-claim contradicted by on-disk artifacts"
 fi
 
+# ⑤-C CARRY-OVER probe — 카드 재작성이 «아직 안 온 기한» 을 날렸는가.
+# WHY (2026-08-24, 실측 손실 1건): ⑤ 재작성이 delta update 가 아니라 새로 쓰기가 되어 미완·
+# 시각박힌 항목이 통째로 사라졌다 — 그날 저녁 19:00 게시, 다음날 GeekNews, 14일 referrer 측정,
+# 08-26 미팅. 세션은 "BEFORE 172 → AFTER 101" 이라는 diff 를 출력하고도 «줄었다» 만 말하고
+# «무엇이 빠졌나» 는 보지 않았다. 운영자가 물어서 발견 — 자력 아니다.
+# 🟥 이것은 tier 문제가 아니라 WIRING 문제다. 카드 규율(§Session Wrap-up)은 「완료 항목이
+# 남는 게 버그」라고 한 방향만 적고 있고, 그 역방향(미완이 사라지는 것)은 검사가 0줄이었다.
+# 규율이 한 방향만 적혀 있으면 그 반대는 안 보인다. base op 이 살리언스에만 얹혀 있었으므로
+# sonnet_floor_doctrine §tier-gated base op = defect 에 해당한다 — N 을 세기 전에 닫는다.
+#
+# WHAT IT ASSERTS (채널이지 결론이 아니다 — CLAUDE.md §Mechanization Boundary):
+#   「이전 카드에 있던 **미래 날짜**가 오늘 카드나 오늘 fh_completed 에 여전히 나타나는가」
+#   = 기록의 성질(존재·귀속). 「이 항목을 지워도 되는가」는 **판정하지 않는다** — 그건 판단이고
+#   얼리면 오늘의 판단이 내일의 천장이 된다. 완료 처리했으면 fh_completed 에 날짜가 남으므로
+#   그 경로로 통과한다.
+#
+# HONEST SCOPE:
+#   · 판별자는 `YYYY-MM-DD` / `MM-DD` 토큰뿐이다. 날짜 없이 적힌 미완(«4090 부팅 UNKNOWN»)은
+#     구조적으로 못 잡는다 — 앵커지 floor 가 아니다.
+#   · 이전 카드는 companion store 의 git 이력에서 온다. 그게 없는 install(대부분의 소비자)에서는
+#     **SKIP 이고 PASS 가 아니다** — 미측정을 초록으로 접지 않는다.
+#   · ASCII 클래스만 쓴다. 다국어 RANGE 를 bracket 안에 넣으면 C 로케일 GNU grep 이
+#     `Invalid collation character` 로 exit 2 하고 **아무것도 안 뱉는다** → no-match 와 구분 불가
+#     (⑤-b 가 2026-07-31 에 정확히 그렇게 무음 통과했다).
+# DEGRADE: 이전 카드 못 구함 → SKIP(미측정 표기) · 구했는데 미래날짜 유실 → FAIL=1.
+#   FAIL 은 FH_SESSION_CLOSE=1 인 close push 만 막고 일반 push 는 surface 한다(가역 표면 규율).
+#   과차단 시 override: FH_CARRYOVER_OK=1 (무엇을 우회했는지 출력에 남는다).
+# 기본값을 두지 않는다 — companion store 의 이름은 install 마다 다르고, 특정 이름을 공개
+# 파일에 박으면 그 자체가 operator-private 토큰이다(이 줄은 실제로 그렇게 한 번 차단됐다).
+# 설정은 각자의 로컬 바인딩에서 FH_COMPANION_STORE 로 준다.
+_CARRY_STORE="${FH_COMPANION_STORE:-}"
+_CARRY_MIRROR="tracks-meta/reference_next_session_starter.md"
+if [ ! -f "$CARD" ]; then
+  : # ⑤ 가 이미 카드 부재를 FAIL 로 보고했다 — 여기서 중복 보고하지 않는다
+elif [ "${FH_CARRYOVER_OK:-0}" = "1" ]; then
+  echo "⚠️  ⑤-C SKIPPED by FH_CARRYOVER_OK=1 — 이전 카드의 미래-날짜 유실 검사를 우회했다"
+elif [ -z "$_CARRY_STORE" ] || [ ! -d "$_CARRY_STORE/.git" ]; then
+  echo "⬜ ⑤-C SKIPPED (not PASS) — companion store 미설정/부재 (FH_COMPANION_STORE). 이전 카드를 못 구해 UNMEASURED"
+else
+  _TODAY_YMD=$(date +%Y-%m-%d)
+  # 오늘 이전에 기록된 마지막 카드 버전. 오늘자 sync 커밋들은 이미 재작성본이라 제외한다.
+  _PRIOR_SHA=$(git -C "$_CARRY_STORE" log --before="${_TODAY_YMD}T00:00:00" -1 --format=%H -- "$_CARRY_MIRROR" 2>/dev/null || true)
+  if [ -z "$_PRIOR_SHA" ]; then
+    echo "⬜ ⑤-C SKIPPED (not PASS) — 오늘 이전 카드 버전이 이력에 없다 (첫 세션?) — UNMEASURED"
+  else
+    _PRIOR_CARD=$(git -C "$_CARRY_STORE" show "$_PRIOR_SHA:$_CARRY_MIRROR" 2>/dev/null || true)
+    if [ -z "$_PRIOR_CARD" ]; then
+      echo "⬜ ⑤-C SKIPPED (not PASS) — 이전 카드를 읽지 못했다 ($_PRIOR_SHA) — UNMEASURED"
+    else
+      # 이전 카드의 날짜 토큰 중 «오늘 이상» 인 것만. YYYY-MM-DD 와 MM-DD 둘 다 본다.
+      _TODAY_MD=$(date +%m-%d)
+      _FUTURE_DATES=$(printf '%s\n' "$_PRIOR_CARD" \
+        | grep -oE '20[0-9]{2}-[0-9]{2}-[0-9]{2}|(^|[^0-9])[01][0-9]-[0-3][0-9]([^0-9]|$)' 2>/dev/null \
+        | grep -oE '20[0-9]{2}-[0-9]{2}-[0-9]{2}|[01][0-9]-[0-3][0-9]' 2>/dev/null \
+        | sort -u | while IFS= read -r d; do
+            # bash 3.2(macOS)는 $( ) 안의 case 패턴 ')' 를 오파싱한다 — 길이로 가른다
+            _ref="$_TODAY_MD"
+            if [ ${#d} -eq 10 ]; then _ref="$_TODAY_YMD"; fi
+            if [ "$d" = "$_ref" ]; then printf '%s\n' "$d"
+            elif [ "$d" \> "$_ref" ]; then printf '%s\n' "$d"
+            fi
+          done)
+      _LOST=0
+      if [ -n "$_FUTURE_DATES" ]; then
+        _TODAY_LOG="$FH/tracks/_meta/fh_completed_${_TODAY_YMD}.md"
+        while IFS= read -r d; do
+          [ -z "$d" ] && continue
+          if grep -qF "$d" "$CARD" 2>/dev/null; then continue; fi
+          if [ -f "$_TODAY_LOG" ] && grep -qF "$d" "$_TODAY_LOG" 2>/dev/null; then continue; fi
+          _CTX=$(printf '%s\n' "$_PRIOR_CARD" | grep -F "$d" | head -1 | cut -c1-90)
+          echo "❌ ⑤-C carry-over 유실: 이전 카드의 미래 기한 '$d' 가 오늘 카드에도 fh_completed 에도 없다"
+          echo "     이전 카드 원문: $_CTX"
+          _LOST=$((_LOST+1))
+        done <<CARRY_EOF
+$_FUTURE_DATES
+CARRY_EOF
+      fi
+      if [ "$_LOST" -gt 0 ]; then
+        echo "   ⇒ ⑤ 는 delta update 다. 완료면 fh_completed 에 적고, 이월이면 카드에 남겨라."
+        echo "     정당하게 취소된 항목이면: FH_CARRYOVER_OK=1 FH_SESSION_CLOSE=1 git push"
+        FAIL=1
+      else
+        echo "✅ ⑤-C 이전 카드의 미래 기한이 전부 카드/완료로그에 살아 있다 (prior=${_PRIOR_SHA%%??????????????????????????????????})"
+      fi
+    fi
+  fi
+fi
+
 echo "── close check: $([ "$FAIL" -eq 0 ] && echo CONSISTENT || echo VIOLATIONS) ──"
 exit "$FAIL"

--- a/scripts/test_session_close_lanes.sh
+++ b/scripts/test_session_close_lanes.sh
@@ -256,6 +256,99 @@ else
 fi
 rm -rf "$T"
 
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ⑤-C CARRY-OVER lanes — 카드 재작성이 «아직 안 온 기한» 을 날렸는가.
+#
+# WHY (2026-08-24, 실측 손실 1건 — 이 레인이 그 결함의 회귀 앵커다): ⑤ 재작성이 delta update 가
+# 아니라 새로 쓰기가 되어 미완·시각박힌 항목이 통째로 사라졌다(그날 저녁 게시, 다음날 GeekNews,
+# 14일 referrer 측정, 08-26 미팅). 세션은 "BEFORE 172 → AFTER 101" 이라는 diff 를 내고도
+# «줄었다» 만 말하고 «무엇이 빠졌나» 는 보지 않았다. 운영자가 물어서 발견 — 자력 아니다.
+# 🟥 tier 문제가 아니라 WIRING 문제였다: 카드 규율은 「완료 항목이 남는 게 버그」라고 한 방향만
+# 적고, 그 역방향은 검사가 0줄이었다. base op 이 살리언스에만 얹혀 있었으므로
+# sonnet_floor_doctrine §tier-gated base op = defect.
+#
+# Lanes (각각 게이트가 옳게 판정해야 하는 결정이지 스모크가 아니다):
+#   ⑤-C-N  이전 카드의 미래 기한이 오늘 카드에 없음        → ❌ MUST fire (유실 지목)
+#   ⑤-C-P  그 기한이 오늘 카드에 살아 있음                 → ✅ must NOT fire (오탐 없음)
+#   ⑤-C-L  카드엔 없지만 오늘 fh_completed 에 있음         → ✅ 완료 처리 경로로 통과
+#           (「이 항목을 지워도 되나」를 판정하지 않는다 — 채널 검사지 결론 검사가 아니다)
+#   ⑤-C-S  companion store 부재                            → ⬜ SKIPPED, **초록 아님**
+#           (not-found ≠ 0. 미측정을 PASS 로 접으면 이 프로브 전체가 장식이 된다)
+#
+# 🟥 픽스처는 «뚫리는 표기» 로 고른다: 미래 날짜를 **MM-DD 축약형** 으로 둔다. YYYY-MM-DD 만
+# 잡는 반쪽 구현은 ⑤-C-N 에서 통과해버린다 — 실제 카드가 「08-26 미팅」처럼 축약형을 쓴다.
+_carry_fixture() {  # $1=오늘카드 본문  $2=fh_completed 본문(빈 문자열=파일 없음)  → "REPO|STORE"
+  local card_body="$1" done_body="$2" T S FUT
+  T=$(mktemp -d); S=$(mktemp -d)
+  ( cd "$T" && git init -q . && git config user.email a@l && git config user.name a \
+    && echo x > unrelated.txt && git add -A && git commit -qm fixture ) >/dev/null 2>&1
+  mkdir -p "$T/tracks/_meta"
+  printf '%s\n' "$card_body" > "$T/tracks/_meta/reference_next_session_starter.md"
+  [ -n "$done_body" ] && printf '%s\n' "$done_body" > "$T/tracks/_meta/fh_completed_${TODAY}.md"
+  # companion store: 어제 날짜로 커밋된 «이전 카드» 미러 하나
+  FUT=$(date -v+2d '+%m-%d' 2>/dev/null || date -d '+2 days' '+%m-%d')
+  ( cd "$S" && git init -q . && git config user.email a@l && git config user.name a \
+    && mkdir -p tracks-meta \
+    && printf '기한 %s 미팅 안건 [B]\n' "$FUT" > tracks-meta/reference_next_session_starter.md \
+    && git add -A \
+    && GIT_AUTHOR_DATE='2020-01-01T00:00:00' GIT_COMMITTER_DATE='2020-01-01T00:00:00' \
+       git commit -qm prior ) >/dev/null 2>&1
+  printf '%s|%s' "$T" "$S"
+}
+_carry_future() { date -v+2d '+%m-%d' 2>/dev/null || date -d '+2 days' '+%m-%d'; }
+
+_carry_lane() {  # $1=name $2=pattern $3=expect $4="REPO|STORE" $5=extra-env(옵션)
+  local name="$1" pat="$2" expect="$3" pair="$4" env5="${5:-}" T S out hit
+  T="${pair%%|*}"; S="${pair##*|}"
+  if [ ! -d "$T/tracks/_meta" ] || [ ! -d "$S/.git" ]; then
+    echo "❌ $name — FIXTURE ERROR: 픽스처가 안 만들어졌다"
+    PREMISE_FAILED=1; rm -rf "$T" "$S"; return
+  fi
+  if [ -n "$env5" ]; then
+    out=$(env "$env5" FH_COMPANION_STORE="$S" bash "$CHECK" "$T" 2>/dev/null)
+  else
+    out=$(FH_COMPANION_STORE="$S" bash "$CHECK" "$T" 2>/dev/null)
+  fi
+  hit=0; printf '%s\n' "$out" | grep -q "$pat" && hit=1
+  rm -rf "$T" "$S"
+  if [ "$hit" = "$expect" ]; then
+    echo "✅ $name (hit=$hit, expected=$expect)"
+  else
+    echo "❌ $name — hit=$hit, expected=$expect"
+    printf '%s\n' "$out" | grep '⑤-C' | sed 's/^/     /'
+    FAILED=1
+  fi
+}
+
+_CF=$(_carry_future)
+_carry_lane "⑤-C-N 미래 기한 유실 → 지목한다" "❌ ⑤-C carry-over 유실" 1 \
+  "$(_carry_fixture '# card' '')"
+_carry_lane "⑤-C-P 기한이 카드에 살아있음 → 조용" "❌ ⑤-C carry-over 유실" 0 \
+  "$(_carry_fixture "# card
+이월: $_CF 미팅 안건 [B]" '')"
+_carry_lane "⑤-C-L 완료로그에 있음 → 통과" "❌ ⑤-C carry-over 유실" 0 \
+  "$(_carry_fixture '# card' "- ✅ $_CF 미팅 — 취소 확정")"
+
+# ⑤-C-S: companion store 부재는 SKIPPED 여야 하고 **✅ 여서는 안 된다**.
+_T4=$(mktemp -d)
+( cd "$_T4" && git init -q . && git config user.email a@l && git config user.name a \
+  && echo x > u.txt && git add -A && git commit -qm f ) >/dev/null 2>&1
+mkdir -p "$_T4/tracks/_meta"; printf '# card\n' > "$_T4/tracks/_meta/reference_next_session_starter.md"
+_out4=$(FH_COMPANION_STORE=/tmp/__no_such_store__ bash "$CHECK" "$_T4" 2>/dev/null)
+if printf '%s\n' "$_out4" | grep -q '⬜ ⑤-C SKIPPED (not PASS)'; then
+  if printf '%s\n' "$_out4" | grep -q '✅ ⑤-C'; then
+    echo "❌ ⑤-C-S  SKIPPED 인데 ✅ 도 같이 찍었다 — 미측정을 초록으로 접고 있다"; FAILED=1
+  else
+    echo "✅ ⑤-C-S companion store 부재 → SKIPPED(not PASS), 초록 아님"
+  fi
+else
+  echo "❌ ⑤-C-S  store 부재를 SKIPPED 로 표기하지 않았다 — not-found 를 0 으로 렌더한다"
+  printf '%s\n' "$_out4" | grep '⑤-C' | sed 's/^/     /'
+  FAILED=1
+fi
+rm -rf "$_T4"
+
 # Premise failure is reported FIRST and with its own exit code: it says "this run's verdicts are
 # meaningless", which is a different instruction to the reader than "the gate is broken". Collapsing
 # them into one red X is what made the original CI flake unreadable.
@@ -267,5 +360,5 @@ if [ "$FAILED" -ne 0 ]; then
   echo "SESSION-CLOSE LANES: FAIL — the gate's instrument is miscalibrated"
   exit 1
 fi
-echo "SESSION-CLOSE LANES: PASS (8/8)"
+echo "SESSION-CLOSE LANES: PASS (12/12)"
 exit 0


### PR DESCRIPTION
**오늘 실제로 난 손실의 회귀 앵커다.**

⑤ 카드 재작성이 delta update 가 아니라 새로 쓰기가 되어 미완·시각박힌 항목이 통째로 사라졌다 — 그날 저녁 게시, 다음날 GeekNews Show GN, 14일 referrer 측정, 08-26 미팅. 세션은 `BEFORE 172 → AFTER 101` 이라는 diff 를 출력하고도 **«줄었다» 만 말하고 «무엇이 빠졌나» 는 보지 않았다.** 운영자가 물어서 발견 — 자력 아니다.

## 🟥 tier 문제가 아니라 wiring 문제다

카드 규율(`CLAUDE.md §Session Wrap-up`)은 **「완료 항목이 남는 게 버그」라고 한 방향만** 적고 있고, 그 역방향(미완이 사라지는 것)은 검사가 0줄이었다. 규율이 한 방향만 적혀 있으면 그 반대는 안 보인다.

base op(마감 체인 ⑤)이 살리언스에만 얹혀 있었으므로 `sonnet_floor_doctrine §tier-gated base op = defect` 에 해당한다. **N 을 세기 전에 닫는다** — 「재발하면 짓자」가 아니라 floor 위반이다.

## 무엇을 단언하나 — 채널이지 결론이 아니다

| 검사한다 (채널) | 검사하지 않는다 (결론) |
|---|---|
| 이전 카드의 **미래 날짜**가 오늘 카드나 오늘 `fh_completed` 에 여전히 있는가 = 기록의 성질 | 「이 항목을 지워도 되는가」 — 판단이고, 얼리면 오늘의 판단이 내일의 천장이 된다 |

완료 처리했으면 `fh_completed` 에 날짜가 남으므로 그 경로로 통과한다.

## known-pair 4팔 (전부 실행 확인)
```
복구된 카드            ✅ PASS, 오탐 0
손실 재현              ❌ '2026-08-25' 정확히 지목
FH_CARRYOVER_OK=1     ⚠️  우회, 무엇을 우회했는지 출력에 남는다
companion store 부재   ⬜ SKIPPED (not PASS) — 미측정을 초록으로 안 접는다
```

**되돌림 컨트롤**: MM-DD 인식만 제거하니 `⑤-C-N` **하나만** 적색, 나머지 셋 초록 유지. 반쪽 구현이 낸 출력이 `✅ 전부 살아 있다` — **거짓 초록**이었다. 🟥 픽스처를 **MM-DD 축약형**(뚫리는 표기)으로 고른 것이 그걸 잡았다. 실제 카드가 「08-26 미팅」처럼 축약형을 쓴다.

레인 **12/12**(기존 8 + ⑤-C 4). `test_session_close_lanes.sh` 는 selfcheck 짝 표에 **이미 등록돼 있어** 새 배선이 필요 없다 — 오늘 아침 물린 phantom 함정(shipped `selfcheck.sh` 가 `files[]` 밖 경로를 이름댐)을 구조적으로 안 밟는다.

## 🟥 게이트가 나를 한 번 막았다

companion store 경로에 실제 이름을 기본값으로 박았다가 **public-surface 스캔에 차단됐다.** 옳게 짖었다 — 그 이름은 install 마다 다르고 공개 파일에 박으면 그 자체가 operator-private 토큰이다. 기본값을 빼고 `FH_COMPANION_STORE` 로 받는다.

## 잔여 (이름으로)
- 🟥 **날짜 없이 적힌 미완은 구조적으로 못 잡는다** — 오늘 날아간 것 중 「4090 부팅 UNKNOWN」·「정체성 ④」·「T13」 셋은 이 프로브가 못 막는다. 앵커지 floor 가 아니다
- `FH_COMPANION_STORE` 미설정 install 은 영구 SKIP — 소비자에겐 이 보호가 없다
- 「완료 처리했다」를 날짜 존재로만 판정한다 — 날짜 없이 완료를 적으면 유실로 오탐한다(override 채널이 그 자리)
- 이 프로브는 세션 말미에 지어졌고 **다음 세션의 실사용은 아직 없다**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjarhjdUatimG2P8qR8gNK