### PR TITLE
feat(pr-reviewer): Step 4 에 nit 상한 5 + do-not-report(게이트 강제·생성 파일) — SDLC playbook REVIEW.md 답습

### DIFF
--- a/plugins/fh-meta/skills/hub-cc-pr-reviewer/SKILL.md
+++ b/plugins/fh-meta/skills/hub-cc-pr-reviewer/SKILL.md
@@ -98,6 +98,17 @@ verdict NOT_CONFIGURED, or the
 returned, what was found — never the matched lines themselves. Same rule as the marker: the file is
 a local artifact, the capsule is what crosses the boundary.
 
+**Noise control — two rules that decide what reaches the comment (absorbed 2026-09-04 from the
+AI-Native SDLC playbook's `REVIEW.md`; FH already tiers findings M/S/R, but had no cap and no
+exclusion list, so a long PR produced a long comment that buried the one finding that mattered):**
+- **Nit cap = 5.** A nit is any finding that would not change behavior, leak data, or breach a
+  baseline rule (style · naming · wording · ordering). Report at most five nits, then one line:
+  `+N more nits (not listed)`. M-tier and S-tier findings are never capped.
+- **Do-not-report list.** Skip anything a mechanical gate already enforces on this repo (the
+  pre-commit 4-axis gate, `validate` CI, `regression_guard`, public-surface scan) and generated or
+  vendored files. Reporting what a gate already blocks is double coverage that reads as noise; if
+  a gate *should* have caught it and did not, that is an S-tier finding about the gate, not a nit.
+
 Then attach the review comment (8-matrix results + self-catch + refinement suggestions + merge
 recommendation) via `gh pr comment`.
 

--- a/plugins/fh-meta/skills/hub-cc-pr-reviewer/SKILL_detail.md
+++ b/plugins/fh-meta/skills/hub-cc-pr-reviewer/SKILL_detail.md
@@ -28,6 +28,9 @@ gh pr comment "$PR_NUMBER" --body "$(cat <<'EOF'
 ### Refinement Suggestions (following simplification guard / areas for subsequent rounds outside this PR)
 {Subsequent round areas / omit if 0 items}
 
+### Nits (max 5; +N more not listed)
+{At most five style/naming/wording items; omit the section if 0. Never list what a gate already enforces.}
+
 ### Admin Override Merge Recommendation
 {User decision delegation / beta stage policy adherence}
 EOF


### PR DESCRIPTION
AI-Native SDLC playbook 답습 Top-3(`frontier_absorb_2026-09-04_ai-native-sdlc.md` §4): REVIEW.md 의 nit 상한 5 + Do-not-report 를 `hub-cc-pr-reviewer` Step 4 에.

## 플로어 블라인드 sim (sonnet, 레포 밖 cwd, --tools Read, 합성 소견 S2·nit12·게이트강제3·생성1)
| 팔 | nit 수 | «+N more」 | 게이트 강제 항목 |
|---|---|---|---|
| ARM(새 SKILL.md) ×3 | **5·5·5** | 3/3 | «Excluded per do-not-report」 로만 |
| CTRL(HEAD) ×3 | 7·9·1 | 0/3 | G1~G3 을 소견으로 보고 |

1차 sim 은 계기 결함(findings 파일 경로 · 스킬의 감사-전 fail-closed 가 정직 작동)으로 두 팔이 같은 이유로 죽었다 — 원문으로 확인 후 전제를 고쳐 재실행. M/S 소견은 상한 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pQzk6DWvzaMns3EzymZMv