### PR TITLE
fix(round): _tsv_pipe 파서 rc 유실 fail-open 4자리 + target_pin mtime 분기 판별 + ccs 오염 게이트 6열 토큰 삼킴

### DIFF
--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -2995,3 +2995,21 @@
     ⓑ tally 경로가 머신 전역이다 — 둘뿐이고, ⓒ 「그래서 누가 썼나」는 미측정이다
     ([[feedback_not_found_is_not_zero_family]]).
     신호: tracks/_meta/fh_signal_2026-09-02_dispatch-tally-attribution.md
+- date: 2026-09-02
+  agent: general-purpose (2) + codex exec sidecar (1) — 프로 세션(Fable 5.1 거버너)
+  count: 3
+  context: >-
+    운영자 «자체개발 거버너모드 · 병렬로». ⓐ ⑤ 증폭자 측정 사전등록 초안(블라인드) ⓑ 카드 미결 2건
+    (eligcheck _tsv_pipe fail-open · target_pin mtime 분기) 조사+패치 제안(패치는 텍스트로 회신,
+    적용은 거버너가 본 체크아웃에서) ⓒ codex 타계열 적대검토(그 diff).
+  outcome: accepted
+  evidence: >-
+    ⓐ prereg_2026-09-02_identity5-natural-proposal.md 230줄 — 팔·P0/P1/P2·성립/반증·추출기 분리·
+    미해결 5항 명시. 거버너가 base 핀만 추가 후 봉인. ⓑ 두 패치 모두 거버너 되돌림 재현 성공
+    (HEAD 사본 E4/E5 적색 · GNU 뮤턴트 P6 적색) + 카드가 가리킨 파일이 죽은 사본이고 정본에 같은
+    구멍이 있음을 잡음(카드 오류 정정). ⓒ 7 지적 → 4 수리(S1·A4·A5·B7) 3 기각(소스 근거).
+  note: >-
+    ⓑ 는 «조사·제안형» 임무로 짰고 트리를 안 건드렸다(2026-08-21 사이드카 트리 편집 사고 규율).
+    Fable 5.1 거버너 관찰: 서브에이전트 보고를 동의로 안 받고 넷 다 실행으로 재현했다 —
+    그 과정에서 codex 3항을 소스로 기각. 자력 적발 0 은 ④ sim 1회차 VOID(out 경로 오용)와
+    selfcheck 오귀속 위험(VOID1 디렉터리)에서 — 둘 다 계기 출력이 잡았지 성실함이 잡은 게 아니다.

--- a/scripts/context_continuity_score.sh
+++ b/scripts/context_continuity_score.sh
@@ -405,6 +405,20 @@ fi
 [ -n "$SEAL" ] && [ -f "$SEAL" ] || { echo "🟥 --seal <실재 파일> 필요" >&2; exit 2; }
 [ -n "$QSET" ] && [ -f "$QSET" ] || { echo "🟥 --qset <실재 파일> 필요" >&2; exit 2; }
 [ -x "$RUNNER" ] || [ -f "$RUNNER" ] || { echo "🟥 러너 없음: $RUNNER" >&2; exit 2; }
+# 🟥 파싱을 «먼저 물질화»하고 rc 를 본다 — eligcheck(55a10ce)·gatecheck 와 같은 모양. 아래 두 루프
+#    (오염 게이트 · 디스패치/채점)가 같은 프로세스 치환 `< <(_tsv_pipe "$QSET")` 을 썼고, awk 가
+#    exit 3(값에 `|`)으로 죽으면 둘 다 «0 행»을 받는다: 오염 0 → 디스패치 0 → ROWS 비어 → 판정선의
+#    분모가 전부 0 이라 어느 분기도 안 걸려 «🟢 계기 생존» rc 0.
+#    실측(2026-09-02, bash 5.3 = CI 의 bash): 값에 `|` 하나 · 빈 qset → 🟢 rc 0. bash 3.2 에서는
+#    `"${ROWS[@]}"` 가 set -u 에 unbound 로 죽어 rc 1 이 나는데 그건 우연이지 게이트가 아니다.
+#    ⚠️ 이 파일은 «파싱된 qset» 이다 — 루프 안 stdin 은 여전히 qset 이므로 러너 호출의
+#    `< /dev/null` 은 그대로 필요하다(아래 :6xx 주석).
+_TSVP="$(mktemp "${TMPDIR:-/tmp}/ccs_tsv.XXXXXX")" || { echo "🟥 mktemp 실패 — UNMEASURED" >&2; exit 2; }
+trap 'rm -f "$_TSVP"' EXIT
+_tsv_pipe "$QSET" > "$_TSVP"; _prc=$?
+if [ "$_prc" -ne 0 ]; then
+  echo "🟥 qset 파싱 실패(rc=$_prc): 값에 '|' 가 있거나 파일을 못 읽었다. 회차를 열지 않는다" >&2; exit 2
+fi
 
 # ── 🟥 qset 오염 게이트 (수리 ③ 의 기계 절반, 2026-08-30) ──────────────────────
 #   헤더의 출제 조건은 **출제자에게 하는 말**이라 다음 회차를 못 막는다. 1차 회차가 그렇게
