### PR TITLE
fix(publish): 타볼 독자 3곳 텍스트 목록 폴백 — files_manifest · public_surface_scan (3.0.0 2차 발행 차단 수리)

### DIFF
--- a/scripts/files_manifest_shipping_check.sh
+++ b/scripts/files_manifest_shipping_check.sh
@@ -129,6 +129,25 @@ if [ "$MODE" = "tarball" ]; then
     sed 's/^/      /' "$FMSC_PACK_ERR" 2>/dev/null
     exit 1
   fi
+  # 2026-09-04 (v3.0.0, first OIDC publish): inside `npm publish`'s prepublishOnly on the CI runner
+  # (Node 22 / npm 10) `npm pack --dry-run --json` returned JSON WITHOUT files[] — the impossible-zero
+  # guard below then (correctly) failed the publish, but with no way forward. Same shape as
+  # package_coverage_check.sh's oracle: when the JSON carries no files[].path, rebuild it from the
+  # text listing (`npm notice <size> <path>` lines), which is what a human reads. If THAT is empty
+  # too, leave the JSON as-is and let the impossible-zero guard fail closed as before.
+  if ! printf '%s' "$PACK_JSON" | python3 -c 'import sys,json
+d=json.load(sys.stdin); e=d[0] if isinstance(d,list) and d else d
+fl=e.get("files") if isinstance(e,dict) else None
+sys.exit(0 if fl and all(isinstance(f,dict) and "path" in f for f in fl) else 1)' 2>/dev/null; then
+    _txt=$(npm pack --dry-run 2>&1)
+    _rebuilt=$(printf '%s\n' "$_txt" | python3 -c 'import sys,re,json
+paths=[m.group(1) for ln in sys.stdin for m in [re.match(r"^npm notice\s+[0-9.]+[kMG]?B\s+(\S+)\s*$", ln)] if m]
+print(json.dumps([{"files":[{"path":p} for p in paths],"_oracle":"text-listing-fallback"}]) if paths else "")')
+    if [ -n "$_rebuilt" ]; then
+      echo "      files-manifest-shipping: npm pack --json carried no files[] — rebuilt from the text listing ($(printf '%s' "$_rebuilt" | python3 -c 'import sys,json;print(len(json.load(sys.stdin)[0]["files"]))') paths)"
+      PACK_JSON="$_rebuilt"
+    fi
+  fi
   printf '%s' "$PACK_JSON" > "$FMSC_PACK_JSON" || {
     echo "FAIL  files-manifest-shipping (--vs-tarball): could not write pack output to scratch dir"
     exit 1

--- a/scripts/public_surface_scan_files.sh
+++ b/scripts/public_surface_scan_files.sh
@@ -124,7 +124,16 @@ fi
 # content-generating lifecycle is ever added.
 # ── Resolve the exact npm-published file set (fail-closed if unresolved OR partial) ──
 FILES=$(npm pack --dry-run --json 2>/dev/null \
-  | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{JSON.parse(s)[0].files.forEach(f=>console.log(f.path))}catch(e){process.exit(3)}})' 2>/dev/null || true)
+  | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{JSON.parse(s)[0].files.forEach(f=>console.log(f.path))}catch(e){process.exit(3)}})' 2>/dev/null)
+# 2026-09-04 (v3.0.0 first OIDC publish): on the CI runner, inside `npm publish`'s prepublishOnly,
+# `npm pack --dry-run --json` returned JSON WITHOUT files[] and this resolution came back EMPTY —
+# fail-closed (correct) but the publish could not proceed at all. Same fallback as the other two
+# tarball readers (package_coverage_check.sh · files_manifest_shipping_check.sh): rebuild the set
+# from the text listing (`npm notice <size> <path>`). Still fail-closed when THAT is empty too.
+if [ -z "$FILES" ]; then
+  FILES=$(npm pack --dry-run 2>&1 | sed -nE 's/^npm notice +[0-9.]+[kMG]?B +([^ ]+) *$/\1/p')
+  [ -n "$FILES" ] && echo "  ⚠️  npm pack --json carried no files[] — file set rebuilt from the text listing ($(printf '%s\n' "$FILES" | wc -l | tr -d ' ') paths)"
+fi
 if [ -z "$FILES" ]; then
   echo "  ❌ could not resolve the npm-published file set (npm pack --dry-run failed)."
   [ "${PUBLIC_SURFACE_OK:-0}" = "1" ] && { echo "  ⚠️  proceeding by PUBLIC_SURFACE_OK=1"; exit 0; }


### PR DESCRIPTION
publish run 33850491565: package_coverage 는 #608 로 통과, 다음 게이트 files_manifest_shipping 이 «npm pack reported 0 files» 로 fail-closed. 소비자 전수 3곳 중 남은 둘에 같은 텍스트 목록 폴백(빈 집합은 종전대로 차단, 오버라이드 안 씀). 로컬 PASS · stub npm 재현 PASS · 레인 13/13. CI nested npm 이 files[] 를 안 주는 원인은 미확정(우회이지 원인 수리 아님). 머지 후 v3.0.0 재태그.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cf4qb1aYst7PQ5AXSm8kb5