### PR TITLE
fix(gates): A3 트리아지 — «파일 없음» 무음 접힘 3자리 수리 + 게이트 파일도 훅 사정거리 안으로 (팔 C wt2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,6 +234,7 @@
     "scripts/stale_clone_guard.sh",
     "scripts/proposal_hook.sh",
     "scripts/test_proposal_hook_lanes.sh",
+    "scripts/test_precommit_pointer_index_lanes.sh",
     "templates/settings.PreToolUse.snippet.json",
     "scripts/halffix_propagation_scan.sh",
     "scripts/test_halffix_lanes.sh",

--- a/scripts/proposal_hook.sh
+++ b/scripts/proposal_hook.sh
@@ -65,7 +65,7 @@ elif tn=="Bash":
 print(fp, flag)
 ' 2>/dev/null) || exit 0
 [ -n "${FP:-}" ] || exit 0
-case "$FP" in *scripts/*.sh|*templates/*.sh|scripts/*.sh|templates/*.sh) ;; *) exit 0 ;; esac
+case "$FP" in *scripts/*.sh|*templates/*.sh|scripts/*.sh|templates/*.sh|*/.git-hooks/*|.git-hooks/*) ;; *) exit 0 ;; esac   # .git-hooks/* has no .sh suffix — the gate files themselves were outside the filter (arm C wt2 2026-09-03: pre-commit edit, no FIRE)
 [ "${FLAG:-0}" = 1 ] || exit 0
 _D="${CLAUDE_PROJECT_DIR:-.}/.claude"; mkdir -p "$_D" 2>/dev/null
 printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "FIRE" "$FP" >> "$_D/.proposal_hook_events.tsv" 2>/dev/null

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -187,10 +187,22 @@ else
   fail=1
 fi
 
-# Bash surface: npm-shipped scripts + local bin wrappers + gate-chain infra
+# Bash surface: npm-shipped scripts + local bin wrappers + gate-chain infra.
+# `bin/fh-gate` · `bin/fh-run` · `bin/fh-goal` are named EXPLICITLY here (not a glob) and, unlike
+# most of this list, are not covered by files_manifest_shipping_check.sh either (only their
+# `.js` counterparts are declared in package.json files[]) — so a plain `[ -f "$f" ] || continue`
+# made their disappearance invisible to BOTH checks at once. Reproduced 2026-09-03: deleting
+# bin/fh-gate from a fixture tree left fail=0, no FAIL line, nothing. `scripts/*.sh` staying a
+# silent skip on a genuinely-empty glob is correct (that arm still has no non-glob name); the
+# named gate-chain-infra paths must not degrade the same way.
 for f in scripts/*.sh bin/fh-gate bin/fh-run bin/fh-goal \
          templates/regression_guard.sh templates/temper_check.sh templates/predelete_check.sh templates/.git-hooks/pre-commit; do
-  [ -f "$f" ] || continue
+  if [ ! -f "$f" ]; then
+    case "$f" in
+      *'*'*) continue ;;   # unmatched glob (nullglob off) — not a real path, legitimate skip
+      *) echo "FAIL  bash -n coverage: gate-chain infra file missing: $f"; fail=1; continue ;;
+    esac
+  fi
   check "bash -n $f" bash -n "$f"
 done
 
@@ -615,6 +627,7 @@ for _pair in \
   ".claude/soul_tenets.txt|scripts/test_marker_soul_tenet_lanes.sh" \
   "templates/.git-hooks/pre-commit|scripts/test_precommit_staged_drift_lanes.sh" \
   "templates/.git-hooks/pre-commit|scripts/test_marker_address_lanes.sh" \
+  "templates/.git-hooks/pre-commit|scripts/test_precommit_pointer_index_lanes.sh" \
   "scripts/residency_closure_scan.py|scripts/test_residency_closure_lanes.sh" \
   "scripts/reviewer_capability_corpus.tsv|scripts/test_reviewer_capability_conformance.sh" \
   "scripts/field_canon_preload.sh|scripts/test_field_canon_lanes.sh" \

--- a/scripts/sync-to-be.sh
+++ b/scripts/sync-to-be.sh
@@ -386,11 +386,18 @@ stamp_banner() {   # $1 = dst dir, $2 = src dir (for mtime restore)
 # (a real change becomes invisible inside the noise). Fix: strip before the compare, re-stamp
 # after. Content then matches on both sides and rsync moves only genuine changes.
 strip_banner() {   # $1 = dst dir
-  local dst="$1" f
+  local dst="$1" f skipped=0
   [ -d "$dst" ] || return 0
   while IFS= read -r f; do
     [ -n "$f" ] || continue
-    [ -f "$f" ] || continue   # vanished since the find snapshot — see stamp_banner's note above
+    # Same TOCTOU as stamp_banner's note above, and until this fix it was handled asymmetrically:
+    # stamp_banner counts+logs this exact case ("A silent skip hides a real failure ... must be
+    # visible rather than absorbed"), strip_banner silently `continue`d with no counter at all —
+    # reproduced 2026-09-03 (a file present in the find snapshot but removed before the -f test
+    # left zero trace). A file that stays un-stripped keeps its banner, so it never content-matches
+    # its source and the "265 files reported synced with nothing changed" churn this function exists
+    # to prevent returns for exactly that file, silently.
+    [ -f "$f" ] || { skipped=$((skipped + 1)); continue; }
     head -1 "$f" 2>/dev/null | grep -q 'MIRROR COPY' || continue
     # mtime must survive the strip: rsync's quick-check is size+mtime, so a strip that bumps
     # mtime to NOW makes every file look changed and the churn returns by another door.
@@ -398,8 +405,10 @@ strip_banner() {   # $1 = dst dir
       mv "$f.tmp$$" "$f"
     else
       rm -f "$f.tmp$$"
+      skipped=$((skipped + 1))
     fi
   done < <(find "$dst" -type f -name '*.md' ! -path '*/logs/*' 2>/dev/null)
+  [ "$skipped" -eq 0 ] || log "strip: $skipped file(s) not stripped in $dst (vanished mid-run or write failed)"
   return 0   # same status-leak shape as stamp_banner above — best-effort, never the script's verdict
 }
 

--- a/scripts/test_precommit_pointer_index_lanes.sh
+++ b/scripts/test_precommit_pointer_index_lanes.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# test_precommit_pointer_index_lanes.sh — known pair for templates/.git-hooks/pre-commit [Pointers]:
+# the Detail-pointer gate must read the STAGED blob, not the working tree. Found 2026-09-03 (arm C
+# wt2, A3 triage): `[ -f "$REPO_ROOT/$f" ] || continue` let a staged .md with a broken
+# `**Detail**: See §X` pointer land silently when the file was rm'd from disk after staging
+# (git commits the INDEX). Runs in a disposable shallow clone — never touches this checkout.
+#   P1 staged broken pointer, file rm'd from disk       → commit BLOCKED (❌ pointer line printed)
+#   N1 staged VALID pointer, file rm'd from disk        → [Pointers] block runs with no ❌ (control: index read works)
+#   N2 staged broken pointer, file still on disk        → BLOCKED (the pre-fix path also caught this — control)
+# Usage: bash scripts/test_precommit_pointer_index_lanes.sh [--hook <path>]   (default = templates/.git-hooks/pre-commit)
+set -u; ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; HOOK="$ROOT/templates/.git-hooks/pre-commit"
+[ "${1:-}" = "--hook" ] && HOOK="$2"
+T=$(mktemp -d); trap 'rm -rf "$T"' EXIT; pass=0; fail=0
+git clone -q --depth 1 "file://$ROOT" "$T/r" 2>/dev/null || { echo "❌ clone failed"; exit 10; }
+cd "$T/r" && git config user.email t@t && git config user.name t && mkdir -p .git/hooks && cp "$HOOK" .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+mkdir -p docs/lanefix; printf '## §Alive\ntext\n' > docs/lanefix/target.md; git add docs/lanefix/target.md; git -c core.hooksPath=/dev/null commit -qm base 2>/dev/null
+run_case(){ local label="$1" want="$2" ptr="$3" rm_after="$4"
+  printf '# probe\n\n> **Detail**: See `docs/lanefix/target.md §%s`\n' "$ptr" > docs/lanefix/probe.md
+  git add docs/lanefix/probe.md; [ "$rm_after" = 1 ] && rm -f docs/lanefix/probe.md
+  out=$(FH_SKIP_GATE_AXES=1 git commit -qm probe 2>&1); rc=$?
+  # Discriminate on the [Pointers] block itself, not on commit rc: the fixture clone carries no
+  # marker/manifest, so OTHER axes block every commit here — rc is not this lane's signal.
+  if printf '%s' "$out" | grep -q "Detail pointer §"; then got=BLOCK_PTR
+  elif printf '%s' "$out" | grep -q "unreadable from the index"; then got=BLOCK_INDEX
+  elif printf '%s' "$out" | grep -q "\[Pointers\]"; then got=PTR_OK
+  else got=PTR_NOT_RUN; fi
+  git reset -q --hard HEAD 2>/dev/null;  # noqa: destructive-op — disposable clone under mktemp git rm -q --cached docs/lanefix/probe.md 2>/dev/null; rm -f docs/lanefix/probe.md
+  if [ "$got" = "$want" ]; then printf '  ✅ %-48s %s\n' "$label" "$got"; pass=$((pass+1)); else printf '  ❌ %-48s %s (expected %s)\n' "$label" "$got" "$want"; fail=$((fail+1)); printf '%s\n' "$out" | grep -E "Pointers|❌" | head -4 | sed 's/^/       /'; fi; }
+echo "[precommit-pointer-index] hook=$HOOK"
+run_case "P1 broken pointer, staged then rm'd from disk"  BLOCK_PTR Ghost 1
+run_case "N1 valid pointer, staged then rm'd (index read)" PTR_OK    Alive 1
+run_case "N2 broken pointer, still on disk (old path too)" BLOCK_PTR Ghost 0
+echo "[precommit-pointer-index] $pass passed, $fail failed"; [ "$fail" -eq 0 ]

--- a/scripts/test_proposal_hook_lanes.sh
+++ b/scripts/test_proposal_hook_lanes.sh
@@ -18,6 +18,8 @@ exp "Bash sed -i no token anywhere (a3)"         CLEAN '{"tool_name":"Bash","too
 exp "Bash redirect into scripts/*.sh w/ token" HIT  '{"tool_name":"Bash","tool_input":{"command":"printf \"%s\\n\" x >> scripts/x.sh; grep -q y scripts/x.sh || exit 3"}}'
 exp "Bash redirect into docs (no)"            CLEAN '{"tool_name":"Bash","tool_input":{"command":"echo \"exit 1\" >> docs/a.md || exit 1"}}'
 exp "Bash ls only (no target)"                CLEAN '{"tool_name":"Bash","tool_input":{"command":"ls scripts/ && [ -d scripts ] || exit 1"}}'
+exp "G1 Edit templates/.git-hooks/pre-commit (no .sh)" HIT '{"tool_name":"Edit","tool_input":{"file_path":"/x/templates/.git-hooks/pre-commit","old_string":"  [ -f x ] || continue","new_string":"  [ -f x ] || { echo missing; PTR_FAIL=1; continue; }"}}'
+exp "G1-ctrl Edit .git-hooks docs-ish no token"        CLEAN '{"tool_name":"Edit","tool_input":{"file_path":"/x/templates/.git-hooks/pre-commit","old_string":"# note a","new_string":"# note b"}}'
 exp "noqa exempts"                            CLEAN '{"tool_name":"Edit","tool_input":{"file_path":"/x/scripts/a.sh","old_string":"a","new_string":"exit 1  # noqa: proposal-hook"}}'
 exp "unparseable payload silent"              CLEAN 'not json'
 msg(){ printf '%s' "$2" | bash "$HDIR/proposal_hook.sh" 2>/dev/null; }

--- a/templates/.git-hooks/pre-commit
+++ b/templates/.git-hooks/pre-commit
@@ -2658,14 +2658,25 @@ if [ -n "$MD_STAGED" ]; then
   echo "[Pointers] Detail-pointer resolution (staged markdown)..."
   PTR_FAIL=0; PTR_CHECKED=0
   for f in $MD_STAGED; do
-    [ -f "$REPO_ROOT/$f" ] || continue
-    fdir="$(cd "$REPO_ROOT/$(dirname "$f")" && pwd)"
-    blocks="$(awk '
+    # Read the STAGED blob, not the working-tree file. diff-filter=ACMR already guarantees $f
+    # exists in the index, but a file can be staged and then deleted or further-edited on disk
+    # before commit — `git commit` commits the INDEX, so `[ -f "$REPO_ROOT/$f" ] || continue`
+    # here silently dropped the check on a committed broken pointer (deleted-on-disk case) and,
+    # for a further-edited case, would have checked the wrong bytes entirely. Reproduced 2026-09-03:
+    # stage a .md with a broken `**Detail**: See §X` pointer, `rm` it from disk (index untouched),
+    # commit — PTR_CHECKED stayed 0 and the broken pointer landed silently.
+    _md_blob="$(git -C "$REPO_ROOT" show ":$f" 2>/dev/null)" || {
+      echo "  ❌ $f: staged (diff-filter=ACMR) but unreadable from the index — cannot verify its Detail pointers"
+      PTR_FAIL=1; continue
+    }
+    fdir="$(cd "$REPO_ROOT/$(dirname "$f")" 2>/dev/null && pwd)"
+    [ -n "$fdir" ] || fdir="$REPO_ROOT/$(dirname "$f")"
+    blocks="$(printf '%s\n' "$_md_blob" | awk '
       inblk && /^>/ { blk=blk" "$0; next }
       inblk { print blk; inblk=0; blk="" }
       /\*\*Detail\*\*: See/ { blk=$0; inblk=1; next }
       END { if(inblk) print blk }
-    ' "$REPO_ROOT/$f")"
+    ')"
     [ -z "$blocks" ] && continue
     while IFS= read -r block; do
       [ -z "$block" ] && continue


### PR DESCRIPTION
블라인드 소넷 워크트리 세션(⑤ 팔 C)이 `[ -f ] || continue` 줄별 판정으로 찾은 진짜 무음 접힘 3건: ⓐ **pre-commit [Pointers] 게이트 우회** — 스테이징 후 디스크에서 rm 하면 포인터 검사가 통째로 빠졌다 → `git show ":$f"` 인덱스 직독. 신규 레인 `test_precommit_pointer_index_lanes.sh`(일회용 얕은 클론): 새 훅 3/3, 옛 훅은 정확히 P1 만 실패(fail-before), N1/N2 컨트롤 ⓑ selfcheck bin/fh-* 명시경로 부재 무음 → FAIL(glob 스킵 유지) ⓒ sync-to-be strip_banner 카운터 비대칭. 덤: proposal_hook 필터가 .sh 만 봐서 게이트 파일 편집에 안 떴다(실측) → `.git-hooks/*` + 레인 G1. selfcheck 완주 PASS · lane_runner 무부채.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cf4qb1aYst7PQ5AXSm8kb5