### PR TITLE
chore(ledger): 09-04 저녁 디스패치 5건 + 원장 YAML 파싱 실패 수리(#611 이후) + validate_yaml.sh 원장 파싱 레인

### DIFF
--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -3087,5 +3087,55 @@
   count: 1
   context: API 529 Overloaded 로 조기 종료 — 산출 없음. sonnet 재시도가 성공(별도 기록).
   outcome: rejected
-  evidence: task-notification «Agent terminated early due to an API error: 529»
+  evidence: "task-notification «Agent terminated early due to an API error: 529»"
   note: 실패 원인은 모델이 아니라 서버 과부하. 이후 디스패치는 sonnet 으로 갔다.
+- date: 2026-09-04
+  agent: claude-code-guide (default model)
+  invoker: forge-harness-28 (Fable 5.1 거버너, 저녁)
+  task: 리모트컨트롤 자동 켜짐 디폴트 off 설정 키 확인(공식 문서)
+  count: 1
+  context: 운영자 중간 요청. ~/.claude.json 의 remoteEnabled 가 안 잡던 동작.
+  outcome: accepted
+  evidence: >-
+    remoteControlAtStartup=false(user settings.json) — 문서 URL 포함 회신. 적용 완료. 116,730 tokens · 6 tool_uses.
+  note: 문서 근거를 요구해 추측 답을 막았다.
+- date: 2026-09-04
+  agent: general-purpose (default model)
+  invoker: forge-harness-28
+  task: qasp 콜드리드 잔여 3건 소 PR (git worktree, 절대경로)
+  count: 1
+  context: 병렬 자율주행 — 정본(starthere_register) 먼저 읽게 함.
+  outcome: accepted
+  evidence: >-
+    qasp-dev #244 MERGED (2파일 9+/8−, 체크 5/5). 143,955 tokens · 7 tool_uses.
+  note: 문서 린트 부재를 «없음」으로 정직 보고.
+- date: 2026-09-04
+  agent: general-purpose (default model)
+  invoker: forge-harness-28
+  task: qasp 3막 FLAKY known-positive 픽스처 + 실물 실행 테스트
+  count: 1
+  context: 발동 0/25 «기전만 확인」을 실행으로 닫기. 정본 6종 먼저.
+  outcome: accepted
+  evidence: >-
+    qasp-dev #245 MERGED — FLAKY 1(비결정)/0(결정) 실행 원문, 결함 2 수리 + 2 보고(exit code 미반영 = 운영자 판단). 268,519 tokens · 44 tool_uses.
+  note: 외부 URL 0, CI 는 사유 있는 skip.
+- date: 2026-09-04
+  agent: general-purpose (default model)
+  invoker: forge-harness-28
+  task: ⑤ 팔 C 라이브 FIRE 7행 첫 독립 채점(다음 세션 채점 규칙)
+  count: 1
+  context: 읽기 전용 + RESULT 1파일. 형식/실행 두 기준 분리 요구.
+  outcome: accepted
+  evidence: >-
+    tracks/_meta/RESULT_2026-09-04_identity5-armC-live-count.md — 2/7 잠정 · 형식 0/7 · 계기 결함 5 · 컨트롤 불성립 · UNRESOLVED 0. 218,308 tokens · 12 tool_uses.
+  note: 계기 결함 발견이 곧 proposal_hook 수리 디스패치의 입력이 됐다.
+- date: 2026-09-04
+  agent: general-purpose (default model)
+  invoker: forge-harness-28
+  task: proposal_hook.sh 계기 결함 수리 — 워크트리 산출 보고형(패치+레인, 커밋 금지)
+  count: 1
+  context: FH 자산은 워크트리 커밋 금지 → 패치 파일로 회수, 거버너가 본 체크아웃에 적용.
+  outcome: accepted
+  evidence: >-
+    scratchpad/proposal_hook_repair.patch — 레인 옛 훅 28/37(신규 9 빨강) → 새 훅 37/37, 거버너 독립 재현. PR fix/proposal-hook-target-scanner. 188,606 tokens · 16 tool_uses.
+  note: 에이전트의 레인 Edit 이 본 체크아웃 옛 훅을 발화시킨 부수 행 1건을 스스로 보고했다.

--- a/scripts/validate_yaml.sh
+++ b/scripts/validate_yaml.sh
@@ -133,6 +133,33 @@ if [ "$_skills" -eq 0 ] || [ "$_agents" -eq 0 ]; then
 fi
 echo "  (scanned: $_skills skill(s), $_agents agent(s))"
 
+# ── Whole-file YAML documents that machinery READS (not frontmatter) ─────────────────────────
+# The dispatch ledger is parsed by session_close_check ④-e / activity_log / round/gatecheck_qset and
+# by the 60/40 promotion gate. Measured 2026-09-04: PR #611 merged an entry whose unquoted scalar
+# carried `: ` (`… API error: 529»`) and the file had been UNPARSEABLE at HEAD since — while its own
+# marker cited "validate_yaml 레인" as the live control. That lane never read this file: it checks
+# SKILL/agent FRONTMATTER only. This block closes that gap for the files listed here. Known pair at
+# wiring time: the #611 HEAD ledger → ❌ (line 3090), the quoted fix → ✅.
+_LEDGERS="knowledge/shared/learnings/subagent_invocations_log.yaml"
+for f in $_LEDGERS; do
+  [ -f "$f" ] || { echo "  ❌ ledger missing: $f (not found ≠ empty)"; ERRORS=$((ERRORS + 1)); continue; }
+  if [ -z "$PARSER" ]; then
+    echo "  ⚠️  $f: UNCALIBRATED — no YAML parser, NOT verified"; UNCALIBRATED=$((UNCALIBRATED + 1)); continue
+  fi
+  out=$(python3 - "$f" <<'PY' 2>&1
+import sys, yaml
+try:
+    d = yaml.safe_load(open(sys.argv[1], encoding='utf-8'))
+except yaml.YAMLError as e:
+    print('PARSE ' + str(e).replace('\n', ' ')[:160]); sys.exit(1)
+if not isinstance(d, list) or not d:
+    print('NOTLIST-OR-EMPTY'); sys.exit(2)
+print('OK %d entries' % len(d))
+PY
+  ); rc=$?
+  if [ "$rc" -eq 0 ]; then echo "  ✅ $f: $out"; else echo "  ❌ $f: $out"; ERRORS=$((ERRORS + 1)); fi
+done
+
 echo ""
 if [ "$UNCALIBRATED" -gt 0 ]; then
   echo "  ⚠️  UNCALIBRATED — $UNCALIBRATED skill(s) unverified (no parser). Not a pass."


### PR DESCRIPTION
## 무엇
- 디스패치 원장 5건 기재(저녁 세션: claude-code-guide · qasp #244 · qasp #245 · ⑤ 팔 C 첫 독립 채점 · proposal_hook 수리 패치).
- 🟥 **발견**: 원장이 #611 이후 HEAD 에서 **파싱 불가**였다 — 3090행 `evidence: … API error: 529»` 의 비인용 콜론. #611 마커는 «validate_yaml 레인」을 컨트롤로 적었지만 그 레인은 SKILL/agent frontmatter 만 본다(규칙이 자기 기계를 오설명). 소비처 4곳(session_close_check ④-e · activity_log · round/gatecheck_qset · 60/40 게이트).
- 수리: 3090행 따옴표. 레인: `validate_yaml.sh` 에 원장 전체 `safe_load`(리스트·비공허) 단계 — CI `validate` 가 이 스크립트를 부르므로 다음 파손은 필수 체크에서 빨개진다.

## known-pair
| 팔 | 결과 |
|---|---|
| HEAD 원장(깨짐, path-scoped stash) | `❌ … PARSE mapping values are not allowed here … line 3090` rc=1 |
| 수리본 | `✅ … OK 262 entries` rc=0, frontmatter 41+8 그대로 ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pQzk6DWvzaMns3EzymZMv