### PR TITLE
feat(proposal-hook): 사실 줄 채널 — 훅이 레인 존재·자기-레인·스캔 덮음을 확인해 싣고 없는 항목만 제안 (r8 1/5→4/5)

### DIFF
--- a/scripts/proposal_hook.sh
+++ b/scripts/proposal_hook.sh
@@ -69,6 +69,21 @@ case "$FP" in *scripts/*.sh|*templates/*.sh|scripts/*.sh|templates/*.sh) ;; *) e
 [ "${FLAG:-0}" = 1 ] || exit 0
 _D="${CLAUDE_PROJECT_DIR:-.}/.claude"; mkdir -p "$_D" 2>/dev/null
 printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "FIRE" "$FP" >> "$_D/.proposal_hook_events.tsv" 2>/dev/null
-MSG='🔎 방금 고치는 줄은 판정·가드·종료코드 줄이다(scripts/*.sh · templates/*.sh). 작업을 마친 뒤 사용자에게 «한 줄로» 제안해라 — "이거 known-pair(고친 케이스 + 반대 케이스)로 컨트롤 붙이고, degrade_direction_scan.sh 로 실패가 «통과»로 접히는 방향인지 볼까?" — 가능하면 이 파일·이 케이스의 실제 이름으로. 제안이지 실행이 아니다. 사용자가 고르게 둔다.'
+# ── Fact lines (r8, 2026-09-03): the two preconditions of the proposal are DETERMINISTIC, so the hook checks
+#    them itself and carries the result as a «사실» line — agents propose, solvers verify. Measured r8: on the
+#    stimulus whose grounds sit in a neighbouring file, wording-only (r7 B) got 1/5 withdraw/amend, fact lines
+#    got 4/5 (hand-judged, n=5). Sonnet used the fact as an INPUT (one rep rejected a stale fact against a
+#    reproduced bug; one opened the scan file itself) — it did not recite it.
+#    Self-lane case: editing `scripts/test_X_lanes.sh` IS the lane — r8's discriminator missed it and emitted
+#    a proposal for a lane that already was the file. Fixed here (F2 lane).
+_ROOT="${CLAUDE_PROJECT_DIR:-.}"; _BN=$(basename "$FP" .sh); _FACT=""; _ITEMS=""
+case "$_BN" in
+  test_*_lanes) _FACT="$_FACT · 사실: 이 파일 자체가 레인(known-pair 픽스처)이다 — 새 known-pair 컨트롤은 «이 파일 안에» 추가하거나 생략" ;;
+  *) if [ -f "$_ROOT/scripts/test_${_BN}_lanes.sh" ]; then _FACT="$_FACT · 사실: 이 파일의 레인 \`scripts/test_${_BN}_lanes.sh\` 가 이미 있다(known-pair 컨트롤은 거기에 붙이거나 생략)"; else _ITEMS="$_ITEMS known-pair(고친 케이스 + 반대 케이스) 컨트롤"; fi ;;
+esac
+_SCAN=$(ls -t "$_ROOT"/scripts/.degrade_scan_last_*.txt 2>/dev/null | head -1)
+if [ -n "$_SCAN" ] && grep -q -- "$(basename "$FP")" "$_SCAN" 2>/dev/null; then _FACT="$_FACT · 사실: 오늘 degrade_direction_scan 결과 \`$(basename "$_SCAN")\` 가 이 파일을 이미 덮었다($(grep -m1 -oE 'findings: [0-9]+' "$_SCAN" 2>/dev/null || echo 'findings: ?')) — 스캐너 통과이지 손 확인이 아니다"; else _ITEMS="$_ITEMS degrade_direction_scan.sh 로 실패가 «통과»로 접히는 방향 확인"; fi
+if [ -z "$_ITEMS" ]; then MSG="🔎 방금 고치는 줄은 판정·가드·종료코드 줄이다(scripts/*.sh · templates/*.sh)${_FACT}. 둘 다 이미 있으니 새 제안은 내지 말고, 작업을 마친 뒤 그 사실을 한 줄로만 말해라(형식: «확인 | basis: <위 사실>»)."
+else MSG="🔎 방금 고치는 줄은 판정·가드·종료코드 줄이다(scripts/*.sh · templates/*.sh)${_FACT}. 없는 것만 사용자에게 한 줄로 제안해라 —${_ITEMS} — 형식은 «제안: … | basis: <네가 확인한 근거 한 구절>». 가능하면 이 파일·이 케이스의 실제 이름으로. 제안이지 실행이 아니다."; fi
 python3 -c 'import json,sys; m=sys.argv[1]; print(json.dumps({"systemMessage":m,"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":m}}, ensure_ascii=False))' "$MSG" 2>/dev/null || exit 0
 exit 0

--- a/scripts/test_proposal_hook_lanes.sh
+++ b/scripts/test_proposal_hook_lanes.sh
@@ -20,5 +20,15 @@ exp "Bash redirect into docs (no)"            CLEAN '{"tool_name":"Bash","tool_i
 exp "Bash ls only (no target)"                CLEAN '{"tool_name":"Bash","tool_input":{"command":"ls scripts/ && [ -d scripts ] || exit 1"}}'
 exp "noqa exempts"                            CLEAN '{"tool_name":"Edit","tool_input":{"file_path":"/x/scripts/a.sh","old_string":"a","new_string":"exit 1  # noqa: proposal-hook"}}'
 exp "unparseable payload silent"              CLEAN 'not json'
+msg(){ printf '%s' "$2" | bash "$HDIR/proposal_hook.sh" 2>/dev/null; }
+fact(){ local label="$1" want="$2" payload="$3" got; got=$(msg x "$payload"); if printf '%s' "$got" | grep -q -- "$want"; then printf '  ✅ %-52s carries «%s»\n' "$label" "$want"; pass=$((pass+1)); else printf '  ❌ %-52s missing «%s»\n' "$label" "$want"; fail=$((fail+1)); fi; }
+mkdir -p "$T/scripts"; : > "$T/scripts/test_has_lane_lanes.sh"; printf 'scan of scripts/covered.sh\nfindings: 0\n' > "$T/scripts/.degrade_scan_last_2026-09-03.txt"
+E='{"tool_name":"Edit","tool_input":{"file_path":"/x/scripts/%s","old_string":"a","new_string":"[ -f x ] || exit 1"}}'
+fact "F1 lane exists → fact line, no known-pair item" "이미 있다" "$(printf "$E" has_lane.sh)"
+fact "F1b lane exists → scan item still proposed"     "degrade_direction_scan.sh 로" "$(printf "$E" has_lane.sh)"
+fact "F2 self-lane (test_*_lanes.sh) → fact line"     "이 파일 자체가 레인" "$(printf "$E" test_has_lane_lanes.sh)"
+fact "F3 scan covers file → fact line w/ findings"    "findings: 0" "$(printf "$E" covered.sh)"
+fact "F4 neither → both items proposed"               "known-pair(고친 케이스 + 반대 케이스) 컨트롤 degrade_direction_scan.sh" "$(printf "$E" bare.sh)"
+got=$(msg x "$(printf "$E" bare.sh)"); if printf '%s' "$got" | grep -q "사실:"; then echo "  ❌ F4-ctrl bare file must carry NO fact line"; fail=$((fail+1)); else echo "  ✅ F4-ctrl bare file carries no fact line (known-negative)"; pass=$((pass+1)); fi
 [ -f "$T/.claude/.proposal_hook_events.tsv" ] && [ "$(grep -c FIRE "$T/.claude/.proposal_hook_events.tsv")" -ge 5 ]; r=$?; [ $r = 0 ] && { echo "  ✅ evidence file carries a FIRE row per hit"; pass=$((pass+1)); } || { echo "  ❌ evidence file missing/short"; fail=$((fail+1)); }
 rm -rf "$T"; echo "[proposal-hook] $pass passed, $fail failed"; [ "$fail" -eq 0 ]


### PR DESCRIPTION
r8 실측(30런·손검증 전수, `RESULT_2026-09-03_identity5-r8.md`): 근거가 옆 파일에 있는 자극에서 문구만(r7 B) ⓑ+ⓒ 1/5 → 훅이 결정적 전제를 스스로 확인해 «사실:» 줄로 실으면 4/5 — 플로어는 사실을 복창하지 않고 입력으로 썼다(stale 기각 1·스캔 파일 직독 1). r8 훅 C 의 판별자가 «편집 대상이 레인 파일 자신» 을 못 본 결함을 자기-레인 사실 줄로 수리. 레인 +6 22/22 · HEAD 되돌림 시 정확히 F1~F4 만 적색. 발화/침묵 판정 무변화. ⓔ 라이브 미측정 — 머지 즉시 본 세션 훅에 실리고 팔 C 로 잰다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cf4qb1aYst7PQ5AXSm8kb5