### PR TITLE
fix(digest): 헤드리스 런 Skill 툴 거부 수리(--allowedTools) · arXiv 429 폴백을 제출일 정렬 listing 으로

### DIFF
--- a/plugins/fh-meta/skills/frontier-digest/SKILL.md
+++ b/plugins/fh-meta/skills/frontier-digest/SKILL.md
@@ -215,7 +215,7 @@ Present Step 4 menu options [1]–[5]. Do not skip to [5] silently — surface t
 ## Simplification Guards
 
 - Video Tier-3 probe fails (any of `yt-dlp` / `curl_cffi` / `ffmpeg` missing, or timedtext returns 429) → fall through to operator summary; never assume `yt-dlp` works
-- If 3+ arxiv queries fail, proceed with HN only (do not abort)
+- If 3+ arxiv queries fail (HTTP 429): back off once → WebFetch the date-sorted `arxiv.org/list/cs.SE/recent` listing → only then HN-only. Never substitute WebSearch (recall channel, 5/5 REPEATs measured 2026-09-04); report `arxiv FAILED (429)`, never `0 items`. Detail: `SKILL_detail.md §Execution form`
 - On curl timeout, skip that item and continue with the rest
 - If synthesis result exceeds 400 characters, retain top 3 items and truncate the rest
 - Without `--save`, do not create files (conversation output only)

--- a/plugins/fh-meta/skills/frontier-digest/SKILL_detail.md
+++ b/plugins/fh-meta/skills/frontier-digest/SKILL_detail.md
@@ -21,9 +21,21 @@ load: on-demand
 > through WebFetch on the same URLs. If an environment *does* allow the curl form, it is equivalent —
 > the transport is not the contract, the endpoints and criteria are.
 >
-> **arXiv HTTP 429 is a separate item, not part of this revision**: it is a remote rate limit
-> (N=11 consecutive, transport-independent). On 429: back off once, then fall back to per-item
-> `https://arxiv.org/abs/{id}` reads; record `FAILED (429)`, never 0 items.
+> **arXiv HTTP 429 — fallback is a TRANSPORT change, never a channel change (revised 2026-09-04).**
+> The export API rate-limits this runner (N=11 consecutive by 08-10; 3 consecutive days 09-02·03·04
+> = past the `N≥3` mechanization bar). The 08-10 prescription («fall back to per-item `abs/{id}`
+> reads») was unrunnable in practice — a 429 on the *query* leaves you with no IDs to read — so runs
+> fell back to **WebSearch**, and the 09-04 run measured what that does: 5/5 papers it returned were
+> REPEATs. Search sorts by *canonicity*, the export API by *submission date* — a search fallback is
+> a **recall channel, not a discovery channel**, and swapping it in silently converts «unrun» into
+> «nothing new» (`not found ≠ 0`). Order on 429:
+> 1. back off once (≥30s), retry the same query;
+> 2. still 429 → WebFetch the **date-sorted HTML listing** `https://arxiv.org/list/cs.SE/recent`
+>    (and `https://arxiv.org/list/cs.AI/recent` if the first is empty of agent/harness items), keep
+>    items whose title/abstract match the three query phrases, cap 6 — same sort axis as the API;
+> 3. only if that also fails → HN-only, and the progress line says `arxiv FAILED (429)`, never `0 items`.
+> 🟥 WebSearch is **not** on this ladder. If a run used it anyway, the arxiv leg is reported as
+> `RECALL-ONLY (WebSearch)` and its items are excluded from the NEW/REPEAT count.
 
 ### HackerNews (Algolia API)
 

--- a/scripts/frontier_digest_daily.sh
+++ b/scripts/frontier_digest_daily.sh
@@ -3,7 +3,8 @@
 # Invoked by launchd (install: see scripts/com.forge-harness.frontier-digest.plist)
 #
 # Required: claude CLI at ~/.local/bin/claude
-# Tool permissions: pre-approved in .claude/settings.json (no interactive prompts needed)
+# Tool permissions: read/fetch pre-approved in .claude/settings.json (gitignored, this node); the Skill
+#   allow rule the run depends on is passed as --allowedTools below so it does not rely on that file
 
 # Auto-detect repo root from this script's location (scripts/ → repo root) and the claude CLI.
 # 🟥 **엔진 루트와 대상 루트는 다르다** (R6, 2026-08-18 — 첫 실사용 발견). 위성은 이 스크립트를
@@ -504,7 +505,14 @@ for ATTEMPT in $(seq 1 $MAX_ATTEMPTS); do
         publish_gate; _pg=$?; [ "$_pg" -eq 0 ] && landing_witness; exit "$_pg"
     fi
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] Attempt ${ATTEMPT}/${MAX_ATTEMPTS}" >> "$LOG_FILE"
+    # 🟥 `Skill(...)` needs an explicit allow rule in headless -p — without one the Skill tool is
+    #    `user-rejected` with no human to answer, the tool_result reads `Execute skill: <name>` with
+    #    is_error=true, and the model silently completes the run by hand-reading SKILL.md (measured
+    #    2026-09-04: 33/35 fh-meta skills denied; the 2 that passed were exactly the 2 with a
+    #    Skill(...) rule in the gitignored settings.local.json). The gitignored settings file is not
+    #    a skeleton — this flag is, so the runner carries it itself.
     "$CLAUDE_BIN" -p --permission-mode acceptEdits \
+        --allowedTools "Skill(fh-meta:frontier-digest)" \
         ${FD_MODEL:+--model "$FD_MODEL"} \
         ${PROFILE_SETTINGS_JSON:+--settings "$PROFILE_SETTINGS_JSON"} \
         "$(_build_prompt)" \


### PR DESCRIPTION
## 무엇
- **Skill 호출 2런 연속 실패의 원인**: 스킬 frontmatter 가 아니라 헤드리스 `-p` 의 Skill 툴 권한 거부(`non_execution_kind: user-rejected`, debug «Skill tool permission denied»). 35 스킬 전수 probe → 33 거부, 통과 2 = gitignored `settings.local.json` 에 `Skill(...)` allow 가 있는 정확히 그 둘.
- **수리**: `frontier_digest_daily.sh` 호출에 `--allowedTools "Skill(fh-meta:frontier-digest)"`. gitignored 설정 파일이 아니라 러너가 규칙을 들고 간다(뼈대).
- **arXiv 429 폴백**: «abs/{id} 읽기」는 query 429 에서 ID 가 없어 실행 불가 → 실제로는 WebSearch 로 갔고 09-04 런이 5/5 REPEAT 실측(회수 채널). `list/cs.SE/recent`(제출일 정렬) 사다리로 교체, WebSearch 는 사다리 밖(`RECALL-ONLY`).

## known-pair (러너의 실제 호출 형태 `-p acceptEdits`, tool_result 원문 직독)
| 팔 | 결과 |
|---|---|
| 로컬 규칙 제거 + `--allowedTools` | `Launching skill` is_error=None ✅ |
| 로컬 규칙 제거, 플래그 없음 | `Execute skill` is_error=true (거부 재현) |
| 컨트롤 `fh`(규칙 없음) | 거부 유지 |

## 잔여
- 진짜 무인 런의 첫 실사용은 09-05 09:00 launchd (defeater: 다이제스트에 «손으로 읽음」 경고 재발).
- `Skill(...)` 이 헤드리스에서 allow 없이 거부되는 것은 **fh-meta 전 스킬**에 해당 — 다른 무인 러너(autopilot Stage 2 는 bypassPermissions 라 무관)가 생기면 같은 플래그가 필요하다.
- standpoint: DEGRADED_NOT_RUN(소비자 install 에서 429 런 미실행 — did not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pQzk6DWvzaMns3EzymZMv