@@ -412,9 +426,14 @@ fi
 #   판정 대상은 **positive 토큰만**이다 — negative 토큰은 «지어냈다면 나올 법한» 문자열이라
 #   레포에 있어도 무해하고, 오히려 실재하는 낱말이 자연스럽다.
 #   ⚠️ 이것은 **채널 검사**다(토큰이 레포에 없는가). «좋은 질문인가»는 판정하지 않는다.
-QSET_BAD=0
-while IFS='|' read -r _q _k _t tok; do
+QSET_BAD=0; QROWS=0
+# 🟥 (별개 결함, 2026-09-02 실측) `read -r _q _k _t tok` 은 마지막 변수가 «남은 필드 전부»를 받는다.
+#    6 열 qset(5·6 열이 비어도)에서는 tok="<토큰>||" 이 되어 `git grep -F` 가 영원히 0 히트 —
+#    오염 게이트가 6 열 세트에서 통째로 눈을 감았다(4 열: 146 파일 히트 exit 5 · 6 열: 0 히트 통과).
+#    ⇒ 열 수만큼 변수를 받는다(4 열 세트에선 뒤 둘이 빈 채로 남아 무해).
+while IFS='|' read -r _q _k _t tok _general _probe; do
   case "$_q" in ''|'#'*) continue ;; esac
+  QROWS=$((QROWS+1))
   # 🟥 2026-08-31 — **여기서 `positive` 만 보던 것이 이 계기의 가장 큰 구멍이었다.**
   #    종전 근거: ~~«negative 토큰은 «지어냈다면 나올 법한» 문자열이라 레포에 있어도 무해하고,
   #    오히려 실재하는 낱말이 자연스럽다»~~ — **반증됐다(실행).**
@@ -459,7 +478,7 @@ while IFS='|' read -r _q _k _t tok; do
     printf '%s\n' "$tok_out" | sed 's|^|     |' | head -5 >&2
     QSET_BAD=1
   fi
-done < <(_tsv_pipe "$QSET")
+done < "$_TSVP"
 if [ "$QSET_BAD" = 1 ]; then
   echo "🟥 회차를 시작하지 않는다. 오염된 토큰으로 재면 «운반체 덕»과 «레포에서 주움»이 안 갈린다." >&2
   echo "   강행: FH_QSET_CONTAMINATED_OK=1 (그러면 이 회차는 CTRL 상한이 오염됐다고 기록해라)" >&2
@@ -467,6 +486,11 @@ if [ "$QSET_BAD" = 1 ]; then
   #    「회차를 시작조차 안 했다」와 「다 돌았는데 계기가 미달이다」를 구분 못 한다.
   [ "${FH_QSET_CONTAMINATED_OK:-}" = 1 ] || exit 5
   echo "   ⚠️ 강행됨 — 이 회차의 CTRL 은 상한이 오염됐다." >&2
+fi
+# 🟥 채점 가능한 행 0 = «잰 것 없음». 디스패치 «전»에 막는다(144 디스패치를 안 태운다).
+#    12 를 쓴다 — 1·2·3·4·5·6·7·8·10·11 과 겹치지 않고, «입력이 틀렸다»(2)와 «입력에 잴 게 없다»를 가른다.
+if [ "$QROWS" = 0 ]; then
+  echo "🟥 UNMEASURED — qset 에 채점 가능한 행이 0 이다(빈 qset·헤더뿐). 회차를 열지 않는다" >&2; exit 12
 fi
 
 # ── 🟥 봉인 대조 (2026-08-31) — verify 가 «구조적으로» 못 잡는 자리 ──────────────────
@@ -620,7 +644,7 @@ $q"
       [ -n "$BASE_REF" ] && args+=(--base-ref "$BASE_REF")
       [ -n "$BASE_SHA" ] && args+=(--base-sha "$BASE_SHA")
       [ -n "$setup" ] && args+=(--setup "$setup")
-      # 🟥 심층 방어 — 이 호출은 `while … done < <(_tsv_pipe "$QSET")` 루프 «안»이라 stdin 이 qset 이다.
+      # 🟥 심층 방어 — 이 호출은 `while … done < "$_TSVP"` 루프 «안»이라 stdin 이 (파싱된) qset 이다.
       #    러너 쪽에도 `< /dev/null` 을 박았지만, 여기서 끊는 것이 근원이다(호출부 책임).
       bash "$RUNNER" "${args[@]}" >/dev/null 2>&1 < /dev/null
     fi
@@ -630,7 +654,7 @@ $q"
       ROWS+=("$qid|$kind|$arm|r$r|$v")
     done
   done
-done < <(_tsv_pipe "$QSET")
+done < "$_TSVP"
 
 # 🟥 매핑은 «여기»에서 쓴다 — 모든 디스패치가 끝난 뒤. 팔이 도는 동안엔 이 파일이 없다.
 if [ "${RESCORE:-0}" != 1 ]; then

