### PR TITLE
fix(guard): pipe_verdict_guard R3 — heredoc 뒤 «리다이렉션만 있는 줄」 검출 (zsh NULLCMD cat 이 CC stdin 파이프를 영원히 읽는 형태, «push 멈춤」 9건의 실제 원인)

### DIFF
--- a/scripts/pipe_verdict_guard.sh
+++ b/scripts/pipe_verdict_guard.sh
@@ -146,6 +146,35 @@ if ! printf '%s' "$NORM" | grep -qE 'set -o pipefail|set -[a-zA-Z]*o[a-zA-Z]* pi
   fi
 fi
 
+# ── R3 — a line that is ONLY redirections (`2>&1` alone on the line after a heredoc). ─────────
+# zsh runs a redirection-only line as `$NULLCMD` (= `cat` by default) — measured 2026-09-04 with
+# `zsh -x`: `+zsh:1> cat`. That `cat` reads STDIN until EOF. In this Bash tool, stdin is `/dev/null`
+# ONLY when the harness appends `< /dev/null`, and it does NOT append it when the top-level command
+# already carries a stdin redirect (`<` or a `<<` heredoc) — then stdin is a pipe held open for the
+# life of the command, and `cat` never returns. Measured 2026-09-04: 9 tasks in two sessions, all of
+# the shape `out=$(git commit -q -F - <<'CEOF' … CEOF ⏎ 2>&1)`: every commit landed within 4 s, no
+# push ever started, the shell sat in `$( )` with no git child, killed later (exit 144). The
+# pre-push hook never ran — it was blamed for a hang that happened before it.
+# Heredoc BODIES are stripped first: a one-word markdown blockquote line (`> 정본`) inside a commit
+# message is data, not a redirection. Deterministic on the remaining lines; zero-FP by construction
+# (a redirection-only line is never what the author meant outside a heredoc body).
+_R3_HIT=$(printf '%s\n' "$CMD" | awk '
+  BEGIN { inhd = 0; d = "" }
+  inhd { if ($0 == d || $0 ~ ("^[[:space:]]*" d "$")) { inhd = 0 }; next }
+  {
+    if (match($0, /<<-?[[:space:]]*["'"'"']?[A-Za-z_][A-Za-z_0-9]*["'"'"']?/)) {
+      d = substr($0, RSTART, RLENGTH); sub(/^<<-?[[:space:]]*/, "", d); gsub(/["'"'"']/, "", d); inhd = 1
+    }
+    # a STATEMENT at line start made only of redirections, ended by `)`, `;`, `}`, `&&`, `||` or EOL —
+    # the measured shape is `2>&1); rc=$?`, where `)` closes the `$( )` and the last statement inside
+    # it is the bare `2>&1`.
+    if ($0 ~ /^[[:space:]]*[0-9]*(>>?|<)(&[0-9]+|[[:space:]]*[^[:space:];|&<>()]+)?([[:space:]]+[0-9]*(>>?|<)(&[0-9]+|[[:space:]]*[^[:space:];|&<>()]+)?)*[[:space:]]*([;)}]|&&|\|\||$)/) { print NR ": " $0; exit }
+  }')
+if [ -n "$_R3_HIT" ]; then
+  add "R3 redirection-only line runs \`cat\` on stdin (line ${_R3_HIT})" \
+      "zsh executes a line that is only redirections as \$NULLCMD=cat, which reads stdin to EOF. This command carries a top-level \`<\`/\`<<\`, so the harness leaves stdin as an OPEN PIPE — that cat never returns and everything after it (the push) never starts. Put the redirection on the command line: \`out=\$(git commit -q -F - 2>&1 <<'"'"'CEOF'"'"'\`."
+fi
+
 [ -n "$hits" ] || exit 0
 
 if [ "${FH_PIPE_VERDICT_BLOCK:-0}" = "1" ]; then

--- a/scripts/test_pipe_verdict_guard_lanes.sh
+++ b/scripts/test_pipe_verdict_guard_lanes.sh
@@ -226,6 +226,16 @@ else
   printf '  ❌ %-52s rc=%s out=%s\n' "C4 ascii-codec env: JSON still delivered" "$c_rc" "$c_out"; fail=$((fail+1))
 fi
 
+# ── R3 — redirection-only statement (zsh NULLCMD=cat reads an open-pipe stdin). Measured 2026-09-04:
+# nine `git commit -q -F - <<'CEOF' … CEOF ⏎ 2>&1)` tasks in two sessions hung after the commit landed.
+# Fixtures are the measured shape verbatim (P), the same shape with the redirect moved onto the
+# command line (N1 — the one-token fix), and a one-word markdown blockquote INSIDE the heredoc body
+# (N2 — data, not a redirection; must stay CLEAN or the guard fires on every quoted commit message).
+expect "R3 measured shape: bare 2>&1 line closes \$( )" HIT   $'out=$(git commit -q -F - <<\'CEOF\'\nfix: x\n\nbody\nCEOF\n2>&1); rc=$?; echo "commit rc=$rc"'
+expect "R3 bare > file line after a heredoc"           HIT   $'cat <<\'EOF\'\nhello\nEOF\n> out.txt\necho done'
+expect "R3 fixed: 2>&1 on the command line"            CLEAN $'out=$(git commit -q -F - 2>&1 <<\'CEOF\'\nfix: x\n\nbody\nCEOF\n); rc=$?; echo "commit rc=$rc"'
+expect "R3 blockquote inside heredoc body is data"     CLEAN $'out=$(git commit -q -F - 2>&1 <<\'CEOF\'\nfix: x\n\n> 정본\n> see also)\nCEOF\n); rc=$?'
+
 echo
 if [ "$fail" -eq 0 ]; then
   echo "[pipe-verdict-guard] ✅ all $pass known pairs hold"; exit 0


### PR DESCRIPTION
## 왜
한 세션에서 9건, 백그라운드 Bash 잡이 «git push 에서 멈춘다」로 보였다(exit 144). 조사 결과 **push 이전**, `$( … <<'EOF' … EOF ⏎ 2>&1)` 의 홀로 선 `2>&1` 줄이 zsh $NULLCMD(cat) 로 실행돼 CC 가 닫지 않는 stdin 파이프를 영원히 읽었다. pre-push 훅은 실행조차 안 됐다(reflog: 커밋 1~4초 착지 · `echo commit rc` 9/9 미출력 · ps 에 git/gh 자식 없음). 로컬 bare 원격 push 4형태·실원격 dry-run 은 전부 0~4초(훅 무죄).

## 무엇
- `pipe_verdict_guard.sh` **R3**: heredoc 본문을 벗긴 뒤 «리다이렉션만 있는 문장」 검출(advisory, R1·R2 와 같은 급).
- 레인 4: 실패 원문 HIT · `> file` HIT · 수리형 CLEAN · heredoc 안 `> 정본` CLEAN. 옛 가드 **3 빨강** → 새 가드 **52/52**.
- 처방: `out=$(cmd 2>&1 <<'EOF'` — 같은 줄. 같은 세션에서 이 형태로 #617 이 한 호출에 커밋→푸시→PR 완주(첫 실사용).

## 잔여
- `git push` 자체의 멈춤은 재현 0(미관측, 배제 아님). CC 의 `</dev/null` 부착 규칙은 4변형 실측이지 소스 확인이 아니다.
- 셸 전역 `NULLCMD=:` 는 운영자 판단.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pQzk6DWvzaMns3EzymZMv