### PR TITLE
fix(onboarding): 안 닫고 끈 사람에게 「완전 신규」가 뜨던 자리 + 재방문 문에 마감 권고

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,7 +471,7 @@ a property of *this* install, not of a consumer's. **Do not cite 1/5 as the ship
 menu at all, and one Korean run opened with an English welcome line. Reps are 1–3 per arm, below this
 repo's own bar. So the softened README wording stays correct; only its *reason* changed.
 
-- **New user** (no session files AND no mapped project tracks under `tracks/` — fresh clone/install; **any underscore-prefixed dir** (`tracks/_*` — `_meta`/`_audit`/`_contrib`/`_chamber`…) doesn't count, general rule not a closed list — `_chamber` holds incubation chamber runs, never mapped projects): 2-door starter, never the returning menu —
+- **New user** (fresh clone/install — **neither** condition below holds): 2-door starter, never the returning menu. 🟥 **The two conditions are scoped differently and the underscore rule touches only the second.** ⓐ **Session files** — any `tracks/**/session_*.md` **or `tracks/_meta/*.md` beyond `.gitkeep`**; 🟥 `_meta` **counts here** (someone who worked and quit without closing has files there, and rendering «looks like you're new» to them is the defect this clause exists to prevent). ⓑ **Mapped project tracks** — `tracks/{name}/` dirs, where **any underscore-prefixed dir** (`tracks/_*` — `_meta`/`_audit`/`_contrib`/`_chamber`…) doesn't count, general rule not a closed list — `_chamber` holds incubation chamber runs, never mapped projects. Canonical: `fh_detail_protocols.md` §Branch test —
 
   > 🐿️  **Welcome to FH.** *Looks like you're new here! What would you like to do?*
   > - **①  Create your first project** — guided
@@ -490,6 +490,10 @@ repo's own bar. So the softened README wording stays correct; only its *reason* 
   > - **📖  Guide / Q&A**
   >
   > (When **FH-dev state exists** — the operator — the welcome line is **"The FH operator — good to see you."** in place of "Welcome back to FH.")
+  >
+  > *…and when you're done, say **"wrap up"** — what you did lands in the session card, and the next session starts from there instead of from scratch.*
+
+  **The wrap-up line is returning-branch only.** A first-time user has nothing to close yet, and the phrase would read as jargon; a returning user is exactly the person whose last session may have ended without it. One line, below the doors, never a numbered door (the door set is fixed — §fh_detail_protocols Step 2).
 
   🟥 **한 줄로 이어붙이지 마라 — 문은 한 줄에 하나다** (운영자 지적 2026-08-20). `·` 로 이어붙인
   한 줄짜리 메뉴는 터미널 폭에서 임의로 접혀서 **어디까지가 한 문인지 눈으로 안 갈린다**. 세로
@@ -1307,7 +1311,7 @@ harvest-loop Step 0-b uses this file as its source — relying on LLM memory aft
 
 **Session close chaining (automatic sequence — not skippable)**:
 ```
-Closing phrase detected ("wrap up", "done", "good work", "end session", etc.)
+Closing phrase detected ("wrap up", "done", "good work", "end session", etc. — 🟥 **in any language**, on the same footing as the greeting trigger: 「마감」·「마무리하자」·「終わり」·「收尾」 all count. The returning-branch greeting *teaches* this phrase **in the user's language**, so a trigger list that only accepts English would tell the user a word the machine then ignores. Found by blind floor-tier sim 2026-08-29: the greeting emitted 「마무리하자」, which appeared nowhere in this list.)
   → ① Check git diff + unpushed commits (status snapshot)
   → ①-b Open-PR sweep — `gh pr list --author @me --state open` (+ `gh search prs --author @me
        --state open` cross-repo). Classify, **surface-not-auto**: **self-mergeable** PR (own repo,

--- a/knowledge/shared/harness-core/fh_detail_protocols.md
+++ b/knowledge/shared/harness-core/fh_detail_protocols.md
@@ -133,6 +133,19 @@ so it must never be the default path. Operating detail (allowed corpus · say "n
 lives in `/fh` Step 3.5.
 
 > (When **FH-dev state exists** — the operator — the welcome line is **"The FH operator — good to see you."** in place of "Welcome back to FH.")
+>
+> *…and when you're done, say **"wrap up"** — what you did lands in the session card, and the next session starts from there instead of from scratch.*
+
+**Wrap-up line — returning branch only, and it is not a door.** A first-time user has nothing to close
+yet and the phrase reads as jargon; a returning user is exactly the person whose *last* session may have
+ended without it, and whose work therefore never reached the card. It sits **below** the doors as one
+line — **G-GREET-03 (fixed 4-door set) and G-GREET-05 (welcome literals) stay satisfied**, because those
+probes pin the door set and the welcome literal, not what follows them.
+🟥 **Say the trigger word, not the machinery.** The close chain is six steps; the consumer needs exactly
+one word. Naming «the close chain» here would be internal vocabulary leaking into the front door.
+⚠️ **Unmeasured**: this line is salience-only, with no mechanical floor (the greeting never has one —
+CLAUDE.md §Voice/Tone). Whether a floor-tier session actually emits it is **not yet blind-sim'd**, so it
+does not meet §Skeleton-Not-Muscle's completion bar. Labelled here rather than assumed.
 
 - **① Map a project** → routes to `auto_project_mapping.md`; after a successful mapping, offer the §6 Full-Harness promotion prompt
 - **② Create a new project** → Step 3-0 (new project setup)


### PR DESCRIPTION
## 운영자 관찰에서 출발

> 처음 사용해보고 마감하지 않고 바로 끈 사람도 있을 거야. 근데 그렇게 해도 메모리에는 남아있을 거고. 그런 경우에도 다시 켰을 때 첫 온보딩 문구가 나올까?

**나올 수 있었다.** 그리고 원인이 정본이 아니라 **상주 요약**이었다.

## ① 「완전 신규」 오판 — 정본은 옳았는데 상주가 안 옳았다

```
정본  fh_detail_protocols.md:90   세션 파일 = tracks/**/session_*.md «또는 tracks/_meta/*.md»
상주  CLAUDE.md                   「밑줄 디렉터리는 안 센다」가 어디에 걸리는지 미정
```

🟥 **인사는 세션 첫 턴이라 detail 을 안 읽고 판정하는 경로가 실재한다.** 상주만 읽는 세션은 `_meta` 를 세션 파일에서도 빼고 「처음 보는 얼굴이네」를 렌더할 수 있었다. 두 조건을 갈라 적고 «`_meta` 는 여기서 센다»를 못 박았다.

## ② 재방문 문 «아래» 마감 권고 한 줄

문이 아니라 **문 아래 줄**이라 `G-GREET-03`(고정 4문)·`G-GREET-05`(환영문 리터럴)를 안 건드린다 — 그 둘은 하류 포크가 기계 매핑하는 앵커다. 신규 문엔 안 넣었다(닫을 게 없고 용어만 된다).

## 🟢 블라인드 sim — 플로어 티어, 격리 클론, 소비자 상황

```
ARM(재방문)    tracks/_meta/*.md 하나만 둠 → 「안녕, 다시 왔네!」 + 4문 + 마감줄 ✅
CONTROL(신규)  그 파일만 지움              → 「처음 보는 얼굴이네」 + 2문 + 마감줄 없음 ✅
```

**파일 하나의 유무로 두 분기가 갈렸다** — 발화가 우연이 아니고, 계기에 판별력이 있다.

## 🟥 sim 이 «텍스트로는 안 보이는» 결함을 잡았다

세션이 **「마무리하자」** 라고 가르쳤는데 마감 트리거 목록은 **영어 예시뿐**이었다:

```
Closing phrase detected ("wrap up", "done", "good work", "end session", etc.)
```

**우리가 가르친 말이 우리 기계에 안 들어갈 수 있었다.** 인사말 트리거는 「어느 언어든」이라고 명시돼 있는데 마감은 아니었다 — **같은 파일 안의 비대칭**이다.

이건 정적 리뷰로 못 잡는다. 「가르친 말」과 「받는 말」이 **다른 절에 있고 둘 다 각자로는 옳기** 때문이다. 트리거를 언어 무관으로 명시해 닫고 **재sim 으로 확인**했다.

## 🟥 마커에서 세 번 막혔고 전부 정당했다

```
floor-status 에 마크다운          → enum 위반
axis2-model 에 판정자+sim대상 혼재 → 「sonnet-5 + above-floor」 모순
상주 +4줄에 residency 유형 미선언  → 유입 게이트 차단
```

세 번째가 특히 옳았다 — 상주층이 하루 2,367 bytes 씩 늘던 문제로 만든 게이트인데, **내가 그 문으로 들어가려 하자 「왜 항상 로드돼야 하나」를 물었다.** `disambiguator` 로 선언하고 근거를 적었다.

## 한계 — 인용 전에 읽어라

- **reps=1** (팔당 1회). 이 저장소 자신의 `reps>=3` 바 미달. **비결정성 미측정**
- `standpoint: tier2(clean-install-sim)` — `git archive` export 이지 **`npm pack` 타르볼이 아니다**
- 마감 권고 줄은 **살리언스 전용**이고 기계 floor 가 없다(인사는 원래 없다 — §Voice/Tone)

Axis 1 ✅ PASS (`--staged`, M=0 S=0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYSKLdAXdpqhSvjJXRB5RM