### PR TITLE
docs(agents): Codex 진입점에 새 차단 게이트를 미러한다 — ④-b 드리프트 판정

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,12 @@ Because non-Claude runtimes do not auto-load Claude path rules, apply these rule
 1. **FH asset change:** before editing, read `.claude/rules/fh_4axis_gate.md`; before the first commit,
    run its required axes. Treat `templates/regression_guard.sh` exit 0 as PASS or SKIP; use its typed
    result channel and never report SKIP as checked.
+   🟥 **New blocking condition, 2026-08-30**: editing a `.md` under `knowledge/` or `docs/` now
+   **blocks the commit** if a world-scoped novelty/absence claim ("선례가 없다", "유일하게",
+   `no prior art`, `unprecedented`, …) stands with **no external anchor within ±6 lines**.
+   Anchors the check accepts: a URL · arXiv/DOI · `WebSearch`/`WebFetch` · `출처` · `원문 확인` ·
+   `서베이`. Override is `FH_NOVELTY_OK=1`, and it appends to `tracks/_meta/.novelty_override_log`.
+   ⚠️ The check sees only that an anchor **exists**, never that it supports the claim.
 2. **Company residency:** raw company source, secrets, hostnames, internal names, stack traces, and
    unredacted findings never leave the local machine, including to same-family cloud models. Only a
    sanitized summary may leave; exceptions require explicit operator approval and a gitignored note.


### PR DESCRIPTION
세션 마감 ④-b 의 **양방향 진입점 드리프트 검사**가 후보를 띄웠다:

```
CLAUDE.md/knowledge 변경 5   vs   AGENTS.md/codex-compat 변경 0
```

**기계는 깃발을 세우고 판정은 사람이 한다** — 그 분담대로 파일을 열어 갈랐다.

| | 판정 | 근거 |
|---|---|---|
| 등급 변경 (`external-grounding 🟡→🟢`) | **미러 불요** | `AGENTS.md:81` 이 이미 *「`ship_readiness_gate.md` 에서 읽어라, 기억으로 재진술하지 마라」* 로 정본을 가리킨다 |
| **novelty 게이트 차단화** | **미러 필요** | Codex 세션이 **실제로 부딪히는 새 차단 조건**이고, `AGENTS.md:94` 가 커밋 게이트를 나열하는 자리다 |

## 넣은 것

무엇이 막히는지 · 검사가 받는 앵커 목록 · override(`FH_NOVELTY_OK=1`)와 그 **원장 경로** ·
그리고 ⚠️ **「앵커의 존재만 보고 진위는 안 본다」**는 한계.

진입점을 옮길 때 **제약은 이식하되 문구는 그대로 옮기지 않는다** — 위치가 바뀌면 청중이 바뀌고,
CC 쪽 단정 문구를 그대로 옮기면 강압으로 읽힌다(`[[feedback_entrypoint_port_constraint_not_wording]]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYSKLdAXdpqhSvjJXRB5RM