### PR TITLE
ci(publish): 운영자 리터럴 패턴을 secret 으로 — 기밀 스캔을 완전한 계기로, 부재면 발행 거부 (3.0.0 3차 차단 수리)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,21 @@ jobs:
           git fetch -q origin main
           [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ] || { echo "🟥 tag is not at origin/main HEAD — refusing"; exit 1; }
           git checkout -q -B main origin/main
+      - name: operator-literal patterns → file (기밀 스캔의 «완전한 계기»)
+        # 🟥 v3.0.0 3차 시도(2026-09-04 run 33851451594): prepublishOnly 의 public_surface_scan_files.sh 가
+        #    «operator-literal override 부재(HIGH 회사·컴패니언 리터럴 미스캔)» 로 fail-closed. 그 파일은
+        #    gitignored 라 체크아웃에 없다 — 이 워크플로가 그 사실을 몰랐다(설계 공백). 시크릿은 base64
+        #    한 줄이고, 파일로 풀어 PSA_PATTERNS 로 넘긴다. 비어 있으면 여기서 죽는다(fail-closed) —
+        #    PUBLIC_SURFACE_OK 로 우회하지 않는다. 내용은 절대 echo 하지 않는다.
+        env:
+          PSA_PATTERNS_B64: ${{ secrets.PSA_PATTERNS_B64 }}
+        run: |
+          [ -n "$PSA_PATTERNS_B64" ] || { echo "🟥 PSA_PATTERNS_B64 secret is empty — the confidentiality scan would be incomplete; refusing to publish"; exit 1; }
+          umask 077; printf '%s' "$PSA_PATTERNS_B64" | base64 -d > "$RUNNER_TEMP/psa_patterns"
+          n=$(grep -cvE '^\s*(#|$)' "$RUNNER_TEMP/psa_patterns" || true)
+          [ "$n" -gt 0 ] || { echo "🟥 decoded pattern file has 0 usable rows"; exit 1; }
+          echo "PSA_PATTERNS=$RUNNER_TEMP/psa_patterns" >> "$GITHUB_ENV"
+          echo "✅ operator-literal patterns loaded ($n rows)"
       - name: publish (prepublishOnly 게이트 경유, provenance)
         run: npm publish --provenance --access public
       - name: verify on registry


### PR DESCRIPTION
run 33851451594: 타볼 독자 3곳 통과 후 public_surface_scan_files 가 «operator-literal override 부재» 로 fail-closed — #590 워크플로가 gitignored 패턴 파일을 실을 길이 없던 설계 공백. 운영자 결정으로 base64 secret(PSA_PATTERNS_B64) 등록, 워크플로가 umask 077 로 풀어 PSA_PATTERNS 전달. secret 비거나 0행이면 exit 1(오버라이드·내용 출력 없음). 머지 후 v3.0.0 재태그 → 4차 발행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cf4qb1aYst7PQ5AXSm8kb5