--- a/scripts/package_coverage_check.sh
+++ b/scripts/package_coverage_check.sh
@@ -63,6 +63,7 @@ ACCEPTED_ABSENT=(
   "scripts/round/target_pin.sh"
   "scripts/round/instrument_manifest.sh"
   "scripts/round/eligcheck_qset.sh"
+  "scripts/round/gatecheck_qset.sh"          # 같은 이유 — 회차 개시 게이트, 소비자 표면 아님 (2026-09-02 짝표 등재로 참조가 생겼다)
   "scripts/test_round_instruments_lanes.sh"
   "scripts/fixtures/isolation_assembly_BROKEN_2026-08-30_ccrun7.json"  # 역사 산출물(등급표가 증거로 인용)
   "scripts/outbound_query_guard.sh"

--- a/scripts/round/eligcheck_qset.sh
+++ b/scripts/round/eligcheck_qset.sh
@@ -13,11 +13,22 @@ SRC="${SRC:-scripts/context_continuity_score.sh}"
 QSET="${1:?usage: eligcheck.sh <qset.tsv> <outdir-with-CTRL>}"; OUT="${2:?}"; REPS="${3:-5}"
 eval "$(grep -m1 '^REFUSE_RE=' "$SRC")"
 sed -n '/^score_one() {/,/^}/p' "$SRC" > /tmp/_so_e.sh; . /tmp/_so_e.sh
+# 🟥 파싱을 «먼저 물질화»하고 rc 를 본다. 프로세스 치환(`< <(_tsv_pipe)`)은 awk 가 exit 3 으로 죽어도
+#    루프에 «0 행»만 전달하고 rc 는 버려진다 → bad=0 → 「🟢 전 문항 적격」. 실증됨(값에 `|` 하나 → PASS).
+#    qset 파일 부재(awk rc 2)도 같은 얼굴이다. 0 행은 «전 문항 적격»이 아니라 «잰 게 없다»다.
+_TSVP="$(mktemp "${TMPDIR:-/tmp}/elig_tsv.XXXXXX")" || { echo "🟥 mktemp 실패 — UNMEASURED" >&2; exit 10; }
+trap 'rm -f "$_TSVP"' EXIT
+_tsv_pipe "$QSET" > "$_TSVP"; _prc=$?
+if [ "$_prc" -ne 0 ]; then
+  echo "🟥 UNMEASURED — qset 파싱 실패(rc=$_prc): 값에 '|' 가 있거나 파일을 못 읽었다. 회차를 열지 않는다" >&2
+  exit 3
+fi
 printf '%-5s %-9s %-22s %s\n' QID KIND 'CTRL 거절/전체' 판정
-bad=0
+bad=0; scored=0
 while IFS='|' read -r qid kind q tok general probe; do
   case "$qid" in ''|'#'*) continue;; esac
   case "$kind" in negative|conflict) ;; *) continue ;; esac
+  scored=$((scored+1))
   ref=0; tot=0; void=0; miss=0
   for r in $(seq 1 "$REPS"); do
     f="$OUT/${qid}_CTRL_r${r}.txt"
@@ -88,6 +99,13 @@ while IFS='|' read -r qid kind q tok general probe; do
   elif [ "$ref" -gt $((tot/2)) ]; then verdict="🟢 적격 (거절 다수결)"
   else verdict="🟥 부적격 — CTRL 이 답했다 ($((tot-ref))/${tot}). 출제자에게 반려"; bad=1; fi
   printf '%-5s %-9s %-22s %s\n' "$qid" "$kind" "$ref/$tot" "$verdict"
-done < <(_tsv_pipe "$QSET")
-echo; [ "$bad" = 0 ] && echo "🟢 전 문항 적격" || echo "🟥 부적격 문항이 있다 — 회차를 열지 않는다"
+done < "$_TSVP"
+# 🟥 cross-family(codex, 2026-09-02) S1: 채점된 행이 0 이어도 「전 문항 적격」이었다 — 빈 qset ·
+#    헤더뿐인 qset · positive 만 있는 qset 전부 rc 0. «잰 것이 없다»는 «전부 통과»가 아니다
+#    ([[feedback_not_found_is_not_zero_family]] 의 빈 집합 얼굴). positive 전용 회차라면 이 게이트를
+#    부를 이유가 없고, 불렀다면 답은 «잴 것 없음» 이다.
+if [ "$scored" = 0 ]; then
+  echo; echo "🟥 UNMEASURED — negative/conflict 행이 0 이다. 잰 것이 없으므로 «적격»이 아니다" >&2; exit 3
+fi
+echo; [ "$bad" = 0 ] && echo "🟢 전 문항 적격 (${scored}행 채점)" || echo "🟥 부적격 문항이 있다 — 회차를 열지 않는다"
 exit $bad

--- a/scripts/round/gatecheck_qset.sh
+++ b/scripts/round/gatecheck_qset.sh
@@ -181,6 +181,17 @@ ref_probe(){ "$GREP" -rlE -- "$1" "$C/repo" 2>/dev/null | wc -l | tr -d ' '; }
 #    다를 수 있다). 그리고 누가 이걸 `$4==prev` 로 «단순화»하면 그 순간 뚫린다.
 #    ⚠️ 이건 오늘의 «셸 이름-경계» 일가와 **다른 축**이다: 그건 「어디까지가 이름인가」,
 #    이건 「두 문자열이 같은가」. 공통점은 **비ASCII 에서만 조용히 틀린다**는 것뿐이다.
