### PR TITLE
ci(publish): npm Trusted Publishing(OIDC) — 태그 푸시로 발행, 토큰·OTP 없이

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,50 @@
+name: publish
+
+# npm Trusted Publishing (OIDC) — 태그 v<version> 푸시 → 사람 토큰·OTP 없이 provenance 발행.
+# 🟥 왜 이 형태인가 (2026-09-03): 사람 계정 토큰 발행은 매번 OTP 웹 인증을 요구했고(2.15.0·2.15.1 둘 다),
+#    «2FA 우회 토큰» 은 npm 이 제한 예고한 데다 머신에 영구 비밀을 남긴다. OIDC 는 둘 다 없다.
+#    npmjs 쪽 1회 등록(패키지 Settings → Trusted publisher → GitHub Actions: chrono-meta / forge-harness /
+#    publish.yml / environment 비움)이 선행조건 — 등록 전엔 이 워크플로가 E404/ENEEDAUTH 로 실패한다.
+#    prepublishOnly 6단 게이트(신선도·락스텝·커버리지·매니페스트·공개표면)는 그대로 돈다.
+
+on:
+  push:
+    tags: ['v[0-9]+.[0-9]+.[0-9]+']
+
+permissions:
+  contents: read
+  id-token: write   # OIDC — 이것이 토큰을 대체한다
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+      - name: npm ≥ 11.5 (Trusted Publishing 지원)
+        run: npm install -g npm@latest && npm --version
+      - name: tag == package.json version (락스텝의 바깥 고리)
+        run: |
+          v=$(node -p "require('./package.json').version")
+          [ "v$v" = "$GITHUB_REF_NAME" ] || { echo "🟥 tag $GITHUB_REF_NAME != package.json v$v"; exit 1; }
+      - name: tag commit == origin/main HEAD (freshness 게이트가 요구하는 «main 의 트리»)
+        # 🟥 태그 체크아웃은 detached 라 publish_freshness_check 가 «HEAD 가 main 이 아니다»로 막는다.
+        #    태그가 main 끝을 가리킬 때만 발행한다 — 우리 흐름(머지 직후 태그)에선 항상 참이고,
+        #    옛 커밋에 태그를 달아 «과거 트리를 발행» 하는 경로는 여기서 죽는다(의도).
+        run: |
+          git fetch -q origin main
+          [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ] || { echo "🟥 tag is not at origin/main HEAD — refusing"; exit 1; }
+          git checkout -q -B main origin/main
+      - name: publish (prepublishOnly 게이트 경유, provenance)
+        run: npm publish --provenance --access public
+      - name: verify on registry
+        run: |
+          v=$(node -p "require('./package.json').version")
+          got=$(npm view @chrono-meta/fh-gate@"$v" version)
+          [ "$got" = "$v" ] || { echo "🟥 registry shows '$got' not '$v'"; exit 1; }
+          echo "✅ @chrono-meta/fh-gate@$v on registry"

--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -3031,3 +3031,17 @@
     ⓒ 회신이 «못 연다»를 낸 것이 가장 값졌다 — 설계가 «새 기계가 아니다»라 적었고 코드가 없었다(rule_misdescribes_its_own_machine).
     ⓕ 는 Write 도구가 없어 거버너가 옮겼다(persona-innovator 도구셋 한계, 기록). codex 추출기 1회는 정답지가
     같은 디렉터리에 있어 오염 → 폐기·재실행. 전 회신을 거버너가 실행으로 재현했고 codex 기각 5건은 소스 근거.
+- date: 2026-09-03
+  agent: UNATTRIBUTED — 이 세션(forge-harness-d5, 프로)이 띄운 것이 아니다
+  count: 2
+  context: >-
+    ④-e 가 «오늘 디스패치 2 · 원장 0» 으로 ❌. 자정 이후 이 세션의 Agent 호출은 0 (도구 호출은 Bash·gh·npm 뿐).
+    tally 실물 `tracks/_meta/.subagent_dispatch_tally` 에 2026-09-03 두 줄. 같은 시각 이 머신에서 sim 추출기
+    `claude -p` 40건과 sim 팔이 돌았으나 SubagentStop 은 Agent 도구에만 걸린다 — 출처 미확인.
+  outcome: pending
+  evidence: >-
+    #584(2026-09-02) 와 같은 얼굴 — tally 는 머신 전역(`CLAUDE_PROJECT_DIR` 미설정 세션이 허브 tally 에 쓴다),
+    ④-e 는 세션 로컬. «내가 안 했다»와 «기록이 없다»를 가를 수단이 없다.
+  note: >-
+    디스패치 기록이 아니라 귀속 불가 tally 의 기록. outcome 은 pending (60/40 게이트 오염 방지).
+    두 번째 발생(N=2) — 세 번째면 tally 에 session id 를 싣는 기계화 후보(fh_signal_2026-09-02_dispatch-tally-attribution.md).


### PR DESCRIPTION
## 왜
2.15.0·2.15.1 발행이 둘 다 사람 토큰의 **OTP 웹 인증**에서 멈췄다. 2FA 우회 토큰은 npm 이 제한 예고(+머신 영구 비밀)라 채택하지 않는다. npm **Trusted Publishing(OIDC)** 로 옮긴다 — 태그 푸시 → GitHub Actions 가 provenance 를 붙여 발행.

## 선행조건 (운영자 1회, npmjs 웹)
패키지 `@chrono-meta/fh-gate` → Settings → **Trusted publisher** → GitHub Actions: `chrono-meta` / `forge-harness` / `publish.yml` / environment 비움. 등록 전엔 워크플로가 인증 오류로 실패한다(의도).

## 게이트 호환
- `prepublishOnly` 6단 그대로 돈다.
- `publish_freshness_check` 는 «HEAD 가 main ∧ origin/main 동일»을 요구 → 태그 커밋 == origin/main HEAD 인지 먼저 확인하고 `checkout -B main origin/main` 후 발행. 옛 커밋에 태그를 달아 과거 트리를 발행하는 경로는 여기서 죽는다.
- 태그 == package.json 버전 대조(락스텝의 바깥 고리) · 발행 후 registry 재조회.

## 첫 실사용
다음 릴리스 태그. 이 PR 자체는 발행하지 않는다(2.15.1 은 이미 나갔다).

같이: ④-e 귀속 불가 tally 1건(N=2) 원장 기재.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbEh8nWo7ApJuMrF2cFuRg