### PR TITLE
feat(hook): proposal_hook — 판정·가드 줄 편집 시 «known-pair + degrade scan 한 줄 제안» 지시를 컨텍스트에

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ outputs/
 # prior-art hook runtime sentinels — per-session state written by the hook itself.
 # Never a commit target; without this they dirty `git status` every session.
 .claude/.prior_art_events.tsv
+.claude/.proposal_hook_events.tsv
 .claude/.prior_art_prompted_*
 
 # python bytecode (preprep 등 스킬 안의 .py 실행 산물)

--- a/package.json
+++ b/package.json
@@ -232,6 +232,8 @@
     "scripts/destructive_pre_gate.sh",
     "scripts/test_stale_clone_guard_lanes.sh",
     "scripts/stale_clone_guard.sh",
+    "scripts/proposal_hook.sh",
+    "scripts/test_proposal_hook_lanes.sh",
     "templates/settings.PreToolUse.snippet.json",
     "scripts/halffix_propagation_scan.sh",
     "scripts/test_halffix_lanes.sh",

--- a/scripts/proposal_hook.sh
+++ b/scripts/proposal_hook.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# proposal_hook.sh — PreToolUse(Edit|Write|Bash) advisory: a verdict/guard line in scripts/**/*.sh or
+# templates/*.sh is about to change → put ONE proposal instruction into the model's context
+# (additionalContext): «offer the user a known-pair control + degrade_direction_scan.sh in one line».
+#
+# WHY A HOOK (identity ⑤, measured 2026-09-03)
+#   r3: a CLAUDE.md table row keyed on this exact file class fired 1/15 at floor tier (that 1 a
+#   recitation). r4: this hook, installed in a disposable clone, fired on 9/10 editing reps and the
+#   floor session relayed the proposal 9/9; the hard negative (a usage-string edit in a .sh) 0/5.
+#   Same tasks, same tier, same prose layer — the row 0, the channel 100%. That is the
+#   «explicit instruction 3/3 · advisory 0/3 · framing 0/3» result of 2026-08-21 seen a second time
+#   (tracks/_meta/RESULT_2026-09-03_identity5-r4.md · prior_art_prompt.sh header). A channel is
+#   built at the channel (§Mechanization Boundary); what the proposal SAYS stays the model's.
+#
+# WHAT IT DOES NOT CLAIM
+#   Relaying an injected instruction is not initiative. Of r4's 9 hits, 4 carried task-specific
+#   substance beyond the hook's own wording (the K1 «judgment residue» — innovator signal
+#   fh_signal_2026-09-03_innovator-identity5-r4.md). This hook opens the window; whether ⑤'s bar
+#   («proposes unasked») counts a relayed proposal is the operator's call, recorded there, not here.
+#
+# DISCRIMINATOR (mechanical, quote-aware where it can be)
+#   file class  : scripts/**/*.sh · templates/*.sh          (docs, tracks, tests-as-fixtures: no)
+#   edit kind   : the touched text carries a verdict/guard token — exit N · return N ·
+#                 `|| continue|exit|true|return` · `&& continue|exit` · -ne/-eq/-gt/-lt · ==/!= ·
+#                 `[ -e/-f/-s/-n/-z` · comm/diff/cmp · grep -q — AND for Edit the change is not
+#                 confined to quoted strings (old/new with quotes stripped must differ). A usage
+#                 string that happens to contain `exit 2` does not fire (r4 HARD 0/5).
+#   Bash path   : an edit made through the shell (sed -i · > · >> · tee) — the r4 miss (T2 r5 edited
+#                 via Bash, hook 0). No old/new here, so the rule is weaker: target file class AND the
+#                 command text outside quotes carries a token. Named residual: a Bash edit whose token
+#                 lives only inside the sed replacement string is quote-stripped away → no fire.
+#
+# DEGRADE DIRECTION: advisory, exit 0 always, no permissionDecision (same contract as pipe_verdict_guard).
+#   Unparseable payload → silent. python3 absent → silent (a dead interpreter must not block edits).
+#   Evidence line appended to $CLAUDE_PROJECT_DIR/.claude/.proposal_hook_events.tsv (gitignored dir)
+#   so a sim arm can prove the hook fired INSIDE its clone (runner header: absence of that file
+#   invalidates the arm, never the hypothesis).
+# Opt out on one call with `# noqa: proposal-hook`.
+# test: printf '%s' '<PreToolUse JSON>' | bash scripts/proposal_hook.sh
+set -u
+RAW=$(cat 2>/dev/null || true)
+printf '%s' "$RAW" | grep -qE '#[[:space:]]*noqa:?[[:space:]]*proposal-hook' && exit 0
+read -r FP FLAG < <(printf '%s' "$RAW" | python3 -c '
+import json,sys,re
+try: d=json.load(sys.stdin)
+except Exception: print("",""); sys.exit(0)
+tn=d.get("tool_name",""); ti=d.get("tool_input",{}) or {}
+TOK=r"exit [0-9]|return [0-9]|\|\| *(continue|exit|true|return)|&& *(continue|exit)|-ne |-eq |-gt |-lt | == | != |\[ -[efsnz] |\bcomm |\bdiff |\bcmp |grep -q"
+def strip(x): return re.sub(r"\"[^\"]*\"|\x27[^\x27]*\x27","",x)
+fp=""; flag="0"
+if tn in ("Edit","Write"):
+    fp=ti.get("file_path","") or ""
+    old=ti.get("old_string","") or ""; new=(ti.get("new_string","") or ti.get("content","") or "")
+    touches=bool(re.search(TOK, old+"\n"+new)); real=strip(old).strip()!=strip(new).strip()
+    flag="1" if (touches and real) else "0"
+elif tn=="Bash":
+    cmd=(ti.get("command","") or "").replace("\n"," ")
+    m=re.search(r"(?:sed\s+-i\S*(?:\s+(?:\x27[^\x27]*\x27|\"[^\"]*\"|\S+)){1,2}\s+|>>?\s*|tee\s+(?:-a\s+)?)[\"\x27]?([^\s\"\x27|;&)<>]+\.sh)\b", cmd)
+    if m:
+        fp=m.group(1); flag="1" if re.search(TOK, strip(cmd)) else "0"
+print(fp, flag)
+' 2>/dev/null) || exit 0
+[ -n "${FP:-}" ] || exit 0
+case "$FP" in *scripts/*.sh|*templates/*.sh|scripts/*.sh|templates/*.sh) ;; *) exit 0 ;; esac
+[ "${FLAG:-0}" = 1 ] || exit 0
+_D="${CLAUDE_PROJECT_DIR:-.}/.claude"; mkdir -p "$_D" 2>/dev/null
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "FIRE" "$FP" >> "$_D/.proposal_hook_events.tsv" 2>/dev/null
+MSG='🔎 방금 고치는 줄은 판정·가드·종료코드 줄이다(scripts/*.sh · templates/*.sh). 작업을 마친 뒤 사용자에게 «한 줄로» 제안해라 — "이거 known-pair(고친 케이스 + 반대 케이스)로 컨트롤 붙이고, degrade_direction_scan.sh 로 실패가 «통과»로 접히는 방향인지 볼까?" — 가능하면 이 파일·이 케이스의 실제 이름으로. 제안이지 실행이 아니다. 사용자가 고르게 둔다.'
+python3 -c 'import json,sys; m=sys.argv[1]; print(json.dumps({"systemMessage":m,"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":m}}, ensure_ascii=False))' "$MSG" 2>/dev/null || exit 0
+exit 0

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -619,6 +619,7 @@ for _pair in \
   "scripts/reviewer_capability_corpus.tsv|scripts/test_reviewer_capability_conformance.sh" \
   "scripts/field_canon_preload.sh|scripts/test_field_canon_lanes.sh" \
   "scripts/stale_clone_guard.sh|scripts/test_stale_clone_guard_lanes.sh" \
+  "scripts/proposal_hook.sh|scripts/test_proposal_hook_lanes.sh" \
   "plugins/fh-commons/skills/ko-tech-writer/SKILL.md|scripts/test_ko_tech_writer_lanes.sh" \
   "scripts/script_caller_ratchet.sh|scripts/test_script_caller_ratchet_lanes.sh" \
   "scripts/script_caller_ratchet.sh|scripts/test_runner_surface_index_lanes.sh" \

--- a/scripts/test_proposal_hook_lanes.sh
+++ b/scripts/test_proposal_hook_lanes.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # test_proposal_hook_lanes.sh — known pairs for scripts/proposal_hook.sh (written before shipping; r4 KP + Bash path)
-set -u; H="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/proposal_hook.sh"; T=$(mktemp -d); pass=0; fail=0
-exp(){ local label="$1" want="$2" payload="$3" got; got=$(printf '%s' "$payload" | CLAUDE_PROJECT_DIR="$T" bash "$H" 2>/dev/null | wc -c | tr -d ' '); [ "$got" -gt 0 ] && got=HIT || got=CLEAN
+set -u; HDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; T=$(mktemp -d); pass=0; fail=0
+export CLAUDE_PROJECT_DIR="$T"
+exp(){ local label="$1" want="$2" payload="$3" got; got=$(printf '%s' "$payload" | bash "$HDIR/proposal_hook.sh" 2>/dev/null | wc -c | tr -d ' '); [ "$got" -gt 0 ] && got=HIT || got=CLEAN
   if [ "$got" = "$want" ]; then printf '  ✅ %-52s %s\n' "$label" "$got"; pass=$((pass+1)); else printf '  ❌ %-52s %s (expected %s)\n' "$label" "$got" "$want"; fail=$((fail+1)); fi; }
 echo "[proposal-hook] known pairs"
 exp "T1 Edit comm+LC_ALL (verdict compare)"   HIT   '{"tool_name":"Edit","tool_input":{"file_path":"/x/scripts/sim_isolated_run.sh","old_string":"  comm -13 <(sort a) <(sort b) \\","new_string":"  comm -13 <(LC_ALL=C sort a) <(LC_ALL=C sort b) \\"}}'

--- a/scripts/test_proposal_hook_lanes.sh
+++ b/scripts/test_proposal_hook_lanes.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# test_proposal_hook_lanes.sh — known pairs for scripts/proposal_hook.sh (written before shipping; r4 KP + Bash path)
+set -u; H="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/proposal_hook.sh"; T=$(mktemp -d); pass=0; fail=0
+exp(){ local label="$1" want="$2" payload="$3" got; got=$(printf '%s' "$payload" | CLAUDE_PROJECT_DIR="$T" bash "$H" 2>/dev/null | wc -c | tr -d ' '); [ "$got" -gt 0 ] && got=HIT || got=CLEAN
+  if [ "$got" = "$want" ]; then printf '  ✅ %-52s %s\n' "$label" "$got"; pass=$((pass+1)); else printf '  ❌ %-52s %s (expected %s)\n' "$label" "$got" "$want"; fail=$((fail+1)); fi; }
+echo "[proposal-hook] known pairs"
+exp "T1 Edit comm+LC_ALL (verdict compare)"   HIT   '{"tool_name":"Edit","tool_input":{"file_path":"/x/scripts/sim_isolated_run.sh","old_string":"  comm -13 <(sort a) <(sort b) \\","new_string":"  comm -13 <(LC_ALL=C sort a) <(LC_ALL=C sort b) \\"}}'
+exp "T2 Edit adds fail-open guard"            HIT   '{"tool_name":"Edit","tool_input":{"file_path":"/x/scripts/capability_effect_probe.sh","old_string":"  h=$(ls -A \"$HOME\" | shasum)","new_string":"  h=$(ls -A \"$HOME\" | shasum) || { echo LS_FAILED; exit 10; }"}}'
+exp "T3 Edit continue guard"                  HIT   '{"tool_name":"Edit","tool_input":{"file_path":"/x/templates/regression_guard.sh","old_string":"      [ -e \"$blk\" ] && [ -s \"$blk\" ] || continue","new_string":"      [ -e \"$blk\" ] || { echo missing >&2; continue; }"}}'
+exp "HARD Edit usage string only (r4 0/5)"    CLEAN '{"tool_name":"Edit","tool_input":{"file_path":"/x/scripts/daily_report.sh","old_string":"  *) echo \"usage: d.sh [run]\" >&2; exit 2 ;;","new_string":"  *) echo \"usage: d.sh [run|--self-test] (DR_DATE)\" >&2; exit 2 ;;"}}'
+exp "docs file with tokens"                   CLEAN '{"tool_name":"Edit","tool_input":{"file_path":"/x/docs/a.md","old_string":"a","new_string":"exit 1 || continue"}}'
+exp "Write new scripts/*.sh with verdict"     HIT   '{"tool_name":"Write","tool_input":{"file_path":"/x/scripts/new_check.sh","content":"#!/bin/bash\n[ -f x ] || exit 1"}}'
+exp "Bash sed -i on scripts/*.sh with token"  HIT   '{"tool_name":"Bash","tool_input":{"command":"sed -i \"\" \"s/comm -13/LC_ALL=C comm -13/\" scripts/sim_isolated_run.sh && [ -s out ] || exit 1"}}'
+exp "Bash redirect into scripts/*.sh w/ token" HIT  '{"tool_name":"Bash","tool_input":{"command":"printf \"%s\\n\" x >> scripts/x.sh; grep -q y scripts/x.sh || exit 3"}}'
+exp "Bash redirect into docs (no)"            CLEAN '{"tool_name":"Bash","tool_input":{"command":"echo \"exit 1\" >> docs/a.md || exit 1"}}'
+exp "Bash ls only (no target)"                CLEAN '{"tool_name":"Bash","tool_input":{"command":"ls scripts/ && [ -d scripts ] || exit 1"}}'
+exp "noqa exempts"                            CLEAN '{"tool_name":"Edit","tool_input":{"file_path":"/x/scripts/a.sh","old_string":"a","new_string":"exit 1  # noqa: proposal-hook"}}'
+exp "unparseable payload silent"              CLEAN 'not json'
+[ -f "$T/.claude/.proposal_hook_events.tsv" ] && [ "$(grep -c FIRE "$T/.claude/.proposal_hook_events.tsv")" -ge 5 ]; r=$?; [ $r = 0 ] && { echo "  ✅ evidence file carries a FIRE row per hit"; pass=$((pass+1)); } || { echo "  ❌ evidence file missing/short"; fail=$((fail+1)); }
+rm -rf "$T"; echo "[proposal-hook] $pass passed, $fail failed"; [ "$fail" -eq 0 ]

--- a/templates/settings.PreToolUse.snippet.json
+++ b/templates/settings.PreToolUse.snippet.json
@@ -61,7 +61,17 @@
     "the actor's task had a different name than the rule's title. Quote-aware state machine, not a regex:",
     "single-quoted text, quoted heredocs (<<'EOF'), and escaped backticks are CLEAN. Same advisory contract;",
     "escalate with FH_BACKTICK_BLOCK=1; opt out with `# noqa: backtick` (whole payload).",
-    "  bash scripts/test_backtick_guard_lanes.sh              # expect: all known pairs hold (count self-reported)"
+    "  bash scripts/test_backtick_guard_lanes.sh              # expect: all known pairs hold (count self-reported)",
+    "",
+    "FIFTH GUARD, Edit|Write|Bash matcher — proposal_hook.sh (added 2026-09-03, identity ⑤ r4):",
+    "advisory when a verdict/guard line in scripts/**/*.sh or templates/*.sh is about to change: puts ONE",
+    "instruction into the model context — offer the user a known-pair control + degrade_direction_scan.sh in",
+    "one line. Measured: the same rule as a CLAUDE.md table row fired 1/15 at floor tier (r3); as this hook",
+    "9/9 relay on editing reps and 0/5 on a usage-string edit (r4). Quote-aware: an edit confined to quoted",
+    "strings does not fire. Bash path (sed -i / > / tee into a .sh) covered with a weaker rule (named",
+    "residual in the script header). Evidence row in .claude/.proposal_hook_events.tsv. Relaying an",
+    "injected instruction is not initiative — see the r4 RESULT for what this does and does not claim.",
+    "  bash scripts/test_proposal_hook_lanes.sh                # expect: all known pairs hold (count self-reported)"
   ],
   "project_settings_json": {
     "hooks": {
@@ -93,6 +103,16 @@
               "type": "command",
               "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/stale_clone_guard.sh\"",
               "timeout": 20
+            }
+          ]
+        },
+        {
+          "matcher": "Edit|Write|Bash",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/proposal_hook.sh\"",
+              "timeout": 5
             }
           ]
         }


### PR DESCRIPTION
## 무엇
`scripts/proposal_hook.sh` — PreToolUse(Edit|Write|Bash) advisory. `scripts/**/*.sh`·`templates/*.sh` 의 판정·가드·종료코드·비교 줄이 바뀌는 순간 additionalContext 로 «known-pair(고친 케이스+반대 케이스) 컨트롤 + degrade_direction_scan.sh 를 한 줄로 제안하라» 를 넣는다. 훅은 창만 열고, 무엇을 제안할지는 모델 몫.

## 근거 (정체성 ⑤ r3·r4, 2026-09-03)
같은 과제 3종·같은 플로어(sonnet)·같은 산문층에서: CLAUDE.md 표의 파일 클래스 행 = 1/15(그 1 도 복창) · 이 훅(클론 전용) = 편집 rep 9/9 전달 · hard negative(usage 문자열 편집) 0/5 · BASE 0/15. 08-21 «명시 지시 3/3 · advisory 0/3 · 프레이밍 0/3» 의 두 번째 표본 — 채널은 채널에(§Mechanization Boundary). RESULT: `tracks/_meta/RESULT_2026-09-03_identity5-r4.md`.

## 말하지 않는 것
전달 ≠ 자발. r4 히트 9 중 훅 문구 밖 과제 고유 구체는 4. 운영자 결정: ⑤ 의 바는 유지(K3 채택 안 함), 훅은 채널로 출하, ⑤ 판정은 r5(K2 침묵 판별)에서.

## 검증
레인 13/13(r4 KP 6 · Bash 4 · noqa · 파싱실패 · 증거파일) · 되돌림(Edit 분기 제거 → Edit/Write 4 적색, Bash 생존) · 이 세션 라이브 발화(FIRE 행 + 컨텍스트) · pack files[] 2 · 4축 PASS.

## 잔여(이름)
Bash 경로는 old/new 가 없어 판별이 약함(sed 치환문 안 토큰은 미발화) · 세 JSON 훅 동시 발화 시 제안률 미측정 · 소비자 install 라이브 발화 미측정(snippet 5번째 항목, 사람 승인 머지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)