+# 🟥 파싱을 «먼저 물질화»하고 rc 를 본다 — eligcheck(55a10ce)와 같은 모양. 프로세스 치환
+#    (`< <(_tsv_pipe)`)은 awk 가 exit 3(값에 `|`)/2(파일 부재)로 죽어도 루프에 «0 행»만 주고
+#    rc 는 버린다 → bad=0·unchecked=0 → 「🟢 개시 게이트 선통과」 rc 0.
+#    실측(2026-09-02): 값에 `|` 하나 · 빈 qset · 헤더뿐 · 파일 부재 → 넷 다 «🟢 선통과» rc 0.
+#    0 행은 «선통과»가 아니라 «잰 게 없다»다. $C 의 EXIT trap 이 이 파일도 같이 지운다.
+_TSVP="$C/qset.pipe"
+_tsv_pipe "$Q" > "$_TSVP"; _prc=$?
+if [ "$_prc" -ne 0 ]; then
+  echo "🟥 UNMEASURED — qset 파싱 실패(rc=$_prc): 값에 '|' 가 있거나 파일을 못 읽었다. 회차를 열지 않는다" >&2
+  exit 2
+fi
 _dup=$(LC_ALL=C awk -F'\t' 'NF>=4 && $1!~/^#/ && $1!="" {if(seen[$4]++) print $1}' "$Q")
 if [ -n "$_dup" ]; then
   echo "🟥 중복 기대토큰 — 두 문항이 독립이 아니다. 임계(Fisher N)가 거짓이 된다:"
@@ -188,11 +199,12 @@ if [ -n "$_dup" ]; then
   bad_dup=1
 else bad_dup=0; fi
 
-bad=$bad_dup; unchecked=0
+bad=$bad_dup; unchecked=0; scored=0
 printf '%-4s %-9s %-8s %-8s %s\n' QID KIND CLONE REF NOTE
 while IFS='|' read -r qid kind q tok general probe; do
   case "$qid" in ''|'#'*) continue;; esac
   [ -n "${tok:-}" ] || continue
+  scored=$((scored+1))
   n=$(hits "$tok"); note=""
   [ "$n" != 0 ] && { note="🟥 클론 오염 — 팔이 주울 수 있다"; bad=1; }
   # ── 🟥 봉인 원장 쪽 검사 (2026-08-31 신설, 검토자 승인) ────────────────────────
@@ -237,12 +249,17 @@ while IFS='|' read -r qid kind q tok general probe; do
       fi ;;
   esac
   printf '%-4s %-9s %-8s %-8s %s\n' "$qid" "$kind" "$n" "$refn" "$note"
-done < <(_tsv_pipe "$Q")
+done < "$_TSVP"
 
 echo
 # 🟥 `UNCHECKED` 를 «통과»로 렌더하지 않는다. 봉인 미지정이면 원장 쪽 계약(positive 는 원장에
 #    있어야·negative 는 없어야·conflict 는 심겼어야)이 **한 건도 검사되지 않았다.**
 #    「선통과」라고만 찍으면 읽는 사람이 «다 봤다»로 읽는다 — 오늘 우리가 센 그 얼굴이다.
+# 🟥 검사된 행 0 은 «선통과»가 아니다 — 빈 qset·헤더뿐·기대토큰 없는 행뿐인 세트는 «잰 것 없음».
+#    6 을 쓴다: 1(부적격)·2(계기/입력 중단)·3(부분 통과 UNCHECKED)·4(핀)·5(이름 누출)와 겹치지 않는다.
+if [ "$scored" = 0 ]; then
+  echo "🟥 UNMEASURED — 검사된 행이 0 이다. «선통과»가 아니다 — 회차를 열지 않는다" >&2; exit 6
+fi
 if [ "$bad" != 0 ]; then echo "🟥 이 세트로 회차를 열면 안 된다"; exit 1
 elif [ "$unchecked" != 0 ]; then
   echo "🟡 부분 통과 — 클론 오염 축은 통과, **원장 축 ${unchecked}건 UNCHECKED**(봉인 미지정)."

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -636,7 +636,8 @@ for _pair in \
   "scripts/round/delta_guard.sh|scripts/test_round_instruments_lanes.sh" \
   "scripts/round/target_pin.sh|scripts/test_round_instruments_lanes.sh" \
   "scripts/round/instrument_manifest.sh|scripts/test_round_instruments_lanes.sh" \
-  "scripts/round/eligcheck_qset.sh|scripts/test_round_instruments_lanes.sh"
+  "scripts/round/eligcheck_qset.sh|scripts/test_round_instruments_lanes.sh" \
+  "scripts/round/gatecheck_qset.sh|scripts/test_round_instruments_lanes.sh"
 do
   _subj="${_pair%%|*}"; _anc="${_pair##*|}"; _lbl="${_anc##*/}"
   if [ ! -f "$_subj" ]; then

