### PR TITLE
feat(hook): 백틱 advisory PreToolUse 훅 — 셸 이중인용 문맥의 백틱을 «쓰기 전에» 잡는다

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,6 +226,8 @@
     "scripts/test_sidecar_calibrate_lanes.sh",
     "scripts/pipe_verdict_guard.sh",
     "scripts/test_pipe_verdict_guard_lanes.sh",
+    "scripts/backtick_guard.sh",
+    "scripts/test_backtick_guard_lanes.sh",
     "scripts/test_destructive_pre_gate_lanes.sh",
     "scripts/destructive_pre_gate.sh",
     "scripts/test_stale_clone_guard_lanes.sh",

--- a/scripts/backtick_guard.sh
+++ b/scripts/backtick_guard.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# backtick_guard.sh — PreToolUse(Bash) advisory: a backtick inside a shell double-quoting context.
+#
+# THE DEFECT
+#   In an unquoted heredoc body (`<<EOF`) or a "double-quoted string", a backtick is COMMAND
+#   SUBSTITUTION: the text between the backticks is REPLACED by that command's output. Written as
+#   markup (`--flag`, `file.sh`), it names no command, so the output is empty and the text is
+#   DELETED — the sentence stays grammatical, only its subject is gone. The one signal is a
+#   `command not found` line at the TOP of the output, where it reads as unrelated noise. Every
+#   record hook (marker · manifest · completed-log) checks a field's PRESENCE, not its completeness,
+#   so the hole commits. Measured 7×: 2026-08-10 (lane stub, stderr noise) · 2026-09-01 ×3 (marker,
+#   failure-message string, seal) · 2026-09-02 ×4 (marker, RESULT doc, fh_completed echo ×2).
+#
+# WHY A HOOK AND NOT A MEMORY RULE
+#   The memory rule existed since 08-10 and was re-read the day of each recurrence. It failed every
+#   time for the same reason: recall is grep, and the actor's task carried a different NAME (writing
+#   a marker · a failure message · a seal) than the rule's title (heredoc). N=7 ≥ 3 → mechanize
+#   (weekly_audit_2026-09-02 HIGH #1). The surface is the Bash tool call, where every recurrence
+#   lived (see KNOWN RESIDUALS for the two that may not have been).
+#
+# TWO RULES
+#   BT1 — unquoted heredoc body: `<<TAG` / `<<-TAG` whose tag is NOT quoted (`'TAG'` `"TAG"` `\TAG`).
+#         A `\`` inside is literal and not flagged. Body ends at a line equal to TAG (`<<-` strips
+#         leading tabs). Several heredocs on one line are queued in order (shell semantics).
+#   BT2 — double-quoted string containing an unescaped backtick. Single-quoted text is literal.
+#         `$( … )` inside double quotes re-enters normal parsing, so a single-quoted backtick
+#         there is literal and not flagged.
+#   Both rules come from ONE quote-aware state machine (N · single · double · $'…' · heredoc
+#   body), not a regex — the defect IS a quoting context, so a quote-blind matcher would flag the
+#   exact prescription (`printf '%s' '…`…`…'`). A heredoc operator counts only in normal context,
+#   comments (`#` at a word start) are skipped, and a quoted heredoc body is skipped whole.
+#   KNOWN RESIDUALS (named, not hidden — several found by the Axis-2 pass of 2026-09-03):
+#   · a bare backtick outside any quote (V=`date`), or inside `$( )` re-entered from double quotes,
+#     is live substitution written on purpose — NOT flagged (an earlier header said BT2; the code
+#     never did, and the code is the intent).
+#   · `# noqa: backtick` exempts the WHOLE payload, including when the phrase appears inside a
+#     record being written (quoting this header's own prescription into a marker exempts that
+#     marker's payload). Same accepted residual as destructive_pre_gate's noqa.
+#   · python3 broken/absent → CMD="" → silent exit 0 even under FH_BACKTICK_BLOCK=1: block mode
+#     fails OPEN on a dead interpreter, the same accepted trade as pipe_verdict_guard (the
+#     alternative blocks every Bash call on such a machine).
+#   · surface = the Bash tool call. Of the 7 measured recurrences, at least 5 were composed Bash
+#     commands; the 2026-08-10 one lived in a shipped lane file (`test_sidecar_calibrate_lanes.sh`,
+#     git log -S confirms) and the 09-01 failure-message one in a script — if those were authored
+#     through Write/Edit, this hook is not on that path. Coverage claim is therefore «the composed
+#     command surface», not 7/7; a file-side scanner is a separate, unbuilt instrument.
+#   · three JSON-emitting PreToolUse(Bash) hooks now fire on every call (pipe_verdict ·
+#     destructive_pre_gate · this one); concurrent emission is unverified at runtime (LOW).
+#
+# DEGRADE DIRECTION: advisory. Warns and exits 0 — a mangled write is re-runnable, and a false block
+#   on the developer's shell trains --no-verify on the hooks that guard irreversible surfaces.
+#   FH_BACKTICK_BLOCK=1 escalates to exit 2. Unparseable payload → silent (not a finding).
+#   DELIVERY: JSON on stdout — additionalContext (model) + systemMessage (user), no
+#   permissionDecision (same contract as pipe_verdict_guard; see its header for why).
+#
+# PRESCRIPTION (memory feedback_unquoted_heredoc_backtick_executes, 4th revision):
+#   ① heredoc → `<<'EOF'`; a value that must expand (hash, time) is computed FIRST into a variable
+#     and substituted after, or printed on its own line — never opened unquoted for one value.
+#   ② one-line append → `printf '%s\n' '…'` (single quotes), not `echo "…"`.
+#
+# Usage:
+#   hook:  PreToolUse matcher "Bash" → bash scripts/backtick_guard.sh
+#   test:  printf '%s' "<command>" | bash scripts/backtick_guard.sh --stdin-raw
+# Opt out on a single call with a trailing `# noqa: backtick` (exempts the whole payload).
+
+set -u
+
+CMD=""
+if [ "${1:-}" = "--stdin-raw" ]; then
+  CMD=$(cat)
+else
+  RAW=$(cat)
+  CMD=$(printf '%s' "$RAW" | python3 -c '
+import json,sys
+try: d = json.load(sys.stdin)
+except Exception: sys.exit(0)
+if d.get("tool_name") != "Bash": sys.exit(0)
+sys.stdout.buffer.write((d.get("tool_input", {}).get("command", "") or "").encode("utf-8"))
+' 2>/dev/null) || CMD=""
+fi
+[ -n "$CMD" ] || exit 0
+printf '%s' "$CMD" | grep -qE '#[[:space:]]*noqa:?[[:space:]]*backtick' && exit 0
+
+# The scanner. Emits one line per finding: "<rule>\t<line>\t<snippet>". Empty output = clean.
+hits=$(printf '%s' "$CMD" | PYTHONIOENCODING=utf-8 python3 -c '
+import re, sys
+text = sys.stdin.read()
+L = len(text)
+findings = []
+# ONE quote-aware pass. Contexts: N normal · S single-quoted · D double-quoted · A $\x27…\x27 ANSI-C.
+# A heredoc operator is recognised ONLY in N (so `"<<EOF"` in a commit message opens nothing), and
+# its body is consumed line-by-line when the operator line ends — quoted bodies are skipped whole,
+# unquoted bodies are scanned for a live backtick (`\\` escapes the next char, so `\\\\`+backtick is live).
+HD = re.compile(r"<<(-?)[ \t]*(?:\x27([^\x27\n]*)\x27|\"([^\"\n]*)\"|\\\\([A-Za-z_][A-Za-z0-9_]*)|([A-Za-z_][A-Za-z0-9_]*))")
+st = ["N"]; depth = []   # depth: paren depth per $( ) nesting opened from D
+pending = []             # (tag, quoted, strip_tabs) heredocs opened on the current line, in order
+line = 1
+k = 0
+def snippet(i):
+    return text[max(0, i-30):i+31].replace("\n", " ").strip()[:90]
+while k < L:
+    c = text[k]
+    top = st[-1]
+    if c == "\n":
+        line += 1; k += 1
+        if pending and top == "N":
+            for tag, quoted, strip_tabs in pending:
+                while k < L:
+                    e = text.find("\n", k)
+                    if e < 0: e = L
+                    ln = text[k:e]
+                    cmp_ = ln.lstrip("\t") if strip_tabs else ln
+                    if cmp_ == tag:
+                        k = e + 1; line += 1; break
+                    if not quoted:
+                        j = 0
+                        while j < len(ln):
+                            if ln[j] == "\\": j += 2; continue
+                            if ln[j] == "`":
+                                findings.append(("BT1", line, ln.strip()[:90])); break
+                            j += 1
+                    k = e + 1; line += 1
+            pending = []
+        continue
+    if top == "S":
+        if c == "\x27": st.pop()
+        k += 1; continue
+    if top == "A":
+        if c == "\\": k += 2; continue
+        if c == "\x27": st.pop()
+        k += 1; continue
+    if c == "\\":
+        k += 2; continue
+    if top == "D":
+        if c == "\"": st.pop(); k += 1; continue
+        if text.startswith("$(", k): st.append("N"); depth.append(1); k += 2; continue
+        if c == "`": findings.append(("BT2", line, snippet(k))); k += 1; continue
+        k += 1; continue
+    # top == N
+    if c == "#" and (k == 0 or text[k-1] in " \t\n;&|(" ) and not depth:
+        e = text.find("\n", k); k = L if e < 0 else e; continue
+    if text.startswith("$\x27", k): st.append("A"); k += 2; continue
+    if c == "\x27": st.append("S"); k += 1; continue
+    if c == "\"": st.append("D"); k += 1; continue
+    if text.startswith("$(", k):
+        if depth: depth[-1] += 1
+        k += 2; continue
+    if c == "(" and depth: depth[-1] += 1; k += 1; continue
+    if c == ")" and depth:
+        depth[-1] -= 1
+        if depth[-1] == 0: depth.pop(); st.pop()
+        k += 1; continue
+    if c == "<" and text.startswith("<<", k) and not text.startswith("<<<", k) and (k == 0 or text[k-1] != "<"):
+        m = HD.match(text, k)
+        if m:
+            dash, q1, q2, esc, bare = m.groups()
+            tag = q1 if q1 is not None else (q2 if q2 is not None else (esc if esc is not None else bare))
+            pending.append((tag, (q1 is not None) or (q2 is not None) or (esc is not None), dash == "-"))
+            k = m.end(); continue
+    k += 1
+seen = set()
+for r, l, s in findings:
+    if (r, l) in seen: continue
+    seen.add((r, l)); print("%s\t%d\t%s" % (r, l, s))
+' 2>/dev/null) || hits=""
+[ -n "$hits" ] || exit 0
+
+msg="  ⚠️  BACKTICK — 셸 이중인용 문맥 안의 백틱은 «명령 치환»이다: 그 자리 텍스트가 명령 출력으로 바뀐다(명령 없으면 삭제·있으면 오삽입). 실측 7회, 마커·기록에 구멍이 뚫린 채 커밋됐다.
+"
+while IFS=$'\t' read -r rule ln snip; do
+  [ -n "$rule" ] || continue
+  case "$rule" in
+    BT1) what="비인용 heredoc 본문";;
+    BT2) what="큰따옴표 문자열";;
+    *)   what="$rule";;
+  esac
+  msg="${msg}      ${rule} L${ln} (${what}): ${snip}
+"
+done <<< "$hits"
+msg="${msg}      처방: heredoc 은 <<'EOF' 로 열고 확장할 값(해시·시각)은 «먼저 변수로 계산해» 뒤에 치환 · 한 줄 append 는 printf '%s\\n' '…'(작은따옴표). 의도된 치환이면 # noqa: backtick
+"
+
+if [ "${FH_BACKTICK_BLOCK:-0}" = "1" ]; then
+  printf '%s' "$msg" >&2
+  exit 2
+fi
+json_out=$(printf '%s' "$msg" | PYTHONIOENCODING=utf-8 python3 -c '
+import json, sys
+h = sys.stdin.read()
+print(json.dumps({"systemMessage": h, "hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": h}}))
+' 2>/dev/null)
+if [ -n "$json_out" ]; then printf '%s\n' "$json_out"; exit 0; fi
+printf '%s' "$msg" >&2
+exit 0

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -1544,6 +1544,17 @@ else
   fail=1
 fi
 
+if [ ! -f scripts/backtick_guard.sh ]; then
+  _absent_subject_verdict "test_backtick_guard_lanes.sh" "scripts/backtick_guard.sh" || fail=1
+elif [ -f scripts/test_backtick_guard_lanes.sh ]; then
+  if ! bash scripts/test_backtick_guard_lanes.sh; then
+    fail=1
+  fi
+else
+  echo "FAIL  test_backtick_guard_lanes.sh: backtick_guard.sh present but its anchor is missing"
+  fail=1
+fi
+
 if [ ! -f scripts/halffix_propagation_scan.sh ]; then
   _absent_subject_verdict "test_halffix_lanes.sh" "scripts/halffix_propagation_scan.sh" || fail=1
 elif [ -f scripts/test_halffix_lanes.sh ]; then

--- a/scripts/test_backtick_guard_lanes.sh
+++ b/scripts/test_backtick_guard_lanes.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# test_backtick_guard_lanes.sh — known pairs for scripts/backtick_guard.sh. Written BEFORE the detector.
+#
+# WHAT IS BEING GUARDED
+#   A backtick inside a shell DOUBLE-QUOTING CONTEXT — an unquoted heredoc body (`<<EOF`) or a
+#   "double-quoted string" — is command substitution: the text between the backticks is REPLACED by
+#   the command's output. With no such command the output is empty, so the text is DELETED; with one,
+#   foreign content is INSERTED. The sentence stays grammatical (only its subject is gone), the only
+#   signal is one `command not found` line at the top of the output, and every marker/record hook
+#   checks a field's presence, not its completeness.
+#   Measured 7× (2026-08-10 · 2026-09-01 ×3 · 2026-09-02 ×4 — marker, RESULT doc, fh_completed echo ×2)
+#   with a resident memory rule that failed each time because the actor's task had a different NAME
+#   (writing a marker · a failure message · a seal). N≥3 → mechanize (weekly_audit_2026-09-02 HIGH #1).
+#
+#   BT1 — unquoted heredoc body (`<<TAG`, `<<-TAG`; NOT `<<'TAG'` / `<<"TAG"` / `<<\TAG`) containing `
+#   BT2 — double-quoted string containing ` (single-quoted text and `\`` are literal → CLEAN)
+#
+# Surface = the Bash tool call itself (interactively-composed commands), same reasoning as
+# pipe_verdict_guard: every recurrence was in a composed command, none in a shipped file.
+
+set -u
+G="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/backtick_guard.sh"
+pass=0; fail=0
+
+# expect <label> <HIT|CLEAN> <command-string>   (the command text is passed raw via --stdin-raw)
+expect() {
+  local label="$1" want="$2" cmd="$3" out got
+  out=$(printf '%s' "$cmd" | bash "$G" --stdin-raw 2>&1)
+  # want may be HIT · CLEAN · HIT:BT1@2 (rule and line asserted — a hit on the WRONG line is a miss)
+  if printf '%s' "$out" | grep -q 'BACKTICK'; then got=HIT; else got=CLEAN; fi
+  case "$want" in HIT:*) printf '%s' "$out" | grep -q "${want#HIT:BT}" 2>/dev/null; :; esac
+  if [ "$got" = HIT ] && [ "${want%%:*}" = HIT ] && [ "$want" != HIT ]; then
+    local r="${want#HIT:}"; r="${r%@*}"; local l="${want##*@}"
+    printf '%s' "$out" | grep -q "$r L$l " || got="HIT-WRONG($(printf '%s' "$out" | grep -oE 'BT[12] L[0-9]+' | head -1))"
+    [ "$got" = HIT ] && got="$want"
+  fi
+  if [ "$got" = "$want" ]; then
+    printf '  ✅ %-56s %s (expected %s)\n' "$label" "$got" "$want"; pass=$((pass+1))
+  else
+    printf '  ❌ %-56s %s (expected %s)\n' "$label" "$got" "$want"; fail=$((fail+1))
+    printf '     cmd: %s\n     out: %s\n' "$cmd" "$out"
+  fi
+}
+BT='`'   # one backtick, spelled once so the lanes below never carry a live one in double quotes
+NL=$'\n'
+
+echo "[backtick-guard] known pairs"
+echo "-- BT1: unquoted heredoc body --"
+# 2026-09-02 ⓐ — the measured shape: a marker written through an unquoted heredoc so a $VAR expands.
+expect "BT1 measured: marker heredoc"        HIT:BT1@3   "cat > m.marker <<EOF${NL}date: \$TODAY${NL}axis2-evidence: 러너가 ${BT}--keep-blind-paths${BT} 를 삼켰다${NL}EOF"
+expect "BT1 <<-TAG (tab-stripped) form"      HIT   "cat <<-EOF${NL}	note ${BT}x${BT}${NL}	EOF"
+expect "BT1 markdown fence in heredoc"       HIT   "cat > r.md <<EOF${NL}\`\`\`${NL}out${NL}\`\`\`${NL}EOF"
+expect "BT1 second of two heredocs on a line" HIT:BT1@4  "diff <(cat <<'A') <(cat <<B)${NL}${BT}a${BT}${NL}A${NL}${BT}b${BT}${NL}B"
+expect "BT1 quoted <<'EOF' is CLEAN"          CLEAN "cat > m.marker <<'EOF'${NL}evidence: ${BT}--keep-blind-paths${BT} 삼킴${NL}EOF"
+expect "BT1 quoted <<\"EOF\" is CLEAN"        CLEAN "cat <<\"EOF\"${NL}${BT}x${BT}${NL}EOF"
+expect "BT1 escaped <<\\EOF is CLEAN"         CLEAN "cat <<\\EOF${NL}${BT}x${BT}${NL}EOF"
+expect "BT1 backslash-escaped backtick CLEAN" CLEAN "cat <<EOF${NL}see \\${BT}x\\${BT}${NL}EOF"
+expect "BT1 backtick AFTER the body ends"     CLEAN "cat <<EOF${NL}plain${NL}EOF${NL}echo '${BT}later${BT}'"
+expect "BT1 <<< herestring is not a heredoc"  CLEAN "grep -c x <<< 'a ${BT}b${BT}'"
+
+echo "-- BT2: double-quoted string --"
+# 2026-09-02 ⓑ — the measured shape: a completion-log append through echo "…".
+expect "BT2 measured: echo append"            HIT:BT2@1   "echo \"- ✅ 러너 ${BT}sim_isolated_run.sh${BT} 헤더 경고\" >> tracks/_meta/fh_completed.md"
+expect "BT2 failure-message string (09-01)"   HIT   "printf '%s\\n' \"(${BT}nameleak_check.sh gen${BT} 을 써라)\""
+expect "BT2 single quote inside dq is inert"  HIT   "echo \"don't ${BT}x${BT}\""
+expect "BT2 single-quoted is CLEAN"           CLEAN "printf '%s\\n' '- ✅ 러너 ${BT}sim_isolated_run.sh${BT} 헤더' >> log.md"
+expect "BT2 escaped \\\` is CLEAN"             CLEAN "echo \"see \\${BT}x\\${BT}\""
+expect "BT2 dq inside single quotes is CLEAN" CLEAN "echo '\"${BT}x${BT}\"'"
+expect "BT2 sq inside \$( ) inside dq CLEAN"  CLEAN "echo \"\$(printf '%s' '${BT}x${BT}')\""
+expect "BT2 no backtick at all"               CLEAN "echo \"\$(git log -1) done\" && cat <<EOF${NL}plain \$X${NL}EOF"
+expect "BT2 bare backtick outside quotes"     CLEAN "V=${BT}date${BT}; echo ok"   # live command substitution on purpose, not a text context
+
+echo "-- Axis-2 pass 2026-09-03 (challenger, repros executed by the governor) --"
+# A1: the first build stripped single-quoted spans BEFORE matching heredoc operators, so <<'EOF' was
+# never a heredoc — three symptoms from one cause. Each pinned in its real shape.
+expect "A1a quoted body with dq+backtick CLEAN" CLEAN "cat <<'EOF'${NL}axis2-evidence: 메시지 \"use ${BT}x${BT}\" 가 떴다${NL}EOF"
+expect "A1b quoted A then unquoted B: only B" CLEAN "diff <(cat <<'A') <(cat <<B)${NL}${BT}a${BT}${NL}A${NL}plain${NL}B"
+expect "A1c apostrophe in quoted body, then echo" HIT:BT2@4 "cat <<'EOF'${NL}don't${NL}EOF${NL}echo \"${BT}x${BT}\" >> log"
+# A2: a comment's apostrophe must not open a single-quote context that swallows the next line.
+expect "A2 comment apostrophe then echo"      HIT:BT2@2 "# don't re-run this${NL}echo \"${BT}x${BT}\" >> f.md"
+expect "A2 url fragment is not a comment"     HIT:BT2@1 "curl \"https://x/a#frag ${BT}x${BT}\""
+# B3: <<TAG inside a double-quoted string (commit message) opens no heredoc.
+expect "B3 <<EOF in commit message is CLEAN" CLEAN "git commit -m \"docs: prefer <<EOF for markers\"${NL}V=${BT}date${BT}; echo ok"
+# B5: escaped backslash + LIVE backtick.
+expect "B5 \\\\ then live backtick HITs"      HIT:BT1@2 "cat <<EOF${NL}path\\\\${BT}x${BT}${NL}EOF"
+# B2: ANSI-C $'…' with an escaped apostrophe does not end early.
+expect "B2 \$'don\\'t' then dq backtick"      HIT:BT2@1 "echo \$'don\\'t' \"${BT}x${BT}\""
+# B1: backtick inside \$( ) re-entered from dq is live substitution — deliberately NOT flagged.
+expect "B1 backtick inside \$( ) in dq CLEAN"  CLEAN "echo \"\$(echo ${BT}x${BT})\""
+
+echo "-- hook mode: JSON payload in → JSON out (A4: detection is worthless if delivery is 0) --"
+jexp() {  # <label> <expect-substring-in-additionalContext|SILENT> <env> <payload>
+  local label="$1" want="$2" env_="$3" payload="$4" out ctx
+  out=$(printf '%s' "$payload" | env $env_ bash "$G" 2>/dev/null)
+  if [ "$want" = SILENT ]; then
+    if [ -z "$out" ]; then printf '  ✅ %-56s SILENT\n' "$label"; pass=$((pass+1)); else printf '  ❌ %-56s expected SILENT, got: %s\n' "$label" "${out:0:80}"; fail=$((fail+1)); fi
+    return
+  fi
+  ctx=$(printf '%s' "$out" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["hookSpecificOutput"]["additionalContext"])' 2>/dev/null)
+  if printf '%s' "$ctx" | grep -q "$want"; then printf '  ✅ %-56s JSON additionalContext carries %s\n' "$label" "$want"; pass=$((pass+1))
+  else printf '  ❌ %-56s no JSON/context (%s)\n' "$label" "${out:0:80}"; fail=$((fail+1)); fi
+}
+P='{"tool_name":"Bash","tool_input":{"command":"echo \"- done `x.sh` ok\""}}'
+jexp "JSON payload → additionalContext"       "BT2 L1" "X=1" "$P"
+jexp "ascii PYTHONIOENCODING still emits"     "BT2 L1" "PYTHONIOENCODING=ascii" "$P"
+jexp "non-Bash tool is SILENT"                SILENT   "X=1" '{"tool_name":"Write","tool_input":{"content":"`x`"}}'
+jexp "unparseable payload is SILENT"          SILENT   "X=1" 'not json'
+
+echo "-- opt-out / payload --"
+expect "noqa exempts"                         CLEAN "echo \"${BT}x${BT}\"  # noqa: backtick"
+expect "empty payload"                        CLEAN ""
+
+echo
+echo "[backtick-guard] $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/templates/settings.PreToolUse.snippet.json
+++ b/templates/settings.PreToolUse.snippet.json
@@ -50,7 +50,18 @@
     "built on a 46-PR-behind clone and manufactured a duplicate of an upstream lane. found→extend",
     "applies at repo level; this is its mechanical layer. Same advisory contract; fail-open on",
     "every uncertainty (non-repo, no upstream, fetch failure).",
-    "  bash scripts/test_stale_clone_guard_lanes.sh           # expect: all known pairs hold (count self-reported)"
+    "  bash scripts/test_stale_clone_guard_lanes.sh           # expect: all known pairs hold (count self-reported)",
+    "",
+    "FOURTH GUARD, Bash matcher — backtick_guard.sh (added 2026-09-03, weekly_audit_2026-09-02 HIGH #1):",
+    "advisory when a Bash call carries a backtick inside a shell DOUBLE-QUOTING context — an unquoted",
+    "heredoc body (<<EOF) or a \"double-quoted string\". There a backtick is command substitution: the text",
+    "between the backticks is REPLACED by the command's output — empty when it names no command, so the",
+    "text is silently DELETED and the record commits with a hole (every record hook checks presence, not",
+    "completeness). Measured 7x 2026-08-10..09-02 with a resident memory rule that failed each time because",
+    "the actor's task had a different name than the rule's title. Quote-aware state machine, not a regex:",
+    "single-quoted text, quoted heredocs (<<'EOF'), and escaped backticks are CLEAN. Same advisory contract;",
+    "escalate with FH_BACKTICK_BLOCK=1; opt out with `# noqa: backtick` (whole payload).",
+    "  bash scripts/test_backtick_guard_lanes.sh              # expect: all known pairs hold (count self-reported)"
   ],
   "project_settings_json": {
     "hooks": {
@@ -66,6 +77,11 @@
             {
               "type": "command",
               "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/destructive_pre_gate.sh\"",
+              "timeout": 5
+            },
+            {
+              "type": "command",
+              "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/backtick_guard.sh\"",
               "timeout": 5
             }
           ]


### PR DESCRIPTION
## 무엇
`scripts/backtick_guard.sh` — PreToolUse(Bash) advisory 훅. 비인용 heredoc 본문(BT1)·큰따옴표 문자열(BT2) 안의 백틱은 명령 치환이라 그 자리 텍스트가 삭제·오삽입된다. 실측 7회(08-10 · 09-01 ×3 · 09-02 ×4), 상주 메모리 규율 4회 실패 = N≥3 → 기계화(weekly_audit_2026-09-02 HIGH #1).

## 어떻게
- 단일 인용-인식 상태머신(N · single · double · `$'…'` · heredoc 본문). heredoc 은 N 에서만 열리고, 주석은 건너뛰고, 인용 본문은 통째로 스킵.
- 형제 `pipe_verdict_guard` 와 같은 advisory 계약(additionalContext + systemMessage · exit 0 · `FH_BACKTICK_BLOCK=1` 승격 · `# noqa: backtick`).
- 배선: `scripts/selfcheck.sh` 레인 블록 · `templates/settings.PreToolUse.snippet.json` 4번째 가드 · `package.json` files[] 2줄.

## 검증
- 레인 34/34 (측정 7건 형태 · Axis-2 지적 A1a/b/c · A2 · B2 · B3 · B5 · JSON 모드 4). 되돌림: BT1 검출 제거 → 정확히 5 적색 · BT2 제거 → 9 적색 · 복원 34/34.
- 챌린저 R1 이 S1(files[] 누락)·A1(초판이 작은따옴표 스트립 «후» heredoc 매칭 → `<<'EOF'` 미인식, 오탐 2·미탐 1)·A2(주석 아포스트로피)·A4(JSON 레인 0) 지적 → 재현 명령 실행으로 확인 후 스캐너 재작성.
- selfcheck 완주 PASS(rc=0). 배선 직후 같은 세션에서 훅 발화 확인(출력에 삭제 실물).

## 잔여(이름으로)
`$( )` 안 백틱은 안 잡음(의도) · noqa 는 페이로드 전체 면제 · python3 부재 시 fail-open(형제와 동일) · 세 JSON 훅 동시 발화 런타임 미검증 · 표면은 Bash 호출뿐(Write/Edit 로 쓴 파일은 경로 밖).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
