### PR TITLE
fix(publish): package-coverage 타볼 오라클 텍스트 폴백 + 진단 — 3.0.0 첫 OIDC 발행 차단 수리

### DIFF
--- a/scripts/package_coverage_check.sh
+++ b/scripts/package_coverage_check.sh
@@ -360,12 +360,34 @@ if ORACLE == 'tarball':
         if r.returncode != 0:
             print(f"ORACLE_UNAVAILABLE\tnpm pack exited {r.returncode}")
             raise SystemExit(2)
-        packed = {f['path'] for f in json.loads(r.stdout)[0]['files']}
+        # Two shapes have been seen for `npm pack --dry-run --json`: the documented one carries
+        # `[0]['files'][*]['path']`; inside `npm publish`'s prepublishOnly on the CI runner
+        # (Node 22 / npm 10, 2026-09-04, v3.0.0 first OIDC publish) the same call returned JSON
+        # WITHOUT that key and this block died with a bare KeyError — fail-closed (correct) but
+        # blind (no diagnosis). Parse defensively, and when the JSON does not carry a file list
+        # fall back to the text listing (`npm notice <size> <path>` lines), which is what a human
+        # reads. The diagnostic line prints the head of stdout so the NEXT failure names its shape.
+        parsed = json.loads(r.stdout)
+        entry = parsed[0] if isinstance(parsed, list) and parsed else (parsed if isinstance(parsed, dict) else None)
+        flist = (entry or {}).get('files') if isinstance(entry, dict) else None
+        if flist and all(isinstance(f, dict) and 'path' in f for f in flist):
+            packed = {f['path'] for f in flist}
+        else:
+            t = subprocess.run(['npm', 'pack', '--dry-run'], capture_output=True, text=True, timeout=180)
+            lines = (t.stdout + '\n' + t.stderr).splitlines()
+            packed = set()
+            for ln in lines:
+                m = re.match(r'^npm notice\s+[0-9.]+[kMG]?B\s+(\S+)\s*$', ln)
+                if m:
+                    packed.add(m.group(1))
+            if not packed:
+                print(f"ORACLE_UNAVAILABLE\tnpm pack --json had no files[].path and the text listing had no file lines; json head: {r.stdout[:200]!r}")
+                raise SystemExit(2)
     except FileNotFoundError:
         print("ORACLE_UNAVAILABLE\tnpm is not on PATH — the tarball cannot be read")
         raise SystemExit(2)
     except (json.JSONDecodeError, KeyError, IndexError) as e:
-        print(f"ORACLE_UNAVAILABLE\tnpm pack --json did not parse ({type(e).__name__})")
+        print(f"ORACLE_UNAVAILABLE\tnpm pack --json did not parse ({type(e).__name__}); stdout head: {r.stdout[:200]!r}")
         raise SystemExit(2)
     except subprocess.TimeoutExpired:
         print("ORACLE_UNAVAILABLE\tnpm pack timed out")

--- a/scripts/test_package_coverage_lanes.sh
+++ b/scripts/test_package_coverage_lanes.sh
@@ -259,6 +259,18 @@ echo
 if [ "$skipped" -gt 0 ]; then
   echo "package-coverage lanes: ${pass} passed, ${fail} failed, ${skipped} UNCALIBRATED (not verified here)"
 else
-  echo "package-coverage lanes: ${pass} passed, ${fail} failed"
+  
+# ── lane 7: tarball oracle JSON without files[] → text-listing fallback (CI 2026-09-04, v3.0.0) ──
+# Known-pair: stub npm returns JSON lacking files[] but delegates the text `pack --dry-run` to the
+# real npm → PASS (7a). Stub returns the same JSON and an EMPTY text listing → ORACLE_UNAVAILABLE rc=2 (7b).
+cd "$REPO_ROOT" || exit 10; _REAL_NPM=$(command -v npm); _ST=$(mktemp -d)   # earlier lanes cd into fixtures — the subject reads .git/package.json from cwd
+printf '#!/bin/bash\nif [ "$*" = "pack --dry-run --json" ]; then echo "[{\\"id\\":\\"x\\"}]"; else exec %s "$@"; fi\n' "$_REAL_NPM" > "$_ST/npm"; chmod +x "$_ST/npm"
+o=$(PATH="$_ST:$PATH" bash "$SUBJECT" --vs-tarball 2>&1); rc=$?
+if [ "$rc" = 0 ] && printf '%s' "$o" | grep -q "^PASS  package-coverage"; then echo "  ✅ lane 7a: JSON without files[] → text listing fallback PASSes"; pass=$((pass+1)); else echo "  ❌ lane 7a: fallback did not PASS (rc=$rc)"; printf "%s\n" "$o" | grep -E "UNAVAILABLE|head:" | cut -c1-220; fail=$((fail+1)); fi
+printf '#!/bin/bash\nif [ "$*" = "pack --dry-run --json" ]; then echo "[{\\"id\\":\\"x\\"}]"; elif [ "$*" = "pack --dry-run" ]; then exit 0; else exec %s "$@"; fi\n' "$_REAL_NPM" > "$_ST/npm"
+o=$(PATH="$_ST:$PATH" bash "$SUBJECT" --vs-tarball 2>&1); rc=$?
+if [ "$rc" = 2 ] && printf '%s' "$o" | grep -q "UNAVAILABLE"; then echo "  ✅ lane 7b: JSON without files[] AND empty text listing → UNAVAILABLE rc=2 (fail-closed)"; pass=$((pass+1)); else echo "  ❌ lane 7b: expected rc=2 UNAVAILABLE, got rc=$rc"; fail=$((fail+1)); fi
+rm -rf "$_ST"
+echo "package-coverage lanes: ${pass} passed, ${fail} failed"
 fi
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
publish run 33849090430 이 prepublishOnly 의 `package_coverage_check.sh --vs-tarball` 에서 «npm pack --json did not parse (KeyError)» 로 막혔다(fail-closed 옳음, 진단 없음). CI nested npm 의 JSON 에 files[] 가 없던 형태 → 방어적 파싱 + `npm pack --dry-run` 텍스트 목록 폴백 + stdout head 진단. 둘 다 없으면 여전히 rc 2. 레인 7a/7b(stub npm) 10/10. 머지 후 v3.0.0 태그를 옮겨 재발행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cf4qb1aYst7PQ5AXSm8kb5