--- a/scripts/test_round_instruments_lanes.sh
+++ b/scripts/test_round_instruments_lanes.sh
@@ -60,6 +60,28 @@ chk "P4 접두 8자 미만 → 인자오류(2)" "$?" 2
 bash "$R/target_pin.sh" >/dev/null 2>&1
 chk "P5 인자 없음 → 2" "$?" 2
 
+# 🟥 P6–P8 mtime 이식성 분기 — rc 로는 안 갈린다(두 분기 중 하나를 지워도 rc=0). 판별자는
+#    출력의 `mtime=` 값이 UNKNOWN 으로 «접히는가»다. 이 머신은 BSD stat 이라 GNU 분기는 실물로
+#    못 태운다 ⇒ PATH 앞에 «한 옵션만 받는 stat 흉내»를 두고 각 분기를 따로 태운다.
+#    실측(2026-09-02, 스크래치 뮤턴트): GNU 분기 삭제 → GNU 흉내 밑에서 UNKNOWN ·
+#    BSD 분기 삭제 → BSD 흉내 밑에서 UNKNOWN · 둘 다 있으면 둘 다 값. P8 은 「둘 다 거절」 컨트롤 —
+#    UNKNOWN 이 «나올 수 있음»을 같은 실행에서 보인다(안 나오면 판별자가 죽은 것).
+_TP="${TARGET_PIN_UNDER_TEST:-$R/target_pin.sh}"
+mkdir -p "$T/shim_gnu" "$T/shim_bsd" "$T/shim_none"
+# 🟥 cross-family(codex, 2026-09-02) A4·A5: 흉내가 «$1 만» 보고 레인이 «mtime= 뒤 아무 글자»를 받았다 —
+#    `%y`→`%Q` 뮤턴트도, `warning mtime=garbage` 를 찍고 죽는 대상도 초록이었다. ⇒ 흉내는 argv 전체
+#    (`-c %y <실재파일>` / `-f %Sm <실재파일>`)를 검사하고, 레인은 rc=0 ∧ **흉내가 낸 리터럴과 정확히 일치**를 요구한다.
+_GNU_LIT="2026-01-01 00:00:00.000000000 +0000"; _BSD_LIT="Jan  1 00:00:00 2026"
+printf '#!/usr/bin/env bash\n[ "$1" = "-c" ] && [ "$2" = "%%y" ] && [ -e "${3:-}" ] || exit 1\necho "%s"\n' "$_GNU_LIT" > "$T/shim_gnu/stat"
+printf '#!/usr/bin/env bash\n[ "$1" = "-f" ] && [ "$2" = "%%Sm" ] && [ -e "${3:-}" ] || exit 1\necho "%s"\n' "$_BSD_LIT" > "$T/shim_bsd/stat"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$T/shim_none/stat"
+chmod +x "$T/shim_gnu/stat" "$T/shim_bsd/stat" "$T/shim_none/stat"
+# _mt 는 «rc<TAB>mtime값» 한 줄을 낸다 — 명령 치환 안에서 변수를 못 올리니 값에 같이 실어 보낸다
+_mt(){ local _o _rc; _o="$(PATH="$1:$PATH" bash "$_TP" "$T/pin.txt" "${H:0:12}" 2>&1)"; _rc=$?; printf '%s\t%s' "$_rc" "$(printf '%s' "$_o" | sed -n 's/.*mtime=//p')"; }
+_r="$(_mt "$T/shim_gnu")";  _v="${_r#*	}"; [ "${_r%%	*}" = 0 ] && [ "$_v" = "$_GNU_LIT" ]; chk "P6 GNU stat(-c %y f 만) 밑에서 mtime 이 흉내 리터럴과 일치 ∧ rc 0 (GNU 분기 생존) [got=${_v:-∅}]" "$?" 0
+_r="$(_mt "$T/shim_bsd")";  _v="${_r#*	}"; [ "${_r%%	*}" = 0 ] && [ "$_v" = "$_BSD_LIT" ]; chk "P7 BSD stat(-f %Sm f 만) 밑에서 mtime 이 흉내 리터럴과 일치 ∧ rc 0 (BSD 분기 생존) [got=${_v:-∅}]" "$?" 0
+_r="$(_mt "$T/shim_none")"; _v="${_r#*	}"; [ "${_r%%	*}" = 0 ] && [ "$_v" = UNKNOWN ]; chk "P8 CONTROL stat 전부 거절 → UNKNOWN 으로 접힘이 «보인다» [got=${_v:-∅}]" "$?" 0
+
 # ───────────────────── instrument_manifest ─────────────────────
 printf 'qid\tkind\n' > "$T/q.tsv"; printf 'seal\n' > "$T/seal.md"; printf 'grade\n' > "$T/grade.md"
 MF="$T/mf.txt"
@@ -78,9 +100,11 @@ bash "$R/instrument_manifest.sh" bogus "$MF" >/dev/null 2>&1
 chk "M6 모르는 모드 → 2" "$?" 2
 
 # ───────────────────────── eligcheck_qset ─────────────────────────
-SRCF="$ROOT/scripts/context_continuity_score.sh"
+SRCF="${CCS_UNDER_TEST:-$ROOT/scripts/context_continuity_score.sh}"
 if [ ! -f "$SRCF" ]; then
