### PR TITLE
fix(landing-check): 자기참조 3분기가 지워도 초록이었다 — 앵커 4개 추가 (뮤테이션 스코어 3/3)

### DIFF
--- a/scripts/digest_landing_check.sh
+++ b/scripts/digest_landing_check.sh
@@ -644,6 +644,62 @@ EOF
       bash "$SELF_DIR/$(basename "${BASH_SOURCE[0]}")" "$IG/wiki/digest.md" ) >/dev/null 2>&1; rc_ie=$?
   _t "★N-input e) 글롭이 확장되지 않는다(진짜 착지면을 과잉 제외 안 함)" 0 "$rc_ie"
   rm -rf "$IG"
+
+  # ── ★N-self (2026-08-30) — 자기참조 차단 «세 분기»의 앵커 ─────────────────────────────
+  # 🟥 왜 지금 붙나: 세 분기(digest 자신 · 그 로그 · 타 digest)를 **각각 `continue` 에서 `:` 로
+  #    되돌려도 20 레인이 전부 초록**이었다(2026-08-30 실측). 즉 위 ★N-input 이 «프로필» 축만
+  #    덮고 있었고, 나머지 세 축은 코드에 있으되 **아무도 안 재는 장식**이었다.
+  #    이 파일 주석이 스스로 «첫 실물 실행에서 100% 오탐을 낸 원인» 이라 적어둔 그 분기들이다.
+  # 🟥 컨트롤 설계: 이 셋은 env 토글이 없다(하드코딩). 그래서 «끄는» 대신 **같은 내용의 파일을
+  #    제외되지 않는 위치에 두는** 팔을 짝으로 둔다 — 한 변수는 «파일의 자리» 하나뿐이다.
+  #    짝이 없으면 「제외가 다 죽인다」와 「픽스처가 애초에 안 잡힌다」가 구분되지 않는다.
+  local SG rc_s ctl_s
+  _mk_self() { # $1=배치할 상대경로 (digest 이후 커밋된다)
+    SG="$(mktemp -d -t dlc_s.XXXXXX)" || return 10
+    ( mkdir -p "$SG/wiki/logs" && cd "$SG" && git init -q . \
+        && git config user.email t@t && git config user.name t
+      printf '# d\n## 📌 FH Immediate Application Candidates\n\n| # | 티어 | 내용 |\n|---|---|---|\n| **A1** | M | `zzz_tok` 후보 |\n\n## end\n' \
+        > wiki/digest.md
+      # 🟥 ⓐ(digest 자신) 는 **별도 파일이 아니라 digest 에 «덧붙여야»** 조건이 성립한다.
+      #    초판은 `> wiki/digest.md` 로 덮어써서 후보 절을 지웠고, 그러면 필터와 무관하게
+      #    rc=10 이 나와 **필터를 죽여도 초록**이었다 — 픽스처가 조건 위에 있지 않은 판
+      #    ([[feedback_anchor_can_be_decorative]] 원인 5). 손으로 재현해서 잡았다.
+      if [ "$1" = "digest.md" ]; then
+        printf 'zzz_tok 이 여기 있다 · zzz_ctl\n' >> wiki/digest.md
+        touch -t 200101010000 wiki/digest.md
+      else
+        touch -t 200101010000 wiki/digest.md
+        mkdir -p "$(dirname "wiki/$1")"
+        printf 'zzz_tok 이 여기 있다 · zzz_ctl\n' > "wiki/$1"
+      fi
+      git add -A && git commit -qm s ) >/dev/null 2>&1
+  }
+  _run_self() {
+    ( cd "$SG" && CLAUDE_PROJECT_DIR="$SG" DLC_TRACKED_PATHS="wiki" DLC_IGNORED_DIR="" \
+        DLC_CONTROLS="zzz_ctl" \
+        bash "$SELF_DIR/$(basename "${BASH_SOURCE[0]}")" "$SG/wiki/digest.md" ) >/dev/null 2>&1
+  }
+
+  # ⓐ digest 자신 — 자기 안에서 후보 토큰이 발견되면 전건이 자동 「착지」가 된다
+  _mk_self "digest.md"; _run_self; rc_s=$?
+  _t "★N-self a) digest 자신은 타깃이 아니다 → 미측정(10)" 10 "$rc_s"
+  rm -rf "$SG"
+  # ⓐ-CTRL 같은 내용을 제외되지 않는 이름으로 두면 «10 이 아니게» 된다 = 픽스처가 살아 있다
+  _mk_self "plain.md"; _run_self; ctl_s=$?
+  _t "★N-self a-CTRL) 제외 안 되는 자리면 10 이 아니다(픽스처 생존 증명)" "not10" "$([ "$ctl_s" -eq 10 ] && echo is10 || echo not10)"
+  rm -rf "$SG"
+
+  # ⓑ 생성 로그 — digest 를 만든 로그는 digest 어휘를 그대로 갖는다
+  _mk_self "logs/run.md"; _run_self; rc_s=$?
+  _t "★N-self b) 생성 로그(*/logs/*)는 타깃이 아니다 → 미측정(10)" 10 "$rc_s"
+  rm -rf "$SG"
+
+  # ⓒ 타 digest — 후보는 이월되며 다음 날 digest 에 다시 등장한다. 그걸 착지로 세면
+  #    「내일도 후보로 남았다」가 「오늘 착지했다」가 된다.
+  _mk_self "frontier_digest_2002_02_02.md"; _run_self; rc_s=$?
+  _t "★N-self c) 타 digest(*frontier_digest_*)는 타깃이 아니다 → 미측정(10)" 10 "$rc_s"
+  rm -rf "$SG"
+
   rm -rf "$EG"
   # ⚠️ **줄 단위로** 본다. `case *"A1"*"미착지"*` 는 마지막 요약줄("N건 중 M건 미착지")까지
   # 삼켜 오매칭한다 — 문자열 위치로 판정하는 prose-grep 함정([[feedback_typed_verdict_channel]]).


