### PR TITLE
fix(gate): 발행 직전 보안 패스가 찾은 fail-open + 2.13.0 노트 보완

### DIFF
--- a/plugins/fh-meta/CHANGELOG.md
+++ b/plugins/fh-meta/CHANGELOG.md
@@ -10,6 +10,22 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### [2.13.0] — 2026-08-29
 
+> **추가 (발행 전 보완)** — 아래 두 항목은 릴리스 커밋 이후, **발행 전에** 같은 2.13.0 으로
+> 들어왔다. 미발행 상태라 노트를 보완하는 것이 태그·타르볼·문서를 일치시키는 정직한 방향이다.
+>
+> - **새 게이트 행 + 필드 렌즈 — `measurement-reps`.** 측정을 기록했는데 `reps` 가 바(3) 미달
+>   이고 그 결론이 **하중을 지면**(판정·등급·교리·비가역 처방) 한 줄 제안이 뜬다. 지금까지는
+>   「바 미달」이라고 **적고 넘어가는 것**이 기본값이었다 — 라벨은 측정이 아니다. §Field-Harness
+>   Diagnostic 도 8렌즈 → **9렌즈**. 🟥 필드 하네스에 돌리기 전에
+>   `knowledge/shared/harness-core/field_harness_diagnostic.md` 의 **Step 0(provenance 분리)**
+>   를 읽어라 — FH 파생 하네스를 그냥 스캔하면 FH 자기 텍스트를 필드 발견으로 되읽는다
+>   (실측: 어느 필드 레포 원시 히트의 2/3).
+> - **인사말 번역 조항** — 문장은 어느 언어로든 자연스럽게 옮기되 이름 「FH」는 움직이지 않는다.
+>   🟥 **측정했고 안 닫혔다**(컨트롤 1/3 · 조항 2/3, n=3 에서 차이 1). 조항은 옳고 싸서 남겼지
+>   효과가 측정돼서가 아니다. 이 축엔 기계 floor 가 없다.
+> - `scripts/activity_log.sh` 가 **files[] 에 진입**했다 — 배포되는 digest 생산자
+>   (`frontier_digest_autopilot.sh`)가 언더스코어 날짜 파일을 만드는데 그 판독기가 안 실려 있었다.
+
 > **BREAKING (gate)**: `templates/regression_guard.sh` 의 Axis 1 pathspec 이 이제
 > `README*.md` · `CHEATSHEET.md` · `CATALOG.md` · `.github/workflows/*.yml` · `scripts/*.py` ·
 > `.claude/registry/*.md` · `package.json` 을 **본다**. **FH 클론에 4축 pre-commit 훅을

--- a/plugins/fh-meta/CHANGELOG.md
+++ b/plugins/fh-meta/CHANGELOG.md
@@ -23,6 +23,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 > - **인사말 번역 조항** — 문장은 어느 언어로든 자연스럽게 옮기되 이름 「FH」는 움직이지 않는다.
 >   🟥 **측정했고 안 닫혔다**(컨트롤 1/3 · 조항 2/3, n=3 에서 차이 1). 조항은 옳고 싸서 남겼지
 >   효과가 측정돼서가 아니다. 이 축엔 기계 floor 가 없다.
+> - 🟥 **fail-open 수리 — `templates/regression_guard.sh` F1(frontmatter).** 발행 직전 보안 패스가
+>   찾았다: 검사기(`python3`)가 없거나 안 도는 머신에서 F1 이 **「✅ frontmatter intact」로 렌더**
+>   됐다 — 출력에 `FAIL` 토큰이 없다는 이유만으로. **macOS 는 python3 를 기본 탑재하지 않으므로**
+>   상당수 소비자에게 이 레인은 늘 초록이었고, 그 초록은 「검사했다」가 아니라 「검사기가 없었다」였다.
+>   이제 **종료코드**로 판정한다(0=정상 · 1=FAIL · 그 외=`⚠️ F1 UNMEASURED`). 🟥 **차단하지 않는다**
+>   — 가역 표면이고, 과차단은 이 파일 자신이 경고한 대로 `--no-verify` 를 근육에 새긴다.
+>   ⚠️ **행동 변화**: 그런 머신에서 이제 경고 줄이 뜬다. 통과/차단 판정은 안 바뀐다.
 > - `scripts/activity_log.sh` 가 **files[] 에 진입**했다 — 배포되는 digest 생산자
 >   (`frontier_digest_autopilot.sh`)가 언더스코어 날짜 파일을 만드는데 그 판독기가 안 실려 있었다.
 