-  echo "SKIP  E1–E3 채점기 부재(scripts/context_continuity_score.sh) — 적격 게이트를 잴 수 없다"
+  # 🟥 cross-family(codex, 2026-09-02) B7: 종전엔 SKIP 만 찍고 rc 0 — 채점기(tracked)가 사라져도 스위트가
+  #    초록이었다. 부재는 «잴 수 없음»이지 «통과»가 아니다 → 적색으로 센다.
+  chk "E0 채점기 부재(scripts/context_continuity_score.sh) — E1–E5 를 잴 수 없다(통과 아님)" 1 0
 else
   mkdir -p "$T/out"
   printf 'N01\tnegative\tq?\tZZQQTOKEN\t\t\n' > "$T/eq.tsv"
@@ -94,6 +118,19 @@ else
   printf '그런 기록은 저장소에 없습니다.\n' > "$T/out/N01_CTRL_r1.txt"
   ( cd "$ROOT" && SRC=scripts/context_continuity_score.sh bash "$R/eligcheck_qset.sh" "$T/eq.tsv" "$T/out" 2 ) >/dev/null 2>&1
   chk "E3 reps=2 인데 응답 1건 부재 → 부적격(1), 다수결로 접히지 않는다" "$?" 1
+  # 🟥 하중선: 파서가 죽으면 루프가 «0 행»을 받는다. 0 행 = 「전 문항 적격」이 아니다.
+  #    실측(2026-09-02): 값에 `|` 하나 → PIPE_IN_VALUE 로 awk exit 3 → 프로세스 치환이라 rc 가 버려지고
+  #    bad=0 → rc 0 «🟢 전 문항 적격». qset 파일 부재(awk rc 2)도 같은 얼굴. 둘 다 비-0 이어야 한다.
+  _EL="${ELIGCHECK_UNDER_TEST:-$R/eligcheck_qset.sh}"
+  printf 'ZZQQTOKEN 입니다.\n' > "$T/out/N01_CTRL_r1.txt"       # 답해버린 CTRL — 행이 채점됐다면 반드시 1
+  printf 'N01\tnegative\tq|x?\tZZQQTOKEN\t\t\n' > "$T/eq_pipe.tsv"
+  ( cd "$ROOT" && SRC=scripts/context_continuity_score.sh bash "$_EL" "$T/eq_pipe.tsv" "$T/out" 1 ) >/dev/null 2>&1; _rc=$?
+  [ "$_rc" -ne 0 ]; chk "E4 값에 '|' → 파서 exit 3 이 «0 행 통과»로 접히지 않는다 (rc≠0) [got=$_rc]" "$?" 0
+  ( cd "$ROOT" && SRC=scripts/context_continuity_score.sh bash "$_EL" "$T/eq_absent.tsv" "$T/out" 1 ) >/dev/null 2>&1; _rc=$?
+  [ "$_rc" -ne 0 ]; chk "E5 qset 파일 부재 → rc≠0 (없음≠빈 qset≠전 문항 적격) [got=$_rc]" "$?" 0
+  printf 'P01\tpositive\tq?\tTOK\t\t\n' > "$T/eq_pos.tsv"       # 채점 대상 행 0 — «잰 것 없음»
+  ( cd "$ROOT" && SRC=scripts/context_continuity_score.sh bash "$_EL" "$T/eq_pos.tsv" "$T/out" 1 ) >/dev/null 2>&1; _rc=$?
+  [ "$_rc" -ne 0 ]; chk "E6 negative/conflict 행 0 → rc≠0 (빈 집합은 «전 문항 적격»이 아니다) [got=$_rc]" "$?" 0
 fi
 
 echo "round-instrument lanes: $P passed, $F failed"

--- a/scripts/test_round_instruments_lanes.sh
+++ b/scripts/test_round_instruments_lanes.sh
@@ -133,5 +133,26 @@ else
   [ "$_rc" -ne 0 ]; chk "E6 negative/conflict 행 0 → rc≠0 (빈 집합은 «전 문항 적격»이 아니다) [got=$_rc]" "$?" 0
 fi
 
