### PR TITLE
test(landing-check): 뮤테이션 스코어로 재채점 — 53% → 60%, 생존자를 실행으로 분류

### DIFF
--- a/scripts/digest_landing_check.sh
+++ b/scripts/digest_landing_check.sh
@@ -694,6 +694,21 @@ EOF
   _t "★N-self b) 생성 로그(*/logs/*)는 타깃이 아니다 → 미측정(10)" 10 "$rc_s"
   rm -rf "$SG"
 
+  # ⓓ 비-.md 타깃 + 빈 제외 토큰 — 뮤테이션 측정(2026-08-30)이 드러낸 **미커버 입력**이다.
+  #    `case "$f" in *.md) ;; *) continue ;;` 와 `[ -n "$_x" ] || continue` 둘 다 되돌려도
+  #    초록이었는데, 이유는 「방어가 필요 없다」가 아니라 **픽스처가 그 입력을 한 번도 안 만든다**
+  #    였다. equivalent 뮤턴트와 미커버 입력은 다르다 — 전자는 못 죽이고 후자는 픽스처로 죽는다.
+  _mk_self "plain.md"
+  ( cd "$SG" && printf 'zzz_tok · zzz_ctl\n' > wiki/notes.txt && git add -A && git commit -qm t ) >/dev/null 2>&1
+  ( cd "$SG" && CLAUDE_PROJECT_DIR="$SG" DLC_TRACKED_PATHS="wiki" DLC_IGNORED_DIR="" \
+      DLC_CONTROLS="zzz_ctl" DLC_EXCLUDE_TARGETS="  wiki/plain.md  " \
+      bash "$SELF_DIR/$(basename "${BASH_SOURCE[0]}")" "$SG/wiki/digest.md" ) >/dev/null 2>&1; rc_s=$?
+  # plain.md 는 제외되고 notes.txt 는 .md 가 아니라 타깃에서 빠진다 ⇒ 타깃 0건 = 미측정(10).
+  # 🟥 `.md` 필터가 죽으면 notes.txt 가 타깃이 되어 「착지」로 렌더된다 = 거짓 양성.
+  # 🟥 빈 토큰 가드가 죽으면 공백 분리로 생긴 빈 문자열이 모든 경로에 매칭될 수 있다.
+  _t "★N-self d) 비-.md 는 타깃이 아니고 빈 제외 토큰은 무시된다 → 미측정(10)" 10 "$rc_s"
+  rm -rf "$SG"
+
   # ⓒ 타 digest — 후보는 이월되며 다음 날 digest 에 다시 등장한다. 그걸 착지로 세면
   #    「내일도 후보로 남았다」가 「오늘 착지했다」가 된다.
   _mk_self "frontier_digest_2002_02_02.md"; _run_self; rc_s=$?


### PR DESCRIPTION
## 왜 이 PR 이 생겼나

운영자 지적: *「자꾸 각종 이유들을 들어가면서 등업을 못 한다고만 반복하고 있어.
세계의 참고할 만한 레퍼런스를 찾아줘. **내부적으로 안 되는 이유만 만들어내지 말고**」*

맞는 지적이었다. 정체성 ④(프런티어 답습)는 **책장 → 도서관** 순인데 나는 **책장만** 돌고 있었다.

## 🟥 도서관에서 찾은 것 — 내 바가 세계 기준으로 틀렸다

우리 「되돌림 프로브」는 **이름 없이 쓰던 뮤테이션 테스팅**이다. 그리고 세계엔 임계가 있다:

| | |
|---|---|
| Stryker 기본 break threshold | **70%** |
| Google 실무 | **70–80% 에서 정체** — 그 위는 조사 비용 > 얻는 통찰 |
| equivalent 뮤턴트 | **~23%** (어떤 테스트로도 못 죽인다) → **실용 천장 ~77%** |

> **내 암묵적 바는 100% 였다** — 「살아남는 분기가 하나라도 있으면 미달」.
> 세계가 **명시적으로 기각한** 기준이고, 「등업 불가」의 상당 부분이 여기서 나왔다.

## 측정 — 손으로 안 고르고 기계로 전수

`do_check`·`_extract`·`do_extract` 본문의 가드 4종(`case` 분기 · `return 10` · `|| continue` ·
단독 `continue`)을 정규식으로 열거 → **15개**.

```
1차                 8 / 15 = 53%
★N-self d 추가       9 / 15 = 60%      ← 비-.md 타깃 + 빈 제외 토큰 커버
```

## 생존자 6 — **눈이 아니라 실행으로** 분류했다

| 줄 | 분류 | 근거 |
|---|---|---|
| L373 · L389 | 🟥 **EQUIVALENT** | 비인용 `for` 확장은 **빈 단어를 만들지 않는다** — bash 실측(`"  a   b  "` → 단어 2 · 빈 것 **0**). 어떤 픽스처로도 못 죽인다 |
| L215 · L263 | 중복 방어 | `do_check:262` 등이 같은 조건을 **먼저** 막는다 → 2차 뮤턴트로만 죽는다 |
| L243 · L313 | 중복 방어 | 뒤따르는 `case *.md` 필터가 같은 입력을 거른다 |

```
60% raw   ·   69% equivalent-adjusted   ·   잔여는 전부 중복방어
```
🟥 **셋 중 하나만 인용하지 마라.** 표준 관행은 원점수 + equivalent 분류를 같이 내는 것이다.

## 🟥 자체 적발 2건 — 둘 다 숫자를 내기 전에 잡았다

1. **열거기가 15개 중 12개를 놓쳤다** — `case` 분기에 주석 꼬리가 붙어 매처를 빠져나갔다.
   그 상태로 냈으면 **3/3 = 100%** 라는 과대평가가 나갔다.
2. **equivalent 판정을 zsh 에서 돌렸다** — zsh 는 비인용 확장을 **기본 비분할**한다.
   대상 셸(bash)로 재실행해 확인. 계기≠대상 축.

## 등급 — 여전히 안 올린다. **그런데 이유가 바뀌었다**

```
종전   앵커가 부실하다        ← 닫혔다 (자기참조 3분기 + .md 필터, 각각 자기 레인만 적색)
지금   배선이다 (앵커 아님)
       · novelty_claim_check 가 rc=2 ADVISORY — 「단독 차단 금지」로 설계돼 있다
       · daily digest launcher 의 plist 가 플레이스홀더 경로다
```

**스코어를 더 올려도 그 둘은 안 닫힌다.** 그리고 첫째는 **운영자 결정**이다 —
`ADVISORY → 차단` 은 소비자 게이트 수용을 깨는 변경이라 `BREAKING (gate):` 급이다.

## 검증

- 로컬 `SELFCHECK: PASS` **완주 확인 후 푸시**
- 25 레인 · 뮤테이션 전수 재측정 · 생존자 분류를 실행으로

정본: `tracks/_meta/mutation_2026-08-30_digest_landing_check.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYSKLdAXdpqhSvjJXRB5RM