### PR TITLE
feat(round): 회차4 이음매 — 채점기 --arms CTRL 사전 디스패치 + eligcheck labelmap 해석

### DIFF
--- a/scripts/context_continuity_score.sh
+++ b/scripts/context_continuity_score.sh
@@ -87,7 +87,7 @@ _tsv_pipe(){ LC_ALL=C awk -F'\t' 'BEGIN{OFS="|"} {for(i=1;i<=NF;i++) if($i ~ /\|
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RUNNER="$HERE/scripts/sim_isolated_run.sh"
 
-SEAL=""; QSET=""; REPS=1; MODEL="sonnet"; OUT=""; DELIVER=0
+SEAL=""; QSET=""; REPS=1; MODEL="sonnet"; OUT=""; DELIVER=0; ARMS="both"
 SELFTEST=0; RESCORE=0; MANIFEST=""; BASE_REF=""; BASE_SHA=""; PROTOCOL_FILE=""
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -105,6 +105,10 @@ while [ $# -gt 0 ]; do
     --base-sha) BASE_SHA="${2:-}"; shift 2 ;;   #    ref 는 움직인다 — sha 를 둘 다 준다
     --protocol) PROTOCOL_FILE="${2:-}"; shift 2 ;;  # 🟥 규약 «문구»는 파일로 받는다 — 코드에 안 박는다
     --rescore) RESCORE=1; shift ;;
+    # 🟥 CTRL 전용 사전 디스패치(2026-09-03, 회차4 개시 조건). 설계(DESIGN_2026-09-01 §3-§4)는 «positive
+    #    적격 게이트를 봉인 «전»에 CTRL 로 돌려 N 을 정한다» 인데 채점기는 늘 두 팔을 함께 돌렸다 —
+    #    ARM 을 먼저 태우면 정답지가 클론에 «보인» 채로 N 이 정해진다. 닫힌 enum: ARM|CTRL|both.
+    --arms) ARMS="${2:-}"; case "$ARMS" in ARM|CTRL|both) ;; *) echo "🟥 --arms 는 ARM|CTRL|both 만: '$ARMS'" >&2; exit 2 ;; esac; shift 2 ;;
     # 🟥 «지금 도는 qset/seal 이 «봉인된 그것»인가» 를 회차 시작 전에 대조한다.
     --manifest) MANIFEST="${2:-}"; shift 2 ;;
     *) echo "unknown flag: $1" >&2; exit 2 ;;
@@ -638,6 +642,7 @@ while IFS='|' read -r qid kind question token general; do
   case "$qid" in ''|'#'*) continue ;; esac
   n=$((n+1))
   for arm in ARM CTRL; do
+    [ "$ARMS" = both ] || [ "$arm" = "$ARMS" ] || continue   # --arms 필터(위 enum)
     setup=""; [ "$arm" = ARM ] && setup="$SETUP_ARM"
     q="$question"
     # ── S5 ② «규약» — typed 채널의 «쓰는 쪽» (2026-09-01 배선) ──────────────────

--- a/scripts/round/eligcheck_qset.sh
+++ b/scripts/round/eligcheck_qset.sh
@@ -11,6 +11,18 @@ set -uo pipefail
 _tsv_pipe(){ LC_ALL=C awk -F'\t' 'BEGIN{OFS="|"} {for(i=1;i<=NF;i++) if($i ~ /\|/){print "PIPE_IN_VALUE:" NR > "/dev/stderr"; exit 3} $1=$1; print}' "$1"; }
 SRC="${SRC:-scripts/context_continuity_score.sh}"
 QSET="${1:?usage: eligcheck.sh <qset.tsv> <outdir-with-CTRL>}"; OUT="${2:?}"; REPS="${3:-5}"
+# 🟥 CTRL 응답 파일 해석(2026-09-03): 채점기는 2026-09-01 부터 익명 라벨 `w<hex>_r<r>.txt` 로 쓰고
+#    `<out>.labelmap`(label|qid|arm) 을 남긴다. 옛 이름 `${qid}_CTRL_r${r}.txt` 가 없고 labelmap 이 있으면
+#    거기서 CTRL 라벨을 찾아 그 파일을 쓴다 — 회차4 가 «CTRL 전용 사전 디스패치(채점기 --arms CTRL)» 산출을
+#    그대로 적격 게이트에 넣을 수 있게 하는 이음매. 둘 다 없으면 종전대로 «부재»(분모 접힘 방지 그대로).
+_ctrl_file() {  # $1=qid $2=rep → 경로(존재 여부는 호출부가 본다)
+  local f="$OUT/${1}_CTRL_r${2}.txt" lm="${OUT%/}.labelmap" lab
+  if [ ! -f "$f" ] && [ -f "$lm" ]; then
+    lab=$(LC_ALL=C awk -F'|' -v q="$1" '$2==q && $3=="CTRL" {print $1; exit}' "$lm")
+    [ -n "$lab" ] && f="$OUT/${lab}_r${2}.txt"
+  fi
+  printf '%s' "$f"
+}
 eval "$(grep -m1 '^REFUSE_RE=' "$SRC")"
 sed -n '/^score_one() {/,/^}/p' "$SRC" > /tmp/_so_e.sh; . /tmp/_so_e.sh
 # 🟥 파싱을 «먼저 물질화»하고 rc 를 본다. 프로세스 치환(`< <(_tsv_pipe)`)은 awk 가 exit 3 으로 죽어도
@@ -42,7 +54,7 @@ while IFS='|' read -r qid kind q tok general probe; do
     if [ -z "${tok:-}" ]; then printf '%-5s %-9s %-22s %s\n' "$qid" "$kind" "-" "UNMEASURED(기대 토큰 없음 — qset 결함, 적격 아님)"; bad=1; continue; fi
     pv=0; tot=0; void=0; miss=0
     for r in $(seq 1 "$REPS"); do
-      f="$OUT/${qid}_CTRL_r${r}.txt"
+      f="$(_ctrl_file "$qid" "$r")"
       [ -f "$f" ] || { miss=$((miss+1)); continue; }
       tot=$((tot+1)); [ -s "$f" ] || { void=$((void+1)); continue; }
       v=$(score_one "$f" positive "$tok")
@@ -58,7 +70,7 @@ while IFS='|' read -r qid kind q tok general probe; do
   fi
   ref=0; tot=0; void=0; miss=0
   for r in $(seq 1 "$REPS"); do
-    f="$OUT/${qid}_CTRL_r${r}.txt"
+    f="$(_ctrl_file "$qid" "$r")"
     # 🟥 2026-09-01: 여기가 그냥 `continue` 였다 — **부재가 분모에서 사라진다.**
     #    reps=3 에서 1건이 비면 2/2 가 되어 다수결을 넘고 **적격이 «더 쉬워진다».**
     #    즉 디스패치 실패가 회차를 «여는» 쪽으로 작용한다. 실증됨(3/3 → 하나 지우면 2/2 적격).
@@ -93,7 +105,7 @@ while IFS='|' read -r qid kind q tok general probe; do
     #    ⇒ 기계로 가를 수 있는 축은 **«CTRL 이 기권했나 답했나»** 다.
     pw=0; tot=0; void=0; miss=0
     for r in $(seq 1 "$REPS"); do
-      f="$OUT/${qid}_CTRL_r${r}.txt"
+      f="$(_ctrl_file "$qid" "$r")"
       [ -f "$f" ] || { miss=$((miss+1)); continue; }   # 🟥 negative 루프와 같은 이유
       tot=$((tot+1)); [ -s "$f" ] || { void=$((void+1)); continue; }
       /usr/bin/grep -qF -- "$general" "$f" 2>/dev/null && pw=$((pw+1))

--- a/scripts/test_round_instruments_lanes.sh
+++ b/scripts/test_round_instruments_lanes.sh
@@ -131,6 +131,17 @@ else
   printf '# comment only\n' > "$T/eq_pos.tsv"       # 채점 대상 행 0 — «잰 것 없음» (positive 는 2026-09-02 부터 채점 대상이라 주석만 남긴다)
   ( cd "$ROOT" && SRC=scripts/context_continuity_score.sh bash "$_EL" "$T/eq_pos.tsv" "$T/out" 1 ) >/dev/null 2>&1; _rc=$?
   [ "$_rc" -ne 0 ]; chk "E6 negative/conflict 행 0 → rc≠0 (빈 집합은 «전 문항 적격»이 아니다) [got=$_rc]" "$?" 0
+  # ── E10–E11 labelmap 해석 + 채점기 --arms (2026-09-03, 회차4 이음매) ─────────────────────────
+  mkdir -p "$T/lm"; printf 'N01\tnegative\tq?\tZZQQTOKEN\t\t\n' > "$T/eq_lm.tsv"
+  printf 'wdeadbeef|N01|CTRL\nwcafe|N01|ARM\n' > "$T/lm.labelmap"      # 채점기 라벨맵 형식 그대로
+  printf 'ZZQQTOKEN 입니다.\n' > "$T/lm/wdeadbeef_r1.txt"                # 익명 라벨 파일만 있고 옛 이름은 없다
+  ( cd "$ROOT" && SRC=scripts/context_continuity_score.sh bash "$_EL" "$T/eq_lm.tsv" "$T/lm" 1 ) >/dev/null 2>&1
+  chk "E10 옛 이름 부재 + labelmap 있음 → 익명 라벨 CTRL 파일을 읽어 채점(답해버림=부적격 1)" "$?" 1
+  rm -f "$T/lm.labelmap"
+  ( cd "$ROOT" && SRC=scripts/context_continuity_score.sh bash "$_EL" "$T/eq_lm.tsv" "$T/lm" 1 ) >/dev/null 2>&1; _rc=$?
+  [ "$_rc" -ne 0 ]; chk "E10-ctrl labelmap 마저 없으면 부재 → 적격 아님(rc≠0, 분모 접힘 없음) [got=$_rc]" "$?" 0
+  ( cd "$ROOT" && bash scripts/context_continuity_score.sh --arms BOGUS --self-test ) >/dev/null 2>&1; _rc=$?
+  [ "$_rc" -eq 2 ]; chk "E11 채점기 --arms 닫힌 enum: BOGUS → rc 2 [got=$_rc]" "$?" 0
   # ── E7–E9 positive 적격 분기 (2026-09-02) — CTRL 이 토큰을 «내면» DEAD_CONTROL ──────────────
   printf 'P01\tpositive\tq?\tZZQQPOS\t\t\n' > "$T/eq_p.tsv"
   printf '그런 값은 기록에 없습니다.\n' > "$T/out/P01_CTRL_r1.txt"


### PR DESCRIPTION
round4_prep(2026-09-02) 이 «열 수 없다»로 적은 두 부재를 닫는다. ⓐ CTRL 전용 사전 디스패치 모드 없음 → `--arms ARM|CTRL|both`(닫힌 enum) ⓑ 채점기 출력명 `w<hex>_r` ↔ eligcheck 기대명 `qid_CTRL_r` 불일치 → eligcheck 가 `<out>.labelmap` 로 익명 라벨 CTRL 파일을 해석(옛 이름 우선, 둘 다 없으면 종전대로 부재). 레인 E10·E10-ctrl·E11, 40/40 · 되돌림 판별 · 채점기 self-test 통과. 순서 규약 하나를 사전등록에 적을 것: `--arms CTRL` 뒤에 `--arms ARM` 을 따로 돌리면 labelmap 이 덮인다(별도 out 디렉터리 사용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)