### PR TITLE
fix(gate): Axis 1 pathspec 확장 — 그리고 내 SKIP 진단 2/3 을 철회한다

### DIFF
--- a/.github/workflows/regression-guard.yml
+++ b/.github/workflows/regression-guard.yml
@@ -9,6 +9,21 @@ on:
       - 'CLAUDE.md'
       - 'templates/*.md'
       - 'templates/regression_guard.sh'
+      # 2026-08-29 — 스크립트의 GUARD_PATHSPEC 과 갈리면 갈린 쪽이 무검사 구간이 된다.
+      # 스크립트가 이미 커버하던 것들 + 이번에 추가한 미커버분을 여기서도 트리거로 잡는다.
+      - 'knowledge/**/*.md'
+      - 'docs/*.md'
+      - 'AGENTS.md'
+      - 'scripts/**'
+      - 'templates/.git-hooks/*'
+      - 'plugins/*/agents/*.md'
+      - '.claude/agents/**/*.md'
+      - 'README*.md'
+      - 'CHEATSHEET.md'
+      - 'CATALOG.md'
+      - '.github/workflows/*.yml'
+      - '.claude/registry/*.md'
+      - 'package.json'
 
 jobs:
   regression-guard:

--- a/scripts/gate_pathspec_check.sh
+++ b/scripts/gate_pathspec_check.sh
@@ -106,13 +106,19 @@ spec_matches() {  # $1 = path
 }
 for pair in \
   "plugins/fh-meta/skills/frontier-digest/SKILL_detail.md|tracks/_meta/x.md|PATHSPEC covers SKILL_detail.md" \
-  "plugins/fh-meta/skills/frontier-digest/SKILL.md|README.md|PATHSPEC still covers SKILL.md" \
+  "plugins/fh-meta/skills/frontier-digest/SKILL.md|docs/demo/gate-block.tape|PATHSPEC still covers SKILL.md" \
   "CLAUDE.md|CLAUDE.local.md|PATHSPEC covers CLAUDE.md but not the local override" \
-  "scripts/selfcheck.sh|README.md|PATHSPEC covers scripts/*.sh (seam #1 — the HEAVY term already gated it, this array did not)" \
-  "scripts/sub/nested.sh|package.json|PATHSPEC covers scripts/ recursively (git/bash globs cross '/')" \
+  "scripts/selfcheck.sh|scripts/fixtures/data.txt|PATHSPEC covers scripts/*.sh (seam #1 — the HEAVY term already gated it, this array did not)" \
+  "scripts/sub/nested.sh|scripts/README.txt|PATHSPEC covers scripts/ recursively (git/bash globs cross '/')" \
   "templates/regression_guard.sh|package-lock.json|PATHSPEC covers templates/*.sh — i.e. the guard can guard ITSELF" \
   "templates/.git-hooks/pre-commit|.gitignore|PATHSPEC covers the git-hook floor (the hook that hard-blocks commits)" \
-  "plugins/fh-meta/agents/challenger.md|tracks/_meta/y.md|PATHSPEC covers agent definitions (seam #3)"
+  "plugins/fh-meta/agents/challenger.md|tracks/_meta/y.md|PATHSPEC covers agent definitions (seam #3)" \
+  "README.ko.md|README.txt|PATHSPEC covers README 4종 — PR #550 이 Axis 1 무검사로 나간 자리 (2026-08-29)" \
+  "CHEATSHEET.md|CONTRIBUTING.md|PATHSPEC covers CHEATSHEET (루트 CONTRIBUTING 은 대상 아님)" \
+  "CATALOG.md|CHANGELOG.md|PATHSPEC covers CATALOG" \
+  ".github/workflows/validate.yml|.github/dependabot.yml|PATHSPEC covers workflow 정의 (yml 만)" \
+  "scripts/index_sync.py|scripts/notes.txt|PATHSPEC covers scripts/*.py" \
+  "package.json|package-lock.json|PATHSPEC covers package.json 이되 «리터럴» — lock 파일까지 삼키지 않는다"
 do
   IFS='|' read -r pos neg label <<< "$pair"
   ok=1

