### PR TITLE
fix(preprep): 드리프트 앵커 D2 — 변수 부재 시 FH_COMPANION_STORE/preprep 자동 후보

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,6 +234,7 @@
     "scripts/stale_clone_guard.sh",
     "scripts/proposal_hook.sh",
     "scripts/test_proposal_hook_lanes.sh",
+    "scripts/test_preprep_drift_anchor_lanes.sh",
     "scripts/test_precommit_pointer_index_lanes.sh",
     "templates/settings.PreToolUse.snippet.json",
     "scripts/halffix_propagation_scan.sh",

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -645,6 +645,7 @@ for _pair in \
   "plugins/fh-commons/skills/preprep/lane_adjacent_dup.py|scripts/test_preprep_adjacent_dup_lanes.sh" \
   "plugins/fh-commons/skills/preprep/lane_promise.py|scripts/test_preprep_promise_lanes.sh" \
   "plugins/fh-commons/skills/preprep/SKILL.md|scripts/test_preprep_drift_anchor.sh" \
+  "scripts/test_preprep_drift_anchor.sh|scripts/test_preprep_drift_anchor_lanes.sh" \
   "scripts/field_canon_preload.sh|scripts/test_skill_canon_preload_lanes.sh" \
   `# ── round/ 회차 계기 4종(2026-09-01). 넷 다 한 스위트가 잡는다 — 주체별로 행을 둔다 ──` \
   "scripts/round/delta_guard.sh|scripts/test_round_instruments_lanes.sh" \

--- a/scripts/test_preprep_drift_anchor.sh
+++ b/scripts/test_preprep_drift_anchor.sh
@@ -16,7 +16,16 @@ set -uo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SRC="$HERE/plugins/fh-commons/skills/preprep"
 # standalone 배포 위치는 환경변수로 받는다. 기본값을 박으면 다른 머신에서 거짓 SKIP 이 된다.
-DIST="${PREPREP_STANDALONE_DIR:-}"
+# 🟥 2026-09-03 — 그런데 «아무도 그 변수를 안 걸어서» D2 가 여태 SKIP 이었고, 그 사이 컴패니언
+#    저장소의 fork(724줄)가 정본(789줄)과 갈라져 L9~L11 을 안 부르고 있었다 — 정본 주석이 이미
+#    한 번 적어 둔 사고의 2회째(fh_signal_2026-09-03_preprep-standalone-anchor-skip.md). 슬롯은
+#    있고 소비처가 0 인 형태. 처방: 명시 변수가 없으면 운영자 로컬 바인딩이 이미 export 하는
+#    FH_COMPANION_STORE 아래 preprep/ 을 «자동 후보»로 쓴다 — 기본값을 박는 게 아니라 이미
+#    선언된 경로를 읽는 것이라 다른 머신에서 거짓 SKIP 을 만들지 않는다(없으면 여전히 SKIP).
+DIST="${PREPREP_STANDALONE_DIR:-}"; DIST_SRC="PREPREP_STANDALONE_DIR"
+if [ -z "$DIST" ] && [ -n "${FH_COMPANION_STORE:-}" ] && [ -d "${FH_COMPANION_STORE}/preprep" ]; then
+  DIST="${FH_COMPANION_STORE}/preprep"; DIST_SRC="FH_COMPANION_STORE/preprep (자동 후보)"
+fi
 PASS=0; FAIL=0; SKIP=0
 ok(){ echo "  ✅ $1"; PASS=$((PASS+1)); }
 ng(){ echo "  ❌ $1"; FAIL=$((FAIL+1)); }
@@ -41,16 +50,16 @@ fi
 
 # D2 — standalone 대조
 if [ -z "$DIST" ]; then
-  sk "D2 standalone 대조 — PREPREP_STANDALONE_DIR 미설정이라 배포본을 못 찾았다"
+  sk "D2 standalone 대조 — PREPREP_STANDALONE_DIR 미설정이고 FH_COMPANION_STORE/preprep 도 없어 배포본을 못 찾았다. UNCHECKED — 배포본이 있는 머신이면 둘 중 하나를 export 해라"
 elif [ ! -d "$DIST" ]; then
-  ng "D2 PREPREP_STANDALONE_DIR 이 가리키는 곳이 없다: $DIST (설정됐는데 부재 = 드리프트 아니라 배선 결함)"
+  ng "D2 $DIST_SRC 이 가리키는 곳이 없다: $DIST (설정됐는데 부재 = 드리프트 아니라 배선 결함)"
 else
   drift=""
   for f in preprep.py interslide_deps.py lane_progression.py lane_adjacent_dup.py; do
     if [ ! -f "$DIST/$f" ]; then drift="$drift $f(부재)"
     elif ! cmp -s "$SRC/$f" "$DIST/$f"; then drift="$drift $f(갈림)"; fi
   done
-  [ -z "$drift" ] && ok "D2 standalone 코드 5파일이 단일 소스와 바이트 동일" \
+  [ -z "$drift" ] && ok "D2 standalone 코드 5파일이 단일 소스와 바이트 동일 ($DIST_SRC)" \
                   || ng "D2 드리프트:$drift ⇒ 사본이 둘이 됐다. 단일 소스에서 다시 뽑아라"
 fi
 

--- a/scripts/test_preprep_drift_anchor_lanes.sh
+++ b/scripts/test_preprep_drift_anchor_lanes.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# test_preprep_drift_anchor_lanes.sh — known pairs for the D2 leg of scripts/test_preprep_drift_anchor.sh
+# WHY (2026-09-03): D2 compared the standalone copy only when PREPREP_STANDALONE_DIR was set. Nobody
+# set it, so the leg SKIPPED for weeks while the companion-store fork drifted (724 vs 789 lines, L9-L11
+# never called) — the second occurrence of the exact accident the canon's own comment records.
+# Fix under test: with the env var unset, the anchor falls back to $FH_COMPANION_STORE/preprep when it
+# exists. These lanes pin: fallback used · fallback discriminates (identical PASS / drifted FAIL) ·
+# explicit var still wins · nothing set → SKIP (never a silent PASS).
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; A="$HERE/scripts/test_preprep_drift_anchor.sh"
+SRC="$HERE/plugins/fh-commons/skills/preprep"; T=$(mktemp -d); pass=0; fail=0
+chk(){ if [ "$1" = 0 ]; then echo "  ✅ $2"; pass=$((pass+1)); else echo "  ❌ $2"; fail=$((fail+1)); fi; }
+mk(){ mkdir -p "$1"; for f in preprep.py interslide_deps.py lane_progression.py lane_adjacent_dup.py lane_promise.py; do cp "$SRC/$f" "$1/$f"; done; }
+echo "[preprep-drift-anchor] D2 known pairs"
+# L1 nothing set → D2 SKIP (skip != pass), rc 0 (D2 is not a FAIL)
+out=$(env -u PREPREP_STANDALONE_DIR FH_COMPANION_STORE="$T/nostore" bash "$A" 2>&1); printf '%s' "$out" | grep -q "D2 .*SKIPPED"; chk $? "L1 var unset + no companion preprep → D2 SKIPPED (not PASS)"
+# L2 companion copy identical → fallback used, D2 PASS
+mk "$T/be/preprep"; out=$(env -u PREPREP_STANDALONE_DIR FH_COMPANION_STORE="$T/be" bash "$A" 2>&1); printf '%s' "$out" | grep -q "✅ D2 .*자동 후보"; chk $? "L2 fallback FH_COMPANION_STORE/preprep identical → D2 PASS via 자동 후보"
+# L3 companion copy drifted → D2 FAIL, rc 1 (the accident class)
+printf '\n# drift\n' >> "$T/be/preprep/preprep.py"; env -u PREPREP_STANDALONE_DIR FH_COMPANION_STORE="$T/be" bash "$A" >"$T/l3.out" 2>&1; rc=$?; [ "$rc" -ne 0 ] && grep -q "D2 드리프트.*preprep.py(갈림)" "$T/l3.out"; chk $? "L3 fallback copy drifted → D2 FAIL rc=$rc (known-positive)"
+# L4 explicit var wins over companion
+mk "$T/explicit"; out=$(PREPREP_STANDALONE_DIR="$T/explicit" FH_COMPANION_STORE="$T/be" bash "$A" 2>&1); printf '%s' "$out" | grep -q "✅ D2 .*(PREPREP_STANDALONE_DIR)"; chk $? "L4 explicit PREPREP_STANDALONE_DIR wins over drifted companion copy"
+rm -rf "$T"; echo "[preprep-drift-anchor] $pass passed, $fail failed"; [ "$fail" -eq 0 ]


### PR DESCRIPTION
D2 가 `PREPREP_STANDALONE_DIR` 없이는 SKIP 이라 컴패니언 fork 드리프트(724 vs 789줄, L9~L11 미호출)를 몇 주 못 봤다 — 정본 주석이 적어 둔 사고의 2회째. 기본 경로를 박지 않고 이미 export 된 `FH_COMPANION_STORE/preprep` 을 자동 후보로 읽는다(명시 변수 우선, 둘 다 없으면 SKIP+UNCHECKED). 레인 4(SKIP·PASS·드리프트 FAIL·명시 우선) + selfcheck 배선. 실환경 D2 PASS. 신호: `tracks/_meta/fh_signal_2026-09-03_preprep-standalone-anchor-skip.md`. 짓지 않은 절반: 컨텍스트 advisory(앵커는 selfcheck 안이라 채널 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)