### PR TITLE
docs(ethos): §7 — 바닥은 하네스가 올리고, 천장은 사람이 올린다

### DIFF
--- a/docs/ETHOS.md
+++ b/docs/ETHOS.md
@@ -111,6 +111,27 @@ forward), so the harness audits itself and the learnings compound session over s
 
 ---
 
+## 7. The floor is ours; the ceiling is yours
+
+A harness raises the **floor** — that is what the Sonnet-floor doctrine is about, and it is most of
+what people notice. It does not raise the **ceiling**. That moves with what the operator knows, and
+the asymmetry is deliberate: an amplifier multiplies what is there and supplies nothing that is not.
+
+So FH does not sell *you no longer need to know*. That sentence is popular and corrosive — a person
+who believes it stops checking, and every failure mode in this repository is a variety of having
+stopped checking. Craft is not overhead the tooling will retire; it is the lever the tooling
+multiplies. Different operators pull different levers out of the same install, and that is expected
+rather than a defect to engineer away.
+
+And the machinery is not the point of it. Mechanization has no natural end — left alone it grows
+until frozen judgment becomes the ceiling it was meant to raise. As the models underneath improve,
+scaffolding sheds; what survives the shedding is the intent it was built to carry, the identity it
+answers to, and the direction it is still moving in. Build for what remains.
+
+> *A harness makes intent executable. It does not make knowledge optional.*
+
+---
+
 ## What FH does not claim
 
 - It is **not** a detection engine, an accuracy multiplier, or a model ranking. The cold pass is your


### PR DESCRIPTION
운영자 축어 셋을 교리로 옮긴다.

> 「하네스 AI 는 **증폭제**」 · 「사람에 따라 **레버가 달라지는 건 자연스럽다**」
> 「**기계화는 끝이 없고**, 모델이 좋아질수록 벗겨진다 — 남는 건 **의도·정체성·방향**」

---

## 왜 필요했나 — 한쪽 교리만 있었다

FH 는 **바닥**에 대한 교리(`sonnet_floor_doctrine`)를 갖고 있는데 **천장에 대한 교리가 없었다.** 한쪽만 있으면 *「도구가 좋으면 사람은 덜 알아도 된다」* 로 읽힌다 — 그리고 그게 대부분의 AI 도구가 파는 문장이다.

📚 **책장 스윕** (컨트롤 동반: 없는 개념 0히트):
```
「몰라도 된다」를 부정하는 절     0 히트          ← 없었다
floor/ceiling 기존 3건            전부 «모델 티어» 얘기 (원문 확인) — 사람 얘기가 아니다
```

## 셋째 문단은 **판단을 바꿔서** 넣었다

처음엔 「무리하지 마라」를 **뺐다** — ETHOS 는 믿음을 적는 곳이고 그건 작업 지침이라서. 운영자가 그 **이유**를 주자(*기계화는 끝이 없고 모델이 좋아지면 벗겨진다*) **믿음 문장으로 성립**함이 확인돼 넣었다.

그리고 그 「천장」은 `CLAUDE.md §Mechanization Boundary` 의 운영자 축어와 **같은 낱말이다**:

> 「판단을 내가 코드로 굳혀두면 그게 바로 **진화를 막는 천장**이 되니까」

**§7 이 그 둘을 잇는다** — 사람의 지식이라는 천장과, 굳은 판단이라는 천장.

## 옮기며 바꾼 것 둘 (숨기지 않는다)

| 원문 | 옮긴 것 | 왜 |
|---|---|---|
| 「도마뱀이 써도 동급 능력은 못 준다」 | *"an amplifier multiplies what is there and supplies nothing that is not"* | 공개 문서라 사용자 비하로 읽힐 여지를 뺐다. 논지는 그대로 |
| 「사람에 따라 레버가 다르다」 | *"expected rather than a defect to engineer away"* | 그대로 살렸다 — 균질화 유혹을 미리 막는 실용적인 줄 |

## 톤 — 스킬을 「썼다」고 적지 않는다

🟥 `ko-tech-writer` 는 **한국어 전용**이라 영어 ETHOS 엔 그대로 못 썼다. 그 **규율만** 손으로 적용했다(실물 표본 톤 캘리브레이션 · 번역투 제거 · 주장 게이트).

**캘리브레이션 위반을 자체 적발했다**: 초안이 20줄로 §6(7줄)의 세 배 → **14줄로 줄였다**(§5 가 13줄).

## 🟥 안 한 것

**콜드리드 미실시.** 처음 읽는 사람에게 이 절이 「장벽」으로 읽히는지 **안 쟀다** — `/sim-conductor A-1(beginner)` 이 그 렌즈이고 안 돌렸다. 마커에 잔여로 명시했다.
그리고 「기계화가 벗겨진다」는 이 저장소 메모리엔 있으나 **공개 문서엔 처음** 적힌다 — 즉 실측 인용이 아니라 **방향 선언**이고, 그렇게 읽혀야 한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYSKLdAXdpqhSvjJXRB5RM