### PR TITLE
fix(round): --arms CTRL 을 «봉인 전»에 실제로 돌게 — seal 미요구 · 게이트 pre · 누출검사 seal 다리

### DIFF
--- a/scripts/context_continuity_score.sh
+++ b/scripts/context_continuity_score.sh
@@ -434,7 +434,14 @@ if [ "$SELFTEST" = 1 ]; then
 fi
 
 # ─────────────────────────────────────────────────────────────────────
-[ -n "$SEAL" ] && [ -f "$SEAL" ] || { echo "🟥 --seal <실재 파일> 필요" >&2; exit 2; }
+# 🟥 CTRL 전용 사전 디스패치(--arms CTRL)는 «봉인 전»에 도는 것이 설계다(DESIGN §4 ①: 적격 게이트를 봉인
+#    전에 CTRL 로 돌려 N 을 정한다) — 그때 봉인 파일은 아직 없다. SEAL 은 ARM 의 SETUP(운반체 심기)에만
+#    쓰이므로 CTRL 전용이면 요구하지 않는다. ARM 이 도는 모드(ARM|both)는 종전대로 실재 파일 필수.
+if [ "$ARMS" = CTRL ]; then
+  [ -z "$SEAL" ] || [ -f "$SEAL" ] || { echo "🟥 --seal 을 줬는데 실재하지 않는다: $SEAL" >&2; exit 2; }
+else
+  [ -n "$SEAL" ] && [ -f "$SEAL" ] || { echo "🟥 --seal <실재 파일> 필요 (--arms CTRL 만 봉인 전 실행 허용)" >&2; exit 2; }
+fi
 [ -n "$QSET" ] && [ -f "$QSET" ] || { echo "🟥 --qset <실재 파일> 필요" >&2; exit 2; }
 [ -x "$RUNNER" ] || [ -f "$RUNNER" ] || { echo "🟥 러너 없음: $RUNNER" >&2; exit 2; }
 # 🟥 파싱을 «먼저 물질화»하고 rc 를 본다 — eligcheck(55a10ce)·gatecheck 와 같은 모양. 아래 두 루프
@@ -563,7 +570,7 @@ fi
 
 OUT="${OUT:-$(mktemp -d -t cc-score)}"
 mkdir -p "$OUT"
-SEAL_ABS="$(cd "$(dirname "$SEAL")" && pwd)/$(basename "$SEAL")"
+SEAL_ABS=""; [ -n "$SEAL" ] && SEAL_ABS="$(cd "$(dirname "$SEAL")" && pwd)/$(basename "$SEAL")"
 
 echo "── context_continuity_score ─────────────────────────────────"
 echo "seal=$(basename "$SEAL")  reps=$REPS  model=$MODEL"
@@ -600,7 +607,17 @@ if [ "${RESCORE:-0}" != 1 ] && [ "${SELFTEST:-0}" != 1 ]; then
   #    폴백은 «가용성»을 사지만 «무엇이 돌았는지»를 판다.
   _GATE="$(dirname "${BASH_SOURCE[0]}")/round/gatecheck_qset.sh"
   [ -f "$_GATE" ] || { echo "🟥 $_GATE 가 없다 — 회차를 열지 않는다(스킵 아님, 폴백 없음)" >&2; exit 8; }
-  if ! bash "$_GATE" "$QSET" "$SEAL" post '' '' "$(basename "${OUT%/}")" "$(bash "$NAMELEAK" gen)" >&2; then
+  if [ "$ARMS" = CTRL ]; then
+    # 🟥 CTRL 전용 사전 디스패치 = 봉인 «전». 게이트는 phase=pre 로 돌고(심기 전이라 정상), 봉인 미지정이면
+    #    원장 축은 UNCHECKED(rc 3 = «부분 통과, 통과 아님»)가 설계된 값이다 — 이 모드에서 rc 3 을 받아들이되
+    #    그 사실을 출력에 남긴다. 오염 축(클론에 정답이 보이나)은 pre 에서도 그대로 검사돼 rc 1/2/5 는 막는다.
+    bash "$_GATE" "$QSET" "${SEAL:-}" pre '' '' "$(basename "${OUT%/}")" "$(bash "$NAMELEAK" gen)" >&2; _grc=$?
+    case "$_grc" in
+      0) ;;
+      3) echo "⚠️  개시 게이트 pre: 원장 축 UNCHECKED(봉인 미지정 — CTRL 전용 사전 디스패치라 정상). 봉인 후 post 로 다시 돈다" >&2 ;;
+      *) echo "🟥 개시 게이트(pre)가 막았다(rc=$_grc) — 디스패치 0건으로 중단한다" >&2; exit 8 ;;
+    esac
+  elif ! bash "$_GATE" "$QSET" "$SEAL" post '' '' "$(basename "${OUT%/}")" "$(bash "$NAMELEAK" gen)" >&2; then
     echo "🟥 개시 게이트가 막았다 — 디스패치 0건으로 중단한다" >&2
     exit 8
   fi
@@ -614,7 +631,10 @@ fi
 #    `--rescore`·`--self-test` 는 디스패치를 안 하므로 볼 팔이 없다.
 #    (초판은 무조건 걸어서 레인 25개를 과차단했다 — 실측. 과차단은 우회를 훈련시킨다)
 if [ "${RESCORE:-0}" != 1 ] && [ "${SELFTEST:-0}" != 1 ]; then
-  if ! bash "$NAMELEAK" "$(basename "$SEAL")" "$(basename "${OUT%/}")" "$(bash "$NAMELEAK" gen)"; then
+  # CTRL 전용(봉인 전)엔 seal 이 없다 — 누출 검사의 seal 다리는 규약 형태 이름(gen-seal)으로 채운다:
+  # 검사 대상은 «팔 시야에 드는 이름»이고, 생성 형태의 이름은 정의상 누출이 아니다.
+  _SEALNAME="${SEAL:+$(basename "$SEAL")}"; [ -n "$_SEALNAME" ] || _SEALNAME="$(bash "$NAMELEAK" gen-seal)"
+  if ! bash "$NAMELEAK" "$_SEALNAME" "$(basename "${OUT%/}")" "$(bash "$NAMELEAK" gen)"; then
     echo "🟥 out-dir 또는 seal 이름이 누출한다 — 회차를 열지 않는다 ('nameleak_check.sh gen' 을 써라)" >&2
     exit 7
   fi

--- a/scripts/test_round_instruments_lanes.sh
+++ b/scripts/test_round_instruments_lanes.sh
@@ -142,6 +142,11 @@ else
   [ "$_rc" -ne 0 ]; chk "E10-ctrl labelmap 마저 없으면 부재 → 적격 아님(rc≠0, 분모 접힘 없음) [got=$_rc]" "$?" 0
   ( cd "$ROOT" && bash scripts/context_continuity_score.sh --arms BOGUS --self-test ) >/dev/null 2>&1; _rc=$?
   [ "$_rc" -eq 2 ]; chk "E11 채점기 --arms 닫힌 enum: BOGUS → rc 2 [got=$_rc]" "$?" 0
+  # ── E12 --arms CTRL 은 «봉인 전» 실행 — --seal 없이 인자 검사를 지난다(다음 검사 = qset) ──────────
+  _m=$( cd "$ROOT" && bash scripts/context_continuity_score.sh --arms CTRL --qset "$T/definitely_absent.tsv" --out "$T/o12" 2>&1 ); _rc=$?
+  printf '%s' "$_m" | grep -q -- '--qset' && ! printf '%s' "$_m" | grep -q -- '--seal <실재 파일> 필요'; chk "E12 --arms CTRL + --seal 없음 → seal 이 아니라 qset 에서 멈춘다(봉인 전 실행 허용) [rc=$_rc]" "$?" 0
+  _m=$( cd "$ROOT" && bash scripts/context_continuity_score.sh --arms both --qset "$T/definitely_absent.tsv" --out "$T/o12" 2>&1 ); _rc=$?
+  printf '%s' "$_m" | grep -q -- '--seal <실재 파일> 필요'; chk "E12-ctrl --arms both 는 종전대로 --seal 필수 [rc=$_rc]" "$?" 0
   # ── E7–E9 positive 적격 분기 (2026-09-02) — CTRL 이 토큰을 «내면» DEAD_CONTROL ──────────────
   printf 'P01\tpositive\tq?\tZZQQPOS\t\t\n' > "$T/eq_p.tsv"
   printf '그런 값은 기록에 없습니다.\n' > "$T/out/P01_CTRL_r1.txt"


### PR DESCRIPTION
#596 이음매의 첫 실사용(1행 qset)이 세 자리에서 막혔다: `--seal` 필수 · 개시 게이트 post(봉인 요구) · nameleak 빈 seal usage. 셋 다 «CTRL 전용 = 봉인 전»(DESIGN §4 ①)을 채점기가 몰랐던 것. CTRL 모드에서만 seal 선택(있으면 실재 검사), 게이트 phase=pre + rc 3(UNCHECKED) 허용하되 경고 출력, seal 다리는 gen-seal 규약 이름(검사 대상은 팔 시야의 이름 — 생성 형태는 정의상 누출 아님). ARM/both 는 종전 그대로. 레인 42/42 · self-test 28/28 · 첫 실사용: pre 경고 → 누출 0 → CTRL 디스패치 → labelmap → eligcheck 적격(0/1). 잔여(이름): 게이트 rc 분기 되돌림 프로브 미실행 · post 재실행 시 labelmap 덮임 규약은 사전등록에.

🤖 Generated with [Claude Code](https://claude.com/claude-code)