+# ───────────────────────── gatecheck_qset ─────────────────────────
+# 🟥 하중선: 파서가 죽으면 루프가 «0 행»을 받고 bad=0·unchecked=0 → 「🟢 개시 게이트 선통과」 rc 0.
+#    실측(2026-09-02, 원본): 값에 `|` · 빈 qset · 헤더뿐 · 파일 부재 → 넷 다 rc 0. 넷 다 비-0 이어야 한다.
+#    seal 이름은 실물 규약 형태여야 nameleak 이 먼저 막지 않는다(L25 와 같은 이유).
+_GK="${GATECHECK_UNDER_TEST:-$R/gatecheck_qset.sh}"
+_GTOK="zzG$$$(date +%s)"
+printf 'P01\tpositive\tq?\t%s\t\t\n' "$_GTOK" > "$T/g_ok.tsv"
+printf 'P01\tpositive\tq|x?\t%s\t\t\n' "$_GTOK" > "$T/g_pipe.tsv"
+: > "$T/g_empty.tsv"; printf '# header only\n' > "$T/g_hdr.tsv"
+_GSEAL="$T/seal_deadbeef-abc_20260901-101010.md"; printf 'seal %s\n' "$_GTOK" > "$_GSEAL"
+( cd "$ROOT" && bash "$_GK" "$T/g_ok.tsv" "$_GSEAL" post ) >/dev/null 2>&1
+chk "G1 CONTROL 정상 1행 + seal → 선통과(0)" "$?" 0
+( cd "$ROOT" && bash "$_GK" "$T/g_pipe.tsv" "$_GSEAL" post ) >/dev/null 2>&1; _rc=$?
+[ "$_rc" -ne 0 ]; chk "G2 값에 '|' → 파서 exit 3 이 «0 행 선통과»로 접히지 않는다 (rc≠0) [got=$_rc]" "$?" 0
+( cd "$ROOT" && bash "$_GK" "$T/g_empty.tsv" "$_GSEAL" post ) >/dev/null 2>&1; _rc=$?
+[ "$_rc" -ne 0 ]; chk "G3 빈 qset → rc≠0 (빈 집합은 «선통과»가 아니다) [got=$_rc]" "$?" 0
+( cd "$ROOT" && bash "$_GK" "$T/g_hdr.tsv" "$_GSEAL" post ) >/dev/null 2>&1; _rc=$?
+[ "$_rc" -ne 0 ]; chk "G4 헤더뿐 qset → rc≠0 [got=$_rc]" "$?" 0
+( cd "$ROOT" && bash "$_GK" "$T/g_absent.tsv" "$_GSEAL" post ) >/dev/null 2>&1; _rc=$?
+[ "$_rc" -ne 0 ]; chk "G5 qset 파일 부재 → rc≠0 (없음≠빈 qset≠선통과) [got=$_rc]" "$?" 0
+
 echo "round-instrument lanes: $P passed, $F failed"
 [ "$F" -eq 0 ]

--- a/scripts/test_verdict_watermark_lanes.sh
+++ b/scripts/test_verdict_watermark_lanes.sh
@@ -11,7 +11,7 @@
 # ⇒ 쓰는 쪽에서 나르게 한다. 이 레인은 «한 줄만 복사해도 딸려오나»를 축자로 검정한다.
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-S="$ROOT/scripts/context_continuity_score.sh"
+S="${CCS_UNDER_TEST:-$ROOT/scripts/context_continuity_score.sh}"   # 되돌림 프로브용 오버라이드(원본 사본을 가리켜 L29 가 빨개지는지 본다)
 T=$(mktemp -d); trap 'rm -rf "$T"' EXIT
 pass=0; fail=0
 ok(){ printf '  ✅ %s\n' "$1"; pass=$((pass+1)); }
@@ -422,6 +422,32 @@ if grep -q 'DELIVER" = 1 \] && \[ "$arm" = ARM' "$S"; then
     rm -f "$_l28c" "$_l28c.m"
   else no "L28b 사본을 못 만들었다 — 되돌림 미검증(스킵 아님)"; fi
 else no "L28 deliver 분기를 못 찾았다 — 검사 못 함(스킵 아님)"; fi
