### PR TITLE
docs(digest): 09-04 후보 2·3 집행 — armature 42% 를 auto-decorrelation «전제」 외부 앵커로 · 19%/10% 를 §Envelope-Boundary 근거로 · HN 레그 /search_by_date(09-01 처방)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ unfamiliar*, not by adding machinery. The reflex fires **before** memory recall,
 always-loaded, not only in memory. (Measured 2026-07-14, one session, 3×: two identities each collapsed
 onto their single hardest sub-mechanism, and a failure from a **non-harness** run mapped onto a harness
 metric — each read a live-but-incomplete thing as zero, each caught by the operator, not self-caught.
-Detail: `[[feedback_reinvention_reflex_normalization_counterweight]]`.)
+Detail: `[[feedback_reinvention_reflex_normalization_counterweight]]`.) **External, family-level number (2026-09-04, digest `HN:49557206`, armature.tech, 5,292 valid sessions)**: Claude Code built in-house instead of adopting an existing tool in **19 %** of sessions vs **10 %** for Codex and Cursor — ≈2× its peers. The reflex this section counterweights is a measured family bias, not a local habit; the one-session 3× above is the internal instance of it.
 
 ## Mechanization Boundary — machinery at irreversible edges and channels, judgment left to evolution
 

--- a/knowledge/shared/harness-core/field_verdict_crossfamily_gate.md
+++ b/knowledge/shared/harness-core/field_verdict_crossfamily_gate.md
@@ -116,6 +116,14 @@ same as the FH cross-family complement.
 
 ## 5. Field evidence — qasp verdict-binding sweep, 2026-07-03 (n=7)
 
+> **External anchor for the PREMISE only (recorded 2026-09-04, digest `HN:49557206`, armature.tech)**:
+> across 5,292 valid sessions (16,893 collected; 51 codebases · 18 sectors · 1,163 prompt variations),
+> Claude Code / Codex / Cursor chose the **same tool in 42 %** of scenarios — a 58 % disagreement rate
+> on a concrete, checkable decision. That is the first outside-FH evidence that model families
+> decorrelate rather than converge. 🟥 Scope: the dependent variable is *tool selection*, not *defect
+> detection* — it supports the assumption this gate rests on; it does **not** validate that the gate
+> catches defects. The n=7 sweep below remains the only evidence of the latter.
+
 The gap that motivated this rule: FH's cross-family decorrelation rigor had **never been
 auto-applied to field-harness code** — only to FH's own assets. A one-time sweep of 3 mapped
 harnesses (qasp / the-bible / pmh) found **9 HIGH default-toward-PASS holes**, all one signature.

--- a/plugins/fh-meta/skills/frontier-digest/SKILL.md
+++ b/plugins/fh-meta/skills/frontier-digest/SKILL.md
@@ -69,7 +69,7 @@ Collect from five sources (bash per source in §Collection-Bash):
 
 | Source | Method | Cap |
 |---|---|---|
-| HackerNews | Algolia API, score > 10, keyword-relevant | 15 items |
+| HackerNews | Algolia API `search_by_date` (date-sorted, never `/search`), score > 30, keyword-relevant | 15 items |
 | arxiv | export API, latest by submittedDate | 6 items |
 | TLDR AI | RSS, title + link | 5 items |
 | The Batch (deeplearning.ai) | HTML scraping, title + issue slug | 5 items |

--- a/plugins/fh-meta/skills/frontier-digest/SKILL_detail.md
+++ b/plugins/fh-meta/skills/frontier-digest/SKILL_detail.md
@@ -42,11 +42,19 @@ load: on-demand
 ```bash
 for KW in "AI agent" "LLM harness" "Claude" "multi-agent" "context engineering"; do
   curl -s --max-time 8 \
-    "https://hn.algolia.com/api/v1/search?query=$(echo $KW | tr ' ' '+')&tags=story&hitsPerPage=5&numericFilters=points>10"
+    "https://hn.algolia.com/api/v1/search_by_date?query=$(echo $KW | tr ' ' '+')&tags=story&hitsPerPage=5&numericFilters=points>30"
 done
 ```
 
-Collection criteria: score > 10, keyword-relevant items only. Max 15 items.
+Collection criteria: score > 30, keyword-relevant items only. Max 15 items.
+
+> **`/search_by_date`, not `/search` (revised 2026-09-04; prescribed 2026-09-01, unapplied for 3 runs).**
+> `/search` ranks by relevance and returned items dated 2025-11→2026-06 on 2026-09-01 — a *relevant-but-stale*
+> leg, the mirror image of the 2026-07-26 arXiv *fresh-but-off-axis* failure, and the HN leg carried neither
+> refresh trigger. `/search_by_date` sorts by submission time; the points floor rises 10→30 to keep the
+> date-sorted window from filling with noise (measured 2026-09-01: `points>30` gave a clean 08-27→08-31
+> window). Same rule as the arXiv leg: a leg that silently falls back to a relevance/recall channel converts
+> «unrun» into «nothing new».
 
 ### arxiv
 


### PR DESCRIPTION
다이제스트 2026-09-04 후보 2·3 + 09-01 HN 처방(4런째 미집행) 집행.

- `field_verdict_crossfamily_gate.md §5`: armature.tech 실측(5,292 세션, 같은 도구 42%) 을 **전제** 외부 앵커로 — 게이트 검증 근거 아님(스코프 명시).
- `CLAUDE.md §Envelope-Boundary`: 자체 구현 19% vs 10% (≈2×) — 반사가 계열 편향이라는 외부 수치.
- frontier-digest: HN 레그 `/search` → `/search_by_date&points>30`(09-01 stale 실측), SKILL.md 표 동기화. 첫 실사용 = 09-05 무인 런.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pQzk6DWvzaMns3EzymZMv