### PR TITLE
fix(session-load): companion divergence 배너에 크기·명령·하류 미측정 표기

### DIFF
--- a/scripts/fh_session_load.sh
+++ b/scripts/fh_session_load.sh
@@ -86,11 +86,38 @@ if [ -d "$BE/.git" ]; then
     _deadline() { shift; "$@"; }
   fi
   PULL_NOTE=""
+  DIVERGED=""          # non-empty ⇒ the local tree is NOT the newest state (see §Diverged below)
+  DIVERGE_BEHIND=""    # commits the companion remote has that this clone does not
+  DIVERGE_AHEAD=""     # commits this clone has that the remote does not
   if _deadline "${FH_FETCH_DEADLINE:-8}" git -C "$BE" fetch --quiet >/dev/null 2>&1; then
     if git -C "$BE" merge --ff-only --quiet >/dev/null 2>&1; then
       PULL_NOTE="fetched + fast-forwarded"
     else
-      PULL_NOTE="fetched but NOT fast-forward (companion diverged — read local + newest remote)"
+      # §Diverged — WHY THIS IS LOUD AND COUNTED (2026-08-28, measured on this repo).
+      # The old line said only "companion diverged — read local + newest remote". A session read it,
+      # did NOT read the newest remote, counted the LOCAL tree, and reported an artifact as absent
+      # that the remote had had for two days (deck v6.3 vs the actual v12.4; 338 commits behind).
+      # Two separate defects, and the second is the dangerous one:
+      #   1) the note carried no MAGNITUDE and no COMMAND — "diverged" reads like a footnote
+      #   2) every downstream freshness check in this script (§NEWER THAN SESSION CARD, the STATUS
+      #      map, INDEX head) is computed over the STALE local tree, so it under-reports and an
+      #      un-pulled file renders as a non-existent one — `not found` ≠ `0`
+      #      ([[feedback_not_found_is_not_zero_family]]).
+      # This is a CHANNEL fix, not a judgment one (§Mechanization Boundary): it reports what the
+      # record IS (how far behind, computed) and never decides whether to merge. The hook still
+      # does NOT auto-rebase — mutating a diverged tree from SessionStart is exactly the
+      # irreversible-shaped act the --ff-only design refuses, and a parallel session may hold it.
+      _UP="$(git -C "$BE" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null)"
+      [ -n "$_UP" ] || _UP="origin/$(git -C "$BE" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+      # Counts: a failure must leave these EMPTY, never 0 — an unmeasured gap rendered as zero is
+      # the same defect this block exists to stop. `git rev-list` prints nothing to stdout on error.
+      _CNT="$(git -C "$BE" rev-list --left-right --count "HEAD...$_UP" 2>/dev/null)"
+      if [ -n "$_CNT" ]; then
+        DIVERGE_AHEAD="$(printf '%s' "$_CNT" | awk '{print $1}')"
+        DIVERGE_BEHIND="$(printf '%s' "$_CNT" | awk '{print $2}')"
+      fi
+      DIVERGED="1"
+      PULL_NOTE="fetched but NOT fast-forward (companion DIVERGED — local tree is stale)"
     fi
   else
     PULL_NOTE="fetch skipped (offline or deadline hit — read local state)"
@@ -501,11 +528,34 @@ fi
   # So: no new hook, no new line, no nag — the node name is appended to a banner that already
   # prints every single session. `hostname -s`, the same source fh_node_check.sh uses.
   echo "🔄 [FH SessionStart] companion-store freshness — $PULL_NOTE. · node: $(hostname -s 2>/dev/null || echo unknown)"
+  # §Diverged banner. Loud, counted, and it names the ONE command — see the §Diverged comment at the
+  # fetch site for the 2026-08-28 measurement that made this necessary. The magnitude line and the
+  # "everything below is stale" line are separate on purpose: the first says the tree is behind, the
+  # second says this script's OWN downstream findings under-report while it is.
+  if [ -n "$DIVERGED" ]; then
+    if [ -n "$DIVERGE_BEHIND" ]; then
+      echo "🟥 COMPANION DIVERGED — this clone is $DIVERGE_BEHIND commit(s) BEHIND the companion remote (and $DIVERGE_AHEAD ahead)."
+    else
+      # UNMEASURED, never 0: rev-list failed (no upstream configured, unreadable ref). Say so.
+      echo "🟥 COMPANION DIVERGED — magnitude UNMEASURED (could not count against upstream; do NOT read that as 'small')."
+    fi
+    echo "   → PULL BEFORE YOU TRUST ANY FRESHNESS ANSWER:  git -C \"$BE\" pull --rebase"
+    echo "   🟥 Everything printed BELOW this line is computed over the STALE local tree, so it"
+    echo "      UNDER-REPORTS. A file the remote already has renders here as absent — \`not found\`"
+    echo "      is not \`0\`. Answering \"what is the newest X\" from this list while diverged has"
+    echo "      already produced a wrong answer once (2026-08-28: reported a 2-day-old artifact as"
+    echo "      the latest). Pull first, or label the answer LOCAL-ONLY."
+  fi
   if [ -n "$NEWER" ]; then
     echo "⚠️ NEWER THAN SESSION CARD — READ THESE BEFORE ACTING (card may be stale):"
     printf "%b" "$NEWER"
   else
