### PR TITLE
fix(templates): fh_audit_check.zsh — 빈 허브 zsh 미매치 glob 오류를 배열 (N.om) 로 수리

### DIFF
--- a/templates/fh_audit_check.zsh
+++ b/templates/fh_audit_check.zsh
@@ -53,7 +53,16 @@ _fh_audit_check() {
   # ① weekly_harvest — 7-day threshold (when CC_HUB_DIR is set)
   if [[ -n "${CC_HUB_DIR}" && -d "${CC_HUB_DIR}/tracks/_meta" ]]; then
     local aud
-    aud=$(ls -t "${CC_HUB_DIR}/tracks/_meta"/harvest_*.md 2>/dev/null | head -1)
+    # zsh: an unmatched glob is a SHELL error raised before `ls` runs — the `2>/dev/null` belongs to
+    # ls, so `_fh_audit_check:N: no matches found: …` printed on every terminal open of a hub with no
+    # harvest files (measured 2026-09-04). 🟥 The obvious fix — appending `(N)` to the ls argument —
+    # is WRONG and was measured wrong the same day: the null glob drops the word entirely, `ls -t`
+    # then lists the CURRENT DIRECTORY, `head -1` returns an unrelated file, and the «No harvest
+    # history» warning silently disappears (not-found rendered as found). Collect into an array with
+    # `(N.om)` (null-glob · plain files · newest-first) and read element 1 — empty array ⇒ empty aud.
+    local -a _fh_harvests
+    _fh_harvests=( "${CC_HUB_DIR}/tracks/_meta"/harvest_*.md(N.om) )
+    aud="${_fh_harvests[1]:-}"
     if [[ -n "$aud" ]]; then
       local d=$(( (now - $(_fh_mtime "$aud")) / 86400 ))
       (( d >= 7 )) && warns+=("weekly_harvest ${d}d elapsed → run /harvest-loop in your CC hub cwd")


### PR DESCRIPTION
카드 «안 닫은 것」 3: `_fh_audit_check:8: no matches found: harvest_*.md` — zsh 는 glob 미매치가 셸 오류라 `ls` 의 `2>/dev/null` 이 못 덮는다.

## known-pair (zsh 로 함수 소싱·호출)
| 팔 | BEFORE | 1차 `(N)` | 2차 배열 `(N.om)` |
|---|---|---|---|
| 빈 허브 | 오류 줄 + «No harvest history» | 오류 없음, **경고도 사라짐** 🟥 | 오류 없음, 경고 존재 ✅ |
| 최신 3d | 경고 없음 | — | 경고 없음 ✅ |
| 옛 34d | — | — | `weekly_harvest 34d elapsed` ✅ |

1차 수리는 널글롭이 낱말을 지워 `ls -t` 가 **cwd** 를 나열, `head -1` 이 무관 파일을 잡아 not-found 를 found 로 렌더했다. 계기의 빈 팔 기대값이 «경고 존재」였기 때문에 잡혔다. 헤더 주석에 그 함정을 적어뒀다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pQzk6DWvzaMns3EzymZMv