### PR TITLE
docs(agents): ④-b 가 띄운 진입점 드리프트를 «기록»이 아니라 «수리»로

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,17 @@ The constraint above is not.
 > **Detail**: See `knowledge/shared/harness-core/agents_md_runtime_details.md §Adding-agents`
 > — creation gate, registry synchronization, and post-use thresholds — read before adding an agent.
 
+> **`reps` below the bar is a TRIGGER, not a label** (2026-08-29). This repo's bar is `reps>=3`.
+> When you record a measurement at reps 1–2 **and its conclusion is load-bearing** — it holds up a
+> verdict, a grade, a doctrine change, or an irreversible prescription — do not write *"below the
+> bar"* and move on. That was the standing default, and a label is not a measurement. Say it in one
+> line instead: *"this is reps={n} — raise it to {target} by simulation?"* 🟥 The **load-bearing**
+> condition is what keeps this from becoming noise: a single run done to confirm an instrument has
+> nothing to raise. The same discipline applies to a field harness's own records, where it is the
+> `measurement-reps` lens of `knowledge/shared/harness-core/field_harness_diagnostic.md` — 🟥 read
+> that file's **Step 0 (provenance split)** before running it anywhere: a harness onboarded by FH is
+> FH-derived, so an unsplit scan reads FH's own text back as a field finding.
+
 > **Removing resident text**: if you are considering deleting a section from `CLAUDE.md` (or any
 > always-loaded asset) because it looks redundant, this repo settles that by measurement rather than
 > by reading. The procedure — two arms, an isolated runtime, `reps>=3`, a question set fixed before


### PR DESCRIPTION
마감 체인 **④-b(진입점 드리프트, 양방향)** 가 CC→Codex 후보를 띄웠다. grep 은 **띄우기만** 하고 정합 판정은 사람 몫이라, 둘을 갈라 판정했다.

| 후보 | 판정 | 근거 |
|---|---|---|
| **reps** | **드리프트 O** | `AGENTS.md` 는 `reps>=3` 을 **바**로는 갖고 있는데(`:251` ablation 절차 · `:159` 마커 fairness 필드) 「미달이면 제안해라」 **트리거가 없다**. 비-CC 런타임에 규율의 **반쪽만** 가 있었다 |
| 인사말 조항 | 드리프트 X (`drift:none`) | `onboarding\|greeting` 1건뿐. Codex 진입점이 인사 렌더를 소관하지 않는다 |

**컨트롤 동반** — known-positive: `reps` 2건 실재(grep 살아있음) · known-negative: `Field-Harness Diagnostic|진단|렌즈` **0건**. 부재 주장이 죽은 grep 의 0 이 아니다.

🟥 **문장을 복사하지 않고 다시 썼다** — `feedback_entrypoint_port_constraint_not_wording`: **위치가 바뀌면 청중이 바뀐다.** AGENTS.md 독자는 비-CC 런타임 운용자라 「§Autonomous Initiative Layer 행」 같은 CC 내부 지명이 안 통하고, 단정 문구를 그대로 옮기면 강압으로 읽힌다.

필드 렌즈 포인터에는 **Step 0(provenance) 경고를 같이** 실었다 — FH 가 온보딩한 하네스는 전부 FH 파생이라 안 가르고 스캔하면 자기 텍스트를 필드 발견으로 되읽는다.

## ⚠️ 안 잰 것

비-CC 런타임에서 이 문단이 **실제로 발화되는지는 미측정**이다. CC 쪽은 2팔 reps=3 으로 쟀지만 이건 다른 런타임이고, 같은 값이 나온다고 가정하지 않는다.

```
Axis 1     : PASS (--staged)
standpoint : not-applicable — 훅·스크립트 무변경이라 소비자 게이트 행동이 안 바뀐다
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYSKLdAXdpqhSvjJXRB5RM