### PR TITLE
docs(changelog): 철회된 sim 결과가 npm 배포 CHANGELOG 에서 근거로 살아 있었다

### DIFF
--- a/plugins/fh-meta/CHANGELOG.md
+++ b/plugins/fh-meta/CHANGELOG.md
@@ -706,6 +706,13 @@ are **blocked at commit**.
 - `standpoint:` gains **`tier1b`** (a STATIC read of a target repo — executed nothing) plus a
   decide-in-order procedure, after blind floor-tier sims graded pure cold-reads as `tier2` for three
   rounds, defeating three separate rewordings via the enum's own internal logic.
+  🟥 **[RETRACTED 2026-08-17, noted here 2026-08-30]** — that sim result is withdrawn: the runs had
+  `tool_uses: 0`, so the agents never opened a file and the grades measure nothing. The live re-run
+  landed the **opposite** result at reps=1, below this repo's own bar — so neither direction is
+  established. **The `tier1b` rung itself stands** on its own wording (a read that executed nothing
+  is not `tier2`), not on this measurement. Canon: `CLAUDE.md` §Skeleton-Not-Muscle ·
+  `field_verdict_crossfamily_gate.md:310`. The sentence above is kept rather than deleted so the
+  citation stays traceable.
 - steel-quench Wave 1's sixth angle (**gate-locality**) gains the output-template row it never had —
   a mandatory angle that was structurally unreportable. Gate-locality failing its own check.
 - `verify-bidirectional` category 5 — **prescriptive doctrine statement**, the operator-correction


### PR DESCRIPTION
## 무엇

`CLAUDE.md` 가 2026-08-17 에 철회한 주장 — *"blind sims graded cold-reads as `tier2`"* — 이
`plugins/fh-meta/CHANGELOG.md:706` 에서 **`tier1b` 도입의 근거로** 그대로 서 있었다.
상세 문서(`field_verdict_crossfamily_gate.md:310·356`)는 철회를 제대로 이고 있었고, **npm 으로
나가는 CHANGELOG 만** 옛 주장을 유지했다 — 소비자가 grep 하면 죽은 숫자를 얻는다.

지우지 않고 `[RETRACTED]` 인라인 표기 + 「rung 자체는 그 측정이 아니라 자기 문면으로 선다」 명시.

## 왜 이게 남았나

철회문의 명시 범위가 **「this paragraph」**였다. 범위를 손으로 적었고, 그 범위가 틀렸다.
같은 날 qasp 에서 같은 형태가 세 건 더 나왔다(`§3·§7` 부재 · `:21→:22` · `:84→:87`).

## 기계화는 하지 않는다 — 재서 결정했다

프로토타입 검사기를 **known-positive 로 대조했더니 NOT FOUND**:

```
철회문 인용 : "Two independent blind Sonnet sims then graded a pure cold-read as `tier2`,"
생존 문장   : "blind floor-tier sims graded pure cold-reads as `tier2` for three rounds"
```

생존한 것은 인용의 **복사가 아니라 패러프레이즈**라 정확일치 grep 이 구조적으로 못 잡는다.
잡으려면 「같은 주장인가」를 판정해야 하고 그건 채널이 아니라 **결론**이다
(`CLAUDE.md §Mechanization Boundary`).

축을 갈라 다시 쟀다 — **B. 앵커 드리프트**(`file:line` 이 가리키는 자리가 틀림)는 잡힌다.
FH 자신에게 돌린 결과: 줄-인용 **24건 · 죽은 포인터 0**. 이유는 FH 가 인용을 대부분
`파일 §절` 로 달기 때문이다 — **§앵커는 줄번호처럼 썩지 않는다.**
⇒ FH 에 레인을 걸면 0건을 내는 장식이다. **안 짓는다.**

정본: `tracks/_meta/fh_signal_2026-08-30_retraction-scope.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYSKLdAXdpqhSvjJXRB5RM