### PR TITLE
fix(hook): proposal_hook Bash 팔 판별자 교체 — 원문 정규식 → 인자 자리 대상 경로 스캐너 (⑤ 반증 창 계기 교체)

### DIFF
--- a/scripts/proposal_hook.sh
+++ b/scripts/proposal_hook.sh
@@ -73,7 +73,13 @@
 set -u
 RAW=$(cat 2>/dev/null || true)
 printf '%s' "$RAW" | grep -qE '#[[:space:]]*noqa:?[[:space:]]*proposal-hook' && exit 0
-PYCODE=$(cat <<'PY'
+# 🟥 bash-version trap (measured 2026-09-04): `PYCODE=$(cat <<'PY' … PY)` parses under macOS bash 3.2 but
+#    bash 5.3 (CI runner, homebrew) scans the $(...) body for a matching `)` BEFORE honoring the quoted
+#    heredoc, so the regex parens below break it — `bash -n` fails, lanes were green locally. The
+#    opposite direction of the bash-3.2 heredoc bug frontier_digest_autopilot.sh documents; neither
+#    version is safe with a heredoc inside a command substitution. A function body is parsed the same
+#    way by both, so the heredoc lives in a function and $(...) only calls it.
+_fh_ph_pycode() { cat <<'PY'
 import json,sys,re
 try: d=json.load(sys.stdin)
 except Exception: print("",""); sys.exit(0)
@@ -158,7 +164,8 @@ elif tn=="Bash":
     fp,flag=bash_targets(ti.get("command","") or "")
 print(fp, flag)
 PY
-)
+}
+PYCODE=$(_fh_ph_pycode)
 read -r FP FLAG < <(printf '%s' "$RAW" | python3 -c "$PYCODE" 2>/dev/null) || exit 0
 [ -n "${FP:-}" ] || exit 0
 case "$FP" in *scripts/*.sh|*templates/*.sh|scripts/*.sh|templates/*.sh|*/.git-hooks/*|.git-hooks/*) ;; *) exit 0 ;; esac   # .git-hooks/* has no .sh suffix — the gate files themselves were outside the filter (arm C wt2 2026-09-03: pre-commit edit, no FIRE)

--- a/scripts/proposal_hook.sh
+++ b/scripts/proposal_hook.sh
@@ -3,6 +3,13 @@
 # templates/*.sh is about to change → put ONE proposal instruction into the model's context
 # (additionalContext): «offer the user a known-pair control + degrade_direction_scan.sh in one line».
 #
+# 🟥 2026-09-04 계기 교체 — 이후 F 행은 이전 F 행과 같은 계기가 아니다. The Bash-path discriminator below
+#    was replaced after the first independent grading of the live FIRE rows
+#    (tracks/_meta/RESULT_2026-09-04_identity5-armC-live-count.md §계기 결함 1·2·3): 3 of 7 rows were not edits
+#    at all, and 6 of 8 load-bearing verdict edits that day never fired. Rows written by the old rule and rows
+#    written by this one must not be pooled into one count. Whether the open falsification window is closed,
+#    restarted, or split is the governor's / operator's decision, recorded there — not here.
+#
 # WHY A HOOK (identity ⑤, measured 2026-09-03)
 #   r3: a CLAUDE.md table row keyed on this exact file class fired 1/15 at floor tier (that 1 a
 #   recitation). r4: this hook, installed in a disposable clone, fired on 9/10 editing reps and the
@@ -19,20 +26,42 @@
 #   («proposes unasked») counts a relayed proposal is the operator's call, recorded there, not here.
 #
 # DISCRIMINATOR (mechanical, quote-aware where it can be)
-#   file class  : scripts/**/*.sh · templates/*.sh          (docs, tracks, tests-as-fixtures: no)
+#   file class  : scripts/**/*.sh · templates/*.sh · */.git-hooks/*   (docs, tracks, tests-as-fixtures: no)
 #   edit kind   : the touched text carries a verdict/guard token — exit N · return N ·
 #                 `|| continue|exit|true|return` · `&& continue|exit` · -ne/-eq/-gt/-lt · ==/!= ·
 #                 `[ -e/-f/-s/-n/-z` · comm/diff/cmp · grep -q — AND for Edit the change is not
 #                 confined to quoted strings (old/new with quotes stripped must differ). A usage
 #                 string that happens to contain `exit 2` does not fire (r4 HARD 0/5).
-#   Bash path   : an edit made through the shell (sed -i · > · >> · tee) — the r4 miss (T2 r5 edited
-#                 via Bash, hook 0). No old/new here, so the rule is weaker: target file class AND the
-#                 the RAW command text (quotes included) carries a token. Quotes are NOT stripped on
-#                 this path — in `sed -i 's/exit 1/exit 2/' x.sh` the token is inside the quotes by
-#                 construction, and stripping made the path silent on exactly the shape it exists for
-#                 (found by the Air node 2026-09-03; the original lane's known-positive only fired
-#                 because its token sat outside the quotes). Named residual now: over-fire when a
-#                 quoted token elsewhere in the command co-occurs with a script-file edit (advisory).
+#   Edit/Write  : the file is `tool_input.file_path` — the tool tells us what changes; nothing is inferred.
+#   Bash path   : the shell has no file_path, so the question «which file does this command WRITE» is answered
+#                 by a small scanner instead of a whole-command regex (the 2026-09-03 rule matched the raw
+#                 text, so a heredoc body, a PR body, or a python string that merely QUOTED `sed -i … x.sh`
+#                 counted as an edit — RESULT 2026-09-04 rows 2·3·4):
+#                   ① heredoc bodies are lifted out (`<<EOF` … `EOF`) and kept aside, keyed to the line that opened them
+#                   ② the rest is split into segments on `;` `&&` `||` newline — OUTSIDE quotes; quoted text is masked
+#                   ③ a target is an ARGUMENT POSITION only: `> path` · `>> path` · `tee [-a] path` (unquoted in the
+#                      masked text, or a quoted path directly after the operator) · the file argument of `sed -i …`
+#                   ④ a `python3 … <<HEREDOC` segment is opened: `open(P,"w"|"a")` / `Path(P).write_text` with P a
+#                      literal or a variable assigned ONCE in the body (`p="scripts/x.sh"`) names the target
+#                      (RESULT §결함 2 — 16 of 27 script edits that day were this shape and all were silent)
+#                   ⑤ the token test runs on the segment that OWNS the target (+ its heredoc body), not on the
+#                      whole command — `|| exit 1` two segments later is a check, not an edit (RESULT §결함 3, row 6).
+#                      For a python heredoc the token text is the body's STRING LITERALS only, so `if a == b:` in the
+#                      python code itself is not a verdict edit, and a comment-word replace stays silent
+#                   ⑥ a path containing `$` is dropped — `: > "$T/scripts/x.sh"` is a fixture root, not this repo
+#                 Quotes are NOT stripped from the owning segment's token text: in `sed -i 's/exit 1/exit 2/' x.sh`
+#                 the token sits inside the quotes by construction (Air 2026-09-03).
+#   WHAT THE BASH PATH STILL CANNOT SEE (named, not closed)
+#                 · a script path reached through a variable (`"$REPO_ROOT/scripts/x.sh"`, `$f`) — ⑥ drops it
+#                 · python targets built at runtime (`os.path.join`, `sys.argv[1]`, `p = base + name`)
+#                 · edits by other tools: `perl -pi`, `awk … > tmp && mv tmp x.sh`, `patch`, `git apply`, `ed`,
+#                   `cp`/`mv`/`install` onto a script, `sponge`
+#                 · an unterminated quote earlier in the command swallows every target after it
+#                 · a token inside the owning segment that is not the edit payload (`sed -i 's/a/b/' x.sh | grep -q y`
+#                   is still one segment) — narrower than before, not zero
+#                 It is PreToolUse, so «what actually changed on disk» is not available here at all; a PostToolUse
+#                 twin diffing mtimes would close the tool-shape residuals above and was NOT built in this patch
+#                 (it needs a wiring change in settings.json, outside this file).
 #
 # DEGRADE DIRECTION: advisory, exit 0 always, no permissionDecision (same contract as pipe_verdict_guard).
 #   Unparseable payload → silent. python3 absent → silent (a dead interpreter must not block edits).
@@ -44,26 +73,93 @@
 set -u
 RAW=$(cat 2>/dev/null || true)
 printf '%s' "$RAW" | grep -qE '#[[:space:]]*noqa:?[[:space:]]*proposal-hook' && exit 0
-read -r FP FLAG < <(printf '%s' "$RAW" | python3 -c '
+PYCODE=$(cat <<'PY'
 import json,sys,re
 try: d=json.load(sys.stdin)
 except Exception: print("",""); sys.exit(0)
 tn=d.get("tool_name",""); ti=d.get("tool_input",{}) or {}
 TOK=r"exit [0-9]|return [0-9]|\|\| *(continue|exit|true|return)|&& *(continue|exit)|-ne |-eq |-gt |-lt | == | != |\[ -[efsnz] |\bcomm |\bdiff |\bcmp |grep -q"
-def strip(x): return re.sub(r"\"[^\"]*\"|\x27[^\x27]*\x27","",x)
+CLASS=re.compile(r"(scripts/[^\s]*\.sh$|templates/[^\s]*\.sh$|(^|/)\.git-hooks/[^/]+$)")
+def strip(x): return re.sub(r"\"[^\"]*\"|'[^']*'","",x)
+def is_target(p): return bool(p) and "$" not in p and bool(CLASS.search(p))
+def tok(x): return bool(re.search(TOK,x))
+
+def lift_heredocs(cmd):
+    # replace each `<<[-]['"]DELIM['"]` with \x02k\x02 and cut its body out; bodies[k]=text
+    HD=re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+    lines=cmd.split("\n"); out=[]; bodies=[]; i=0
+    while i<len(lines):
+        ln=lines[i]; i+=1; ms=list(HD.finditer(ln))
+        for m in ms:
+            k=len(bodies); body=[]
+            while i<len(lines) and lines[i].strip()!=m.group(2): body.append(lines[i]); i+=1
+            i+=1
+            bodies.append("\n".join(body)); ln=ln.replace(m.group(0),"\x02%d\x02"%k,1)
+        out.append(ln)
+    return "\n".join(out),bodies
+
+def segments(text):
+    # split on ; && || newline outside quotes; returns [(raw, masked, quoted_list)]
+    segs=[]; raw=[]; masked=[]; quoted=[]; q=None; i=0; n=len(text)
+    def flush():
+        segs.append(("".join(raw),"".join(masked),list(quoted))); raw[:]=[]; masked[:]=[]; quoted[:]=[]
+    while i<n:
+        c=text[i]
+        if q:
+            j=i
+            while j<n:
+                if text[j]=="\\" and q=='"' and j+1<n: j+=2; continue
+                if text[j]==q: break
+                j+=1
+            body=text[i:j]; raw.append(body); masked.append("\x01%d\x01"%len(quoted)); quoted.append(body)
+            if j<n: raw.append(q); masked.append(q)
+            q=None; i=j+1; continue
+        if c in "\"'": q=c; raw.append(c); masked.append(c); i+=1; continue
+        if c=="\\" and i+1<n: raw.append(text[i:i+2]); masked.append(text[i:i+2]); i+=2; continue
+        if text.startswith("&&",i) or text.startswith("||",i): flush(); i+=2; continue
+        if c==";" or c=="\n": flush(); i+=1; continue
+        raw.append(c); masked.append(c); i+=1
+    flush(); return segs
+
+PATH_RE=r"(?:[\"']\x01(\d+)\x01[\"']|([^\s\"'|;&<>()]+))"
+RED=re.compile(r"(?:(?<![<\w])>>?|\btee\s+(?:-a\s+)?)\s*"+PATH_RE)
+PYW=re.compile(r"open\(\s*(?:['\"]([^'\"]+)['\"]|([A-Za-z_]\w*))\s*,\s*['\"][wa]|Path\(\s*(?:['\"]([^'\"]+)['\"]|([A-Za-z_]\w*))\s*\)\.write_(?:text|bytes)|\b([A-Za-z_]\w*)\.write_(?:text|bytes)\(")
+PYSTR=re.compile(r"\"\"\"(?:.|\n)*?\"\"\"|'''(?:.|\n)*?'''|\"(?:\\.|[^\"\\\n])*\"|'(?:\\.|[^'\\\n])*'")
+
+def bash_targets(cmd):
+    text,bodies=lift_heredocs(cmd); found=[]
+    for raw,masked,quoted in segments(text):
+        hb="\n".join(bodies[int(k)] for k in re.findall(r"\x02(\d+)\x02",masked))
+        cands=[]
+        for m in RED.finditer(masked):
+            p=quoted[int(m.group(1))] if m.group(1) else m.group(2)
+            if is_target(p): cands.append((p,raw+"\n"+hb))
+        if re.search(r"\bsed\s+(?:-\S+\s+)*-i",masked):
+            for a in masked.split():
+                if is_target(a): cands.append((a,raw+"\n"+hb)); break
+        if hb and re.search(r"\bpython[0-9.]*\b",masked):
+            assigns=dict(re.findall(r"^\s*([A-Za-z_]\w*)\s*=\s*(?:Path\(\s*)?['\"]([^'\"\n]+)['\"]\s*\)?\s*$",hb,re.M))
+            lits=" ".join(PYSTR.findall(hb))
+            for m in PYW.finditer(hb):
+                p=m.group(1) or m.group(3) or assigns.get(m.group(2) or m.group(4) or m.group(5) or "","")
+                if is_target(p): cands.append((p,lits))
+        for p,ttext in cands: found.append((p,"1" if tok(ttext) else "0"))
+    for p,f in found:
+        if f=="1": return p,f
+    return (found[0] if found else ("","0"))
+
 fp=""; flag="0"
 if tn in ("Edit","Write"):
     fp=ti.get("file_path","") or ""
     old=ti.get("old_string","") or ""; new=(ti.get("new_string","") or ti.get("content","") or "")
-    touches=bool(re.search(TOK, old+"\n"+new)); real=strip(old).strip()!=strip(new).strip()
+    touches=tok(old+"\n"+new); real=strip(old).strip()!=strip(new).strip()
     flag="1" if (touches and real) else "0"
 elif tn=="Bash":
-    cmd=(ti.get("command","") or "").replace("\n"," ")
-    m=re.search(r"(?:sed\s+-i\S*(?:\s+(?:\x27[^\x27]*\x27|\"[^\"]*\"|\S+)){1,2}\s+|>>?\s*|tee\s+(?:-a\s+)?)[\"\x27]?([^\s\"\x27|;&)<>]+\.sh)\b", cmd)
-    if m:
-        fp=m.group(1); flag="1" if re.search(TOK, cmd) else "0"   # raw cmd, NOT strip(): in a sed -i the token lives INSIDE the quoted expression by construction (Air 2026-09-03: a1 silent, known-positive only fired because its token sat outside the quotes)
+    fp,flag=bash_targets(ti.get("command","") or "")
 print(fp, flag)
-' 2>/dev/null) || exit 0
+PY
+)
+read -r FP FLAG < <(printf '%s' "$RAW" | python3 -c "$PYCODE" 2>/dev/null) || exit 0
 [ -n "${FP:-}" ] || exit 0
 case "$FP" in *scripts/*.sh|*templates/*.sh|scripts/*.sh|templates/*.sh|*/.git-hooks/*|.git-hooks/*) ;; *) exit 0 ;; esac   # .git-hooks/* has no .sh suffix — the gate files themselves were outside the filter (arm C wt2 2026-09-03: pre-commit edit, no FIRE)
 [ "${FLAG:-0}" = 1 ] || exit 0

--- a/scripts/test_proposal_hook_lanes.sh
+++ b/scripts/test_proposal_hook_lanes.sh
@@ -15,9 +15,30 @@ exp "Bash sed -i on scripts/*.sh with token"  HIT   '{"tool_name":"Bash","tool_i
 exp "Bash sed -i token ONLY inside quotes (a1)"  HIT   '{"tool_name":"Bash","tool_input":{"command":"sed -i \"\" \"s/exit 1/exit 2/\" scripts/target.sh"}}'
 exp "Bash sed -i single-quoted token (a1b)"      HIT   '{"tool_name":"Bash","tool_input":{"command":"sed -i '"'"''"'"' '"'"'s/|| continue/|| { echo x; continue; }/'"'"' scripts/target.sh"}}'
 exp "Bash sed -i no token anywhere (a3)"         CLEAN '{"tool_name":"Bash","tool_input":{"command":"sed -i \"\" s/foo/bar/ scripts/target.sh"}}'
-exp "Bash redirect into scripts/*.sh w/ token" HIT  '{"tool_name":"Bash","tool_input":{"command":"printf \"%s\\n\" x >> scripts/x.sh; grep -q y scripts/x.sh || exit 3"}}'
+exp "Bash redirect into scripts/*.sh w/ token" HIT  '{"tool_name":"Bash","tool_input":{"command":"printf \"[ -f x ] || exit 1\\n\" >> scripts/x.sh; grep -q y scripts/x.sh"}}'
 exp "Bash redirect into docs (no)"            CLEAN '{"tool_name":"Bash","tool_input":{"command":"echo \"exit 1\" >> docs/a.md || exit 1"}}'
 exp "Bash ls only (no target)"                CLEAN '{"tool_name":"Bash","tool_input":{"command":"ls scripts/ && [ -d scripts ] || exit 1"}}'
+# ── 2026-09-04 계기 교체 lanes — fixtures are the SHAPES the first independent grading quoted
+#    (tracks/_meta/RESULT_2026-09-04_identity5-armC-live-count.md §계기 결함), not easier spellings.
+#    Fail-before: the HEAD~ hook (whole-command regex) is HIT on R2/R3/R4-ctrl/D3-*/D4 and CLEAN on D2-* (recorded in
+#    proposal_hook_repair_lanes.txt for the patch); the scanner hook inverts exactly those.
+exp "R2 marker heredoc QUOTES sed -i … scripts/target.sh (row 2)" CLEAN '{"tool_name":"Bash","tool_input":{"command":"cat > tracks/_meta/.axes_23_2026-09-03.marker <<'"'"'MK'"'"'\naxes-run: ⓐ ⓑ\na1 `sed -i '"'"''"'"' '"'"'s/exit 1/exit 2/'"'"' scripts/target.sh` → HIT · lanes 16/16 · [ -s x ] || exit 1\nMK"}}'
+exp "R3 gh pr --body QUOTES sed -i … scripts/target.sh (row 3)"  CLEAN '{"tool_name":"Bash","tool_input":{"command":"gh pr create --title \"fix(hook): a1\" --body \"Lanes: a1 `sed -i '"'"''"'"' '"'"'s/exit 1/exit 2/'"'"' scripts/target.sh` now HIT; 16/16 · revert 14/16 || exit 1\""}}'
+exp "R4-ctrl : > \"\$T/scripts/…\" fixture root (var path)"      CLEAN '{"tool_name":"Bash","tool_input":{"command":"mkdir -p \"$T/scripts\"; : > \"$T/scripts/test_has_lane_lanes.sh\"; [ -f x ] || exit 1"}}'
+exp "D2-P python heredoc open(p,\"w\") verdict edit (8746)"      HIT   '{"tool_name":"Bash","tool_input":{"command":"python3 - <<'"'"'PY'"'"'\np=\"scripts/package_coverage_check.sh\"\ns=open(p).read()\nassert s.count(\"  exit 2\") == 1\ns=s.replace(\"  exit 2\", \"  echo \\\"PKG_ORACLE_MISSING: npm pack gave no files[]\\\" >&2; exit 2\")\nopen(p,\"w\").write(s)\nPY"}}'
+exp "D2-P2 python heredoc q=Path(…); q.write_text (verdict)"     HIT   '{"tool_name":"Bash","tool_input":{"command":"python3 - <<'"'"'PY'"'"'\nfrom pathlib import Path\nq=Path(\"scripts/selfcheck.sh\")\nq.write_text(q.read_text().replace(\"run_lane x\", \"run_lane x || exit 1\"))\nPY"}}'
+exp "D2-ctrl python heredoc comment-word replace (== in code only)" CLEAN '{"tool_name":"Bash","tool_input":{"command":"python3 - <<'"'"'PY'"'"'\np=\"scripts/sim_isolated_run.sh\"\ns=open(p).read()\nassert s.count(\"# 옛말\") == 1\ns=s.replace(\"# 옛말\", \"# 조직\")\nopen(p,\"w\").write(s)\nPY"}}'
+exp "D3 row 6: sed comment word + || exit 1 in another segment"  CLEAN '{"tool_name":"Bash","tool_input":{"command":"sed -i '"'"''"'"' '"'"'s/옛말/조직/g'"'"' scripts/sim_isolated_run.sh && bash scripts/test_sim_isolated_run_lanes.sh; rc=$?; [ $rc = 0 ] || exit 1"}}'
+exp "D3 row 1: self-probe sed (no token in expr) + [ -s ] || exit 1" CLEAN '{"tool_name":"Bash","tool_input":{"command":"sed -i '"'"''"'"' '"'"'s/^#NOOP-PROBE-LINE$//'"'"' scripts/proposal_hook.sh && [ -s scripts/proposal_hook.sh ] || exit 1; tail -1 .claude/.proposal_hook_events.tsv"}}'
+exp "D4 old shape: payload w/o token, check in next segment"      CLEAN '{"tool_name":"Bash","tool_input":{"command":"printf \"%s\\n\" x >> scripts/x.sh; grep -q y scripts/x.sh || exit 3"}}'
+exp "H1 cat > scripts/new.sh <<EOF body carries token"           HIT   '{"tool_name":"Bash","tool_input":{"command":"cat > scripts/new_lane.sh <<'"'"'EOF'"'"'\n#!/usr/bin/env bash\n[ -f x ] || exit 1\nEOF"}}'
+exp "H2 cat <<EOF > \"scripts/q.sh\" (quoted target after >)"    HIT   '{"tool_name":"Bash","tool_input":{"command":"cat <<'"'"'EOF'"'"' > \"scripts/q.sh\"\nexit 1\nEOF"}}'
+exp "H3 printf | tee -a scripts/t.sh"                            HIT   '{"tool_name":"Bash","tool_input":{"command":"printf \"exit 1\\n\" | tee -a scripts/t.sh"}}'
+# R4 proper: the real edit is a python heredoc whose CONTENT quotes `: > "$T/scripts/test_has_lane_lanes.sh"` — the hook
+# must record the file the python writes, not the fixture root inside the string (row 4 recorded `$T/scripts/…`).
+R4='{"tool_name":"Bash","tool_input":{"command":"python3 - <<'"'"'PY'"'"'\np=\"scripts/test_proposal_hook_lanes.sh\"\ns=open(p).read()\ns=s.replace(\"exp \\\"noqa\", \"mkdir -p \\\"$T/scripts\\\"; : > \\\"$T/scripts/test_has_lane_lanes.sh\\\"; [ -f x ] || exit 1; exp \\\"noqa\")\nopen(p,\"w\").write(s)\nPY"}}'
+printf '%s' "$R4" | bash "$HDIR/proposal_hook.sh" >/dev/null 2>&1; r4fp=$(tail -1 "$T/.claude/.proposal_hook_events.tsv" 2>/dev/null | cut -f3)
+if [ "$r4fp" = "scripts/test_proposal_hook_lanes.sh" ]; then printf '  ✅ %-52s fp=%s\n' "R4 python heredoc → recorded fp is the WRITTEN file" "$r4fp"; pass=$((pass+1)); else printf '  ❌ %-52s fp=%s (expected scripts/test_proposal_hook_lanes.sh)\n' "R4 python heredoc → recorded fp is the WRITTEN file" "${r4fp:-<none>}"; fail=$((fail+1)); fi
 exp "G1 Edit templates/.git-hooks/pre-commit (no .sh)" HIT '{"tool_name":"Edit","tool_input":{"file_path":"/x/templates/.git-hooks/pre-commit","old_string":"  [ -f x ] || continue","new_string":"  [ -f x ] || { echo missing; PTR_FAIL=1; continue; }"}}'
 exp "G1-ctrl Edit .git-hooks docs-ish no token"        CLEAN '{"tool_name":"Edit","tool_input":{"file_path":"/x/templates/.git-hooks/pre-commit","old_string":"# note a","new_string":"# note b"}}'
 exp "noqa exempts"                            CLEAN '{"tool_name":"Edit","tool_input":{"file_path":"/x/scripts/a.sh","old_string":"a","new_string":"exit 1  # noqa: proposal-hook"}}'


### PR DESCRIPTION
## 왜
⑤ 팔 C 라이브 F 행의 첫 독립 채점(`RESULT_2026-09-04_identity5-armC-live-count.md`)이 계기 결함을 찾았다:
- **오탐 3/7** — 마커 heredoc·PR 본문·python 문자열 안에 `scripts/x.sh` 가 «인용」된 명령을 편집으로 셌다.
- **미탐 6/8** — 그날 하중 지는 판정 편집은 python heredoc `open(p,"w")` 형이라 전부 무FIRE.
- **과발화** — 주석 낱말 교체 + 다른 세그먼트의 `|| exit 1` 만으로 FIRE.

## 무엇
Bash 팔 판별자를 «명령 원문 정규식」에서 «인자 자리 대상 경로 스캐너」로: heredoc 분리 → 따옴표 밖 세그먼트 분할 → `> p`·`>> p`·`tee p`·`sed -i … p` 의 인자 자리 → python heredoc 의 `open(P,"w"|"a")`/`write_text` → 토큰 검사는 대상을 가진 세그먼트에서만. Edit/Write 팔은 무변경.

## 계기
| | 옛 훅 | 새 훅 |
|---|---|---|
| 레인(기존 24 + 신규 9 + 사실줄) | 28 passed / **9 failed** — 정확히 신규 9 | **37 / 0** |

fail-before 는 에이전트(워크트리)와 거버너(본 체크아웃, path-scoped stash 되돌림) 두 번 독립 재현. 픽스처는 RESULT 가 인용한 실제 형 그대로(기밀 스캔에 걸린 낱말 하나만 중립어로).

## 잔여(헤더에 이름으로)
변수 경유 경로 · 런타임 조립 python 경로 · `perl -pi`/`awk > tmp && mv`/`patch`/`cp` 류 · 미종결 따옴표 · 같은 세그먼트 안 비-페이로드 토큰. PreToolUse 라 «디스크에서 실제로 바뀐 것」은 못 본다 — PostToolUse mtime 쌍둥이는 settings 배선이 필요해 이 PR 밖.

🟥 **반증 창**: 머지 시점부터 F 행은 다른 계기의 행이다. 그 앞 7행은 RESULT 파일이 봉인. 창을 재개시/대체할지는 운영자 판정(RESULT §거버너 결정 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pQzk6DWvzaMns3EzymZMv