+
+
+# ── L29 (2026-09-02, 전파 — eligcheck 와 같은 `_tsv_pipe` 프로세스 치환 구멍) ──
+SEAL29="$T/seal_deadbeef-abc_20260901-101010.md"; : > "$SEAL29"
+run29(){ ( cd "$ROOT" && bash "$S" --seal "$SEAL29" --qset "$1" --reps 1 --out "$2" --rescore 2>&1 </dev/null ); }
+# ── L29 🟥 파서 실패/0 행이 «🟢 계기 생존»으로 접히지 않는다 ─────────────────────────
+#    실측(2026-09-02, 원본, bash 5.3): 값에 `|` 하나 · 빈 qset → 두 루프가 0 행 → ROWS 비어 →
+#    판정선 분모 전부 0 → 「🟢 계기 생존」 rc 0. bash 3.2 는 unbound 로 rc 1 — 우연이지 게이트가 아니다.
+PT="ZZL29POS$(printf '%s' 4419)"
+printf 'q1\tpositive\t질문P\t%s\t\t\n' "$PT" > "$T/q6.tsv"           # 6 열 컨트롤 (round2 실물 폭)
+printf 'q1\tpositive\t질문|P\t%s\t\t\n' "$PT" > "$T/q_pipe.tsv"
+: > "$T/q_empty.tsv"
+mkdir -p "$T/o"; printf '답은 %s 입니다.\n' "$PT" > "$T/o/q1_ARM_r1.txt"; printf '모르겠습니다. 기록이 없습니다.\n' > "$T/o/q1_CTRL_r1.txt"
+O=$(run29 "$T/q6.tsv" "$T/o"); rc=$?
+[ "$rc" = 0 ] && printf '%s' "$O" | grep -q '🟢' && ok "L29a CONTROL 6열 정상 qset → 🟢 rc 0" || no "L29a 컨트롤이 죽었다 (rc=$rc) — 아래는 무의미"
+O=$(run29 "$T/q_pipe.tsv" "$T/o"); rc=$?
+# 🟥 «크래시»는 게이트가 아니다 — bash 3.2 는 set -u 의 `"${ROWS[@]}"` unbound 로 rc 1 에 죽어 rc≠0 이
+#    «우연히» 나온다(bash 5.3 = CI 에선 🟢 rc 0). 그래서 unbound 를 명시적으로 배제한다.
+if [ "$rc" -ne 0 ] && ! printf '%s' "$O" | grep -q '🟢 계기 생존' && ! printf '%s' "$O" | grep -q 'unbound variable'; then ok "L29b 값에 '|' → 타입된 차단(rc≠0 ∧ 🟢 없음 ∧ 크래시 아님) [rc=$rc]"; else no "L29b 파서 실패가 «🟢 계기 생존»으로 접히거나 크래시로만 막힌다 [rc=$rc]"; fi
+O=$(run29 "$T/q_empty.tsv" "$T/o"); rc=$?
+if [ "$rc" -ne 0 ] && ! printf '%s' "$O" | grep -q '🟢 계기 생존' && ! printf '%s' "$O" | grep -q 'unbound variable'; then ok "L29c 빈 qset → 타입된 차단(rc≠0 ∧ 🟢 없음 ∧ 크래시 아님) [rc=$rc]"; else no "L29c 빈 qset 이 «🟢 계기 생존»으로 접히거나 크래시로만 막힌다 [rc=$rc]"; fi
+# ── L29d 🟥 오염 게이트가 6 열 qset 에서 눈을 감지 않는다 (read 가 뒤 열을 tok 에 삼키는 결함) ──
+#    실측(원본): 4 열 + tracked 토큰 → exit 5 · 6 열 같은 토큰 → 통과. 토큰은 «이 파일 자신»에 확실히 있는 낱말.
+printf 'q1\tpositive\t질문P\tcontext_continuity\t\t\n' > "$T/q6c.tsv"
+O=$(run29 "$T/q6c.tsv" "$T/o"); rc=$?
+[ "$rc" = 5 ] && ok "L29d 6열 qset 의 tracked 토큰 → 오염 차단(5)" || no "L29d 6열 qset 에서 오염 게이트가 눈을 감는다 [rc=$rc]"
 
 echo "verdict watermark lanes: $pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
## 무엇이 막히나 (요약)
회차 계기 넷에서 «깨진 qset 이 회차를 적격/선통과/계기 생존으로 열던» 경로를 닫는다.

| 자리 | 전 | 후 |
|---|---|---|
| `scripts/round/eligcheck_qset.sh` | 값에 `|` / 파일 부재 / 채점 행 0 → 「🟢 전 문항 적격」 rc 0 | UNMEASURED rc 3 |
| `scripts/round/gatecheck_qset.sh:240` | 같은 얼굴 → 「🟢 개시 게이트 선통과」 rc 0 | 파서 실패 2 · 0행 6 |
| `scripts/context_continuity_score.sh:462·:633` | 같은 얼굴 → 「🟢 계기 생존」 rc 0 (CI bash 5) · macOS 는 `set -u` 크래시가 우연히 막음 | 파서 실패 2 · 0행 12 (디스패치 전) |
| ccs 오염 게이트 `read` 4변수 | 6열 qset → tok=`"tok||"` → git grep 영원히 0 히트. **실회차 round2 qset 2건 통과** | 6변수 read — 재검 결과 그 16 토큰 tracked 0 히트(실피해 0) |
| `target_pin.sh` mtime GNU/BSD 분기 | 레인이 rc 만 봐서 어느 분기를 지워도 초록 | PATH 앞 stat 흉내 3종 · rc∧리터럴 일치 (P6/P7 + 컨트롤 P8) |

## 근거
- 되돌림(각각 정확히 그 레인만 적색): HEAD eligcheck → E4/E5/E6 · GNU 분기 삭제 → P6 · `%y→%Q` 뮤턴트 → P6 · 채점기 부재 → E0 · 원본 gatecheck → G2~G5 · 원본 ccs → L29b/c/d
- 수리본: round lanes 31/31 · watermark lanes 47/47 · selfcheck PASS (로컬 완주 4회)
- cross-family codex 7 지적 → 4 수리(S1 빈 집합 · A4 흉내 argv · A5 값/rc · B7 무음 SKIP) · 3 기각(소스 근거 마커에)
- 전파 3자리는 pre-commit 훅의 half-fix 경고가 잡았다

## 🟥 머지 시점
**⑤ 증폭자 측정(35런, `main@3e58e35` 핀)이 끝난 뒤 머지.** 이 브랜치가 그 측정의 과제 T1·T2 를 없애기 때문.

## 잔여
- G/L29 의 GNU 분기는 흉내로만 태운다 — 실 GNU coreutils 는 CI 에서만
- positive 전용 qset 에 eligcheck 를 부르면 이제 rc 3 — 그런 회차가 실재하면 호출자 쪽에서 안 부르는 게 맞다
- ccs `/tmp/_so_e.sh` 고정 경로(기존) 미손질

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbEh8nWo7ApJuMrF2cFuRg