### PR TITLE
fix(chamber): step 5 가 2026-08-17 교리 어휘(CURATED · NOT-APPLICABLE)를 받는다 — 18일간 러너가 교리를 거부하고 있었다

### DIFF
--- a/scripts/chamber_run.sh
+++ b/scripts/chamber_run.sh
@@ -168,12 +168,17 @@ fi
 _stamp "step-4-done"; echo "  ✓ step 4: $NPERS blind persona sections present (isolation-gate satisfied)"
 _witness_record "$WS/SIM_NOTES.md"
 
-# STEP 5 — Emission Gate. Require a VERDICT: EMIT | PARTIAL-EMIT | KILL.
+# STEP 5 — Emission Gate. Require a VERDICT: EMIT | PARTIAL-EMIT | KILL | CURATED | NOT-APPLICABLE.
+# 🟥 2026-09-04: the doctrine re-routed two outcomes on 2026-08-17 (§3-SCREEN-2026-08-17 — net-new
+#    shortfall → CURATED, judgment-shaped candidate → NOT-APPLICABLE) and this regex kept parsing the
+#    OLD vocabulary for 18 days; run #16 had to file «KILL + CURATED 재료 동봉» to get past it, and the
+#    pre-registered taxonomy known-pair (5 old runs → CURATE) could not be replayed at all. A runner that
+#    rejects the doctrine's own words is [[feedback_rule_misdescribes_its_own_machine]] in the code half.
 if [ ! -f "$WS/EMISSION_VERDICT.md" ]; then
   cat > "$WS/EMISSION_VERDICT.md" <<EOF
 # Emission Gate Verdict — $SLUG (chamber run)
 
-VERDICT: <EMIT | PARTIAL-EMIT | KILL>
+VERDICT: <EMIT | PARTIAL-EMIT | KILL | CURATED | NOT-APPLICABLE>
 
 ## Judged: does the simulation hold?  (+ mechanical anchor: overlap grep / gate verdicts / reproduced flows)
 
@@ -183,11 +188,11 @@ EOF
   echo "  ⛔ step 5 BLOCKED: decide WITH the operator (HITL), record VERDICT in $WS/EMISSION_VERDICT.md, re-run."; exit 1
 fi
 # PARTIAL-EMIT listed FIRST in every alternation so it is never mis-extracted as its EMIT substring.
-VERDICT=$(grep -ioE '^VERDICT:[[:space:]]*(PARTIAL-EMIT|EMIT|KILL)' "$WS/EMISSION_VERDICT.md" 2>/dev/null | head -1 | grep -ioE 'PARTIAL-EMIT|EMIT|KILL' | head -1 | tr 'a-z' 'A-Z')
+VERDICT=$(grep -ioE '^VERDICT:[[:space:]]*(PARTIAL-EMIT|EMIT|KILL|CURATED|NOT-APPLICABLE)' "$WS/EMISSION_VERDICT.md" 2>/dev/null | head -1 | grep -ioE 'PARTIAL-EMIT|EMIT|KILL|CURATED|NOT-APPLICABLE' | head -1 | tr 'a-z' 'A-Z')
 # a bare "## Verdict:" prose line (run #3 style) also counts if it names KILL/EMIT
-[ -z "$VERDICT" ] && VERDICT=$(grep -ioE 'VERDICT[: *]+\**(PARTIAL-EMIT|EMIT|KILL)' "$WS/EMISSION_VERDICT.md" 2>/dev/null | grep -ioE 'PARTIAL-EMIT|EMIT|KILL' | head -1 | tr 'a-z' 'A-Z')
+[ -z "$VERDICT" ] && VERDICT=$(grep -ioE 'VERDICT[: *]+\**(PARTIAL-EMIT|EMIT|KILL|CURATED|NOT-APPLICABLE)' "$WS/EMISSION_VERDICT.md" 2>/dev/null | grep -ioE 'PARTIAL-EMIT|EMIT|KILL|CURATED|NOT-APPLICABLE' | head -1 | tr 'a-z' 'A-Z')
 if [ -z "$VERDICT" ]; then
-  echo "  ⛔ step 5 BLOCKED: no VERDICT (EMIT|PARTIAL-EMIT|KILL) found in $WS/EMISSION_VERDICT.md, re-run."; exit 1
+  echo "  ⛔ step 5 BLOCKED: no VERDICT (EMIT|PARTIAL-EMIT|KILL|CURATED|NOT-APPLICABLE) found in $WS/EMISSION_VERDICT.md, re-run."; exit 1
 fi
 _stamp "step-5-done"; echo "  ✓ step 5: Emission Gate verdict = $VERDICT"
 _witness_record "$WS/EMISSION_VERDICT.md"
@@ -269,6 +274,10 @@ case "$VERDICT" in
                 echo "                 existing asset / the skeleton (no new asset). Workspace stays as evidence." ;;
   KILL) echo "TERMINUS (KILL): first-class success — a cheap run prevented a speculative/reinvention build."
         echo "                 No emit. Workspace stays as the evidence record; seen-filter will skip re-listing it." ;;
+  CURATED) echo "TERMINUS (CURATED): net-new shortfall is not a kill (§3-SCREEN-2026-08-17) — hand the maker the"
+           echo "                 prior-art list, the closest existing asset, and the delta it does not cover." ;;
+  NOT-APPLICABLE) echo "TERMINUS (NOT-APPLICABLE): judgment-shaped candidate — not this incubator's output form."
+                  echo "                 Route to doctrine (a rule/lens), not to a build. Workspace stays as evidence." ;;
 esac
 echo "chamber run '$SLUG' COMPLETE (STATUS: step-7-done, verdict $VERDICT)."
 # EMIT/PARTIAL-EMIT 인데 순서 증인이 없으면 **비영 종료**한다. KILL 은 영향 없다 —

--- a/scripts/test_chamber_run_lanes.sh
+++ b/scripts/test_chamber_run_lanes.sh
@@ -157,6 +157,22 @@ case "$_out" in
   *)             echo "❌ L9b — 원장 부재가 무음으로 넘어갔다"; FAIL=$((FAIL+1)) ;;
 esac
 
+# ── L10c/L10d 2026-08-17 교리 어휘(CURATED · NOT-APPLICABLE)를 러너가 받는다 ───────────
+# 2026-09-04 실측: 러너 정규식이 옛 어휘(EMIT|PARTIAL-EMIT|KILL)만 받아 «VERDICT: CURATED» 가
+# step 5 에서 차단됐다(런 #16 이 KILL+동봉으로 우회). 수리 전엔 이 두 레인이 빨갛다.
+for _v in CURATED NOT-APPLICABLE; do
+  _g="g10$(printf '%s' "$_v" | tr -d '-' | tr 'A-Z' 'a-z')"
+  mkdir -p "$(_ws "$_g")"; [ -f "$T/tracks/_chamber/INDEX.md" ] || printf "# Chamber Run Ledger (G4)\n\n## Runs\n\n| # | date | slug | verdict | carry | ws |\n|---|---|---|---|---|---|\n" > "$T/tracks/_chamber/INDEX.md"
+  _mk_intent "$_g"; _mk_budget "$_g"; _mk_sim3 "$_g"; _mk_verdict "$_g" "$_v"; _mk_actual "$_g"
+  rc=0; _run "$_g" >/dev/null 2>&1 || rc=$?
+  _t "L10c PASS — VERDICT: $_v 로 완주한다(교리 어휘)" 0 "$rc"
+  if grep -q "$_v" "$T/tracks/_chamber/INDEX.md" 2>/dev/null; then
+    _t "L10d PASS ★ 원장에 $_v 로 기록" 0 0
+  else
+    _t "L10d PASS ★ 원장에 $_v 로 기록" 0 1
+  fi
+done
+
 # ── L10 PARTIAL-EMIT 이 EMIT 로 오인되지 않는다 ──────────────────────────────
 # 원장을 만들어 둔다 — 위 L9b 가 "없을 때" 를 쟀으니 여기서는 "있을 때" 를 잰다.
 printf '# Chamber Run Ledger (test)\n\n## Runs\n\n| Run | Date | Candidate | Verdict | Carry | Workspace |\n|---|---|---|---|---|---|\n' \


### PR DESCRIPTION
## 왜
교리(`harness_incubator_doctrine.md §3-SCREEN-2026-08-17`)는 챔버 결과 어휘를 EMIT / KILL / **CURATED** / **NOT-APPLICABLE** 로 바꿨는데 `chamber_run.sh` step 5 는 옛 어휘만 파싱했다 — 18일간. 런 #16 이 `VERDICT: CURATED` 로 차단돼 «KILL + CURATED 재료 동봉」으로 우회했고, 사전등록 taxonomy known-pair(옛 5런 → CURATE)는 이 러너로 재판정이 불가능했다. 러너가 교리의 낱말을 거부하는 형태.

## 무엇
- 정규식 2곳 · 템플릿 · 차단 메시지에 두 어휘 수용, TERMINUS case 에 라우팅 문구(CURATED = 선행목록+델타 인계 / NOT-APPLICABLE = 교리로). EMIT 계열 승격 분기 무변경.
- 레인 4(L10c·L10d × 2): 옛 러너 **4 빨강** → 새 러너 **37/37**.

## 정직
첫 레인 4 빨강은 러너가 아니라 레인 결함(ws dir 미생성)이었다 — 수동 실행으로 러너 rc=0 을 먼저 확인하고 레인을 고쳤다. known-pair 5런 재판정은 이 PR 밖(다음 세션 첫 실사용 후보).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pQzk6DWvzaMns3EzymZMv