### PR TITLE
feat(marker): 옵셔널 `affected:` 필드 — 영향 범위 + 열린 질문 (SDLC playbook intent.md 답습, 없으면 통과·있으면 비공허)

### DIFF
--- a/.claude/rules/fh_4axis_gate.md
+++ b/.claude/rules/fh_4axis_gate.md
@@ -130,7 +130,7 @@ no runnable path exists (run-first, ask-last — sonnet_floor_doctrine.md §Auto
 
 Record sim results in the Axes 2–3 marker + sub-agent invocation log.
 
-### Marker axis fields — `axes-run:` · `controls:` · `standpoint:` · `soul:` · `soul-check:` · `defeater:` · `tenets:`
+### Marker axis fields — `axes-run:` · `controls:` · `standpoint:` · `soul:` · `soul-check:` · `defeater:` · `tenets:` · `affected:`
 
 🟥 **기호 규칙 (2026-09-04, six_axis_review 판정안 8) — ⓐ~ⓕ 는 축 전용 기호다, 열거로 재사용하지
 마라.** 산문에서 목록을 셀 때는 `①②③` 또는 `(a)(b)(c)` 를 쓴다. 오늘(2026-09-04) 같은 이틀치
@@ -170,6 +170,18 @@ Record sim results in the Axes 2–3 marker + sub-agent invocation log.
 `FH-T\d\d` ID 만 허용되고, 미등록 ID 는 차단된다(오타를 조용히 버리지 않기 위해서다).
 🟥 인용은 **이 줄에서만** 읽는다 — 다른 줄에서 ID 를 «설명»하는 것은 인용이 아니다.
 인용이 하나도 없으면 통과한다(채택은 점진적이다).
+
+**`affected:` — 선택. 「이 변경이 건드리는 것(사람·하네스·표면) + 열린 질문」 한 줄.**
+(2026-09-04, frontier absorption — Anthropic AI-Native SDLC playbook `intent.md` 의 «Affected
+users and systems» · «Open questions» 두 칸을 흡수한다. 두 필드로 쪼개지 않는다 — 별도 필드마다
+빈 칸이 하나씩 늘어나는 것은 이 절이 이미 피하는 모양이다. 한 줄 산문 안에 «열린 질문 = …»
+관례로 같이 담는다.) **없으면 통과**(soul-check:/tenets: 와 같은 패턴, 채택은 점진적이다). 있으면
+비공허성만 본다 — `defeater:` 와 달리 **「없음/TBD/-」류 자리표시자만 있는 값은 차단된다**: 모든
+변경은 반드시 무언가를 건드리므로(제로 영향은 명제상 없다) 자리표시자만 있는 값은 정직한 부재가
+아니라 안 채운 것이다. 중복 줄도 차단된다(읽는 쪽은 첫 줄만 취한다).
+```
+affected: 소비자 install 의 pre-commit 사용자(마커 형식) · 열린 질문 = 필드 강제 시점
+```
 
 
 These are enforced (the first two) or expected (the third) on the Axes 2–3 marker. Until 2026-08-17

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ core invariants never melt). The nursery also **verifies what it births**: harne
 > · ③ **각 축의 컨트롤과 그 생사**. 축을 «돌렸다»의 **최소 증거 = 컨트롤이 살아 있는 실행 출력**
 > 이다 — 안 고른 이유만 적은 것은 준수가 아니다.
 > **비용 경계**: 넷을 매번 다 돌리지 않는다. 실패 모드에 맞춰 **고른다**.