--- a/templates/regression_guard.sh
+++ b/templates/regression_guard.sh
@@ -170,6 +170,25 @@ GUARD_PATHSPEC=(
   'templates/.git-hooks/*'
   'plugins/*/agents/*.md'
   '.claude/agents/*.md'
+  # ── Added 2026-08-29 — 세 번의 SKIP 을 추적해 보니 «진짜 갭 1 · 계기 오용 2» 였다.
+  # 계기 오용: `--pr` 는 커밋된 ref 를 비교하는데 커밋 «전에» 불렀다 → merge-base==HEAD → 빈 diff
+  # → skip. (--staged 가 그 자리에 있는 이유이고, 위 --staged 주석이 이미 그렇게 적고 있었다.)
+  # 진짜 갭: README 4종. 공개 첫 화면인데 Axis 1 이 구조적으로 안 돌았다 — PR #550 이 실물이다.
+  # 같이 들어온 나머지는 4축 자산 목록과 이 배열을 기계로 대조해 나온 미커버분이다.
+  # 캘리브레이션(양방향, 넓힌 사본으로 실제 이력에 실행):
+  #   · 이력 20 커밋(README·CHEATSHEET·package.json 등을 건드린 것) → M=0 S=0, 전부 pass.
+  #     오탐 폭풍 없음. 그리고 SKIP 이 아니라 pass 라는 것이 «파일이 실제로 선택됐다»의 컨트롤이다
+  #     (무기력한 pathspec 에서 오는 깨끗한 0 을 배제한다 — 2026-08-04 항목과 같은 규율).
+  #   · known-positive: README.md 를 60% 절단 → ❌ BLOCK (M-tier 2, 'BLOCK' 토큰 66% 소실, rc=2).
+  # package.json 은 md/sh 형 검사 대부분이 무력하지만 F6 줄-감소가 살아 있다 — files[] 항목이
+  # 대량 삭제되는 회귀가 이 저장소에서 실제로 있었던 클래스다.
+  'README*.md'
+  'CHEATSHEET.md'
+  'CATALOG.md'
+  '.github/workflows/*.yml'
+  'scripts/*.py'
+  '.claude/registry/*.md'
+  'package.json'
 )
 
 # 계기 무결: base ref 가 안 풀리면 diff 실패가 2>/dev/null 로 삼켜져 CHANGED 공백 →


### PR DESCRIPTION
## 🟥 먼저 — 오늘 내가 세 번 한 주장 중 둘은 거짓이었다

「Axis 1 SKIP — pathspec 미커버」를 #549 · #550 · #551 세 곳에 적었다. 실측하니 갈린다:

```
#549  올바르게 부르면 ✅ PASS (파일 검사됨)   ← 내 계기 오용
#551  같은 형태                              ← 내 계기 오용
#550  올바르게 불러도 🟥 SKIP                ← 진짜 갭
```

**원인**: `--pr` 는 **커밋된 ref** 를 비교하는데 나는 **커밋 전에** 불렀다 → `merge-base==HEAD` → 빈 diff → skip. `--staged` 가 정확히 그 자리에 있고, **스크립트 주석이 이미 그렇게 적고 있었다.** 읽고도 틀렸다.

#549 · #551 은 이미 머지됐으므로 그쪽에 정정 코멘트를 단다.

## 진짜 갭 — 실물 사례가 있다

**PR #550 이 공개 첫 화면 4개 언어판을 바꾸면서 Axis 1 이 구조적으로 안 돌았다.** README 가 pathspec 에 없었다.

## 변경

| 파일 | 무엇 |
|---|---|
| `templates/regression_guard.sh` | `GUARD_PATHSPEC` **+7** — `README*.md` · `CHEATSHEET.md` · `CATALOG.md` · `.github/workflows/*.yml` · `scripts/*.py` · `.claude/registry/*.md` · `package.json` |
| `.github/workflows/regression-guard.yml` | `paths:` 를 스크립트 배열과 맞춤 — **두 목록이 갈리면 갈린 쪽이 조용히 무검사 구간**이 된다(스크립트 주석의 경고) |
| `scripts/gate_pathspec_check.sh` | known-negative **3건 교체** + 앵커 **6건 추가** |

### 🟥 검사기가 내 변경을 잡았다

`README.md`·`package.json` 이 **known-NEGATIVE 로 쓰이고 있었다.** 커버 대상으로 만들자 3쌍이 깨졌고, 검사기가 직접 경고한다 — *"Do NOT relax the anchor to make it green — fix the term, or retire the pair deliberately."*

앵커를 푸는 대신 **쌍을 의도적으로 교체**했다. 새 negative 중 `package-lock.json` 은 새 `package.json` 항이 **리터럴인지** 검증한다 — glob 이었으면 lock 파일까지 삼킨다.

## 캘리브레이션 — 양방향

```
원인 분리       같은 커밋(f104995) 좁은 원본 → SKIP / 넓힌 사본 → PASS
                «0 이 무기력한 pathspec 에서 왔나» 를 배제하는 컨트롤 (2026-08-04 항목과 같은 규율)
이력 오탐       대상 파일을 건드린 최근 20 커밋 → 전부 M=0 S=0 pass. 폭풍 없음
known-positive  README.md 60% 절단 → ❌ BLOCK (M-tier 2, 'BLOCK' 토큰 66% 소실, rc=2)
되돌림 프로브    README*.md 항만 제거 → gate_pathspec_check FAIL, 복원 → PASS (30쌍)
Axis 1          ✅ PASS (--staged, 3파일, M=0 S=0)
```

## ⚠️ 계기가 두 번 죽었다가 살아났다

측정 도중 ⓐ `mapfile` 이 zsh 에 없어 패턴 배열이 비었고 「전부 미커버」가 나왔다 ⓑ `pats.txt` 마지막 줄 개행 부재로 패턴 하나가 누락돼 `.claude/agents/*.md` 가 「미커버」로 보였다. **둘 다 결과가 아니라 계기 오류**였고, 출력이 이상해서 되짚어 잡았다. 그대로 채택했으면 거짓 커버리지 보고가 나갔다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYSKLdAXdpqhSvjJXRB5RM