### PR TITLE
fix(lanes): 팔 C 2·3차 — 레인 이중 실행 단일화 · 실패 분기 출력 덤프 · self-test 배선 · 이식성 (블라인드 소넷 6세션)

### DIFF
--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -3045,3 +3045,17 @@
   note: >-
     디스패치 기록이 아니라 귀속 불가 tally 의 기록. outcome 은 pending (60/40 게이트 오염 방지).
     두 번째 발생(N=2) — 세 번째면 tally 에 session id 를 싣는 기계화 후보(fh_signal_2026-09-02_dispatch-tally-attribution.md).
+- date: 2026-09-03
+  agent: fh-meta:expert
+  invoker: forge-harness-27 (Fable 5.1 거버너, 야간 위임)
+  task: 웹 QA 에이전트 프런티어(2025-2026) ↔ qasp 1/2/3막 대응표 + 2주 내 비저자 첫 완주 델타 5
+  count: 2
+  context: >-
+    운영자 «qasp 세계에 물어보고 개발 위탁, 다다음주 AX lobby QA 투입». 1차(기본 모델)는 API 529 로 조기 종료,
+    2차 sonnet 재시도 성공(검색 12·fetch 1·155,866 tokens). 읽기 전용, 회사 내부 정보 검색어 배제.
+  outcome: accepted
+  evidence: >-
+    tracks/qasp/frontier_webqa_map_2026-09-03.md — 강점 4(SOTA 일치·앞섬), 델타 5(난이도 캘리브레이션·FLAKY bin·
+    n=1 명기·backtracking 확인·MCP 표면), Open 3. 인용 URL 전부 회신에 실림.
+  note: >-
+    델타 1~3 은 비저자 첫 완주 세션 결과와 합쳐 qasp-dev 수리 임무로 간다. «없음(강점)» 4행은 재발명 차단 근거로 인용.

--- a/scripts/fh-gate.sh
+++ b/scripts/fh-gate.sh
@@ -745,9 +745,9 @@ fi
 cat "$PARSE_FILE"
 
 # B4: Write governance log — structured header only (clean YAML, no raw markdown)
-FINDINGS_A_LOG=$(grep -m 1 "^FH_FINDINGS_A:" "$PARSE_FILE" 2>/dev/null | awk '{print $2}' | tr -d '[:space:]' || echo "0")
-FINDINGS_B_LOG=$(grep -m 1 "^FH_FINDINGS_B:" "$PARSE_FILE" 2>/dev/null | awk '{print $2}' | tr -d '[:space:]' || echo "0")
-FINDINGS_N_LOG=$(grep -m 1 "^FH_FINDINGS_COUNT:" "$PARSE_FILE" 2>/dev/null | awk '{print $2}' | tr -d '[:space:]' || echo "0")
+FINDINGS_A_LOG=$(grep -m 1 "^FH_FINDINGS_A:" "$PARSE_FILE" 2>/dev/null | awk '{print $2}' | tr -d '[:space:]' || echo "0")  # portability-noqa: already ends in `|| echo "0"` (P1's own prescribed remedy) — the assignment cannot die under set -e
+FINDINGS_B_LOG=$(grep -m 1 "^FH_FINDINGS_B:" "$PARSE_FILE" 2>/dev/null | awk '{print $2}' | tr -d '[:space:]' || echo "0")  # portability-noqa: same as FINDINGS_A_LOG above
+FINDINGS_N_LOG=$(grep -m 1 "^FH_FINDINGS_COUNT:" "$PARSE_FILE" 2>/dev/null | awk '{print $2}' | tr -d '[:space:]' || echo "0")  # portability-noqa: same as FINDINGS_A_LOG above
 {
   printf -- "- timestamp: %s\n" "$TIMESTAMP"
   printf "  caller: %s\n" "$FH_CALLER"

--- a/scripts/gate_pathspec_check.sh
+++ b/scripts/gate_pathspec_check.sh
@@ -118,7 +118,7 @@ for pair in \
   "CATALOG.md|CHANGELOG.md|PATHSPEC covers CATALOG" \
   ".github/workflows/validate.yml|.github/dependabot.yml|PATHSPEC covers workflow 정의 (yml 만)" \
   "scripts/index_sync.py|scripts/notes.txt|PATHSPEC covers scripts/*.py" \
-  "package.json|package-lock.json|PATHSPEC covers package.json 이되 «리터럴» — lock 파일까지 삼키지 않는다"
+  "package.json|package-lock.json|PATHSPEC covers package.json 이되 «리터럴» — lock 파일까지 삼키지 않는다"  # portability-noqa: string literal fed to spec_matches()'s glob-case test, never read from disk — same reason as test_heavy_classifier_lanes.sh:106
 do
   IFS='|' read -r pos neg label <<< "$pair"
   ok=1

--- a/scripts/new_code_anchor_check.sh
+++ b/scripts/new_code_anchor_check.sh
@@ -507,8 +507,24 @@ def indirect(name, txt):
 # A subject may carry its own known-pair behind `--self-test`. That counts as an anchor ONLY if a
 # runner surface actually dispatches it — otherwise it is a lane suite nobody runs, which is
 # precisely the decoration this whole check is about. Two propositions, kept separate.
+# 🟥 BOTH forms are built via chr(), not written as literal text, and that is load-bearing here —
+# not just heredoc-paren-safety. `lane_runner_check.sh`'s OWN embedded-self-test SUBJECT scan
+# (`_st_names`) matches these same two forms ANYWHERE in a file's raw text, with no distinction
+# between "this file dispatches ITSELF on the flag" and "this file's source merely CONTAINS the
+# detection string as data" — a residual that file's own header names but leaves open. Until
+# 2026-09-03 the quoted form was one literal Python string (dquote, dash-dash-self-test, dquote,
+# all adjacent), which put that exact quoted substring in THIS file's own source — and
+# lane_runner_check.sh read it as this checker having an unwired embedded self-test of its own. It
+# does not: this file's real known-pair calibration is scripts/test_new_code_anchor_lanes.sh (lanes
+# N15/N16 exercise selftest_wired() directly), already wired and counted by that checker's PRIMARY
+# suite scan. Building the string from parts (never letting the quote and the flag text sit
+# adjacent in this file's own source) removes the false positive at its root instead of teaching
+# this checker a fake self-test mode just to satisfy a scan that was never measuring a real gap
+# here. 🟥 Do not "fix" this note by pasting the literal quoted form back in as an example — that
+# reproduces the exact substring this paragraph exists to keep out of the file.
 _CP = chr(41)
-SELFTEST_FORMS = ('"--self-test"', '--self-test' + _CP)
+_DQ = chr(34)
+SELFTEST_FORMS = (_DQ + '--self-test' + _DQ, '--self-test' + _CP)
 
 def selftest_wired(path):
     txt = read(path)

--- a/scripts/public_surface_scan_files.sh
+++ b/scripts/public_surface_scan_files.sh
@@ -135,7 +135,7 @@ fi
 # Wrong-set guard (challenger M6): a future npm --json shape change could yield a NON-empty but PARTIAL
 # file list (forEach iterates a renamed/nested structure without throwing) → files silently unscanned.
 # npm always ships package.json in the tarball; its absence means the parse got a wrong set → fail-closed.
-if ! printf '%s\n' "$FILES" | grep -qx "package.json"; then
+if ! printf '%s\n' "$FILES" | grep -qx "package.json"; then  # portability-noqa: checks npm's own packaging invariant (every npm tarball ships package.json), not a repo-specific fixture read from disk — true for any ported npm package
   echo "  ❌ published file set looks wrong — 'package.json' (always shipped) is absent from the parse."
   [ "${PUBLIC_SURFACE_OK:-0}" = "1" ] && { echo "  ⚠️  proceeding by PUBLIC_SURFACE_OK=1"; exit 0; }
   echo "     Fail-closed (possible npm --json shape change). Verify npm pack output or PUBLIC_SURFACE_OK=1."

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -1070,6 +1070,29 @@ else
   esac
 fi
 
+# prepublish_scope_note — an embedded --self-test subject lane_runner_check.sh flagged as having
+# no dispatcher anywhere (2026-09-03): its own 7-lane known-pair (does validate.yml still call
+# selfcheck.sh — known-positive/negative, missing-workflow, commented-out call, real call beside a
+# stale commented one, the real `run: |` block-scalar shape, and echo-mention-is-not-a-call) lives
+# behind `--self-test`, and nothing runs it. It IS invoked at publish time (package.json
+# `prepublishOnly`) — but that is `check()`, the gate's default argument-less mode, running for
+# real; it never exercises the gate's OWN calibration. Not in the `for _subj in ...` loop above:
+# its terminal line is `── N pass / M fail`, never 캘리브레이션, same reason capability_registry_check
+# and capability_effect_probe were pulled out of that loop. Direct dispatch instead, same shape as
+# capability_effect_probe.sh above — whole-line terminal verdict with a non-zero PASS count, so an
+# emptied suite cannot certify itself. Ships via package.json files[], so absence is FAIL, not SKIP.
+if [ ! -f scripts/prepublish_scope_note.sh ]; then
+  echo "FAIL  prepublish_scope_note.sh: missing — it ships via package.json files[], so absence is deletion, not package mode"
+  fail=1
+elif _out=$(bash scripts/prepublish_scope_note.sh --self-test < /dev/null 2>&1) \
+     && printf '%s\n' "$_out" | grep -qE '^  ── [1-9][0-9]* pass / 0 fail$'; then
+  echo "PASS  prepublish_scope_note.sh --self-test ($(printf '%s\n' "$_out" | grep -oE '[0-9]+ pass / [0-9]+ fail' | tail -1))"
+else
+  echo "FAIL  prepublish_scope_note.sh: --self-test failed or produced no terminal verdict line"
+  _show_failure "$_out"
+  fail=1
+fi
+
 # memory-link-check — the memory store is a GRAPH (memory_intent_recall.md: nodes=files,
 # edges=[[links]], recall walks one hop). Measured 2026-07-28: 50 of 872 edges pointed at a note
 # that existed under a different separator and 22 at nothing — a dead edge returns nothing and is

--- a/scripts/sim_isolated_run.sh
+++ b/scripts/sim_isolated_run.sh
@@ -46,6 +46,18 @@
 #       same clone, --tools "", no --restricted   → "🐿️"                  (memory PRESENT)
 #   One variable, opposite answers. ([[feedback_instrument_cannot_discriminate_hypotheses]])
 #
+# 🟥 THE SAME FLAG ALSO KILLS `act` MODE'S WRITE PATH — measured 2026-09-03, known-pair.
+#   `--restricted` ignores settings for PERMISSIONS too, not just memory, and `-p` has no TTY to
+#   ask a human — so `act`+`--no-harness` cannot Write/Edit AT ALL, regardless of what the model
+#   decides. Confirmed with one variable (`--restricted` on/off, same prompt, same --tools): Edit
+#   succeeds without it; with it every rep says "The edit was blocked — permission to write to
+#   file.txt wasn't granted." Deterministic, not a race — this is why a real run reads 5/5.
+#   ⇒ A "did not edit" result from `act --no-harness` is NOT evidence the base model chose not to
+#   write. Use `--no-harness` as an observe-mode control (memory presence, per the pair above)
+#   only — never to ask whether a write would have happened. Workaround not built: `--restricted`
+#   still honors an explicit `--settings <file>` (per `claude --help`), so a minimal file carrying
+#   only Write/Edit approval could restore act-mode fidelity here — filed, not implemented.
+#
 # 🟢 AND THE DEFECT IS REUSABLE AS AN INSTRUMENT. `--no-harness` answers a question this repo
 #   asks constantly and usually by eye: **does this behaviour come from FH, or would the base
 #   model have done it anyway?** Run the same prompt with and without the flag; a behaviour that

--- a/scripts/sync-from-be.sh
+++ b/scripts/sync-from-be.sh
@@ -592,7 +592,7 @@ resolve_mem_dir() {   # the first-loop half of sync-to-be.sh's resolution — it
   local root="$1" projects="$HOME/.claude/projects" tail d
   [ -d "$projects" ] || return 0
   tail="$(basename "$(dirname "$root")")-$(basename "$root")"
-  for d in "$projects"/*"$tail"/; do [ -d "${d}memory" ] && { printf '%s' "${d}memory"; return 0; }; done
+  for d in "$projects"/*"$tail"/; do [ -d "${d}memory" ] && { printf '%s' "${d}memory"; return 0; }; done  # portability-noqa: an unmatched glob leaves $d as the literal pattern; [ -d "${d}memory" ] on that bogus path is always false, so the loop no-ops safely — same protective effect as [ -e ] || continue, different shape
   return 0
 }
 MEM="$(resolve_mem_dir "$FH")"

--- a/scripts/test_degrade_scan_shell_probes.sh
+++ b/scripts/test_degrade_scan_shell_probes.sh
@@ -81,7 +81,7 @@ EOF
 cat > "$TMP/non_detections.sh" <<'EOF'
 #!/usr/bin/env bash
 # (a) integer sanitization — the PRESCRIBED remedy for the pipefail-fallback class, not the defect.
-count=$(grep -c pattern file)
+count=$(grep -c pattern file)  # portability-noqa: fixture text written by a quoted heredoc, never executed — statically grepped by degrade_direction_scan.sh only
 if [ "${count:-0}" -gt 0 ]; then echo "found"; fi
 # (b) SCOPE guards — "this run does not apply here" is not a claim that a check passed.
 [ -d "$HOME/projects" ] || exit 0
@@ -165,11 +165,11 @@ N=$(find /nope . -maxdepth 1 2>/dev/null | grep -c . || echo 0)
 M=$(git log --oneline 2>/dev/null | wc -l || echo 0)
 # WIDENED 2026-08-04. Every line below was INVISIBLE to the narrowed rule, and each was verified to
 # actually produce "0\n0" before being pinned here (line count measured, not assumed):
-P=$(cat /etc/hosts | grep -c . | tr -d ' ' || echo 0)   # transparent filter after the counter
-Q=$(grep -c "^nosuchline$" /etc/hosts 2>/dev/null | tr -d ' ' || echo 0)  # the PR #251 shape
-R=$(grep -Ec "^nosuchline$" /etc/hosts || echo 0)       # combined flag cluster -Ec
-S=$(grep --count "^nosuchline$" /etc/hosts || echo 0)   # long option
-T=$(grep -Fcx "nosuchline" /etc/hosts || echo 0)        # -Fcx
+P=$(cat /etc/hosts | grep -c . | tr -d ' ' || echo 0)   # transparent filter after the counter  # portability-noqa: fixture text, never executed
+Q=$(grep -c "^nosuchline$" /etc/hosts 2>/dev/null | tr -d ' ' || echo 0)  # the PR #251 shape  # portability-noqa: fixture text, never executed
+R=$(grep -Ec "^nosuchline$" /etc/hosts || echo 0)       # combined flag cluster -Ec  # portability-noqa: fixture text, never executed
+S=$(grep --count "^nosuchline$" /etc/hosts || echo 0)   # long option  # portability-noqa: fixture text, never executed
+T=$(grep -Fcx "nosuchline" /etc/hosts || echo 0)        # -Fcx  # portability-noqa: fixture text, never executed
 U=$(false | grep -c . | cat || echo 0)                  # trailing stage that always emits
 V=$(false | grep -c . | grep -v nosuch || echo 0)       # trailing grep whose pattern misses the "0"
 EOF
@@ -688,7 +688,7 @@ fi
 # flips to a hit — proves the exclusion is load-bearing for this specific fixture, not just
 # present somewhere in the file.
 _scan_reverted="$TMP/scan_reverted.sh"
-_excl_line=$(grep -n "grep -vE 'in \[A-Z_\]" "$SCAN" | head -1 | cut -d: -f1)
+_excl_line=$(grep -n "grep -vE 'in \[A-Z_\]" "$SCAN" | head -1 | cut -d: -f1)  # portability-noqa: this file has no `set -e` (top line 22 is `set -uo pipefail` only) and the next line already guards empty via -z
 if [ -z "$_excl_line" ]; then
   bad "C2-REVERT could not locate the exclusion line by its known text — fixture cannot run"
 else

--- a/scripts/test_files_manifest_shipping_lanes.sh
+++ b/scripts/test_files_manifest_shipping_lanes.sh
@@ -46,9 +46,9 @@ trap 'rm -rf "$LANE2_DIR"' EXIT
 cp package.json "$LANE2_DIR/package.json.orig"
 node -e '
   const fs = require("fs");
-  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));  // # portability-noqa: cwd is REPO_ROOT (line 18) -- this is the subject under tests own manifest, not a foreign fixture
   pkg.files.push("scripts/__test_fixture_does_not_exist__.sh");
-  fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+  fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");  // # portability-noqa: same as above -- writes back to the same repo-relative manifest it read
 '
 restore_pkg() { cp "$LANE2_DIR/package.json.orig" package.json; }
 
@@ -132,7 +132,7 @@ D6="$(fixture_dir)"
 mkdir -p "$D6/.git"
 node -e '
   const fs = require("fs");
-  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));  // # portability-noqa: cwd is REPO_ROOT -- seeds the fixture from the subject own real manifest, then mutates a copy
   pkg.files = ".";
   fs.writeFileSync(process.argv[1], JSON.stringify(pkg, null, 2) + "\n");
 ' "$D6/package.json"
@@ -152,7 +152,7 @@ D7="$(fixture_dir)"
 mkdir -p "$D7/.git"
 node -e '
   const fs = require("fs");
-  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));  // # portability-noqa: cwd is REPO_ROOT -- seeds the fixture from the subject own real manifest, then mutates a copy
   pkg.files.push("missing\nPASS\\t999 entries checked, 0 phantom, 0 unpacked");
   fs.writeFileSync(process.argv[1], JSON.stringify(pkg, null, 2) + "\n");
 ' "$D7/package.json"
@@ -175,7 +175,7 @@ mkdir -p "$D8/.git" "$D8/scripts_dummy"
 echo x > "$D8/scripts_dummy/foo.sh"
 node -e '
   const fs = require("fs");
-  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));  // # portability-noqa: cwd is REPO_ROOT -- seeds the fixture from the subject own real manifest, then mutates a copy
   pkg.files = ["scripts_dummy"];
   delete pkg.scripts.prepare;
   delete pkg.scripts.prepublishOnly;

--- a/scripts/test_heavy_classifier_lanes.sh
+++ b/scripts/test_heavy_classifier_lanes.sh
@@ -103,7 +103,7 @@ check carveout  "README.md"                  "npm-shipped surface — first-scre
 check carveout  "README.ko.md"               "language variants route the same way"
 check carveout  "README.zh-CN.md"            "🟥 5-char locale forms too — cross-family caught [a-z]{2} missing these"
 check uncovered ".claude/registry/README.md" "🟥 STILL UNCOVERED — in files[] but not root; named, not closed"
-check uncovered "package.json"               "files[] / version changes are unclassified"
+check uncovered "package.json"               "files[] / version changes are unclassified"  # portability-noqa: "package.json" is a string literal fed to classify()'s regex test, never opened from disk — a ported repo without this exact file still exercises the same classifier logic
 check uncovered ".github/workflows/validate.yml" "🟥 CI definition — changing what CI runs is unclassified"
 check uncovered "scripts/memory_link_check.py"   "🟥 .py is not .sh — shipped python is unclassified"
 

--- a/scripts/test_lane_runner_lanes.sh
+++ b/scripts/test_lane_runner_lanes.sh
@@ -30,18 +30,32 @@ mkfixture() { # $1 = dir
   printf '#!/usr/bin/env bash\nbash scripts/lane_runner_check.sh\n' > "$d/scripts/selfcheck.sh"
   printf '#!/usr/bin/env bash\n: orphan lane suite\n'  > "$d/scripts/test_orphan_lanes.sh"
 }
-run() { ( cd "$1" && bash scripts/lane_runner_check.sh 2>&1 ); }
-rcof() { ( cd "$1" && bash scripts/lane_runner_check.sh >/dev/null 2>&1; echo $? ); }
+# ONE execution per fixture, stdout AND rc from the SAME run — never two separate invocations.
+# Until 2026-09-03 this was split into run()+rcof(), each running lane_runner_check.sh on its own.
+# lane_runner_check.sh reads live filesystem/git state on every invocation (its own mktemp, a
+# `.git` up-chain walk, `git ls-files -z`, a python3 subprocess) and is not guaranteed to answer
+# identically twice in a row under CI resource pressure — so a call site combining `$(run "$D")`
+# with a SEPARATE `$(rcof "$D")` could silently pair stdout from one run with the exit code of a
+# DIFFERENT run. That produced an impossible-looking CI flake: rc=0 with the literal substring
+# "declared debt" absent from $out, even though every rc=0 exit path in lane_runner_check.sh
+# unconditionally prints that substring (traced exhaustively — see
+# tracks/_meta/armC_armC-wt2_report2_2026-09-03.md). Sets LRC_OUT/LRC_RC as globals: this file is
+# flat top-level (no `local` scoping across call sites), and bash functions cannot return two
+# values through their exit status alone.
+run_check() {   # $1 = fixture dir
+  LRC_OUT="$(cd "$1" && bash scripts/lane_runner_check.sh 2>&1)"; LRC_RC=$?
+}
 
 # ── L1 known-POSITIVE: an undeclared orphan suite must FAIL ───────────────────────────────────
 # Without this arm every lane below proves nothing: a checker that passed unconditionally would
 # satisfy all the "declaration suppresses it" lanes.
 D="$T/l1"; mkfixture "$D"
-out=$(run "$D"); rc=$(rcof "$D")
+run_check "$D"; out="$LRC_OUT"; rc="$LRC_RC"
 if [ "$rc" = "1" ] && printf '%s' "$out" | grep -q 'test_orphan_lanes.sh'; then
   ok "L1 known-positive: undeclared orphan suite → rc=1 and it is named"
 else
   bad "L1 known-positive did not fire (rc=$rc) — every lane below is meaningless without it"
+  printf '%s\n' "$out" | sed 's/^/       │ /'
 fi
 
 # ── IDX7 the FAIL path must EXECUTE the provenance note, not merely contain a call to it ──────
@@ -55,7 +69,7 @@ fi
 # It asserts the SHAPE of provenance, not the exact sentence: the fixture is a non-git dir, so the
 # honest answer there is the DISK one, and pinning the index wording would make the lane wrong.
 D="$T/idx7"; mkfixture "$D"
-out=$(run "$D")
+run_check "$D"; out="$LRC_OUT"
 if printf '%s' "$out" | grep -qE 'unbound variable|command not found|syntax error'; then
   bad "IDX7 the FAIL path errored: $(printf '%s' "$out" | grep -E 'unbound|not found|syntax' | head -1)"
 elif printf '%s' "$out" | grep -qE 'ⓘ|🟥'; then
@@ -67,41 +81,45 @@ fi
 # ── L2 NO-OP: no declaration file → behaviour is exactly the L1 behaviour ─────────────────────
 # This is the arm that protects THIS repo, which ships no company/ directory.
 D="$T/l2"; mkfixture "$D"
-out=$(run "$D")
+run_check "$D"; out="$LRC_OUT"
 if ! printf '%s' "$out" | grep -q 'lane_declarations'; then
   ok "L2 no-op: absent declaration file is silent (no mention in output)"
 else
   bad "L2 no-op: output mentions the declaration file when none exists"
+  printf '%s\n' "$out" | sed 's/^/       │ /'
 fi
 
 # ── L3 org EXEMPT suppresses the orphan ───────────────────────────────────────────────────────
 D="$T/l3"; mkfixture "$D"; mkdir -p "$D/company"
 printf 'exempt:\n  - test_orphan_lanes.sh   # org-owned, runs in the org CI only\n' > "$D/company/lane_declarations.yaml"
-out=$(run "$D"); rc=$(rcof "$D")
+run_check "$D"; out="$LRC_OUT"; rc="$LRC_RC"
 if [ "$rc" = "0" ] && printf '%s' "$out" | grep -q '1 exempt'; then
   ok "L3 org exempt: declared suite no longer fails the check (rc=0, counted exempt)"
 else
-  bad "L3 org exempt did not suppress (rc=$rc) — out: $(printf '%s' "$out" | tail -1)"
+  bad "L3 org exempt did not suppress (rc=$rc)"
+  printf '%s\n' "$out" | sed 's/^/       │ /'
 fi
 
 # ── L4 org DEBT suppresses AND is counted as debt ─────────────────────────────────────────────
 D="$T/l4"; mkfixture "$D"; mkdir -p "$D/company"
 printf 'debt:\n  - test_orphan_lanes.sh\n' > "$D/company/lane_declarations.yaml"
-out=$(run "$D"); rc=$(rcof "$D")
+run_check "$D"; out="$LRC_OUT"; rc="$LRC_RC"
 if [ "$rc" = "0" ] && printf '%s' "$out" | grep -q 'declared debt'; then
   ok "L4 org debt: declared suite suppressed and reported as debt"
 else
   bad "L4 org debt did not land (rc=$rc)"
+  printf '%s\n' "$out" | sed 's/^/       │ /'
 fi
 
 # ── L5 VISIBILITY: an org-declared list must never look like this repo's own zero ─────────────
 D="$T/l5"; mkfixture "$D"; mkdir -p "$D/company"
 printf 'debt:\n  - test_orphan_lanes.sh\n' > "$D/company/lane_declarations.yaml"
-out=$(run "$D")
+run_check "$D"; out="$LRC_OUT"
 if printf '%s' "$out" | grep -q 'org-declared'; then
   ok "L5 visibility: output names the org file and its counts"
 else
   bad "L5 visibility: org declarations are invisible in the output"
+  printf '%s\n' "$out" | sed 's/^/       │ /'
 fi
 
 # ── L6 FAIL-CLOSED on an unparseable file ─────────────────────────────────────────────────────
@@ -109,41 +127,46 @@ fi
 # render UNMEASURED as ZERO, and it would do so on the arm where a fork is relying on the file.
 D="$T/l6"; mkfixture "$D"; mkdir -p "$D/company"
 printf 'exempt:\n  this line is not an entry\n' > "$D/company/lane_declarations.yaml"
-out=$(run "$D"); rc=$(rcof "$D")
+run_check "$D"; out="$LRC_OUT"; rc="$LRC_RC"
 if [ "$rc" = "2" ] && printf '%s' "$out" | grep -q 'UNMEASURED'; then
   ok "L6 fail-closed: unparseable declaration file → rc=2 and says UNMEASURED"
 else
   bad "L6 fail-closed FAILED (rc=$rc) — a malformed file was read as 'no declarations'"
+  printf '%s\n' "$out" | sed 's/^/       │ /'
 fi
 
 # ── L6b control for L6: the SAME orphan tree with a WELL-FORMED file must not exit 2 ──────────
 # Without this, L6 would also pass on a checker that exits 2 for any declaration file at all.
 D="$T/l6b"; mkfixture "$D"; mkdir -p "$D/company"
 printf 'exempt:\n  - test_orphan_lanes.sh\n' > "$D/company/lane_declarations.yaml"
-if [ "$(rcof "$D")" != "2" ]; then
+run_check "$D"; out="$LRC_OUT"; rc="$LRC_RC"
+if [ "$rc" != "2" ]; then
   ok "L6b control: a well-formed file does NOT trip the fail-closed arm"
 else
   bad "L6b control: every declaration file exits 2 — L6 proved nothing"
+  printf '%s\n' "$out" | sed 's/^/       │ /'
 fi
 
 # ── L7 unknown section is a parse failure, not a silent skip ──────────────────────────────────
 D="$T/l7"; mkfixture "$D"; mkdir -p "$D/company"
 printf 'allowed:\n  - test_orphan_lanes.sh\n' > "$D/company/lane_declarations.yaml"
-out=$(run "$D")
-if [ "$(rcof "$D")" = "2" ] && printf '%s' "$out" | grep -q "unknown section"; then
+run_check "$D"; out="$LRC_OUT"; rc="$LRC_RC"
+if [ "$rc" = "2" ] && printf '%s' "$out" | grep -q "unknown section"; then
   ok "L7 unknown section → rc=2 and names the section"
 else
-  bad "L7 unknown section was tolerated — a typo'd header would silently declare nothing"
+  bad "L7 unknown section was tolerated — a typo'd header would silently declare nothing (rc=$rc)"
+  printf '%s\n' "$out" | sed 's/^/       │ /'
 fi
 
 # ── L8 the same name in both sections is ambiguous, not last-wins ─────────────────────────────
 D="$T/l8"; mkfixture "$D"; mkdir -p "$D/company"
 printf 'exempt:\n  - test_orphan_lanes.sh\ndebt:\n  - test_orphan_lanes.sh\n' > "$D/company/lane_declarations.yaml"
-out=$(run "$D")
-if [ "$(rcof "$D")" = "2" ] && printf '%s' "$out" | grep -q "both exempt and debt"; then
+run_check "$D"; out="$LRC_OUT"; rc="$LRC_RC"
+if [ "$rc" = "2" ] && printf '%s' "$out" | grep -q "both exempt and debt"; then
   ok "L8 same suite in both sections → rc=2 (ambiguous, not silently resolved)"
 else
-  bad "L8 double declaration was silently resolved"
+  bad "L8 double declaration was silently resolved (rc=$rc)"
+  printf '%s\n' "$out" | sed 's/^/       │ /'
 fi
 
 # ── L9 a stale entry WARNS but does not block (same voice as upstream DEBT hygiene) ───────────
@@ -151,20 +174,23 @@ fi
 # would train forks to delete the file, which costs more than a stale line.
 D="$T/l9"; mkfixture "$D"; mkdir -p "$D/company"
 printf 'exempt:\n  - test_orphan_lanes.sh\n  - test_deleted_lanes.sh\n' > "$D/company/lane_declarations.yaml"
-out=$(run "$D"); rc=$(rcof "$D")
+run_check "$D"; out="$LRC_OUT"; rc="$LRC_RC"
 if [ "$rc" = "0" ] && printf '%s' "$out" | grep -q 'test_deleted_lanes.sh'; then
   ok "L9 stale entry: warns and names it, does not block (rc=0)"
 else
   bad "L9 stale entry handling wrong (rc=$rc)"
+  printf '%s\n' "$out" | sed 's/^/       │ /'
 fi
 
 # ── L10 comments and blank lines are not entries ──────────────────────────────────────────────
 D="$T/l10"; mkfixture "$D"; mkdir -p "$D/company"
 printf '# org lane declarations\n\nexempt:\n\n  - test_orphan_lanes.sh   # reason lives here\n' > "$D/company/lane_declarations.yaml"
-if [ "$(rcof "$D")" = "0" ]; then
+run_check "$D"; out="$LRC_OUT"; rc="$LRC_RC"
+if [ "$rc" = "0" ]; then
   ok "L10 comments/blank lines tolerated (a file people can annotate)"
 else
-  bad "L10 a commented, spaced file failed to parse"
+  bad "L10 a commented, spaced file failed to parse (rc=$rc)"
+  printf '%s\n' "$out" | sed 's/^/       │ /'
 fi
 
 # ── L11/L12 embedded --self-test subjects (found→extend, 2026-08-14) ──────────────────────────
@@ -186,7 +212,7 @@ mkfixture_clean() { # $1 = dir
 # L11 known-POSITIVE: an unwired --self-test subject is reported, advisory (rc stays 0).
 D="$T/l11"; mkfixture_clean "$D"
 printf '#!/usr/bin/env bash\n[ "${1:-}" = "--self-test" ] && { echo ok; exit 0; }\n' > "$D/scripts/orphan_probe.sh"
-out=$(run "$D"); rc=$(rcof "$D")
+run_check "$D"; out="$LRC_OUT"; rc="$LRC_RC"
 if [ "$rc" = "0" ] && printf '%s' "$out" | grep -q 'orphan_probe'; then
   ok "L11 known-positive: unwired --self-test subject named, advisory (rc=0)"
 else
@@ -206,7 +232,7 @@ for _subj in orphan_probe; do
   bash "scripts/$_subj.sh" --self-test
 done
 SC
-out=$(run "$D")
+run_check "$D"; out="$LRC_OUT"
 if ! printf '%s' "$out" | grep -q 'orphan_probe'; then
   ok "L12 known-negative: --self-test subject wired via _subj for-loop is not reported"
 else
@@ -228,7 +254,7 @@ bash scripts/lane_runner_check.sh
 bash scripts/test_ok_lanes.sh
 bash scripts/orphan_probe.sh --self-test >/dev/null 2>&1
 SC
-out=$(run "$D")
+run_check "$D"; out="$LRC_OUT"
 if ! printf '%s' "$out" | grep -q 'orphan_probe'; then
   ok "L13 known-negative: --self-test subject wired via direct dispatch is not reported"
 else
@@ -262,7 +288,7 @@ cat > "$D/scripts/orphan_probe.sh" <<'SUBJ'
 #   bash scripts/orphan_probe.sh --self-test        # known-pair calibration
 [ "${1:-}" = "--self-test" ] && { echo ok; exit 0; }
 SUBJ
-out=$(run "$D"); rc=$(rcof "$D")
+run_check "$D"; out="$LRC_OUT"; rc="$LRC_RC"
 if [ "$rc" = "0" ] && printf '%s' "$out" | grep -q 'orphan_probe'; then
   ok "L14 known-positive: subject's own usage comment is not a caller — still reported unwired"
 else
@@ -280,7 +306,7 @@ bash scripts/lane_runner_check.sh
 bash scripts/test_ok_lanes.sh
 # historical note: we used to run `bash scripts/orphan_probe.sh --self-test` here, removed 2026-01-01
 SC
-out=$(run "$D"); rc=$(rcof "$D")
+run_check "$D"; out="$LRC_OUT"; rc="$LRC_RC"
 if [ "$rc" = "0" ] && printf '%s' "$out" | grep -q 'orphan_probe'; then
   ok "L15 known-positive: a commented-out dispatch in another file is not a caller"
 else
@@ -302,7 +328,7 @@ usage() { echo "run: bash scripts/orphan_probe.sh --self-test"; }
 [ "${1:-}" = "--self-test" ] && { echo ok; exit 0; }
 usage
 SUBJ
-out=$(run "$D"); rc=$(rcof "$D")
+run_check "$D"; out="$LRC_OUT"; rc="$LRC_RC"
 if [ "$rc" = "0" ] && printf '%s' "$out" | grep -q 'orphan_probe'; then
   ok "L16 known-positive: a subject's own NON-comment self-reference is not a caller"
 else
@@ -323,36 +349,36 @@ fi
 # ([[feedback_not_found_is_not_zero_family]]).
 _ISN=$(mktemp); sed -n '/^index_source_note()/,/^}/p' "$CHECK" > "$_ISN"
 if ! grep -q 'UNMEASURED' "$_ISN"; then
-  no "IDX-harness — index_source_note did not extract from $CHECK (lanes would measure nothing)"
+  bad "IDX-harness — index_source_note did not extract from $CHECK (lanes would measure nothing)"
 else
   # shellcheck disable=SC1090
   . "$_ISN"
   o=$(index_source_note "index")
   printf '%s' "$o" | grep -q "INDEX 기준" && printf '%s' "$o" | grep -q "스테이징" \
     && ok "IDX1 index mode names the index AND the staging remedy" \
-    || no "IDX1 index mode note missing/incomplete: $o"
+    || bad "IDX1 index mode note missing/incomplete: $o"
 
   o=$(index_source_note "nongit")
   printf '%s' "$o" | grep -q "DISK" && ok "IDX2 nongit mode says DISK, not index" \
-                                    || no "IDX2 nongit: $o"
+                                    || bad "IDX2 nongit: $o"
 
   o=$(index_source_note "UNMEASURED")
   printf '%s' "$o" | grep -q "못 셌다" && ok "IDX3 UNMEASURED says «could not count», not «none»" \
-                                       || no "IDX3 UNMEASURED: $o"
+                                       || bad "IDX3 UNMEASURED: $o"
 
   # 🟥 CONTROL — an unknown/empty mode must stay SILENT. Inventing a source line for a state the
   # check does not recognise is worse than saying nothing, and without this lane the function
   # could pass IDX1–IDX3 while emitting the index sentence for every input.
   o=$(index_source_note "")
   [ -z "$o" ] && ok "IDX4 control — empty mode is silent (no invented provenance)" \
-              || no "IDX4 control — empty mode spoke: $o"
+              || bad "IDX4 control — empty mode spoke: $o"
 
   # 🟥 CONTROL 2 — the three states must be DISTINGUISHABLE from each other, not merely non-empty.
   a=$(index_source_note "index"); b=$(index_source_note "nongit"); c=$(index_source_note "UNMEASURED")
   if [ "$a" != "$b" ] && [ "$b" != "$c" ] && [ "$a" != "$c" ]; then
     ok "IDX5 control — the three states produce three different sentences"
   else
-    no "IDX5 control — states collapsed into the same sentence"
+    bad "IDX5 control — states collapsed into the same sentence"
   fi
 fi
 rm -f "$_ISN"
@@ -362,7 +388,7 @@ if sed -n '/lane suite(s) with no runner and no declaration/,/Fix by ONE of/p' "
      | grep -q 'index_source_note'; then
   ok "IDX6 the note is CALLED on the FAIL path (not just defined)"
 else
-  no "IDX6 index_source_note is defined but the FAIL path does not call it"
+  bad "IDX6 index_source_note is defined but the FAIL path does not call it"
 fi
 
 echo "----"

--- a/scripts/test_mapped_tracks_lanes.sh
+++ b/scripts/test_mapped_tracks_lanes.sh
@@ -53,7 +53,7 @@ EXPECT=3   # the_bible + pmh-dev + qasp ; _meta and _audit excluded
 
 # PREMISE — if the worktree can already see the fixtures, every verdict below is meaningless.
 NAIVE_WT=0
-for d in "$TMP/wt"/tracks/*/; do [ -d "$d" ] || continue; case "$(basename "$d")" in _*) continue;; esac; NAIVE_WT=$((NAIVE_WT+1)); done
+for d in "$TMP/wt"/tracks/*/; do [ -d "$d" ] || continue; case "$(basename "$d")" in _*) continue;; esac; NAIVE_WT=$((NAIVE_WT+1)); done  # portability-noqa: the [ -d "$d" ] || continue guard is on this SAME line (right after 'do'), not the next 1-2 lines the P8 scanner checks
 [ "$NAIVE_WT" -lt "$EXPECT" ] \
   && ok "premise: a naive cwd count from the worktree sees $NAIVE_WT of $EXPECT — the blindness is real here" \
   || ng "premise BROKEN: worktree already sees $NAIVE_WT — fixture does not reproduce the defect"

--- a/scripts/test_node_check_lanes.sh
+++ b/scripts/test_node_check_lanes.sh
@@ -42,43 +42,43 @@ echo "── node-check lanes ──"
 # LANE 1 (S3-1) — NOT a git repo. The git-hook floor cannot be installed here at all, so it is
 # N/A, not missing. Reporting it would be an unfixable notice repeating every session forever.
 mkdir -p "$TMP/nogit"
-out="$(run "$TMP/nogit" "$TMP/s1" FH_MACHINE_ID=nogitbox)"
+out="$(run "$TMP/nogit" "$TMP/s1" FH_MACHINE_ID=nogitbox)"; rc=$?
 # POSITIVE CONTROL: assert what MUST appear alongside what must not. Absence-only lanes are
 # satisfied by a script that prints nothing at all — an `exit 0` stub passed lanes 1, 4 and 7
 # (cross-family mutation 2026-07-30), so each now pins an expected utterance too.
 case "$out" in
-  *"Missing mechanical floor"*) bad "lane1 non-git: must NOT claim a missing floor (N/A, unfixable)" "$out" ;;
+  *"Missing mechanical floor"*) bad "lane1 non-git: must NOT claim a missing floor (N/A, unfixable)" "rc=$rc | $out" ;;
   *"first session for this clone"*) ok "lane1 non-git: N/A on the git floor, but still reports the node event" ;;
-  *) bad "lane1 non-git: silent — a stub would pass this lane" "$out" ;;
+  *) bad "lane1 non-git: silent — a stub would pass this lane" "rc=$rc | $out" ;;
 esac
 
 # LANE 2 (S3-2) — hooks exist but belong to another framework (husky/pre-commit). Executable ≠ FH's
 # gate. Silence here is the exact accident this check was built for: FH gates absent, machine quiet.
 mk_git_hub "$TMP/husky" no
-out="$(run "$TMP/husky" "$TMP/s2" FH_MACHINE_ID=huskybox)"
+out="$(run "$TMP/husky" "$TMP/s2" FH_MACHINE_ID=huskybox)"; rc=$?
 case "$out" in
   *"Missing mechanical floor"*) ok "lane2 foreign hooks: FH gate absence reported" ;;
-  *) bad "lane2 foreign hooks: non-FH hooks were accepted as FH floors" "$out" ;;
+  *) bad "lane2 foreign hooks: non-FH hooks were accepted as FH floors" "rc=$rc | $out" ;;
 esac
 
 # LANE 3 (S3-3) — Mode D user on a FRESH clone: companion store present, settings.local.json absent
 # (it is gitignored, so a clone never has it). This is the MEASURED 2026-07-30 incident. Must speak.
 mk_git_hub "$TMP/moded" yes
 mkdir -p "$TMP/companion/.git"
-out="$(run "$TMP/moded" "$TMP/s3" FH_MACHINE_ID=modedbox BE_DIR="$TMP/companion")"
+out="$(run "$TMP/moded" "$TMP/s3" FH_MACHINE_ID=modedbox BE_DIR="$TMP/companion")"; rc=$?
 case "$out" in
   *companion-load*) ok "lane3 fresh Mode D clone: companion-load absence surfaced" ;;
-  *) bad "lane3 fresh Mode D clone: SILENT — the measured incident would recur" "$out" ;;
+  *) bad "lane3 fresh Mode D clone: SILENT — the measured incident would recur" "rc=$rc | $out" ;;
 esac
 
 # LANE 4 (M2-4) — public non-Mode-D user: no companion store anywhere. The companion item must not
 # appear, or the majority path gets a false positive for a feature it does not use.
 mk_git_hub "$TMP/public" yes
-out="$(run "$TMP/public" "$TMP/s4" FH_MACHINE_ID=publicbox)"
+out="$(run "$TMP/public" "$TMP/s4" FH_MACHINE_ID=publicbox)"; rc=$?
 case "$out" in
-  *companion-load*) bad "lane4a non-Mode-D: companion item shown to a user with no store" "$out" ;;
+  *companion-load*) bad "lane4a non-Mode-D: companion item shown to a user with no store" "rc=$rc | $out" ;;
   *"first session for this clone"*) ok "lane4a non-Mode-D: companion absent, node event still reported" ;;
-  *) bad "lane4a non-Mode-D: silent — a stub would pass this lane" "$out" ;;
+  *) bad "lane4a non-Mode-D: silent — a stub would pass this lane" "rc=$rc | $out" ;;
 esac
 
 # LANE 4b (S4-1) — CLAUDE.local.md is Claude Code's STANDARD local-override file; anyone may keep
@@ -86,9 +86,9 @@ esac
 # gets a companion notice every session forever (state-based emission makes it permanent, not
 # one-shot). Only the binding INSIDE the file counts.
 printf '# my local notes\nuse tabs not spaces\n' > "$TMP/public/CLAUDE.local.md"
-out="$(run "$TMP/public" "$TMP/s4b" FH_MACHINE_ID=publicbox)"
+out="$(run "$TMP/public" "$TMP/s4b" FH_MACHINE_ID=publicbox)"; rc=$?
 case "$out" in
-  *companion-load*) bad "lane4b plain CLAUDE.local.md: existence alone classified the user as Mode D" "$out" ;;
+  *companion-load*) bad "lane4b plain CLAUDE.local.md: existence alone classified the user as Mode D" "rc=$rc | $out" ;;
   *) ok "lane4b plain CLAUDE.local.md: not treated as a Mode D signal" ;;
 esac
 
@@ -106,10 +106,10 @@ for binding in 'BE_DIR=/x/store' 'companion store: ~/notes' '컴패니언 스토
                'vault: ~/vaults/notes' 'gbrain ingest target: ~/gbrain' 'backend: obsidian'; do
   i=$((i+1))
   printf '# local\n%s\n' "$binding" > "$TMP/public/CLAUDE.local.md"
-  out="$(run "$TMP/public" "$TMP/s4c$i" FH_MACHINE_ID=publicbox)"
+  out="$(run "$TMP/public" "$TMP/s4c$i" FH_MACHINE_ID=publicbox)"; rc=$?
   case "$out" in
     *companion-load*) ok "lane4c.$i Mode D detected via: $binding" ;;
-    *) bad "lane4c.$i binding present but Mode D not detected: $binding" "$out" ;;
+    *) bad "lane4c.$i binding present but Mode D not detected: $binding" "rc=$rc | $out" ;;
   esac
 done
 rm -f "$TMP/public/CLAUDE.local.md"
@@ -136,24 +136,24 @@ done
 # exist and working hooks read as missing.
 mk_git_hub "$TMP/wt" yes
 git -C "$TMP/wt" worktree add -q "$TMP/wt_linked" -b lane7 2>/dev/null
-out="$(run "$TMP/wt_linked" "$TMP/s7" FH_MACHINE_ID=wtbox)"
+out="$(run "$TMP/wt_linked" "$TMP/s7" FH_MACHINE_ID=wtbox)"; rc=$?
 case "$out" in
-  *"Missing mechanical floor"*) bad "lane7 worktree: false missing-floor (hooks resolve to the main gitdir)" "$out" ;;
+  *"Missing mechanical floor"*) bad "lane7 worktree: false missing-floor (hooks resolve to the main gitdir)" "rc=$rc | $out" ;;
   *"first session for this clone"*) ok "lane7 worktree: hooks resolved correctly, node event reported" ;;
-  *) bad "lane7 worktree: silent — a stub would pass this lane" "$out" ;;
+  *) bad "lane7 worktree: silent — a stub would pass this lane" "rc=$rc | $out" ;;
 esac
 
 # LANE 8 (M3-3) — python3 unavailable: the companion verdict is UNMEASURED, never silently "fine".
 # Simulated by a PATH with no python3, for a Mode D hub (so the check is applicable).
 mk_git_hub "$TMP/nopy" yes
 mkdir -p "$TMP/emptybin" "$TMP/companion2/.git"
-out="$(PATH="$TMP/emptybin:/usr/bin:/bin" run "$TMP/nopy" "$TMP/s8" FH_MACHINE_ID=nopybox BE_DIR="$TMP/companion2")"
+out="$(PATH="$TMP/emptybin:/usr/bin:/bin" run "$TMP/nopy" "$TMP/s8" FH_MACHINE_ID=nopybox BE_DIR="$TMP/companion2")"; rc=$?
 if command -v python3 >/dev/null 2>&1 && [ -x /usr/bin/python3 ]; then
   ok "lane8 skipped: /usr/bin/python3 exists so absence cannot be simulated via PATH"
 else
   case "$out" in
     *UNMEASURED*|*unmeasured*) ok "lane8 no python3: reported UNMEASURED, not silence" ;;
-    *) bad "lane8 no python3: absence read as pass" "$out" ;;
+    *) bad "lane8 no python3: absence read as pass" "rc=$rc | $out" ;;
   esac
 fi
 
@@ -249,11 +249,11 @@ else
   fi
   git -C "$_dn" fetch -q origin >/dev/null 2>&1
   _h0="$(git -C "$_dn" rev-parse HEAD)"
-  run "$_dn" "$_ap_root/s_a" >/dev/null 2>&1
+  _out_a="$(run "$_dn" "$_ap_root/s_a" 2>&1)"; _rc_a=$?
   if [ "$(git -C "$_dn" rev-parse HEAD)" != "$_h0" ]; then
     ok "lane10-a APPLY: consented + on default branch → fast-forwarded"
   else
-    bad "lane10-a APPLY: consented + on default branch did NOT fast-forward (feature inert — every refuse lane below is then vacuous)" "$_h0"
+    bad "lane10-a APPLY: consented + on default branch did NOT fast-forward (feature inert — every refuse lane below is then vacuous)" "before=$_h0 rc=$_rc_a out=$_out_a"
   fi
 
   # b — the envelope. Never applies off the default branch, and NEVER switches branches.
@@ -267,13 +267,13 @@ else
   # version of this lane asserted only those two and stayed green against a defeated envelope —
   # decorative. The tip that must not move is the CURRENT branch's own.
   _f0="$(git -C "$_dn" rev-parse feat-x)"
-  run "$_dn" "$_ap_root/s_b" >/dev/null 2>&1
+  _out_b="$(run "$_dn" "$_ap_root/s_b" 2>&1)"; _rc_b=$?
   if [ "$(git -C "$_dn" rev-parse "$_DEF")" = "$_m0" ] \
      && [ "$(git -C "$_dn" rev-parse feat-x)" = "$_f0" ] \
      && [ "$(git -C "$_dn" branch --show-current)" = "feat-x" ]; then
     ok "lane10-b ENVELOPE: off default branch → no apply on EITHER branch, no switch"
   else
-    bad "lane10-b ENVELOPE: a branch tip moved off the default branch — the shared-checkout hazard" "main=$_m0->$(git -C "$_dn" rev-parse "$_DEF") feat-x=$_f0->$(git -C "$_dn" rev-parse feat-x) branch=$(git -C "$_dn" branch --show-current)"
+    bad "lane10-b ENVELOPE: a branch tip moved off the default branch — the shared-checkout hazard" "main=$_m0->$(git -C "$_dn" rev-parse "$_DEF") feat-x=$_f0->$(git -C "$_dn" rev-parse feat-x) branch=$(git -C "$_dn" branch --show-current) rc=$_rc_b out=$_out_b"
   fi
   git -C "$_dn" switch -q "$_DEF" >/dev/null 2>&1
 
@@ -285,29 +285,29 @@ p=sys.argv[1]; s=open(p,encoding='utf-8').read()
 open(p,'w',encoding='utf-8').write(re.sub(r'\nstanding_consent:\n(?:  .*\n|    .*\n)*', '\n', s, count=1))
 PYX
   _h1="$(git -C "$_dn" rev-parse HEAD)"
-  run "$_dn" "$_ap_root/s_c" >/dev/null 2>&1
+  _out_c="$(run "$_dn" "$_ap_root/s_c" 2>&1)"; _rc_c=$?
   [ "$(git -C "$_dn" rev-parse HEAD)" = "$_h1" ] \
     && ok "lane10-c NO-GRANT: absent standing_consent → no apply" \
-    || bad "lane10-c NO-GRANT: applied without a grant" "$_h1"
+    || bad "lane10-c NO-GRANT: applied without a grant" "before=$_h1 rc=$_rc_c out=$_out_c"
 
   # d — expired lease. A lease nobody enforces is not a lease.
   cp "$_ap_root/uap.bak" "$_dn/tracks/_meta/user_adaptation_profile.md"
   sed -i.bak2 's/expires: [0-9-]*/expires: 2020-01-01/' "$_dn/tracks/_meta/user_adaptation_profile.md"
   _h2="$(git -C "$_dn" rev-parse HEAD)"
-  run "$_dn" "$_ap_root/s_d" >/dev/null 2>&1
+  _out_d="$(run "$_dn" "$_ap_root/s_d" 2>&1)"; _rc_d=$?
   [ "$(git -C "$_dn" rev-parse HEAD)" = "$_h2" ] \
     && ok "lane10-d EXPIRED: past-dated lease → no apply" \
-    || bad "lane10-d EXPIRED: applied under an expired lease" "$_h2"
+    || bad "lane10-d EXPIRED: applied under an expired lease" "before=$_h2 rc=$_rc_d out=$_out_d"
   cp "$_ap_root/uap.bak" "$_dn/tracks/_meta/user_adaptation_profile.md"
 
   # e — divergence. --ff-only must refuse rather than absorb, and local work must survive.
   (cd "$_dn" && echo local-only > mine.txt && git add -A && git commit -qm diverge) >/dev/null 2>&1
   _h3="$(git -C "$_dn" rev-parse HEAD)"
-  run "$_dn" "$_ap_root/s_e" >/dev/null 2>&1
+  _out_e="$(run "$_dn" "$_ap_root/s_e" 2>&1)"; _rc_e=$?
   if [ "$(git -C "$_dn" rev-parse HEAD)" = "$_h3" ] && [ -f "$_dn/mine.txt" ]; then
     ok "lane10-e DIVERGED: ff refused, local commit survives"
   else
-    bad "lane10-e DIVERGED: local history was moved or lost" "$_h3 -> $(git -C "$_dn" rev-parse HEAD)"
+    bad "lane10-e DIVERGED: local history was moved or lost" "$_h3 -> $(git -C "$_dn" rev-parse HEAD) rc=$_rc_e out=$_out_e"
   fi
 
   # f — WRONG CLASS. The refusal that the other three arms structurally cannot produce.
@@ -367,7 +367,7 @@ PYX
   if [ "$_h5" = "$(git -C "$_dn" rev-parse "origin/$_DEF")" ]; then
     bad "lane10-f VACUOUS: clone is not behind origin, so 'no apply' proves nothing" "$_h5"
   fi
-  run "$_dn" "$_ap_root/s_f" >/dev/null 2>&1
+  _out_f="$(run "$_dn" "$_ap_root/s_f" 2>&1)"; _rc_f=$?
   _filewide=0
   bash "$FH_REPO/scripts/consent_registry_check.sh" \
        "$_dn/tracks/_meta/consent_classes.yaml" \
@@ -375,9 +375,9 @@ PYX
   if [ "$(git -C "$_dn" rev-parse HEAD)" = "$_h5" ] && [ "$_filewide" = "0" ]; then
     ok "lane10-f WRONG-CLASS: another class granted, this one only in prose → no apply (file-wide check still 0)"
   elif [ "$_filewide" != "0" ]; then
-    bad "lane10-f VACUOUS: the fixture broke the file-wide verdict (rc=$_filewide), so it re-tests lane10-c's axis, not the class join" "rebuild the fixture so the bare check returns 0"
+    bad "lane10-f VACUOUS: the fixture broke the file-wide verdict (rc=$_filewide), so it re-tests lane10-c's axis, not the class join" "rebuild the fixture so the bare check returns 0 | run_rc=$_rc_f run_out=$_out_f"
   else
-    bad "lane10-f WRONG-CLASS: applied on a class that was never granted" "$_h5 -> $(git -C "$_dn" rev-parse HEAD)"
+    bad "lane10-f WRONG-CLASS: applied on a class that was never granted" "$_h5 -> $(git -C "$_dn" rev-parse HEAD) run_rc=$_rc_f run_out=$_out_f"
   fi
   cp "$_ap_root/uap.bak" "$_dn/tracks/_meta/user_adaptation_profile.md"
 
@@ -387,10 +387,10 @@ PYX
   (cd "$_ap_root/up" && echo newer3 > f.txt && git commit -qam ahead3) >/dev/null 2>&1
   git -C "$_dn" fetch -q origin >/dev/null 2>&1
   _h4="$(git -C "$_dn" rev-parse HEAD)"
-  run "$_dn" "$_ap_root/s_f" >/dev/null 2>&1
+  _out_ctrl="$(run "$_dn" "$_ap_root/s_f" 2>&1)"; _rc_ctrl=$?
   [ "$(git -C "$_dn" rev-parse HEAD)" != "$_h4" ] \
     && ok "lane10-CONTROL: apply arm still fires after the refuse arms (instrument alive)" \
-    || bad "lane10-CONTROL: apply arm went inert — the refuse lanes above prove nothing" "$_h4"
+    || bad "lane10-CONTROL: apply arm went inert — the refuse lanes above prove nothing" "before=$_h4 rc=$_rc_ctrl out=$_out_ctrl"
 fi
 rm -rf "$_ap_root"
 

--- a/scripts/test_package_coverage_lanes.sh
+++ b/scripts/test_package_coverage_lanes.sh
@@ -36,7 +36,9 @@ trap 'rm -rf "$TMP"' EXIT
 
 pass=0; fail=0; skipped=0
 ok()  { printf '  ✅ %s\n' "$1"; pass=$((pass+1)); }
-bad() { printf '  ❌ %s\n' "$1"; fail=$((fail+1)); }
+# $2 (optional) = the actual stdout/stderr/rc this case caught — printed so a red lane in CI is
+# diagnosable without re-running it by hand. Truncated/flattened like the node-check lanes' bad().
+bad() { printf '  ❌ %s\n' "$1"; [ -n "${2:-}" ] && printf '     got: %s\n' "$(printf '%s' "$2" | tr '\n' '|' | cut -c1-220)"; fail=$((fail+1)); }
 # A skip is COUNTED and reported. An uncounted skip is how "could not run" becomes indistinguishable
 # from "ran and passed" in the summary line — measured on this very suite in review round 2, where a
 # broken git produced "7 passed, 0 failed" and exit 0 while the real-worktree claim went untested.
@@ -70,23 +72,30 @@ make_tree() { # make_tree <dir> <git_shape> <cover_target:yes|no> [omit_manifest
 }
 
 run_tree() { bash "$1/scripts/package_coverage_check.sh" 2>&1; }
-rc_tree()  { bash "$1/scripts/package_coverage_check.sh" >/dev/null 2>&1; echo $?; }
+# 🟥 no more rc_tree(): it used to re-run the subject a SECOND time just to get $? (`out=$(run_tree
+# ...); rc=$(rc_tree ...)` — two executions of the same script, so a nondeterministic subject could
+# report an (out, rc) pair that never co-occurred in either real run). Every call site below now
+# does `out=$(run_tree ...); rc=$?` — one execution, $? read off THAT command substitution.
 
 # Assert a POSITIVE outcome, never merely the absence of the SKIP line. Cross-family review caught
 # the first draft here: it checked only that `SKIP  package-coverage` was missing, so a checker that
 # exited 1 on every worktree — the opposite defect, equally broken — would have passed the lane that
 # exists to prove the worktree path works. "Did not say the wrong thing" is not "did the right
 # thing"; a lane phrased as a negative can only ever fail one way.
+# Both functions below stash their single execution's output/rc in _LAST_OUT/_LAST_RC (not `local`,
+# deliberately — the caller reads them straight off the one run instead of re-invoking the subject a
+# second time just to build a diagnostic string, which would be the same two-executions-for-one-
+# verdict shape the L3–L7 dual-execution fix below removes).
 ran_clean() { # ran_clean <dir> -> 0 iff the check actually ran AND reported a clean scan
-  local d="$1" o rc
-  o=$(bash "$d/scripts/package_coverage_check.sh" 2>&1); rc=$?
-  [ "$rc" -eq 0 ] && printf '%s' "$o" | grep -q 'PASS  package-coverage' \
-    && ! printf '%s' "$o" | grep -q 'SKIP  package-coverage'
+  local d="$1"
+  _LAST_OUT=$(bash "$d/scripts/package_coverage_check.sh" 2>&1); _LAST_RC=$?
+  [ "$_LAST_RC" -eq 0 ] && printf '%s' "$_LAST_OUT" | grep -q 'PASS  package-coverage' \
+    && ! printf '%s' "$_LAST_OUT" | grep -q 'SKIP  package-coverage'
 }
 caught_defect() { # caught_defect <dir> -> 0 iff the check FOUND the planted omission
-  local d="$1" o rc
-  o=$(bash "$d/scripts/package_coverage_check.sh" 2>&1); rc=$?
-  [ "$rc" -eq 1 ] && printf '%s' "$o" | grep -q 'scripts/helper.sh'
+  local d="$1"
+  _LAST_OUT=$(bash "$d/scripts/package_coverage_check.sh" 2>&1); _LAST_RC=$?
+  [ "$_LAST_RC" -eq 1 ] && printf '%s' "$_LAST_OUT" | grep -q 'scripts/helper.sh'
 }
 # A CLEAN LANE ALONE PROVES NOTHING ABOUT THE WORKTREE PATH. Cross-family review round 2 demonstrated
 # this by EXECUTION: it replaced the subject with a mutant that printed `PASS  package-coverage`
@@ -99,11 +108,11 @@ wt_pair() { # wt_pair <label> <dir> <git_shape>
   local label="$1" d="$2" shape="$3"
   make_tree "$d" "$shape" yes
   if ! ran_clean "$d"; then
-    bad "$label — clean leg: did not run to a PASS ($(run_tree "$d" | head -1))"; return
+    bad "$label — clean leg: did not run to a PASS (rc=$_LAST_RC)" "$_LAST_OUT"; return
   fi
   make_tree "$d" "$shape" no        # identical tree, files[] no longer covers the referenced path
   if ! caught_defect "$d"; then
-    bad "$label — DEFECT leg: planted omission not caught, so the clean PASS proved nothing"; return
+    bad "$label — DEFECT leg: planted omission not caught, so the clean PASS proved nothing (rc=$_LAST_RC)" "$_LAST_OUT"; return
   fi
   ok "$label"
 }
@@ -171,15 +180,20 @@ else
     esac
   }
   mkdir -p "$TMP/emptytpl"
-  if git "${GIT_ISO[@]}" -C "$TMP/realrepo" init -q --template="$TMP/emptytpl" . >/dev/null 2>&1 \
+  # The whole fixture-build chain runs as ONE group so its combined stdout+stderr lands in one
+  # variable instead of /dev/null — a failed build used to report only "could not be built", with
+  # no way to tell which of the four steps broke or why.
+  _l1b_ok=1
+  _l1b_out="$( { git "${GIT_ISO[@]}" -C "$TMP/realrepo" init -q --template="$TMP/emptytpl" . \
      && _gitdir_ok \
-     && git "${GIT_ISO[@]}" -C "$TMP/realrepo" commit -q --allow-empty -m init >/dev/null 2>&1 \
-     && git "${GIT_ISO[@]}" -C "$TMP/realrepo" worktree add -q --detach "$TMP/realwt" >/dev/null 2>&1 \
-     && [ -f "$TMP/realwt/.git" ]; then
+     && git "${GIT_ISO[@]}" -C "$TMP/realrepo" commit -q --allow-empty -m init \
+     && git "${GIT_ISO[@]}" -C "$TMP/realrepo" worktree add -q --detach "$TMP/realwt" \
+     && [ -f "$TMP/realwt/.git" ]; } 2>&1 )" || _l1b_ok=0
+  if [ "$_l1b_ok" -eq 1 ]; then
     wt_pair "L1-b real \`git worktree add\` (.git is a genuine gitdir pointer): scans for real" \
             "$TMP/realwt" none          # the REAL .git file is already in place; do not overwrite it
   else
