### PR TITLE
docs(salience-splitter): description 다이어트 561 → 375자 (외부 리스트 ~100토큰 기준)

### DIFF
--- a/plugins/fh-meta/skills/salience-splitter/SKILL.md
+++ b/plugins/fh-meta/skills/salience-splitter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: salience-splitter
-description: 'Splits an over-loaded always-loaded context asset — a SKILL.md, CLAUDE.md, or memory index — into a lean always-loaded layer + an on-demand layer, using a governance-semantic criterion (not length, but when the content is needed), connected by imperative pointers. Based on paper §9.5 Protocol-Priority Split pattern. Diagnoses, classifies, splits, and verifies in one pass. Renamed from skill-splitter (old name still routes here). Triggers: "SKILL.md too large", "split this skill", "skill is bloated", "skill file too long", "CLAUDE.md 너무 커".'
+description: 'Splits an over-loaded always-loaded context asset (SKILL.md, CLAUDE.md, memory index) into a lean resident layer plus an on-demand layer, by when content is needed rather than by length, linked by imperative pointers. Alias: skill-splitter. Triggers: "SKILL.md too large", "split this skill", "skill is bloated", "skill file too long", "CLAUDE.md 너무 커".'
 user-invocable: true
 allowed-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob", "Agent"]
 model: sonnet


### PR DESCRIPTION
## 무엇
`plugins/fh-meta/skills/salience-splitter/SKILL.md` frontmatter `description` 한 줄: 561자(≈140토큰) → 375자(≈94토큰).
트리거 5구(`SKILL.md too large` · `split this skill` · `skill is bloated` · `skill file too long` · `CLAUDE.md 너무 커`) 보존, what/when 보존. 뺀 것(논문 §9.5 · «한 번에 진단·분류·분할·검증» · 구명 안내)은 본문에 있다.

## 왜
`VoltAgent/awesome-agent-skills` 등재 준비 — 그쪽 «Skill Quality Standards» 4항 중 «메타데이터 ~100토큰»만 미달이었다. 이름이 salience-splitter 인 스킬의 description 이 비대하면 리뷰어 눈에 정확히 띈다.

## 근거
- 블라인드 플로어 sim(sonnet, 관측, reps=3, 새 description 을 `--setup` 으로 클론 주입): «CLAUDE.md 너무 커서 토큰 아깝다 — 뭘 쓰나» → salience-splitter 명명 **ARM 3/3 · CTRL(옛) 2/3**. 라우팅 손실 0.
- YAML 파싱 확인, 트리거 5구 grep 보존.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbEh8nWo7ApJuMrF2cFuRg