### PR DESCRIPTION
## 무엇

`digest_landing_check.sh` 의 **자기참조 차단 세 분기**(digest 자신 · 그 생성 로그 · 타 digest)가
**지워도 20 레인 전부 초록**이었다. 이 파일 주석이 스스로 *「첫 실물 실행에서 100% 오탐을 낸
원인」*이라 적어둔 분기들인데, 기존 레인은 `★N-input`(프로필 축)만 덮고 있었다.

**20 → 24 레인.** `★N-self a/b/c` + `a-CTRL`.

## 이건 뮤테이션 테스팅이다 — 그리고 이제 그렇게 채점한다

되돌림 프로브(`continue` → `:`)는 **뮤턴트를 심는 것**이고, 「레인이 빨개지나」는 **뮤턴트를
죽이는 것**이다. 우리는 이 기법을 이름 없이 쓰고 있었다.

```
심은 뮤턴트 3  ·  죽인 뮤턴트 3  →  이 서브시스템 뮤테이션 스코어 3/3
각각 «자기 레인만» 적색 · 복원 후 전건 초록
```

업계 기준(Stryker break threshold 70% · Google 실무 70–80% 정체 · equivalent 뮤턴트 ~23%로
실용 천장 ~77%)에 대면 **이 서브시스템은 통과 구간을 넘는다.**
⚠️ 스코프 정직: 이 스코어는 **자기참조 필터 3분기**에 대한 것이지 파일 전체가 아니다.

## 컨트롤 설계 — env 토글이 없을 때

이 셋은 하드코딩이라 「끄는」 방법이 없다. 그래서 **같은 내용의 파일을 제외되지 않는 자리에 두는**
팔을 짝으로 뒀다 — 한 변수는 **파일의 자리** 하나뿐. 짝이 없으면 「제외가 다 죽인다」와
「픽스처가 애초에 안 잡힌다」가 구분되지 않는다.

## 🟥 자체 적발 2건 — 둘 다 앵커를 믿기 전에 잡았다

| | 무엇 | 왜 위험했나 |
|---|---|---|
| ① | **첫 되돌림 프로브가 죽어 있었다** — `case` 분기를 `: ;` 로 바꿔 문법이 깨졌고(`rc=2`) 자기검사가 아예 안 돌았다 | 「적색 0」을 **「장식 확정」**으로 읽을 뻔했다. 계기 사망을 결과로 렌더하는 판. 프로브에 `bash -n` 게이트 추가 |
| ② | **픽스처가 조건 위에 없었다** — ⓐ 레인이 digest 를 **덮어써서** 후보 절을 지웠고, 그러면 필터와 무관하게 `rc=10` | 필터를 죽여도 초록. 손 재현으로 잡았다: 필터 살아있음 `rc=10` / 죽임 `rc=0 «착지 1건»` — **거짓 착지가 실재한다** (`[[feedback_anchor_can_be_decorative]]` 원인 5) |

## 등급

`external-grounding` **🟡 유지.** 이건 다리 하나이고, 남은 둘이 그대로다 —
`novelty_claim_check` 가 `rc=2 ADVISORY(단독 차단 금지)` 이고, daily digest launcher 의
plist 가 **플레이스홀더 경로**다.

## 검증

- 로컬 `SELFCHECK: PASS` **완주 확인 후 푸시** (직전 PR 에서 이걸 안 해서 CI 가 잡았다 —
  §Local Execution First)
- 되돌림 3/3, 각각 자기 레인만 · 복원 전건 초록

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYSKLdAXdpqhSvjJXRB5RM