### PR TITLE
fix(runner): 헤더 «일회용 클론에선 프로젝트 훅이 안 돈다» 철회 — known-pair 실측으로 반증

### DIFF
--- a/scripts/sim_isolated_run.sh
+++ b/scripts/sim_isolated_run.sh
@@ -69,13 +69,23 @@
 #   FH defect (a normal session has Bash and can `ls`) — but scoring an arm without knowing it
 #   produces a confident zero from a fixture that was never observable.
 #
-# 🟥 PROJECT HOOKS DO NOT RUN IN A DISPOSABLE CLONE — so this runner cannot measure anything
-#   that depends on one. Measured 2026-08-30: an arm copied `.claude/settings.json` into its clone
-#   to make the PreToolUse PriorArt hook live; not one of the three clones grew
-#   `.claude/.prior_art_events.tsv`, while the live repo's copy carries entries from the same hour.
-#   The hook never fired, so the "hook vs no-hook" contrast was HOOK ≡ NOHOOK and either verdict
-#   would have been false. ⇒ Before claiming a hook-dependent result, check the hook's own
-#   evidence file INSIDE the clone; absence of that file invalidates the arm, not the hypothesis.
+# 🟥 PROJECT HOOKS DO RUN IN A DISPOSABLE CLONE — an earlier version of this paragraph said the
+#   opposite, and it was wrong (RETRACTED 2026-09-03). It read: "PROJECT HOOKS DO NOT RUN IN A
+#   DISPOSABLE CLONE … measured 2026-08-30: an arm copied `.claude/settings.json` into its clone to
+#   make the PreToolUse PriorArt hook live; not one of the three clones grew
+#   `.claude/.prior_art_events.tsv`". That absence was read as "hooks never fire here" with NO
+#   control arm whose hook was known to fire — and it narrowed two rounds of the identity-⑤
+#   design (the hook-layer arm was declared unmeasurable). Known pair, 2026-09-03: a PreToolUse
+#   Bash hook that appends to `$CLAUDE_PROJECT_DIR/_hook_evidence.txt`, installed via
+#   `--setup 'cp <settings.json> .claude/settings.json'`, FIRED inside this runner's own clone
+#   (act mode, deny settings.local.json present) and in a bare `claude -p` clone, trusted or not.
+#   Why the 2026-08-30 arm saw nothing is UNKNOWN (candidates: the PriorArt hook's own trigger
+#   vocabulary never matched, its evidence path was outside the clone, the copy never landed) —
+#   none of them is "hooks do not run". Signal: tracks/_meta/fh_signal_2026-09-03_runner-hooks-do-fire.md
+#   What SURVIVES from the old paragraph: before claiming a hook-dependent result, check the
+#   hook's own evidence file INSIDE the clone; absence of that file invalidates the ARM, never the
+#   hypothesis. And `--setup` writing an UNTRACKED file (.claude/settings.json is gitignored) is
+#   not contamination — the tree baseline is taken after setup, and git status never sees it.
 #
 # 🟥 CONTROL IS NOT OPTIONAL. Always run at least one arm whose correct answer is "the thing
 #   being measured should NOT fire". An instrument that fires on everything measures nothing

--- a/scripts/sim_isolated_run.sh
+++ b/scripts/sim_isolated_run.sh
@@ -79,9 +79,13 @@
 #   Bash hook that appends to `$CLAUDE_PROJECT_DIR/_hook_evidence.txt`, installed via
 #   `--setup 'cp <settings.json> .claude/settings.json'`, FIRED inside this runner's own clone
 #   (act mode, deny settings.local.json present) and in a bare `claude -p` clone, trusted or not.
-#   Why the 2026-08-30 arm saw nothing is UNKNOWN (candidates: the PriorArt hook's own trigger
-#   vocabulary never matched, its evidence path was outside the clone, the copy never landed) —
-#   none of them is "hooks do not run". Signal: tracks/_meta/fh_signal_2026-09-03_runner-hooks-do-fire.md
+#   Why the 2026-08-30 arm saw nothing — CONFIRMED the same day, one more known pair: with the
+#   real project hook set copied into a clone, an arm asked to build a new mechanism script FOUND
+#   PRIOR ART and never called Write (identity-④ behaviour), so the Write-matched PriorArt hook had
+#   nothing to fire on; an arm forced to Write a new scripts/*.sh produced `.prior_art_events.tsv`
+#   with a FIRE row inside the clone. The stimulus never reached the hook — a hook that is never
+#   triggered looks identical to a hook that cannot run, which is why a control arm whose hook is
+#   KNOWN to fire is mandatory. Signal: tracks/_meta/fh_signal_2026-09-03_runner-hooks-do-fire.md
 #   What SURVIVES from the old paragraph: before claiming a hook-dependent result, check the
 #   hook's own evidence file INSIDE the clone; absence of that file invalidates the ARM, never the
 #   hypothesis. And `--setup` writing an UNTRACKED file (.claude/settings.json is gitignored) is


### PR DESCRIPTION
## 무엇
`scripts/sim_isolated_run.sh` 헤더의 «PROJECT HOOKS DO NOT RUN IN A DISPOSABLE CLONE»(2026-08-30 실측 근거)를 철회하고 실측 문단으로 교체. 코드 0줄.

## 근거 (known-pair, 2026-09-03)
PreToolUse Bash 훅(`$CLAUDE_PROJECT_DIR/_hook_evidence.txt` append)을 클론의 `.claude/settings.json` 에 넣고:
- A 미신뢰 클론 `claude -p --tools Bash` → FIRED
- B `hasTrustDialogAccepted:true` 주입(백업·복원) → FIRED (신뢰 여부는 변수가 아니었다)
- 러너 실경로(act, deny `settings.local.json` 주입, `--setup cp`) → FIRED, RESULT CLEAN

08-30 «안 돌았다»는 컨트롤 없는 부재 측정이었고 원인은 UNKNOWN(후보 셋 명시). 그 문장이 ⑤ r2·r3 사전등록에서 훅층 팔을 «측정 불가»로 좁혔다 — 이제 r4 가 ⓑ 훅층을 잴 수 있다.

살아남는 규칙: 훅 의존 결과는 클론 안 증거 파일로 확인 · `--setup` 이 untracked 파일을 쓰는 것은 오염이 아님. 옛 문단은 RETRACTED 인용으로 보존. 레인 24/24 · 4축 PASS. 신호: `tracks/_meta/fh_signal_2026-09-03_runner-hooks-do-fire.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