-    echo "   (no companion files newer than the session card)"
+    if [ -n "$DIVERGED" ]; then
+      echo "   (no companion files newer than the session card — 🟥 but the tree is STALE, so this is"
+      echo "    NOT evidence of 'nothing new'. It is an unmeasured surface. Pull, then re-read.)"
+    else
+      echo "   (no companion files newer than the session card)"
+    fi
   fi
   if [ -n "$STATUS_MAP" ]; then
     echo "── handoff/signal STATUS map (mtime-independent — closed items) ──"


### PR DESCRIPTION
## 왜

세션 시작 훅이 정확히 짖었다 — `fetched but NOT fast-forward (companion diverged — read local + newest remote)`.
그런데 세션이 그 줄을 읽고도 **로컬만 셌다.** companion store 가 338 커밋 뒤였고, 발표 덱의 최신본을 `v6.3` 이라고 보고했다. 실물은 `v12.4` 로 이틀 전부터 원격에 있었다. 같은 세션에서 **같은 형태가 한 번 더** 났다 — 주간감사를 「없다」고 보고했는데 다른 노드가 쓴 `weekly_audit_2026-08-26.md` 가 원격에 있었다.

둘 다 운영자가 잡았다. 자력 적발 0.

## 결함 둘, 둘째가 위험하다

1. 옛 줄에 **크기도 칠 명령도 없어** 각주처럼 읽힌다. 「⚠️ NEWER THAN SESSION CARD」 블록보다 조용한데, diverged 는 카드 stale 보다 나쁜 상태다.
2. 🟥 이 스크립트의 **하류 판정 전부**(§NEWER THAN CARD · STATUS map · INDEX head)가 stale 로컬 트리 위에서 계산된다 ⇒ 과소보고 ⇒ **안 당겨온 파일이 「없는 파일」로 렌더된다.** `not found` 를 `0` 으로 읽는 그 일가.

2번이 실제로 속인 실물이다.

## 무엇을 했나

**채널 수리다. 판단 수리가 아니다** (§Mechanization Boundary). 기록이 무엇인지(얼마나 뒤인지, 셌는지 못 셌는지)만 말하고, 병합할지는 결정하지 않는다.

- diverged 일 때 `behind`/`ahead` 를 **세어서** 찍는다
- 칠 명령 한 줄(`git -C <be> pull --rebase`)을 찍는다
- **아래 목록이 stale 트리 위에서 계산돼 과소보고한다**고 명시한다
- 「새 파일 없음」 줄도 diverged 일 때 문구를 바꾼다 — 「없음」이 아니라 **「미측정 표면이다. 당기고 다시 읽어라」**
- 카운트 실패는 `0` 이 아니라 `UNMEASURED` 로 찍는다

🟥 **자동 rebase 는 안 한다.** `--ff-only` 설계는 그대로다. SessionStart 가 diverged 트리를 변형하는 건 병렬 세션이 쥔 작업면을 뺏는 형태다.

## 검증 — 알려진 쌍을 실행했다 (`bash -n` 은 계기가 아니다)

픽스처: 베어 remote 1 + 클론 3

| 팔 | 구성 | 결과 |
|---|---|---|
| known-positive | ahead 1 / behind 3 | `3 commit(s) BEHIND ... (and 1 ahead)` — 구성값과 **일치**. PULL 명령 · STALE 경고 · 「없음」 문구 교체 전부 발화 |
| known-negative | clean fast-forward | `DIVERGED` 줄 **0건**, 기존 문구 그대로 |
| degrade | 카운트 불가 | `magnitude UNMEASURED (... do NOT read that as 'small')` |

degrade 팔은 **픽스처로 도달 못 했다** — 스크립트 자신의 `fetch` 가 지운 `origin/main` 을 되살린다. 되돌림 프로브 3단(적용확인 `grep PROBE` → 실행 → 복원, 원본에 흔적 0 재확인)으로 확인했고, **실사용 도달 곤란한 방어 분기**라고 적는다. 「테스트했다」가 아니다.

**standpoint `tier2(consumer-install)`** — 이 파일은 `package.json files[]` 에 실린다(`npm notice 41.6kB scripts/fh_session_load.sh`). 소비자 세션 배너가 바뀌므로 과녁은 팩된 산출물이다:
`npm pack` → `tar -xzf` → `cmp -s` packed vs 워킹트리 **동일** → `BE_DIR=<POS> bash package/scripts/fh_session_load.sh` 실행, 위 출력 재현.

## 명시 잔여

- **자동 pull 은 안 했다** — 사람이 여전히 `pull --rebase` 를 쳐야 한다. 의도적 미실시
- ⓐ계열 · ⓒ격리그라운딩 · ⓓ3자대면 미실시 (마커에 사유)
- `crossfamily: DEGRADED_PANEL_UNUSED` — 판정 enum · 게이트 종료코드 · 비가역 경로 · 안전 불변식 중 무엇도 안 건드린다(항상 `exit 0` 인 보고 채널)고 판단했으나 **그 판단은 자평이다**
- detached HEAD 이면서 upstream 과 동일하면 `0 commit(s) BEHIND (and 0 ahead)` 가 찍힐 수 있다. 거짓은 아니나 혼란스럽다 — 범위 밖, 이름으로 남김
- **더 깊은 뿌리는 이 PR 이 안 닫는다**: `tracks/` 는 gitignored 라 노드 간에 git 으로 안 건너가고, 경로는 hub→be 단방향 하나뿐이다. 노드 A 가 쓴 tracks 파일은 노드 B 의 hub 에서 구조적으로 안 보인다. 이 PR 은 **「당겨라」고 크게 말하는 것**까지다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142FoWu6rC1GBGJar5QYagF