--- a/templates/regression_guard.sh
+++ b/templates/regression_guard.sh
@@ -383,7 +383,27 @@ for req in ('name:', 'description:'):
         sys.exit(1)
 print('OK')
 " 2>&1)
-    if echo "$fm_check" | grep -q FAIL; then
+    fm_rc=$?
+    # 🟥 An ABSENT instrument is not a clean result. Before 2026-08-29 this `else` printed
+    # "✅ frontmatter intact" whenever `$fm_check` merely lacked the token FAIL — and
+    # `python3: command not found` lacks it. macOS ships no python3 by default, so on a stock
+    # consumer machine F1 was ALWAYS green, and that green meant "no checker", not "no defect".
+    # Measured by execution, not reading: same broken content, python3 present → `❌ M-TIER`,
+    # python3 shadowed with a 127 stub → `✅ frontmatter intact`.
+    # Degrade direction: this is the REVERSIBLE commit surface, so it degrades to a LOUD
+    # ADVISORY and deliberately does NOT touch S_TIER — bumping it would exit 1 and redden every
+    # such consumer's CI on any SKILL.md edit, and this file's own line 659 warns that
+    # over-blocking is what trains `--no-verify` into muscle memory. Not-silent and not-blocking
+    # are different properties; only the first is mandatory here.
+    # 🟥 The discriminator is the EXIT CODE, not `command -v`. A first pass at this fix asked
+    # "is python3 available?" and a three-way known-pair immediately broke it: a 127-stub IS on
+    # PATH, so `command -v` succeeded and the fail-open survived. The checker contract is
+    # rc 0 = intact · rc 1 = a FAIL line was printed · anything else = the instrument did not run
+    # (127 absent, 126 not-executable, a broken interpreter), which covers absent AND broken with
+    # one branch instead of enumerating causes.
+    if [ "$fm_rc" -ne 0 ] && [ "$fm_rc" -ne 1 ]; then
+      echo "  ⚠️  F1 UNMEASURED — frontmatter checker did not run (rc=$fm_rc): $fm_check"
+    elif echo "$fm_check" | grep -q FAIL; then
       echo "  ❌ M-TIER  frontmatter: $fm_check"
       M_TIER=$((M_TIER + 1))
     else


### PR DESCRIPTION
## 왜

#557 이 릴리스 커밋 뒤·**발행 전에** 머지되면서, 2.13.0 타르볼이 CHANGELOG 가 언급하지 않는 내용을 싣게 됐다 — `measurement-reps` 게이트 행 + 9번째 필드 렌즈 + 인사말 번역 조항 + `activity_log.sh` 의 `files[]` 진입.

## 선택지 둘

| | |
|---|---|
| ⓐ 릴리스 커밋(`eebed30`)을 detached 로 체크아웃해 발행 | CHANGELOG 는 정확해지지만 공유 체크아웃에서 detached HEAD 로 발행하는 형태이고 `prepublishOnly` 가 그 트리에서 돈다 |
| **ⓑ 미발행 노트를 보완하고 main 에서 발행** | 태그·타르볼·문서가 **한 지점에서 일치** |

ⓑ 를 골랐다.

🟥 **이미 발행된 버전의 노트를 고치는 것이면 안 했다** — 그건 사후 서술 변경이다. 레지스트리에 2.13.0 이 아직 없음을 확인했고(최신 `2.12.1`), 그래서 이건 «출하 전 문서 정합»이다.

## 무엇을 적었나

소비자가 실제로 마주치는 것만, **한계와 함께**:

- 인사말 조항 → *「측정했고 안 닫혔다(컨트롤 1/3 · 조항 2/3, n=3 에서 차이 1)」*
- 필드 렌즈 → *「Step 0 provenance 분리를 먼저 읽어라 — FH 파생 하네스를 그냥 스캔하면 자기 텍스트를 필드 발견으로 되읽는다」*

새 기능을 성과로만 적으면 소비자가 잘못된 기대를 갖는다.

```
Axis 1: SKIP (not-checked, NOT a pass) — plugins/fh-meta/CHANGELOG.md 는 GUARD_PATHSPEC 밖.
        게이트의 알려진 미커버 잔여이지 이 델타의 성질이 아니다.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYSKLdAXdpqhSvjJXRB5RM