### PR TITLE
fix(sync): 정방향 exclude 에 manifests/ · _index/ — 회수 경로와 대칭

### DIFF
--- a/scripts/sync-to-be.sh
+++ b/scripts/sync-to-be.sh
@@ -205,7 +205,14 @@ DIRTY=0   # cp-fallback mode can't count cheaply → mark work done, let git-dif
 # 합집합이 내려와 "2번 닫음"으로 잘못 세고, session_close_check.sh 가 불필요한 재작업을
 # 지시한다 — 흔한 케이스가 흔하게 오탐한다는 뜻. 이 파일은 크로스머신 소비자가 아예 없으므로
 # (기계고유 카운터), .fh_node_state 처럼 통째로 sync 대상에서 뺀다 — 머신 스코프조차 불필요.
-SYNC_EXCLUDES=('.gitkeep' '*.marker' 'logs/' '.fh_node_state' '.close_stamps_*')
+# `manifests/` · `_index/` (2026-09-03, found by the Air node): these are the RE-HOME targets — this
+# script writes its own edit_manifest.yaml to tracks-meta/manifests/<MID>.yaml (:52x) and MEMORY.md
+# to memory/_index/<MID>.md. The return path never pulls a peer's copies of them (sync-from-be.sh
+# `! -path '*/manifests/*' ! -path '*/_index/*'`), but the forward path had no matching exclude —
+# so a hub that somehow holds tracks/_meta/manifests/<peer>.yaml pushed it path-for-path onto the
+# peer's LIVE re-homed file and tripped the destination-newer abort on the other node. Symmetric
+# now: a directory that exists only as a re-home target is never mirrored as ordinary content.
+SYNC_EXCLUDES=('.gitkeep' '*.marker' 'logs/' '.fh_node_state' '.close_stamps_*' 'manifests/' '_index/')
 
 NEWER_HITS=""
 
@@ -253,7 +260,7 @@ check_dest_newer() {   # $1 = src dir, $2 = dst dir
     # array-expanded safely here, so they are duplicated — the one place this file tolerates it.
     # Changing SYNC_EXCLUDES without changing this line reopens the false-abort/false-pass gap;
     # scripts/sync_guard_check.sh asserts the two stay equivalent.
-  done < <(find "$src" -type f ! -name '.gitkeep' ! -name '*.marker' ! -name '.fh_node_state' ! -name '.close_stamps_*' ! -path '*/logs/*' 2>/dev/null)
+  done < <(find "$src" -type f ! -name '.gitkeep' ! -name '*.marker' ! -name '.fh_node_state' ! -name '.close_stamps_*' ! -path '*/logs/*' ! -path '*/manifests/*' ! -path '*/_index/*' 2>/dev/null)
 }
 
 # ── Shared abort message for BOTH destination-newer sites ─────────────────────
@@ -429,7 +436,7 @@ sync_dir() {
   else
     # rsync absent (default Windows git-bash): tar-pipe mirror with the same excludes,
     # no --delete (append-only). Source is canonical, so overwriting be's copy is correct.
-    if ( cd "$src" && tar cf - --exclude='.gitkeep' --exclude='*.marker' --exclude='.fh_node_state' --exclude='.close_stamps_*' --exclude='logs' . ) \
+    if ( cd "$src" && tar cf - --exclude='.gitkeep' --exclude='*.marker' --exclude='.fh_node_state' --exclude='.close_stamps_*' --exclude='logs' --exclude='manifests' --exclude='_index' . ) \
          | ( cd "$dst" && tar xf - ); then
       DIRTY=1; log "mirrored (cp mode) → $dst"; stamp_banner "$dst" "$src"
     else

--- a/scripts/sync_guard_check.sh
+++ b/scripts/sync_guard_check.sh
@@ -57,6 +57,9 @@ else
       # silently fails — measured on this anchor's own first run, where `*.marker` was reported
       # missing while sitting in the file. Literal matching is the only honest comparison here.
       logs/) grep -qF -- "! -path '*/logs/*'" "$SYNC" || missing="$missing $e" ;;
+      # directory excludes (2026-09-03): re-home targets, same -path form as logs/.
+      manifests/) grep -qF -- "! -path '*/manifests/*'" "$SYNC" || missing="$missing $e" ;;
+      _index/)    grep -qF -- "! -path '*/_index/*'"    "$SYNC" || missing="$missing $e" ;;
       *)     grep -qF -- "! -name '$e'" "$SYNC"       || missing="$missing $e" ;;
     esac
   done

--- a/scripts/sync_to_be_lanes.sh
+++ b/scripts/sync_to_be_lanes.sh
@@ -87,6 +87,20 @@ MID=lanea run >/dev/null 2>&1
 [ -f "$BEX/tracks-meta/normal2.md" ]; chk $? "CONTROL: an ordinary file synced (run actually executed)"
 [ ! -f "$BEX/tracks-meta/.close_stamps_2026-08-14" ]; chk $? "close-stamp file never landed in the companion store at all"
 
+echo "── L4b manifests/ · _index/ are re-home TARGETS, never mirrored as ordinary content (2026-09-03, Air node) ──"
+# The return path never pulls a peer's tracks-meta/manifests/<MID>.yaml, but the forward path had no
+# matching exclude: a hub holding tracks/_meta/manifests/<peer>.yaml pushed it path-for-path onto the
+# peer's LIVE re-homed manifest and tripped the destination-newer abort on the other machine.
+new_env l4b
+mkdir -p "$HUB/tracks/_meta/manifests"
+printf 'peer: stale-copy\n' > "$HUB/tracks/_meta/manifests/peerx.yaml"
+printf -- '- date: 2026-09-03\n  change: own\n' > "$HUB/tracks/_meta/edit_manifest.yaml"
+printf 'ordinary\n' > "$HUB/tracks/_meta/normal4b.md"
+MID=lanea run >/dev/null 2>&1
+[ -f "$BEX/tracks-meta/normal4b.md" ]; chk $? "CONTROL: an ordinary file synced (run actually executed)"
+[ -f "$BEX/tracks-meta/manifests/lanea.yaml" ]; chk $? "CONTROL: own manifest still RE-HOMED to manifests/\$MID.yaml (the exclude did not kill the re-home)"
+[ ! -f "$BEX/tracks-meta/manifests/peerx.yaml" ]; chk $? "a peer manifest copy under the hub's manifests/ never landed in the store (forward exclude)"
+
 echo "── L5 destination-newer abort CITES the return path and drops the false single-cause claim (2026-08-20) ──"
 # The old message asserted one cause ("it was edited in the MIRROR") and offered only
 # SYNC_OVERWRITE_OK=1 — measured 0/4 correct on the air node, where all four hits were a PEER NODE's


### PR DESCRIPTION
## 무엇
`sync-from-be` 는 남의 `tracks-meta/manifests/*`·`memory/_index/*` 를 안 당기는데 `sync-to-be` 는 그 둘을 exclude 하지 않았고, 자기 정본을 `manifests/<MID>.yaml` 로 재홈한다. 허브에 남의 사본이 있으면 정방향이 경로 그대로 밀어 재홈 자리의 살아있는 파일을 덮으려다 destination-newer 가드에 걸린다 — 에어 노드 2026-09-03 1차 abort 의 실체(에어 FH 세션이 소스 줄번호로 지목, 거버너가 대조).

## 어떻게
세 lockstep 자리(SYNC_EXCLUDES · find 술어 · tar 폴백) 전부 + `sync_guard_check.sh` 패리티 case 2줄 + 레인 L4b(컨트롤: ordinary 착지 · 자기 재홈 착지 / 대상: peer 사본 미착지).

## 검증
레인 36/36 · guard_check PASS · 되돌림: 배열만 빼면 정확히 L4b 1레인 적색 · 4축 PASS. 실환경(에어에서 머지 후 sync-to-be 재실행)은 그쪽 실행으로 확인 예정.

## 잔여
`sync_guard_check` 패리티는 배열→find 한 방향만 본다(find 에 있고 배열에 없는 경우 미검사). 남의 사본이 허브 `manifests/` 로 들어온 경로(`--include-new`?)는 미조사.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