-    bad "L1-b git IS installed but the real-worktree fixture could not be built — the claim was testable and was not tested"
+    bad "L1-b git IS installed but the real-worktree fixture could not be built — the claim was testable and was not tested" "$_l1b_out"
   fi
 fi
 
@@ -190,11 +204,11 @@ wt_pair "L2 ordinary checkout (.git is a DIR): scans for real — both legs" "$T
 # The widening from -d to -e must not cost the legitimate skip. An installed npm package has no
 # .git of either kind; making it fail there would fire on every consumer running `npm test`.
 make_tree "$TMP/l3" none yes
-out=$(run_tree "$TMP/l3"); rc=$(rc_tree "$TMP/l3")
+out=$(run_tree "$TMP/l3"); rc=$?
 if printf '%s' "$out" | grep -q 'SKIP  package-coverage' && [ "$rc" -eq 0 ]; then
   ok "L3 package mode (no .git): still skips, exit 0"
 else
-  bad "L3 package mode (no .git): expected SKIP+0, got rc=$rc / $(printf '%s' "$out" | head -1)"
+  bad "L3 package mode (no .git): expected SKIP+0, got rc=$rc" "$out"
 fi
 
 # ── L4 · a checkout with no manifest is UNMEASURED, not clean ────────────────────────
@@ -203,42 +217,42 @@ fi
 # file list cannot be read, which is "cannot measure", not "nothing to measure". An anchor that
 # pins the wrong direction is worse than no anchor — it makes the hole look deliberate.
 make_tree "$TMP/l4" dir yes omit
-out=$(run_tree "$TMP/l4"); rc=$(rc_tree "$TMP/l4")
+out=$(run_tree "$TMP/l4"); rc=$?
 if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q 'UNMEASURED, not clean'; then
   ok "L4 .git present but no package.json: FAILS as unmeasured, not a clean skip"
 else
-  bad "L4 no package.json: expected exit 1 (unmeasured), got rc=$rc / $(printf '%s' "$out" | head -1)"
+  bad "L4 no package.json: expected exit 1 (unmeasured), got rc=$rc" "$out"
 fi
 
 # ── L5/L6 · KNOWN PAIR ───────────────────────────────────────────────────────────────
 # Same tree twice; the ONLY difference is whether files[] covers the referenced path.
 # L5 known-POSITIVE: referenced, exists, not shipped -> must FAIL.
 make_tree "$TMP/l5" dir no
-out=$(run_tree "$TMP/l5"); rc=$(rc_tree "$TMP/l5")
+out=$(run_tree "$TMP/l5"); rc=$?
 if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q 'scripts/helper.sh'; then
   ok "L5 known-positive (referenced ∧ exists ∧ ¬shipped): FAIL, names the path"
 else
-  bad "L5 known-positive: expected exit 1 naming scripts/helper.sh, got rc=$rc"
+  bad "L5 known-positive: expected exit 1 naming scripts/helper.sh, got rc=$rc" "$out"
 fi
 
 # L6 known-NEGATIVE: identical, but the path is in files[] -> must PASS.
 make_tree "$TMP/l6" dir yes
-out=$(run_tree "$TMP/l6"); rc=$(rc_tree "$TMP/l6")
+out=$(run_tree "$TMP/l6"); rc=$?
 if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q 'PASS  package-coverage'; then
   ok "L6 known-negative (same tree, path shipped): PASS"
 else
-  bad "L6 known-negative: expected exit 0 PASS, got rc=$rc"
+  bad "L6 known-negative: expected exit 0 PASS, got rc=$rc" "$out"
 fi
 
 # ── L7 · the impossible-zero guard is not reachable by an empty files[] ──────────────
 # A manifest with no shipped docs must report the extractor as broken, not print a pass.
 mkdir -p "$TMP/l7/scripts"; cp "$SUBJECT" "$TMP/l7/scripts/"; mkdir -p "$TMP/l7/.git"
 printf '{"files":[]}\n' > "$TMP/l7/package.json"
-out=$(run_tree "$TMP/l7"); rc=$(rc_tree "$TMP/l7")
+out=$(run_tree "$TMP/l7"); rc=$?
 if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q 'the check broke, it did not pass'; then
   ok "L7 zero shipped docs: reported as broken extractor, not as a pass"
 else
-  bad "L7 zero shipped docs: expected exit 1 'check broke', got rc=$rc"
+  bad "L7 zero shipped docs: expected exit 1 'check broke', got rc=$rc" "$out"
 fi
 
 echo

--- a/scripts/test_pipe_verdict_guard_lanes.sh
+++ b/scripts/test_pipe_verdict_guard_lanes.sh
@@ -45,9 +45,9 @@ expect() {
 echo "[pipe-verdict-guard] known pairs"
 echo "-- R1: PIPESTATUS under zsh (deterministic) --"
 # The exact shape emitted 6× in this project, including twice on 2026-07-31.
-expect "R1 the measured shape"            HIT   'bash x.sh | tail -5; echo "exit=${PIPESTATUS[0]}"'
-expect "R1 any index"                     HIT   'a | b; rc=${PIPESTATUS[1]}'
-expect "R1 inside a larger command"       HIT   'cd /r && npm t | tail; E=${PIPESTATUS[0]}; echo $E'
+expect "R1 the measured shape"            HIT   'bash x.sh | tail -5; echo "exit=${PIPESTATUS[0]}"'  # portability-noqa: fixture string fed to pipe_verdict_guard.sh for static analysis, never executed by this shell
+expect "R1 any index"                     HIT   'a | b; rc=${PIPESTATUS[1]}'  # portability-noqa: same as above
+expect "R1 inside a larger command"       HIT   'cd /r && npm t | tail; E=${PIPESTATUS[0]}; echo $E'  # portability-noqa: same as above
 # zsh's own spelling is correct here and must never be flagged.
 expect "R1 zsh spelling is CLEAN"         CLEAN 'a | b; rc=$pipestatus[1]'
 
@@ -83,7 +83,7 @@ echo x | grep -q y
 rc=$?'
 # B: zsh accepts `$PIPESTATUS[0]` without braces; the brace-anchored regex missed it.
 expect "B PIPESTATUS without braces"      HIT   'a | b; rc=$PIPESTATUS[0]'
-expect "B braced form still caught"       HIT   'a | b; rc=${PIPESTATUS[0]}'
+expect "B braced form still caught"       HIT   'a | b; rc=${PIPESTATUS[0]}'  # portability-noqa: fixture string fed to pipe_verdict_guard.sh for static analysis, never executed by this shell
 
 echo "-- D: statement-continuation flatten + wrapped filter (leg-C MED round, 2026-08-01) --"
 # The blanket newline→`;` rewrite broke the CONTINUATION shapes: a newline after `|`/`&&` or a
@@ -167,7 +167,7 @@ echo "-- C: delivery channel (closes N=8 — detection without delivery is decor
 # NAMED RESIDUAL (cross-family LOW, accepted): $(…) capture strips NUL bytes, so a mutant emitting
 # NUL+JSON would pass C1. The producer's hits text is static ASCII+⚠️ with no NUL source, so the
 # lane does not pay for a byte-exact harness; revisit only if the producer ever emits dynamic bytes.
-HIT_CMD='bash x.sh | tail -5; echo "exit=${PIPESTATUS[0]}"'
+HIT_CMD='bash x.sh | tail -5; echo "exit=${PIPESTATUS[0]}"'  # portability-noqa: fixture string fed to the guard for static analysis, never executed by this shell
 payload() { python3 -c 'import json,sys; print(json.dumps({"tool_name":"Bash","tool_input":{"command":sys.argv[1]}}))' "$1"; }
 
 # All C lanes measure ONE invocation: stdout, stderr, and exit code from the same run (a pair of

--- a/scripts/test_runner_surface_index_lanes.sh
+++ b/scripts/test_runner_surface_index_lanes.sh
@@ -229,6 +229,7 @@ if printf '%s' "$OUT" | grep -q "$PROBE_SUITE" && [ "$RC" -ne 0 ]; then
   ok "L1 untracked .github/workflows runner does NOT certify a suite as WIRED"
 else
   bad "L1 untracked workflow still certifies the suite (rc=$RC) — D-5 is live"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
 fi
 
 D="$(_lrc_fixture lrc_tracked_wf workflow 1)" || { echo "FAIL harness: fixture build"; exit 2; }
@@ -237,6 +238,7 @@ if [ "$RC" -eq 0 ] && ! printf '%s' "$OUT" | grep -q "no runner and no declarati
   ok "L2 TRACKED workflow runner still certifies WIRED (no over-block)"
 else
   bad "L2 over-block: a runner that IS in the index was dropped (rc=$RC)"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
 fi
 
 D="$(_lrc_fixture lrc_untracked_hook hook 0)" || { echo "FAIL harness: fixture build"; exit 2; }
@@ -245,6 +247,7 @@ if printf '%s' "$OUT" | grep -q "$PROBE_SUITE" && [ "$RC" -ne 0 ]; then
   ok "L3 untracked templates/.git-hooks runner does NOT certify WIRED (second spelling)"
 else
   bad "L3 the hook glob still resolves against disk — the repair was partial (rc=$RC)"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
 fi
 
 D="$(_lrc_fixture lrc_untracked_script script 0)" || { echo "FAIL harness: fixture build"; exit 2; }
@@ -253,6 +256,7 @@ if printf '%s' "$OUT" | grep -q "$PROBE_SUITE" && [ "$RC" -ne 0 ]; then
   ok "L4 untracked scripts/*.sh runner does NOT certify WIRED (third spelling)"
 else
   bad "L4 the scripts glob still resolves against disk (rc=$RC)"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
 fi
 
 # ── L5: UNMEASURED is not zero ────────────────────────────────────────────────────────────────
@@ -264,6 +268,7 @@ if [ "$RC" -ne 0 ] && printf '%s' "$OUT" | grep -qi "UNMEASURED"; then
   ok "L5 empty index in tracked territory → UNMEASURED, refuses to report zero runners"
 else
   bad "L5 an empty index was folded into a verdict (rc=$RC)"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
 fi
 
 # ── L6: no index at all (an unpacked npm tarball) degrades to disk, LABELLED ──────────────────
@@ -287,6 +292,7 @@ if [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q "$PROBE_SUBJ"; then
   ok "L7 untracked .github/workflows runner does NOT certify a script as having a caller"
 else
   bad "L7 untracked workflow still counts as a caller (rc=$RC) — D-5 is live"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
 fi
 
 D="$(_rat_fixture rat_tracked_wf workflow 1)" || { echo "FAIL harness: fixture build"; exit 2; }
@@ -295,6 +301,7 @@ if [ "$RC" -eq 0 ]; then
   ok "L8 TRACKED workflow runner still counts as a caller (no over-block)"
 else
   bad "L8 over-block: a runner that IS in the index was dropped (rc=$RC)"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
 fi
 
 D="$(_rat_fixture rat_untracked_hook hook 0)" || { echo "FAIL harness: fixture build"; exit 2; }
@@ -303,6 +310,7 @@ if [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q "$PROBE_SUBJ"; then
   ok "L9 untracked templates/.git-hooks runner does NOT count as a caller (second spelling)"
 else
   bad "L9 the hook glob still resolves against disk — the repair was partial (rc=$RC)"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
 fi
 
 # ══ FAIL-BEFORE for D-5 itself ════════════════════════════════════════════════════════════════
@@ -396,6 +404,7 @@ else
     ok "L16 fail-before: the first repair PASSES with a totally broken git (defect reproduced)"
   else
     bad "L16 fail-before did NOT reproduce (rc=$RC) — L12/L13 then prove nothing"
+    printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
   fi
 fi
 
@@ -410,6 +419,7 @@ else
     ok "L17 fail-before: the first repair PASSES with a totally broken git (defect reproduced)"
   else
     bad "L17 fail-before did NOT reproduce (rc=$RC) — L14/L15 then prove nothing"
+    printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
   fi
 fi
 
@@ -425,6 +435,7 @@ if [ "$RC" -ne 0 ] && printf '%s' "$OUT" | grep -q "$PROBE_SUITE"; then
   ok "L18 a TRACKED hidden .github/workflows/.x.yml does NOT certify WIRED (glob hides dotfiles)"
 else
   bad "L18 the index surface is WIDER than the glob.glob it replaced (rc=$RC)"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
 fi
 
 D="$(_lrc_fixture lrc_dothook dothook 1)" || { echo "FAIL harness: fixture build"; exit 2; }
@@ -433,6 +444,7 @@ if [ "$RC" -ne 0 ] && printf '%s' "$OUT" | grep -q "$PROBE_SUITE"; then
   ok "L19 a TRACKED hidden file inside the .git-hooks DOT-DIRECTORY does NOT certify WIRED"
 else
   bad "L19 dotfile parity was fixed in one spelling only (rc=$RC)"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
 fi
 
 D="$(_rat_fixture rat_dothook dothook 1)" || { echo "FAIL harness: fixture build"; exit 2; }
@@ -441,6 +453,7 @@ if [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q "$PROBE_SUBJ"; then
   ok "L20 caller-ratchet: a TRACKED hidden runner does NOT count as a caller"
 else
   bad "L20 caller-ratchet's surface is wider than glob.glob (rc=$RC)"
+  printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
 fi
 
 echo "── fail-before: dotfile guard (removed, executed) ────────────────────────────────────────"
@@ -454,6 +467,7 @@ else
     ok "L21 fail-before: without the guard the hidden runner DOES certify (defect reproduced)"
   else
     bad "L21 fail-before did NOT reproduce (rc=$RC) — L18/L19 then prove nothing"
+    printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
   fi
 fi
 
@@ -468,6 +482,7 @@ else
     ok "L22 fail-before: without the guard the hidden runner DOES count as a caller"
   else
     bad "L22 fail-before did NOT reproduce (rc=$RC) — L20 then proves nothing"
+    printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
   fi
 fi
 
@@ -527,6 +542,7 @@ else
     ok "L26 fail-before: reading the body from disk certifies the unstaged line (defect reproduced)"
   else
     bad "L26 fail-before did NOT reproduce (rc=$RC) — L24 then proves nothing"
+    printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
   fi
 fi
 
@@ -542,6 +558,7 @@ else
     ok "L27 fail-before: reading the body from disk certifies the unstaged line (defect reproduced)"
   else
     bad "L27 fail-before did NOT reproduce (rc=$RC) — L25 then proves nothing"
+    printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
   fi
 fi
 
@@ -588,6 +605,7 @@ else
     ok "L30 fail-before: the isfile filter silently drops the tracked runner (defect reproduced)"
   else
     bad "L30 fail-before did NOT reproduce (rc=$RC) — L28 then proves nothing"
+    printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
   fi
 fi
 
@@ -603,6 +621,7 @@ else
     ok "L31 fail-before: the isfile filter silently drops the tracked runner (defect reproduced)"
   else
     bad "L31 fail-before did NOT reproduce (rc=$RC) — L29 then proves nothing"
+    printf '%s\n' "$OUT" | tail -3 | sed 's/^/       /'
   fi
 fi
 

--- a/scripts/test_script_caller_ratchet_lanes.sh
+++ b/scripts/test_script_caller_ratchet_lanes.sh
@@ -118,7 +118,7 @@ rm -rf "$d"
 d="$(mkfix)"
 printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/orphan.sh"
 printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
-rc="$(rcof "$d")"; o="$(run "$d")"
+o="$(run "$d")"; rc=$?
 if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q 'scripts/orphan.sh'; then
   ok "L1 known-positive — undeclared zero-caller blocks (exit 1) and is NAMED"
 else
@@ -143,7 +143,7 @@ printf '#!/usr/bin/env bash\necho old\n' > "$d/scripts/olddebt.sh"
 printf '#!/usr/bin/env bash\necho new\n' > "$d/scripts/newdebt.sh"
 printf 'exempt:\nbaseline:\n  - scripts/olddebt.sh   # grandfathered measured debt\n' > "$d/scripts/caller_zero_baseline.txt"
 printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\nbash scripts/olddebt.sh\n' > "$d/.github/workflows/ci.yml"
-rc="$(rcof "$d")"; o="$(run "$d")"
+o="$(run "$d")"; rc=$?
 if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q 'scripts/newdebt.sh' \
    && ! printf '%s' "$o" | grep -q 'FAIL.*olddebt'; then
   ok "L3 identity-keyed — count unchanged (1→1) yet the NEW callerless script blocks"
@@ -203,7 +203,7 @@ rm -rf "$d"
 d="$(mkfix)"
 printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/orphan.sh"
 printf '#!/usr/bin/env bash\n#   bash scripts/orphan.sh   <- usage example\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
-rc="$(rcof "$d")"; o="$(run "$d")"
+o="$(run "$d")"; rc=$?
 if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q 'scripts/orphan.sh'; then
   ok "L8 mention≠invocation — a commented usage line does not certify a caller"
 else
@@ -240,7 +240,7 @@ printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/daily.sh"
 printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/autopilot.sh"
 printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
 printf '%s\n' '<plist>' '<!-- point this at scripts/daily.sh instead -->' '<string>/x/scripts/autopilot.sh</string>' '</plist>' > "$d/scripts/x.plist"
-rc="$(rcof "$d")"; o="$(run "$d")"
+o="$(run "$d")"; rc=$?
 if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q 'scripts/daily.sh' \
    && ! printf '%s' "$o" | grep -q '· scripts/autopilot.sh'; then
   ok "L11 plist — <string> dispatch wires autopilot, an XML-commented path does NOT wire daily"
@@ -266,7 +266,7 @@ d="$(mkfix)"
 printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/fixed.sh"
 printf 'exempt:\nbaseline:\n  - scripts/fixed.sh   # was debt, wired since\n' > "$d/scripts/caller_zero_baseline.txt"
 printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\nbash scripts/fixed.sh\n' > "$d/.github/workflows/ci.yml"
-rc="$(rcof "$d")"; o="$(run "$d")"
+o="$(run "$d")"; rc=$?
 # 🟥 The grep is 'now WIRED', not 'shrink-only'. When the shrink-only ENFORCEMENT lanes below were
 # added, the checker started printing a `shrink-only: UNMEASURED` line on every non-git fixture —
 # which contains the substring 'shrink-only' and would have kept THIS lane green even if the
@@ -301,7 +301,7 @@ rm -rf "$d"
 d="$(gitfix)"
 printf '#!/usr/bin/env bash\necho new\n' > "$d/scripts/newdebt.sh"
 printf 'exempt:\nbaseline:\n  - scripts/newdebt.sh   # freshly added debt, the illegal move\n' > "$d/scripts/caller_zero_baseline.txt"
-rc="$(rcof "$d")"; o="$(run "$d")"
+o="$(run "$d")"; rc=$?
 if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q 'SHRINK-ONLY' \
    && printf '%s' "$o" | grep -q 'scripts/newdebt.sh'; then
   ok "L15 shrink-only — a NEW baseline: entry blocks (exit 1) and is NAMED"
@@ -326,7 +326,7 @@ rc="$(rcof "$d")"
 # labels were printed.
 printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\nbash scripts/newdebt.sh\n' > "$d/.github/workflows/ci.yml"
 printf 'exempt:\nbaseline:\n' > "$d/scripts/caller_zero_baseline.txt"
-rc="$(rcof "$d")"; o="$(run "$d")"
+o="$(run "$d")"; rc=$?
 if [ "$rc" = "0" ] && printf '%s' "$o" | grep -q 'shrink-only WORKTREE_ONLY' \
    && ! printf '%s' "$o" | grep -q 'ENFORCED'; then
   ok "L15c twin — an unchanged baseline: passes, labelled WORKTREE_ONLY (never ENFORCED vs HEAD)"
@@ -364,7 +364,7 @@ rm -rf "$d"
 # 🟥 Three-valued on purpose. "could not compare" must never render as "compared, nothing found".
 d="$(mkfix)"          # deliberately NOT a git repo
 printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
-rc="$(rcof "$d")"; o="$(run "$d")"
+o="$(run "$d")"; rc=$?
 if [ "$rc" = "0" ] && printf '%s' "$o" | grep -q 'shrink-only UNMEASURED' \
    && printf '%s' "$o" | grep -q 'shrink-only: UNMEASURED'; then
   ok "L17 degrade — no base: labelled UNMEASURED in BOTH the body and the PASS line, non-blocking"
@@ -387,7 +387,7 @@ rm -rf "$d"
 d="$(mkfix)"
 printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/foo.sh"
 printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\nbash scripts/foo.sh.bak --quiet\n' > "$d/.github/workflows/ci.yml"
-rc="$(rcof "$d")"; o="$(run "$d")"
+o="$(run "$d")"; rc=$?
 if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q 'scripts/foo.sh$'; then
   ok "L18 token boundary — a .bak suffix does NOT wire foo.sh (blocks, exit 1)"
 else
@@ -405,7 +405,7 @@ d="$(mkfix)"
 printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/foo.sh"
 printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/myfoo.sh"
 printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\nbash scripts/myfoo.sh\n' > "$d/.github/workflows/ci.yml"
-rc="$(rcof "$d")"; o="$(run "$d")"
+o="$(run "$d")"; rc=$?
 if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q '· scripts/foo.sh' \
    && ! printf '%s' "$o" | grep -q '· scripts/myfoo.sh'; then
   ok "L18c token boundary — myfoo.sh is wired, foo.sh is not; the longer name does not cover it"
@@ -442,7 +442,7 @@ d="$(mkfix)"
 printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/daily.sh"
 printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
 printf '%s\n' '<plist>' '<string>/path/to/forge-harness/scripts/daily.sh</string>' '</plist>' > "$d/scripts/x.plist"
-rc="$(rcof "$d")"; o="$(run "$d")"
+o="$(run "$d")"; rc=$?
 if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q '· scripts/daily.sh' \
    && printf '%s' "$o" | grep -q 'PLACEHOLDER path'; then
   ok "L19 placeholder plist — /path/to/ does not wire, and the run SAYS why (named, not silent)"
@@ -466,7 +466,7 @@ rm -rf "$d"
 d="$(gitfix)"
 printf '#!/usr/bin/env bash\necho new\n' > "$d/scripts/newdebt.sh"
 printf 'exempt:\nbaseline:\n  - scripts/newdebt.sh   # freshly added debt, the illegal move\n' > "$d/scripts/caller_zero_baseline.txt"
-rc="$(rcofx "$d" --base HEAD)"; o="$(runx "$d" --base HEAD)"
+o="$(runx "$d" --base HEAD)"; rc=$?
 if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q 'SHRINK-ONLY'; then
   ok "L20 explicit --base — the named ref is used and the new baseline: entry blocks"
 else
@@ -516,7 +516,7 @@ d="$(gitfix2)"
 # accidentally re-testing the worktree case that already had power.
 st="$(git -C "$d" status --short)"
 [ -z "$st" ] || no "L21 SETUP — fixture tree is not clean, the lane would measure the wrong thing" "$st"
-rc="$(FH_RATCHET_REQUIRE_BASE=1 rcof "$d")"; o="$(FH_RATCHET_REQUIRE_BASE=1 run "$d")"
+o="$(FH_RATCHET_REQUIRE_BASE=1 run "$d")"; rc=$?
 if [ "$rc" = "2" ] && printf '%s' "$o" | grep -q 'not a usable comparison'; then
   ok "L21 base≠HEAD — a self-comparison under CI settings is exit 2, not a vacuous pass"
 else
@@ -526,8 +526,7 @@ fi
 # ── L21b known-NEGATIVE twin — the SAME tree with a REAL base actually CATCHES it ─────────────
 # 🟥 Without this twin L21 would also be green if the fix simply made CI always exit 2. The claim
 # under test is that naming an immutable base RESTORES the verdict, not that it suppresses it.
-rc="$(FH_RATCHET_BASE_REF=HEAD~1 FH_RATCHET_REQUIRE_BASE=1 rcof "$d")"
-o="$(FH_RATCHET_BASE_REF=HEAD~1 FH_RATCHET_REQUIRE_BASE=1 run "$d")"
+o="$(FH_RATCHET_BASE_REF=HEAD~1 FH_RATCHET_REQUIRE_BASE=1 run "$d")"; rc=$?
 if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q 'SHRINK-ONLY' \
    && printf '%s' "$o" | grep -q 'scripts/newdebt.sh'; then
   ok "L21b twin — with an immutable base the committed illegal move BLOCKS and is NAMED"
@@ -542,8 +541,7 @@ printf 'exempt:\nbaseline:\n' > "$d/scripts/caller_zero_baseline.txt"
 git -C "$d" add scripts .github >/dev/null 2>&1
 git -C "$d" -c user.email=lane@example.invalid -c user.name=lane \
     -c core.hooksPath=/nonexistent-fixture-hooks commit -q --no-verify -m legal >/dev/null 2>&1
-rc="$(FH_RATCHET_BASE_REF=HEAD~1 FH_RATCHET_REQUIRE_BASE=1 rcof "$d")"
-o="$(FH_RATCHET_BASE_REF=HEAD~1 FH_RATCHET_REQUIRE_BASE=1 run "$d")"
+o="$(FH_RATCHET_BASE_REF=HEAD~1 FH_RATCHET_REQUIRE_BASE=1 run "$d")"; rc=$?
 if [ "$rc" = "0" ] && printf '%s' "$o" | grep -q 'shrink-only ENFORCED'; then
   ok "L21c twin — a legal commit with a real base passes, and the run says ENFORCED for real"
 else
@@ -556,7 +554,7 @@ rm -rf "$d"
 # stay non-blocking: an over-blocking local gate trains `--no-verify` and disarms its neighbours.
 # But it must NOT be able to print the word a CI log would be quoted from.
 d="$(gitfix2)"
-rc="$(rcof "$d")"; o="$(run "$d")"
+o="$(run "$d")"; rc=$?
 if [ "$rc" = "0" ] && printf '%s' "$o" | grep -q 'shrink-only WORKTREE_ONLY' \
    && ! printf '%s' "$o" | grep -q 'ENFORCED'; then
   ok "L22 degrade — locally a self-comparison passes but is LABELLED, never called ENFORCED"
@@ -578,7 +576,7 @@ for _form in '$HOME/projects/repo/scripts/daily.sh' \
   printf '#!/usr/bin/env bash\necho hi\n' > "$d/scripts/daily.sh"
   printf '#!/usr/bin/env bash\nbash scripts/alpha.sh\n' > "$d/.github/workflows/ci.yml"
   printf '%s\n' '<plist>' "<string>$_form</string>" '</plist>' > "$d/scripts/x.plist"
-  rc="$(rcof "$d")"; o="$(run "$d")"
+  o="$(run "$d")"; rc=$?
   if [ "$rc" = "1" ] && printf '%s' "$o" | grep -q '· scripts/daily.sh' \
      && printf '%s' "$o" | grep -q 'PLACEHOLDER path'; then
     ok "L23 unexpanded plist path — '$_form' does NOT wire, and the run SAYS why"
@@ -686,8 +684,7 @@ fi
 # under the OLD code this pair printed "shrink-only ENFORCED" and exited 0 over the illegal move.
 # The control runs first so the checker is proven live on this very fixture before the arm's
 # non-verdict is read as anything.
-ctl_rc="$(FH_RATCHET_BASE_REF="$A" FH_RATCHET_REQUIRE_BASE=1 rcof "$d")"
-ctl_o="$(FH_RATCHET_BASE_REF="$A" FH_RATCHET_REQUIRE_BASE=1 run "$d")"
+ctl_o="$(FH_RATCHET_BASE_REF="$A" FH_RATCHET_REQUIRE_BASE=1 run "$d")"; ctl_rc=$?
 if [ "$ctl_rc" = "1" ] && printf '%s' "$ctl_o" | grep -q 'scripts/newdebt.sh'; then
   ok "L24c CONTROL — with the true base the checker catches the illegal move on this fixture"
 else

--- a/scripts/test_session_close_lanes.sh
+++ b/scripts/test_session_close_lanes.sh
@@ -138,9 +138,7 @@ PREMISE_FAILED=0
 # Human-readable on both platforms: GNU prints a date for %y, BSD's %Fm prints a raw epoch, so the
 # BSD branch asks for a formatted date instead — the whole point of this line is eyeballing.
 _mtime_h() {
-  stat -c %y "$1" 2>/dev/null \
-    || stat -f "%Sm" -t "%Y-%m-%d %H:%M:%S" "$1" 2>/dev/null \
-    || echo "?"
+  stat -c %y "$1" 2>/dev/null || stat -f "%Sm" -t "%Y-%m-%d %H:%M:%S" "$1" 2>/dev/null || echo "?"
 }
 
 _assert_newer() {  # $1=expected-newer  $2=reference  $3=lane label — returns 1 if premise fails
@@ -298,7 +296,7 @@ _carry_fixture() {  # $1=오늘카드 본문  $2=fh_completed 본문(빈 문자�
   printf '%s\n' "$card_body" > "$T/tracks/_meta/reference_next_session_starter.md"
   [ -n "$done_body" ] && printf '%s\n' "$done_body" > "$T/tracks/_meta/fh_completed_${TODAY}.md"
   # companion store: 어제 날짜로 커밋된 «이전 카드» 미러 하나
-  FUT=$(date -v+2d '+%m-%d' 2>/dev/null || date -d '+2 days' '+%m-%d')
+  FUT=$(date -d '+2 days' '+%m-%d' 2>/dev/null || date -v+2d '+%m-%d')
   ( cd "$S" && git init -q . && git config user.email a@l && git config user.name a \
     && mkdir -p tracks-meta \
     && printf '기한 %s 미팅 안건 [B]\n' "$FUT" > tracks-meta/reference_next_session_starter.md \
@@ -307,7 +305,7 @@ _carry_fixture() {  # $1=오늘카드 본문  $2=fh_completed 본문(빈 문자�
        git commit -qm prior ) >/dev/null 2>&1
   printf '%s|%s' "$T" "$S"
 }
-_carry_future() { date -v+2d '+%m-%d' 2>/dev/null || date -d '+2 days' '+%m-%d'; }
+_carry_future() { date -d '+2 days' '+%m-%d' 2>/dev/null || date -v+2d '+%m-%d'; }
 
 _carry_lane() {  # $1=name $2=pattern $3=expect $4="REPO|STORE" $5=extra-env(옵션)
   local name="$1" pat="$2" expect="$3" pair="$4" env5="${5:-}" T S out hit

--- a/scripts/utterance_landing_check.sh
+++ b/scripts/utterance_landing_check.sh
@@ -132,7 +132,7 @@ done
 _probe_hits() {
   local pat="$1"; shift
   grep -lE -- "$pat" "$@" 2>/dev/null
-  return "${PIPESTATUS[0]:-$?}"
+  return "${PIPESTATUS[0]:-$?}"  # portability-noqa: shebang (line 1) pins bash — PIPESTATUS is a real array there, unlike zsh
 }
 
 # ── 1단계: 컨트롤. 살아있음을 증명하기 전에는 타깃을 인쇄하지 않는다 ──
@@ -179,7 +179,7 @@ MISS=0; N=0
 while IFS=$'\t' read -r kind pat label; do
   [ "${kind:-}" = "TARGET" ] || continue
   N=$((N+1))
-  hits=$(_probe_hits "$pat" "${FILES[@]}" | wc -l | tr -d ' '); _rc=${PIPESTATUS[0]}
+  hits=$(_probe_hits "$pat" "${FILES[@]}" | wc -l | tr -d ' '); _rc=${PIPESTATUS[0]}  # portability-noqa: shebang (line 1) pins bash — PIPESTATUS is a real array there, unlike zsh
   if [ "$_rc" -ge 2 ]; then
     printf "  🟥 %-46s 프로브 오류\n" "${label:-$pat}"
     BAD_PAT="${BAD_PAT:+$BAD_PAT, }TARGET/${label:-$pat}"


### PR DESCRIPTION
⑤ 팔 C(실상황 계수) 2·3차 워크트리 6세션의 수리 통합. 오늘 CI 비결정 L4(«org debt did not land rc=0»)의 통로 = test_lane_runner_lanes 가 out 과 rc 를 **다른 실행**에서 뽑던 구조 → run_check() 단일 실행(L7/L8 동반), 같은 패턴을 caller_ratchet(24곳)·package_coverage(L3~L7)에서도 발견·수리. 덤: no() 미정의 7곳(set -u 무음 사망, BEFORE/AFTER/CONTROL 재현) · 실패 분기 출력 덤프(runner_surface 19·node_check 15) · prepublish_scope_note self-test 배선(known-pair 3종) · new_code_anchor SELFTEST_FORMS 리터럴 오탐 제거 · portability 11파일(GNU-first 실수리 2 + 근거 noqa) · sim_isolated_run 헤더(act+--no-harness = 계기 오독). **12 스위트 판정 집합 불변** · lane_runner 94/94(self-test 19/19) · selfcheck 완주 PASS. 반증 = 카운트 변동 · L4 재발. 보고서: tracks/_meta/armC_armC-wt{1..6}_report*_2026-09-03.md(gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cf4qb1aYst7PQ5AXSm8kb5