+> **옵셔널 `affected:`** — 「이 변경이 건드리는 것 + 열린 질문」 한 줄(없으면 통과, 자리표시자만
+> 있으면 차단). 상세는 `fh_4axis_gate.md §Marker axis fields`.
 > 🟥 **자평이다 · 게임 가능하다 — 둘은 안 닫혔다. 「훅이 없다」는 2026-08-17 부로 거짓이 됐고,
 > 그 정정이 경계를 더 선명하게 만든다.** 그날 `standpoint:`(PR #429)와 `thirdparty:`(PR #434)에
 > 값 검증 레인이 붙어, `crossfamily:` 와 함께 **세 필드가 훅에서 닫힌 enum + 비공허 근거로

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "scripts/test_marker_thirdparty_lanes.sh",
     "scripts/test_marker_axes_run_lanes.sh",
     "scripts/test_marker_soul_check_lanes.sh",
+    "scripts/test_marker_affected_lanes.sh",
     "scripts/test_heavy_classifier_lanes.sh",
     "scripts/residency_admission_check.sh",
     "scripts/test_residency_admission_lanes.sh",

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -618,6 +618,7 @@ for _pair in \
   "templates/.git-hooks/pre-commit|scripts/test_marker_thirdparty_lanes.sh" \
   "templates/.git-hooks/pre-commit|scripts/test_marker_soul_check_lanes.sh" \
   "templates/.git-hooks/pre-commit|scripts/test_marker_soul_tenet_lanes.sh" \
+  "templates/.git-hooks/pre-commit|scripts/test_marker_affected_lanes.sh" \
   "scripts/sim_isolated_run.sh|scripts/test_sim_path_isolation_lanes.sh" \
   "templates/.git-hooks/pre-commit|scripts/test_marker_first_use_lanes.sh" \
   "scripts/fixture_guard_lib.sh|scripts/test_fixture_guard_lanes.sh" \

--- a/scripts/test_hook_leg_wiring_lanes.sh
+++ b/scripts/test_hook_leg_wiring_lanes.sh
@@ -100,6 +100,13 @@ wiring_lane W4-defeater validate_defeater_leg \
 defeater: 틀렸을 수도" \
   'defeater 가 공허하다'
 
+# W5 — 2026-09-04 신설 다리 (affected:). 옵셔널 필드지만, «값이 있는데 자리표시자뿐이면 차단»은
+# 실제 호출부가 있어야만 의미가 있다 — 같은 되돌림 known-pair 로 확인한다.
+wiring_lane W5-affected validate_affected_leg \
+  "$SOUL_OK
+affected: 없음" \
+  '자리표시자뿐이다'
+
 echo
 if [ $FAIL -eq 0 ]; then echo "HOOK LEG WIRING LANES: PASS"; else echo "HOOK LEG WIRING LANES: FAIL"; fi
 exit $FAIL

--- a/scripts/test_marker_affected_lanes.sh
+++ b/scripts/test_marker_affected_lanes.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# test_marker_affected_lanes.sh — regression fixtures for pre-commit's
+# validate_affected_leg (2026-09-04, frontier absorption of Anthropic AI-Native SDLC
+# playbook intent.md's "Affected users and systems" / "Open questions" columns).
+#
+# WHY: FH does not split the two source columns into two marker fields — a second field is
+# a second empty slot, the exact shape soul-check:/tenets:/thirdparty: already avoid. One
+# free-prose line carries both, by convention ("건드리는 것 · 열린 질문 = …").
+#
+# SCOPE — channel, not judgment: single line · no duplicate · non-vacuous · not a bare
+# placeholder. Unlike defeater:, "없음" is NOT a legal declared-absence here — every change
+# touches something, so a placeholder-only value is an unfilled field, not an honest record
+# of nothing. Absent (no `affected:` line at all) is legal — adoption is incremental, same
+# shape as soul-check:/tenets:.
+#
+# Fixtures assert BOTH directions (known-pair): every intended shape is admitted, and every
+# hole this lane closes still blocks.
+#
+# Usage: bash scripts/test_marker_affected_lanes.sh   Exit: 0 = all behave; 1 = regression.
+
+set -uo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$REPO_ROOT/templates/.git-hooks/pre-commit"
+T=$(mktemp -d); trap 'rm -rf "$T"' EXIT
+
+# 헬퍼도 같이 추출한다 — 안 하면 다리가 fail-open 이 되고 레인이 거짓 PASS 를 낸다
+# (defeater/soul-check 가 이미 겪은 형태: [[feedback_broken_parser_reports_a_verdict]]).
+sed -n '/^marker_recreate_hint()/,/^}/p'     "$HOOK" >  "$T/_helpers.sh"
+sed -n '/^_marker_template_residue()/,/^}/p' "$HOOK" >> "$T/_helpers.sh"
+sed -n '/^validate_affected_leg()/,/^}/p'    "$HOOK" >  "$T/fn0.sh"
+cat "$T/_helpers.sh" "$T/fn0.sh" > "$T/fn.sh"
+
+# Instrument calibration — an empty extraction would let every fixture "pass" against nothing.
+if ! grep -q 'validate_affected_leg' "$T/fn.sh"; then
+  echo "❌ HARNESS-ERROR — validate_affected_leg did not extract from $HOOK."
+  echo "   Fixtures below would measure an empty function. Aborting rather than reporting green."
+  exit 1
+fi
+grep -q '^_marker_template_residue()' "$T/fn.sh" || { echo "❌ HARNESS-ERROR — 헬퍼 미결합"; exit 1; }
+
+FAIL=0
+lane() { # $1 = id  $2 = expect(BLOCK|PASS)  $3 = marker body
+  local id="$1" expect="$2" body="$3" rc out
+  printf '%s\n' "$body" > "$T/m.marker"
+  out=$( bash -c 'set -uo pipefail; . "$1"; validate_affected_leg "$2"' _ "$T/fn.sh" "$T/m.marker" 2>&1 ); rc=$?
+  local got=PASS; [ $rc -ne 0 ] && got=BLOCK
+  if [ "$got" = "$expect" ]; then
+    printf '  ✅ %-40s %s\n' "$id" "$got"
+  else
+    printf '  ❌ %-40s expected %s, got %s\n     %s\n' "$id" "$expect" "$got" "$(printf '%s' "$out" | head -3)"
+    FAIL=1
+  fi
+}
+
+echo "== affected: lanes — PASS side (absent / genuinely filled) =="
+lane P1-absent-is-legal        PASS  "axis2-model: opus
+axes-run: ⓐ=codex"
+lane P2-real-content           PASS  "affected: 소비자 install 의 pre-commit 사용자(마커 형식) · 열린 질문 = 필드 강제 시점"
+lane P3-real-content-no-openq  PASS  "affected: the private companion store 미러 사용자 · 인덱스 재생성 스크립트가 이 필드를 안 읽는다"
+lane P4-korean-multiword       PASS  "affected: 마커를 grep 으로 감사하는 하류 세션 전부 · 열린 질문 = 강제 시점을 정할 것인가"
+
+echo "== affected: lanes — BLOCK side (holes that must stay closed) =="
+lane G1-placeholder-none-ko    BLOCK "affected: 없음"
+lane G2-placeholder-tbd        BLOCK "affected: TBD"
+lane G3-placeholder-tbd-lower  BLOCK "affected: tbd"
+lane G4-placeholder-dash       BLOCK "affected: -"
+lane G5-placeholder-na         BLOCK "affected: n/a"
+lane G6-empty-field            BLOCK "affected:"
+lane G7-duplicate-line         BLOCK "affected: 소비자 install 사용자
+affected: 정정 — 사실은 필드 하네스 사용자다"
+lane G8-nearmiss-plural        BLOCK "affects: 소비자 install 사용자"
+lane G9-nearmiss-space         BLOCK "affected : 소비자 install 사용자"
+lane G10-nearmiss-typo         BLOCK "affeted: 소비자 install 사용자"
+lane G11-too-short             BLOCK "affected: TBD 확인"
+# 🟥 _marker_template_residue 는 힌트에서 파생한 자리표시자만 본다(v3, defeater 의 R1~R4 가
+# 이미 겪은 형태). `affected:` 는 힌트에 아직 실려 있지 않아서 필드-고유 자리표시자는 못
+# 잡는다 — 명명된 잔여(defeater 절 참고). 잡히는 것은 다른 필드와 **공유하는** `<...>` 뿐이다.
+lane G13-shared-hint-placeholder BLOCK "affected: <...>"
+
+echo
+echo "== 실물 코퍼스 대조 (있으면) =="
+# 실물 마커에 affected: 가 아직 없는 것이 정상이다 — 이 필드는 오늘 신설이다. 부재 마커도
+# 여전히 PASS 여야 한다는 것을 실물로도 한 번 더 확인한다(계기가 실물 코퍼스에서도 안 죽는가).
+_real="$REPO_ROOT/tracks/_meta/.axes_23_passed_fix_chamber-run-doctrine-vocabulary_2026-09-04.marker"
+if [ -f "$_real" ]; then
+  lane R1-real-corpus-marker-still-passes PASS "$(cat "$_real")"
+else
+  echo "  ⚠️  실물 마커 부재 — SKIPPED (아직 오늘자 the private companion store 미러가 없을 수 있다, 통과 아님)"
+fi
+
+echo
+if [ $FAIL -eq 0 ]; then echo "AFFECTED LANES: PASS"; else echo "AFFECTED LANES: FAIL"; fi
+exit $FAIL

--- a/templates/.git-hooks/pre-commit
+++ b/templates/.git-hooks/pre-commit
@@ -1360,6 +1360,82 @@ validate_defeater_leg() { # $1 = marker path
 }
 
 
+# ── ⑤ affected: — 「이 변경이 건드리는 것 + 열린 질문」 (2026-09-04, frontier absorption) ──
+# tenet: FH-T02 (기록의 속성) · FH-T07 (행위자가 읽는 자리)
+#
+# WHY: Anthropic AI-Native SDLC playbook `intent.md` 는 «Affected users and systems» ·
+# «Open questions» 두 칸을 싣는다. FH 는 두 칸으로 쪼개지 않는다 — 별도 필드마다 빈 칸이 하나씩
+# 늘어나는 것이 이 절 전체(soul-check·tenets·thirdparty)가 이미 피하는 모양이다. 한 줄 자유
+# 산문 안에 「건드리는 것」과 「열린 질문 = …」 관례를 같이 담는다.
+#
+# SCOPE — **채널 검사만**. `defeater:` 와 같은 형태(단일 줄·중복 차단·비공허)이지만 한 가지
+# 다르다: `defeater:` 는 「없음」을 정직한 선언으로 인정한다(반증 조건이 실제로 없을 수 있다).
+# `affected:` 는 다르다 — 어떤 변경이든 반드시 무언가를 건드린다(제로 영향은 명제상 없다). 그래서
+# 「없음/TBD/-」류 자리표시자만 있는 값은 정직한 부재가 아니라 **안 채운 것**이고, 차단한다.
+#
+# 옵셔널 필드다 — **없으면 통과**(soul-check:/tenets: 와 같은 패턴. 채택은 점진적이다).
+validate_affected_leg() { # $1 = marker path
+  local m="$1" n line body words
+  n=$(grep -cE '^[[:space:]]*affected:' "$m" 2>/dev/null); n=${n:-0}
+  if [ "$n" -eq 0 ]; then
+    # near-miss: 키 오타는 부재가 아니라 오타다 (defeater: 와 같은 이유 — 저자는 적었다고
+    # 믿는데 게이트는 못 읽는 것이 가장 조용한 실패다).
+    if grep -qE '^[[:space:]]*(affects:|affected[[:space:]]+:|affeted:|affcted:|effected:)' "$m" 2>/dev/null; then
+      echo "  ❌ FAIL — affected 키처럼 보이지만 정확히 'affected:' 가 아닌 줄이 있다."
+      grep -nE '^[[:space:]]*(affects:|affected[[:space:]]+:|affeted:|affcted:|effected:)' "$m" | sed 's/^/       /'
+      echo "     읽는 쪽은 정확히 'affected:' 만 읽는다."
+      return 1
+    fi
+    return 0   # 진짜 부재 — 옵셔널 필드, 채택은 점진적이다(soul-check:/tenets: 와 같은 형태)
+  fi
+  if [ "$n" -gt 1 ]; then
+    echo "  ❌ FAIL — 마커에 'affected:' 줄이 둘 이상이다."
+    grep -nE '^[[:space:]]*affected:' "$m" | sed 's/^/       /'
+    echo "     읽는 쪽은 첫 줄을 취하므로 나중에 붙인 정정이 조용히 가려진다."
+    return 1
+  fi
+  line=$(grep -m1 -E '^[[:space:]]*affected:' "$m" | sed -E 's/^[[:space:]]*affected:[[:space:]]*//')
+  body=$(printf '%s' "$line" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+  # 양끝 구두점/공백만 벗긴다 — 클래스 파싱(`tr -d '[:punct:]'` 류)은 한글 바이트를 지우는
+  # 이식성 결함을 낸 전례가 있다(defeater 의 2026-08-30 CI 리트로). 파라미터 확장만 쓴다.
+  _av="$body"
+  while :; do
+    case "$_av" in
+      ' '*|'	'*) _av="${_av# }"; _av="${_av#	}" ;;
+      *' '|*'	') _av="${_av% }"; _av="${_av%	}" ;;
+      *'.'|*'·'|*'—'|*'-'|*']') _av="${_av%?}" ;;
+      *) break ;;
+    esac
+  done
+  case "$(printf '%s' "$_av" | tr 'A-Z' 'a-z')" in
+    없음|none|n/a|na|tbd|todo|-|해당없음|'')
+      echo "  ❌ FAIL — affected 가 자리표시자뿐이다 ('$body')."
+      echo "     이 변경이 건드리는 것(사람·하네스·표면)과 아직 열린 질문을 한 줄로 적어라."
+      echo "       affected: 소비자 install 의 pre-commit 사용자(마커 형식) · 열린 질문 = 필드 강제 시점"
+      echo "     Append to: $m"
+      return 1 ;;
+  esac
+  # 🟥 헬퍼 부재를 «잔여 없음»으로 렌더하지 않는다 — 레인 스위트가 이 함수만 추출하면 헬퍼가
+  # 안 따라오고, 정의되지 않은 명령은 거짓이 되어 fail-open 이 된다(defeater 가 이미 겪었다).
+  if ! declare -f _marker_template_residue >/dev/null 2>&1; then
+    echo "  ❌ HARNESS-ERROR — _marker_template_residue 가 정의돼 있지 않다."
+    echo "     격리 실행이면 그 헬퍼도 같이 추출해야 한다. 부재는 «통과»가 아니다."
+    return 1
+  fi
+  if _marker_template_residue "$body"; then
+    echo "  ❌ FAIL — affected 가 힌트의 자리표시자 그대로다 (기록이 아직 안 쓰였다)."
+    return 1
+  fi
+  words=$(printf '%s' "$body" | wc -w | tr -d ' '); words=${words:-0}
+  if [ "$words" -lt 3 ]; then
+    echo "  ❌ FAIL — affected 가 공허하다 ($words 낱말). 건드리는 것 · 열린 질문을 적어라."
+    return 1
+  fi
+  echo "  ✅ affected 기록됨 ($words 낱말)"
+  return 0
+}
+
+
 SOUL_PRESENT_GRACE_DATE="2026-08-21"
 validate_soul_present_leg() { # $1 = marker path
   # ── ①영혼 존재 검사 (2026-08-21) ──────────────────────────────────────────────
@@ -2057,6 +2133,7 @@ if [ "$GATE_MODE" = "full" ]; then
     #    ([[feedback_built_but_not_wired]] — 오늘만 다섯 번째 얼굴).
     validate_soul_tenet_refs "$MARKER" || _SOUL_OK=0
     validate_defeater_leg "$MARKER" || _SOUL_OK=0
+    validate_affected_leg "$MARKER" || _SOUL_OK=0
     if [ "$_DEFENSE_OK" -eq 1 ] && [ "$_SOUL_OK" -eq 1 ] && validate_marker_floor "$MARKER" && validate_marker_axes_run "$MARKER" && validate_first_use_leg "$MARKER"; then
       echo "  ✅ PASS (marker confirmed + floor/axes fields valid:"
       echo "     .axes_23_passed_${BRANCH_SLUG}_${TODAY}.marker)"


### PR DESCRIPTION
AI-Native SDLC playbook 답습 Top-1: intent.md 의 «Affected users and systems / Open questions」 를 4축 마커의 **옵셔널** `affected:` 한 필드로. 없으면 통과(점진 채택), 있으면 비공허만(플레이스홀더·중복·오타 키 차단) — 진위는 안 본다(§Mechanization Boundary).

- `pre-commit` `validate_affected_leg` + 레인 17 + W5 배선 프로브(live=1/dead=0) + selfcheck·files[] 등록 · `fh_4axis_gate.md` 문단 · `CLAUDE.md` 포인터 두 줄(residency: pointer)
- fail-before: HEAD 훅에 새 레인 rc=1 · 기존 marker 레인 4종 초록 · bash 3.2/5.3 `-n`
- 이 PR 의 마커가 `affected:` 를 직접 쓴다(첫 실사용). residual: `marker_recreate_hint` 미등재(옵셔널 관례)
- 게이트가 잡은 것 4(evidence 판정 토큰 · 레인 주석의 스토어명/사내 토큰 · 상주 유입 residency 미선언) — 전부 수리 후 재커밋

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pQzk6DWvzaMns3EzymZMv