### PR TITLE
feat(eval): probe_live_eval — /prompt-regression 의 라이브 짝 (probes.md 선택 12 · 격리 클론 실행 · 4값 채점 · launchd 템플릿) — SDLC playbook evals 답습

### DIFF
--- a/.claude/regression/probes_live.yaml
+++ b/.claude/regression/probes_live.yaml
@@ -1,0 +1,125 @@
+# probes_live.yaml — LIVE (behavioral) subset of .claude/regression/probes.md
+#
+# WHY THIS FILE EXISTS. `/prompt-regression` (plugins/fh-meta/skills/prompt-regression/SKILL.md)
+# is a STATIC check: it reads changed source and asks "does the text still say the right thing".
+# Its own SKILL.md names the gap plainly (§Step 4, "What it therefore cannot catch"): a rule that
+# is present but has stopped FIRING, a trigger shadowed by a higher-priority route, any behavior
+# change that leaves the source text identical. This file is the "live twin" the SKILL.md points
+# at — `scripts/probe_live_eval.sh` runs each entry below through `scripts/sim_isolated_run.sh`
+# (isolated clone, floor-tier `claude -p`, observe mode) and greps the ACTUAL RESPONSE, not the
+# source. It answers "does it fire", never "was it worded correctly" — the two checks are
+# complementary, not redundant (CLAUDE.md §Anthropic SDLC evals: "settings-changed PR + eval run").
+#
+# SELECTION RULE (mechanical, applied by `probe_live_eval.sh --dry-run` against probes.md, not
+# hand-maintained here — this file is the OUTCOME of that rule, re-derive rather than trust it):
+#   1. Class in {mandatory-pass, measured} in probes.md          → excludes `judged` rows (a judged
+#      verdict needs a human/adversarial reader, not a keyword grep — scoring one by regex would be
+#      exactly the "grep-collision" class CLAUDE.md's Typed-Verdict-Channel memory entry warns about)
+#   2. Input Pattern cell is UTTERANCE-SHAPED — contains a backtick-quoted or double-quoted literal
+#      a user could actually type to Claude (excludes state/event-triggered rows like "new SKILL.md
+#      commit" or "CATALOG.md-only change" — those need a git/commit precondition this runner does
+#      not build, not a chat turn)
+#   3. NOT an `[INERT-ANCHOR]` row (probes.md's own caveat: G-GATE-08/09 are deletion anchors for an
+#      ablation, "nothing evaluates them on an ordinary session" — scoring them live would invent a
+#      live signal for a probe designed to have none)
+#   4. NOT in the hand-curated CLI-event exclude set inside `probe_live_eval.sh`
+#      (`_cli_event_exclude()`) — G-CODE-01/02/03 pass rules 1-3 (their cells ARE backtick-quoted:
+#      `npm test`, `npm publish`) but the quoted text is a SHELL COMMAND, not something a user says
+#      IN CONVERSATION to Claude; passing it as `--prompt` would test "does Claude talk about npm
+#      test" not "does npm test actually gate publish". This is the one judgment call rules 1-3
+#      cannot make mechanically, so it is named here rather than left implicit in a regex.
+#
+# Applying rules 1-4 to the 33-row probes.md (2026-09-04 snapshot) selects exactly the 12 rows below
+# — see `probe_live_eval.sh --dry-run` for the live recount and the excluded-21 reason table. If that
+# recount and this file's id list ever disagree, TRUST THE RECOUNT (probes.md may have grown a new
+# row this file has not been curated against yet) and re-author the missing entries by hand — this
+# file's `polarity`/`expect_re`/`control_input` fields are judgment, not mechanically derivable.
+#
+# SCHEMA (per probe — deliberately NOT full YAML; parsed by a small fixed-format reader in
+# `probe_live_eval.sh`'s embedded Python, see that script's `_parse_probes_live()`):
+#   id             — must exist in probes.md (dead-pointer guard, lane-tested)
+#   polarity       — present: expect_re MUST appear in the PRIMARY response, and must NOT appear in
+#                    the CONTROL response (control proves the pattern isn't a universal false-positive)
+#                  — absent:  expect_re must NOT appear in PRIMARY, and MUST appear in CONTROL
+#                    (control proves the pattern CAN fire — an absent-polarity probe whose control
+#                    also never fires is not "safely passing", it is an instrument that never worked)
+#   input          — the literal utterance sent as PRIMARY via sim_isolated_run.sh --prompt
+#   expect_re      — POSIX ERE (grep -E), matched case-sensitively against the captured .txt response
+#   control_input  — the known-negative (or known-positive, for polarity=absent) utterance
+#
+# A probe whose control does not discriminate as its polarity predicts scores UNCALIBRATED for that
+# probe, not PASS/FAIL — see probe_live_eval.sh header §Scoring. This is the known-pair discipline
+# CLAUDE.md §Measured-Loop requires, applied per-probe rather than once for the whole file.
+
+probes:
+  - id: G-GREET-01
+    polarity: present
+    input: "안녕"
+    expect_re: "🐿️"
+    control_input: "package.json 파일의 dependencies 목록만 알려줘"
+
+  - id: G-GREET-04
+    polarity: absent
+    input: "package.json 파일에 있는 dependencies 목록을 알려줘"
+    expect_re: "🐿️"
+    control_input: "안녕"
+
+  - id: G-TRIG-01
+    polarity: present
+    input: "recommend a plugin for this"
+    expect_re: "plugin-recommender"
+    control_input: "오늘 날씨 어때?"
+
+  - id: G-TRIG-02
+    polarity: present
+    input: "context is getting long"
+    expect_re: "context-doctor"
+    control_input: "오늘 날씨 어때?"
+
+  - id: G-TRIG-03
+    polarity: present
+    input: "this harness is complex"
+    expect_re: "harness-doctor"
+    control_input: "오늘 날씨 어때?"
+
+  - id: G-TRIG-04
+    polarity: present
+    input: "wrap up this week"
+    expect_re: "harvest-loop"
+    control_input: "오늘 날씨 어때?"
+
+  - id: G-TRIG-05
+    polarity: present
+    input: "I want to make this repo public"
+    expect_re: "(public-surface-audit|marketplace-gate|Pre-Publish)"
+    control_input: "오늘 날씨 어때?"
+
+  - id: G-TRIG-06
+    polarity: present
+    input: "run this whole thing autonomously as a /goal task"
+    expect_re: "goal-quench"
+    control_input: "오늘 날씨 어때?"
+
+  - id: G-TRIG-07
+    polarity: present
+    input: "정리해줘"
+    expect_re: "deep-clarify"
+    control_input: "오늘 날씨 어때?"
+
+  - id: G-CLOSE-01
+    polarity: present
+    input: "wrap up"
+    expect_re: "(session_close_check|fh_completed|close chain|카드|세션 마감)"
+    control_input: "오늘 날씨 어때?"
+
+  - id: G-SEARCH-01
+    polarity: present
+    input: "find past work on the 4-axis gate"
+    expect_re: "CATALOG"
+    control_input: "오늘 날씨 어때?"
+
+  - id: G-MAP-01
+    polarity: present
+    input: "connect a project to this hub"
+    expect_re: "(auto_project_mapping|매핑)"
+    control_input: "오늘 날씨 어때?"

--- a/package.json
+++ b/package.json
@@ -285,6 +285,11 @@
     "scripts/test_mapped_tracks_lanes.sh",
     "!**/__pycache__",
     "!**/__pycache__/**",
-    "!**/*.pyc"
+    "!**/*.pyc",
+    "scripts/probe_live_eval.sh",
+    "scripts/probe_live_eval_lib.py",
+    "scripts/test_probe_live_eval_lanes.sh",
+    ".claude/regression/probes_live.yaml",
+    "scripts/com.forge-harness.live-eval.plist"
   ]
 }

--- a/scripts/com.forge-harness.live-eval.plist
+++ b/scripts/com.forge-harness.live-eval.plist
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Replace every /path/to/... below with your own absolute paths before installing.
+         Follows the same template shape as scripts/com.forge-harness.daily-report.plist —
+         see that file's own comments for the general launchd-on-macOS caveats (sleep/wake
+         does not guarantee the exact minute, StandardOutPath dirs must pre-exist). -->
+    <key>Label</key>
+    <string>com.forge-harness.live-eval</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/path/to/forge-harness/scripts/probe_live_eval.sh</string>
+        <!-- 🟥 COST + API-KEY DECISION IS THE OPERATOR'S — this template ships with NO default
+             --subset/--ids limiter, i.e. installing it as-is runs the FULL selected set (12
+             probes x 2 calls = 24 live `claude -p` invocations) every night. Read
+             scripts/probe_live_eval.sh's own header (§COST) before installing, and add a
+             --subset N or --ids P1,P2 argument here if a nightly full-set run is not what you
+             want. This plist is a template, not a recommendation of scope. -->
+    </array>
+
+    <!-- 매일 02:30 (야간, 다른 cron 과 안 겹치는 시간대 — frontier-digest=09:00, daily-report=07:30
+         과 분리). 잠자는 중이면 launchd 가 깨어난 뒤 한 번 돌린다(정각 보장 아님). -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key><integer>2</integer>
+        <key>Minute</key><integer>30</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>/path/to/forge-harness/tracks/_meta/logs/live_eval_out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/path/to/forge-harness/tracks/_meta/logs/live_eval_err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <!-- must include wherever `claude` and `python3` resolve for this user -->
+        <string>/path/to/home/.local/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>/path/to/home</string>
+    </dict>
+</dict>
+</plist>
+
+<!--
+INSTALL (manual — no launchd_wiring_check.sh render- helper exists for this plist yet; unlike
+com.forge-harness.daily-report.plist, this one is not wired into that renderer, so every
+/path/to/... above must be hand-edited before `launchctl load`):
+
+  1. cp scripts/com.forge-harness.live-eval.plist ~/Library/LaunchAgents/com.forge-harness.live-eval.plist
+  2. Edit every /path/to/... above to this checkout's absolute path and your $HOME.
+  3. mkdir -p tracks/_meta/logs   (StandardOutPath/StandardErrorPath dirs must pre-exist)
+  4. launchctl load ~/Library/LaunchAgents/com.forge-harness.live-eval.plist
+  5. Verify: launchctl list | grep com.forge-harness.live-eval
+
+UNINSTALL:
+  launchctl unload ~/Library/LaunchAgents/com.forge-harness.live-eval.plist
+  rm ~/Library/LaunchAgents/com.forge-harness.live-eval.plist
+
+The nightly run appends its record to tracks/_meta/live_eval_<date>.md (created fresh each run —
+not append-only; a stale prior day's file is left alone, per date, exactly like
+tracks/_meta/daily_report_<date>.md and tracks/_meta/frontier_digest_<date>.md).
+-->

--- a/scripts/probe_live_eval.sh
+++ b/scripts/probe_live_eval.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# probe_live_eval.sh — the LIVE twin of /prompt-regression's static probe check.
+#
+# WHY THIS EXISTS. `plugins/fh-meta/skills/prompt-regression/SKILL.md` says this about itself,
+# verbatim, in its own §Step 4: "What it therefore cannot catch — a rule that is still present but
+# has stopped FIRING (salience loss, ordering, competition from another rule) — a trigger phrase
+# present in the file but shadowed by a higher-priority route — any behavior change that leaves the
+# source text identical." That gap is exactly what an eval-style harness closes (CLAUDE.md
+# §Autonomous Initiative Layer cites the shape: settings-changed PR + a scored run against real
+# tasks, not a source grep). This script IS that harness for FH's own golden probe set
+# (.claude/regression/probes.md): it sends each selected probe's literal utterance to a floor-tier
+# `claude -p` inside an ISOLATED, disposable clone (via scripts/sim_isolated_run.sh — never the live
+# repo, per that script's own header) and greps the ACTUAL RESPONSE, not the source.
+#
+# WHAT IT IS NOT. It does not replace /prompt-regression (source-correctness stays cheap and
+# instant) and it does not replace a blind sim-conductor persona run (which reads a whole artifact
+# for open-ended judgment). This is narrow, mechanical, known-answer, and cheap enough to run
+# nightly — the same trade CLAUDE.md's Measured-Loop memory entry describes for any recurring
+# measurement: sealed pre-registration (probes_live.yaml is authored BEFORE a run, not fit to one),
+# one variable per probe (ARM=primary utterance, CTRL=known-negative), a scorer that runs before
+# results are read, and the falsification condition (a probe whose control does not discriminate
+# is not scored PASS/FAIL — see §Scoring) executed exactly as it is written.
+#
+# SELECTION. Not every probes.md row is live-runnable — see .claude/regression/probes_live.yaml's
+# header for the 4-step mechanical rule (class filter, utterance-shape filter, INERT-ANCHOR filter,
+# hand-curated CLI-event filter) and scripts/probe_live_eval_lib.py for the implementation. Run
+# `--dry-run` to see the full 33-row breakdown: which probes are selected, which are excluded and
+# why, and which pass the mechanical rule but have no authored expect/control yet
+# (NOT-YET-AUTHORED — an honest gap, not a silent drop; G-LINT-01 is the current example, deferred
+# because scoring a full /harness-doctor Step 5 run needs more than a keyword regex).
+#
+# COST. Each selected probe costs TWO live `claude -p` calls (primary + control). Do not run the
+# full selected set casually — use --subset N or --ids P1,P2 for a spot-check, and read
+# sim_isolated_run.sh's own header before running unattended (isolation guarantees, what "observe"
+# mode does and does not prevent, the three-valued rc/bytes verdict for a timeout vs an empty
+# answer).
+#
+# 🟥 «미실행 ≠ 0» — a probe whose primary or control call produced 0 bytes (timeout, rate limit,
+# crash) is scored FAILED-TO-RUN, excluded from the pass-rate denominator, and its count is
+# reported separately. A FAILED-TO-RUN probe is not evidence the behavior is absent — it is
+# evidence nothing was measured (CLAUDE.md §Instrument-Calibration: "not found ≠ 0").
+#
+# SCORING (see scripts/probe_live_eval_lib.py:score_probe for the exact rule). Each probe declares
+# a `polarity` in probes_live.yaml:
+#   present — expect_re must appear in PRIMARY and must NOT appear in CONTROL
+#   absent  — expect_re must NOT appear in PRIMARY and MUST appear in CONTROL
+# Either direction of "the control disagrees with what polarity predicts" scores that probe
+# UNCALIBRATED, never PASS or FAIL — an instrument that cannot discriminate has not measured
+# anything, per this repo's own instrument-calibration discipline. If ANY probe in a run is
+# UNCALIBRATED, the WHOLE RUN's overall verdict is UNCALIBRATED (rc=2) — a pass rate computed
+# alongside a proven-blind probe is not trustworthy just because the other rows look fine.
+#
+# EXIT CODES: 0 = PASS (pass_rate >= threshold, no UNCALIBRATED). 1 = FAIL (pass_rate < threshold).
+# 2 = UNCALIBRATED or NO-PROBES-RAN (no verdict rendered — fix the instrument before trusting it).
+#
+# USAGE
+#   bash scripts/probe_live_eval.sh --dry-run
+#   bash scripts/probe_live_eval.sh --ids G-GREET-01,G-TRIG-02 --model sonnet
+#   bash scripts/probe_live_eval.sh --subset 3
+#   bash scripts/probe_live_eval.sh                      # full selected set — nightly cron shape
+#
+# PORTABILITY: bash 3.2 (macOS) + bash 5.x (Linux CI). No associative arrays, no `${var,,}`,
+# heredocs only inside functions with quoted delimiters (see [[feedback_unquoted_heredoc_backtick_executes]]
+# — this script has none; the one heredoc-shaped block lives in probe_live_eval_lib.py, a real
+# file, not a bash heredoc).
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROBES_MD="$REPO_ROOT/.claude/regression/probes.md"
+PROBES_LIVE="$REPO_ROOT/.claude/regression/probes_live.yaml"
+LIB="$REPO_ROOT/scripts/probe_live_eval_lib.py"
+SIM_RUNNER="$REPO_ROOT/scripts/sim_isolated_run.sh"
+
+# ── file-header constant — the "문턱" the design brief calls for. Change here, not per-invocation. ──
+THRESHOLD="0.8"
+
+MODEL="sonnet"
+DRYRUN=0
+SUBSET=""
+IDS=""
+OUTDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --subset)   SUBSET="${2:-}"; shift 2 ;;
+    --ids)      IDS="${2:-}"; shift 2 ;;
+    --model)    MODEL="${2:-sonnet}"; shift 2 ;;
+    --dry-run)  DRYRUN=1; shift ;;
+    --out)      OUTDIR="${2:-}"; shift 2 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+command -v python3 >/dev/null 2>&1 || { echo "FAIL: python3 required" >&2; exit 2; }
+[ -f "$PROBES_MD" ]   || { echo "FAIL: $PROBES_MD not found" >&2; exit 2; }
+[ -f "$PROBES_LIVE" ] || { echo "FAIL: $PROBES_LIVE not found" >&2; exit 2; }
+[ -f "$LIB" ]         || { echo "FAIL: $LIB not found" >&2; exit 2; }
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/fh-live-eval-XXXXXX")"
+SPEC_DIR="$WORKDIR/spec"
+SELECT_JSON="$WORKDIR/select.json"
+
+SELECT_ARGS=(select --probes-md "$PROBES_MD" --probes-live "$PROBES_LIVE"
+             --json-out "$SELECT_JSON" --spec-dir "$SPEC_DIR")
+[ -n "$SUBSET" ] && SELECT_ARGS+=(--subset "$SUBSET")
+[ -n "$IDS" ]     && SELECT_ARGS+=(--ids "$IDS")
+
+python3 "$LIB" "${SELECT_ARGS[@]}"
+select_rc=$?
+# select_rc nonzero = a DEAD-POINTER (probes_live.yaml names an id absent from probes.md). That is
+# an authoring bug in this repo's own asset, not a runtime condition — fail loudly rather than
+# silently running a smaller set than intended.
+if [ "$select_rc" -ne 0 ]; then
+  echo "" >&2
+  echo "❌ selection reported a dead pointer — fix .claude/regression/probes_live.yaml before running." >&2
+  rm -rf "$WORKDIR"
+  exit "$select_rc"
+fi
+
+if [ "$DRYRUN" -eq 1 ]; then
+  rm -rf "$WORKDIR"
+  exit 0
+fi
+
+[ -f "$SPEC_DIR/selected_ids.txt" ] || { echo "FAIL: selection produced no spec dir" >&2; rm -rf "$WORKDIR"; exit 2; }
+SELECTED_COUNT=$(wc -l < "$SPEC_DIR/selected_ids.txt" | tr -d ' ')
+if [ "$SELECTED_COUNT" -eq 0 ]; then
+  echo "❌ 0 probes selected after filtering — nothing to run (check --ids / --subset against the" >&2
+  echo "   SELECTED list printed above)." >&2
+  rm -rf "$WORKDIR"
+  exit 2
+fi
+
+command -v claude >/dev/null 2>&1 || { echo "FAIL: claude CLI not on PATH — cannot run live" >&2; rm -rf "$WORKDIR"; exit 2; }
+
+RUN_DATE="$(date +%Y-%m-%d)"
+OUTDIR="${OUTDIR:-$WORKDIR/run}"
+mkdir -p "$OUTDIR"
+
+echo ""
+echo "── live run: $SELECTED_COUNT probe(s), model=$MODEL, out=$OUTDIR ──────────────────────"
+
+while IFS= read -r id; do
+  [ -z "$id" ] && continue
+  input_text="$(cat "$SPEC_DIR/$id.input.txt")"
+  control_text="$(cat "$SPEC_DIR/$id.control.txt")"
+  probe_out="$OUTDIR/$id"
+  mkdir -p "$probe_out"
+
+  echo ""
+  echo "▶ $id — primary"
+  bash "$SIM_RUNNER" --arm primary --reps 1 --prompt "$input_text" \
+       --mode observe --model "$MODEL" --out "$probe_out" \
+       > "$probe_out/_runner_primary.log" 2>&1
+  tail -n 6 "$probe_out/_runner_primary.log"
+
+  echo "▶ $id — control"
+  bash "$SIM_RUNNER" --arm control --reps 1 --prompt "$control_text" \
+       --mode observe --model "$MODEL" --out "$probe_out" \
+       > "$probe_out/_runner_control.log" 2>&1
+  tail -n 6 "$probe_out/_runner_control.log"
+done < "$SPEC_DIR/selected_ids.txt"
+
+echo ""
+REPORT_PATH="$REPO_ROOT/tracks/_meta/live_eval_${RUN_DATE}.md"
+python3 "$LIB" score \
+  --probes-live "$PROBES_LIVE" \
+  --select-json "$SELECT_JSON" \
+  --ids-file "$SPEC_DIR/selected_ids.txt" \
+  --run-root "$OUTDIR" \
+  --threshold "$THRESHOLD" \
+  --model "$MODEL" \
+  --report-out "$REPORT_PATH" \
+  --run-date "$RUN_DATE"
+score_rc=$?
+
+echo ""
+echo "run artifacts kept at: $OUTDIR"
+echo "(temp selection workspace $WORKDIR is NOT auto-deleted when --out was passed explicitly; ok to remove by hand)"
+
+exit "$score_rc"

--- a/scripts/probe_live_eval_lib.py
+++ b/scripts/probe_live_eval_lib.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""probe_live_eval_lib.py — parsing + scoring core for scripts/probe_live_eval.sh.
+
+Split out of the .sh entrypoint on purpose: the lane test
+(scripts/test_probe_live_eval_lanes.sh) needs to calibrate the SCORER against known-pair fixture
+text — PASS/FAIL/UNCALIBRATED/FAILED-TO-RUN — without ever invoking `claude`. A pure, import-safe
+module makes that a direct function call instead of a shell-out with a live API dependency.
+
+No third-party deps (no pyyaml) — `probes_live.yaml` is deliberately NOT full YAML; it's a fixed,
+hand-authored subset this module parses with a small line-based reader (see `parse_probes_live`).
+If that format ever needs real YAML nesting, switch formats deliberately — don't let a stdlib-only
+parser silently start guessing.
+"""
+import json
+import re
+import sys
+import os
+import glob
+from datetime import date
+
+ID_RE = re.compile(r'^[A-Z][A-Z0-9]*-[A-Z0-9]+-[0-9]+$')
+UTTERANCE_RE = re.compile(r'`[^`]+`|"[^"]+"')
+VALID_CLASSES = ('mandatory-pass', 'measured', 'judged')
+
+# The one judgment call the mechanical rule (class + quoted-literal) cannot make: these rows ARE
+# backtick-quoted (`npm test`, `npm publish`) but the quoted text is a SHELL COMMAND a CI job runs,
+# not something a user types to Claude in conversation. Passing it as --prompt would test "does
+# Claude talk about npm test", not "does npm test actually gate publish" — a different question the
+# probe was never about. Named here, not folded into the regex, so it stays greppable as a decision
+# rather than disappearing into pattern tuning.
+CLI_EVENT_EXCLUDE = {"G-CODE-01", "G-CODE-02", "G-CODE-03"}
+
+
+def parse_probes_md(path):
+    """Return [{id, input, class, raw_class}] for every table-row probe in probes.md.
+
+    Markdown-table split by '|', not a markdown library — probes.md cells contain no literal
+    pipe characters (checked: the file is hand-authored prose + code spans only), so this is a
+    faithful parse, not a heuristic one. Rows are recognized by column-1 matching ID_RE after
+    stripping backticks; the header row, the `|---|` separator, and prose lines that happen to
+    start with '|' (none currently do) are excluded by that same test.
+    """
+    rows = []
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            line = line.rstrip('\n')
+            if not line.startswith('|'):
+                continue
+            cells = [c.strip() for c in line.split('|')]
+            # split('|') on "| a | b | c | d | e |" yields ['', a, b, c, d, e, ''] — 7 elements.
+            if len(cells) != 7:
+                continue
+            id_cell = cells[1].strip('`').strip()
+            if not ID_RE.match(id_cell):
+                continue
+            input_cell = cells[2]
+            class_cell = cells[5]
+            class_tok = class_cell.split('—')[0].strip()
+            rows.append({
+                'id': id_cell,
+                'input': input_cell,
+                'class': class_tok,
+                'raw_class': class_cell,
+            })
+    return rows
+
+
+def parse_probes_live(path):
+    """Fixed-format reader for probes_live.yaml's `- id: ...` / `    key: value` block shape.
+
+    Deliberately not a general YAML parser (no pyyaml dependency, see module docstring). Values
+    are taken verbatim after the first ':' and unquoted if wrapped in matching double-quotes —
+    this is why every value in probes_live.yaml that could contain a literal colon is avoided by
+    convention (documented in that file's header) rather than escaped here.
+    """
+    probes = []
+    cur = None
+    with open(path, encoding='utf-8') as f:
+        for raw in f:
+            line = raw.rstrip('\n')
+            stripped = line.strip()
+            if not stripped or stripped.startswith('#'):
+                continue
+            if stripped == 'probes:':
+                continue
+            if stripped.startswith('- id:'):
+                if cur is not None:
+                    probes.append(cur)
+                cur = {'id': _unquote(stripped[len('- id:'):].strip())}
+                continue
+            if cur is None:
+                continue
+            m = re.match(r'^([a-z_]+):\s*(.*)$', stripped)
+            if not m:
+                continue
+            key, val = m.group(1), _unquote(m.group(2).strip())
+            cur[key] = val
+    if cur is not None:
+        probes.append(cur)
+    return probes
+
+
+def _unquote(s):
+    if len(s) >= 2 and s[0] == '"' and s[-1] == '"':
+        return s[1:-1]
+    return s
+
+
+def classify(id_, input_pat, class_tok):
+    """Apply the mechanical selection rule. Returns (bucket, reason) — reason is None iff
+    bucket == 'SELECTABLE'."""
+    if class_tok == 'judged':
+        return 'EXCLUDED', 'JUDGED'
+    if class_tok not in VALID_CLASSES:
+        return 'EXCLUDED', 'UNKNOWN-CLASS(%s)' % (class_tok or '<empty>')
+    if input_pat.strip().startswith('[INERT-ANCHOR]'):
+        return 'EXCLUDED', 'INERT-ANCHOR'
+    if id_ in CLI_EVENT_EXCLUDE:
+        return 'EXCLUDED', 'NOT-CHAT-UTTERANCE (shell command, not a chat turn)'
+    if not UTTERANCE_RE.search(input_pat):
+        return 'EXCLUDED', 'NO-UTTERANCE (no quoted/backticked literal a user would type)'
+    return 'SELECTABLE', None
+
+
+def build_selection(probes_md_rows, live_rows):
+    """Cross-reference probes.md (source of truth for WHICH probes exist and their class) against
+    probes_live.yaml (source of truth for HOW to score the selected ones).
+
+    Returns dict: selected [{id,input,control_input,polarity,expect_re}], excluded [{id,reason}],
+    warnings [str] — warnings never block a run, they name drift between the two files.
+    """
+    live_by_id = {p['id']: p for p in live_rows}
+    md_ids = set()
+    selected, excluded, warnings = [], [], []
+
+    for row in probes_md_rows:
+        md_ids.add(row['id'])
+        bucket, reason = classify(row['id'], row['input'], row['class'])
+        if bucket == 'EXCLUDED':
+            in_yaml = row['id'] in live_by_id
+            excluded.append({'id': row['id'], 'reason': reason, 'in_probes_live': in_yaml})
+            if in_yaml:
+                warnings.append(
+                    "STALE-YAML-ENTRY: %s is authored in probes_live.yaml but the mechanical rule "
+                    "excludes it (%s) — re-curate or remove it." % (row['id'], reason))
+            continue
+        # SELECTABLE per the mechanical rule.
+        if row['id'] not in live_by_id:
+            excluded.append({'id': row['id'], 'reason': 'NOT-YET-AUTHORED', 'in_probes_live': False})
+            warnings.append(
+                "NOT-YET-AUTHORED: %s passes the mechanical selection rule but has no entry in "
+                "probes_live.yaml — add polarity/expect_re/control_input by hand to include it."
+                % row['id'])
+            continue
+        spec = live_by_id[row['id']]
+        missing = [k for k in ('polarity', 'input', 'expect_re', 'control_input') if k not in spec]
+        if missing:
+            excluded.append({'id': row['id'], 'reason': 'INCOMPLETE-YAML-ENTRY(%s)' % ','.join(missing),
+                              'in_probes_live': True})
+            warnings.append("INCOMPLETE-YAML-ENTRY: %s is missing field(s): %s"
+                             % (row['id'], ','.join(missing)))
+            continue
+        if spec['polarity'] not in ('present', 'absent'):
+            excluded.append({'id': row['id'], 'reason': 'BAD-POLARITY(%s)' % spec['polarity'],
+                              'in_probes_live': True})
+            warnings.append("BAD-POLARITY: %s declares polarity=%r (must be present|absent)"
+                             % (row['id'], spec['polarity']))
+            continue
+        selected.append({
+            'id': row['id'],
+            'input': spec['input'],
+            'control_input': spec['control_input'],
+            'polarity': spec['polarity'],
+            'expect_re': spec['expect_re'],
+        })
+
+    # Dead-pointer guard: an id in probes_live.yaml that does not exist in probes.md AT ALL.
+    for p in live_rows:
+        if p['id'] not in md_ids:
+            warnings.append(
+                "DEAD-POINTER: %s is in probes_live.yaml but does not exist in probes.md — "
+                "probes.md is the source of truth, remove or fix the id." % p['id'])
+
+    return {'selected': selected, 'excluded': excluded, 'warnings': warnings}
+
+
+def filter_selection(selected, subset=None, ids=None):
+    """Apply --subset N (first N in file order) or --ids P1,P2 (exact set, order preserved from
+    the request; unknown ids are reported, not silently dropped)."""
+    if ids:
+        wanted = [i.strip() for i in ids.split(',') if i.strip()]
+        by_id = {p['id']: p for p in selected}
+        out, unknown = [], []
+        for w in wanted:
+            if w in by_id:
+                out.append(by_id[w])
+            else:
+                unknown.append(w)
+        return out, unknown
+    if subset:
+        n = int(subset)
+        return selected[:n], []
+    return selected, []
+
+
+# ── Scoring ──────────────────────────────────────────────────────────────────────────────────
+FAILED_TO_RUN = 'FAILED-TO-RUN'
+UNCALIBRATED = 'UNCALIBRATED'
+PASS = 'PASS'
+FAIL = 'FAIL'
+
+
+def _read_text(path):
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, encoding='utf-8', errors='replace') as f:
+            return f.read()
+    except OSError:
+        return None
+
+
+def score_probe(primary_text, control_text, polarity, expect_re):
+    """Three-valued-plus-one verdict for one probe. `primary_text`/`control_text` are None when
+    the corresponding output file was missing or empty — that is FAILED-TO-RUN, never a silent
+    FAIL (an unreachable API and a wrong response are different failure classes; collapsing them
+    is the exact defect CLAUDE.md's not-found-is-not-zero memory entry names)."""
+    if primary_text is None or control_text is None or primary_text == '' or control_text == '':
+        return FAILED_TO_RUN, False, False
+    pat = re.compile(expect_re)
+    primary_hit = bool(pat.search(primary_text))
+    control_hit = bool(pat.search(control_text))
+    if polarity == 'present':
+        if control_hit:
+            # The pattern fired on a KNOWN-NEGATIVE input too — it cannot discriminate, so a
+            # primary hit proves nothing. Per-probe calibration failure, not a pass or a fail.
+            return UNCALIBRATED, primary_hit, control_hit
+        return (PASS if primary_hit else FAIL), primary_hit, control_hit
+    else:  # polarity == 'absent'
+        if not control_hit:
+            # The control was supposed to be the case where the pattern DOES fire, proving the
+            # instrument can detect it at all. If it never fires here either, primary's silence
+            # is not evidence of anything — it could just be a pattern that never matches.
+            return UNCALIBRATED, primary_hit, control_hit
+        return (PASS if not primary_hit else FAIL), primary_hit, control_hit
+
+
+def score_run(live_rows, run_root, ids_in_order, threshold, model):
+    """Read <run_root>/<id>/primary_r1.txt + control_r1.txt for every id, score each, and return
+    a report dict. Does not touch the network or spawn `claude` — pure filesystem + regex."""
+    by_id = {p['id']: p for p in live_rows}
+    rows = []
+    for pid in ids_in_order:
+        spec = by_id.get(pid)
+        if spec is None:
+            rows.append({'id': pid, 'verdict': 'UNKNOWN-ID', 'primary_hit': None, 'control_hit': None})
+            continue
+        base = os.path.join(run_root, pid)
+        primary_text = _read_text(os.path.join(base, 'primary_r1.txt'))
+        control_text = _read_text(os.path.join(base, 'control_r1.txt'))
+        verdict, phit, chit = score_probe(primary_text, control_text, spec['polarity'], spec['expect_re'])
+        rows.append({'id': pid, 'verdict': verdict, 'primary_hit': phit, 'control_hit': chit,
+                      'polarity': spec['polarity']})
+
+    failed_to_run = [r for r in rows if r['verdict'] == FAILED_TO_RUN]
+    uncalibrated = [r for r in rows if r['verdict'] == UNCALIBRATED]
+    ran = [r for r in rows if r['verdict'] in (PASS, FAIL)]
+    passed = [r for r in rows if r['verdict'] == PASS]
+
+    if uncalibrated:
+        overall = 'UNCALIBRATED'
+        rc = 2
+        pass_rate = None
+    elif not ran:
+        overall = 'NO-PROBES-RAN'
+        rc = 2
+        pass_rate = None
+    else:
+        pass_rate = len(passed) / float(len(ran))
+        if pass_rate < threshold:
+            overall = 'FAIL'
+            rc = 1
+        else:
+            overall = 'PASS'
+            rc = 0
+
+    return {
+        'rows': rows,
+        'total': len(rows),
+        'failed_to_run': len(failed_to_run),
+        'uncalibrated': len(uncalibrated),
+        'ran': len(ran),
+        'passed': len(passed),
+        'pass_rate': pass_rate,
+        'threshold': threshold,
+        'overall': overall,
+        'rc': rc,
+        'model': model,
+    }
+
+
+def render_report_md(select_result, score_result, run_date):
+    lines = []
+    lines.append("# live_eval — %s" % run_date)
+    lines.append("")
+    lines.append("Live (behavioral) probe run — see `.claude/regression/probes_live.yaml` for what "
+                  "each probe checks and why. Static-only coverage lives in `/prompt-regression`; "
+                  "this file is its live twin's record.")
+    lines.append("")
+    lines.append("## Selection")
+    lines.append("- Selected: %d" % len(select_result['selected']))
+    lines.append("- Excluded: %d" % len(select_result['excluded']))
+    if select_result['warnings']:
+        lines.append("- Warnings: %d (see below)" % len(select_result['warnings']))
+    lines.append("")
+    if score_result is not None:
+        lines.append("## Run — model=%s threshold=%.2f" % (score_result['model'], score_result['threshold']))
+        lines.append("")
+        lines.append("| Probe | Verdict | primary_hit | control_hit | polarity |")
+        lines.append("|---|---|---|---|---|")
+        for r in score_result['rows']:
+            lines.append("| %s | %s | %s | %s | %s |" % (
+                r['id'], r['verdict'], r.get('primary_hit'), r.get('control_hit'), r.get('polarity', '')))
+        lines.append("")
+        pr = score_result['pass_rate']
+        pr_s = ("%.2f" % pr) if pr is not None else "n/a"
+        lines.append("**Overall: %s** — ran=%d failed_to_run=%d uncalibrated=%d passed=%d pass_rate=%s"
+                      % (score_result['overall'], score_result['ran'], score_result['failed_to_run'],
+                         score_result['uncalibrated'], score_result['passed'], pr_s))
+        lines.append("")
+    lines.append("## Excluded (from probes.md, 33-row snapshot)")
+    lines.append("")
+    lines.append("| Probe | Reason |")
+    lines.append("|---|---|")
+    for e in select_result['excluded']:
+        lines.append("| %s | %s |" % (e['id'], e['reason']))
+    if select_result['warnings']:
+        lines.append("")
+        lines.append("## Warnings")
+        for w in select_result['warnings']:
+            lines.append("- %s" % w)
+    return "\n".join(lines) + "\n"
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────────────────────
+def _cmd_select(args):
+    probes_md_rows = parse_probes_md(args.probes_md)
+    live_rows = parse_probes_live(args.probes_live)
+    result = build_selection(probes_md_rows, live_rows)
+    filtered, unknown = filter_selection(result['selected'], subset=args.subset, ids=args.ids)
+
+    print("── probe_live_eval selection ──────────────────────────────────────")
+    print("probes.md rows: %d   selectable-per-rule: %d   authored-in-yaml: %d"
+          % (len(probes_md_rows),
+             sum(1 for r in probes_md_rows if classify(r['id'], r['input'], r['class'])[0] == 'SELECTABLE'),
+             len(result['selected'])))
+    if args.subset or args.ids:
+        print("filter applied: %s -> %d probe(s) this run"
+              % (('--subset ' + str(args.subset)) if args.subset else ('--ids ' + args.ids), len(filtered)))
+    if unknown:
+        print("⚠️  unknown ids requested via --ids (not in the live-authored set): %s" % ', '.join(unknown))
+    print("")
+    print("SELECTED (%d):" % len(filtered))
+    for p in filtered:
+        print("  %-14s polarity=%-7s input=%r" % (p['id'], p['polarity'], p['input']))
+    print("")
+    print("EXCLUDED (%d):" % len(result['excluded']))
+    for e in result['excluded']:
+        print("  %-14s %s" % (e['id'], e['reason']))
+    if result['warnings']:
+        print("")
+        print("WARNINGS (%d):" % len(result['warnings']))
+        for w in result['warnings']:
+            print("  - %s" % w)
+
+    if args.json_out:
+        with open(args.json_out, 'w', encoding='utf-8') as f:
+            json.dump({'selected': filtered, 'excluded': result['excluded'],
+                       'warnings': result['warnings'], 'unknown_ids': unknown,
+                       'full_selected': result['selected']}, f, ensure_ascii=False, indent=2)
+    if args.spec_dir:
+        os.makedirs(args.spec_dir, exist_ok=True)
+        for p in filtered:
+            with open(os.path.join(args.spec_dir, p['id'] + '.input.txt'), 'w', encoding='utf-8') as f:
+                f.write(p['input'])
+            with open(os.path.join(args.spec_dir, p['id'] + '.control.txt'), 'w', encoding='utf-8') as f:
+                f.write(p['control_input'])
+        with open(os.path.join(args.spec_dir, 'selected_ids.txt'), 'w', encoding='utf-8') as f:
+            for p in filtered:
+                f.write(p['id'] + '\n')
+
+    # Dead pointers and stale yaml entries are authoring bugs, not scoring failures — the lane
+    # test asserts this exit code directly (fixture with a deliberately dead id → nonzero).
+    dead = [w for w in result['warnings'] if w.startswith('DEAD-POINTER')]
+    return 1 if dead else 0
+
+
+def _cmd_score(args):
+    live_rows = parse_probes_live(args.probes_live)
+    with open(args.select_json, encoding='utf-8') as f:
+        select_result = json.load(f)
+    ids_in_order = [line.strip() for line in open(args.ids_file, encoding='utf-8') if line.strip()]
+    score_result = score_run(live_rows, args.run_root, ids_in_order, args.threshold, args.model)
+
+    print("── probe_live_eval score ──────────────────────────────────────────")
+    for r in score_result['rows']:
+        print("  %-14s %-14s primary_hit=%-5s control_hit=%-5s polarity=%s"
+              % (r['id'], r['verdict'], r.get('primary_hit'), r.get('control_hit'), r.get('polarity', '')))
+    print("")
+    pr = score_result['pass_rate']
+    pr_s = ("%.2f" % pr) if pr is not None else "n/a"
+    print("total=%d ran=%d failed_to_run=%d uncalibrated=%d passed=%d pass_rate=%s threshold=%.2f"
+          % (score_result['total'], score_result['ran'], score_result['failed_to_run'],
+             score_result['uncalibrated'], score_result['passed'], pr_s, score_result['threshold']))
+    print("OVERALL: %s (rc=%d)" % (score_result['overall'], score_result['rc']))
+
+    if args.report_out:
+        md = render_report_md(select_result, score_result, args.run_date or str(date.today()))
+        os.makedirs(os.path.dirname(args.report_out), exist_ok=True)
+        with open(args.report_out, 'w', encoding='utf-8') as f:
+            f.write(md)
+        print("report: %s" % args.report_out)
+
+    return score_result['rc']
+
+
+def main():
+    import argparse
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest='cmd', required=True)
+
+    sp = sub.add_parser('select')
+    sp.add_argument('--probes-md', required=True)
+    sp.add_argument('--probes-live', required=True)
+    sp.add_argument('--subset')
+    sp.add_argument('--ids')
+    sp.add_argument('--json-out')
+    sp.add_argument('--spec-dir')
+
+    sc = sub.add_parser('score')
+    sc.add_argument('--probes-live', required=True)
+    sc.add_argument('--select-json', required=True)
+    sc.add_argument('--ids-file', required=True)
+    sc.add_argument('--run-root', required=True)
+    sc.add_argument('--threshold', type=float, required=True)
+    sc.add_argument('--model', required=True)
+    sc.add_argument('--report-out')
+    sc.add_argument('--run-date')
+
+    args = ap.parse_args()
+    if args.cmd == 'select':
+        sys.exit(_cmd_select(args))
+    elif args.cmd == 'score':
+        sys.exit(_cmd_score(args))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -620,6 +620,9 @@ for _pair in \
   "templates/.git-hooks/pre-commit|scripts/test_marker_soul_tenet_lanes.sh" \
   "templates/.git-hooks/pre-commit|scripts/test_marker_affected_lanes.sh" \
   "scripts/sim_isolated_run.sh|scripts/test_sim_path_isolation_lanes.sh" \
+  `# ── live-eval — the live twin of the static /prompt-regression probe check (2026-09-04) ──` \
+  "scripts/probe_live_eval.sh|scripts/test_probe_live_eval_lanes.sh" \
+  "scripts/probe_live_eval_lib.py|scripts/test_probe_live_eval_lanes.sh" \
   "templates/.git-hooks/pre-commit|scripts/test_marker_first_use_lanes.sh" \
   "scripts/fixture_guard_lib.sh|scripts/test_fixture_guard_lanes.sh" \
   "scripts/stray_path_scan.sh|scripts/test_stray_path_lanes.sh" \

--- a/scripts/test_probe_live_eval_lanes.sh
+++ b/scripts/test_probe_live_eval_lanes.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# test_probe_live_eval_lanes.sh — regression lanes for scripts/probe_live_eval.sh's SCORER and
+# SELECTOR (scripts/probe_live_eval_lib.py). Never calls `claude` and spawns no live session —
+# this pins the scoring logic and the probes.md/probes_live.yaml cross-reference against fixture
+# text, exactly the split ablation_calibrate.sh's own header argues for ("the pair gates the
+# runner; the runner never gates itself" — applied here to the scorer instead of a sim runner).
+#
+# LANE CLASSES
+#   score-pair     known-pair calibration of score_probe(): PASS / FAIL / UNCALIBRATED(present) /
+#                  UNCALIBRATED(absent) / FAILED-TO-RUN, both empty-string and missing-file shapes
+#   select-guard   the mechanical selection rule (class filter, utterance-shape, INERT-ANCHOR,
+#                  CLI-event exclude) reproduces the 12-selected / 21-excluded split against the
+#                  REAL probes.md + probes_live.yaml shipped in this repo
+#   dead-pointer   probes_live.yaml naming an id absent from probes.md is caught (nonzero exit),
+#                  not silently ignored — this IS the "id 가 probes.md 에 실재하는지" guard the
+#                  dispatching session's task named explicitly
+#   dry-run        `--dry-run` on the real files exits 0 and touches nothing under run/ (no live
+#                  network call, no OUTDIR created)
+#
+# exit: 0 = all lanes as expected · 1 = regression · 10 = harness error (setup failed, not a verdict)
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB="$REPO_ROOT/scripts/probe_live_eval_lib.py"
+RUNNER="$REPO_ROOT/scripts/probe_live_eval.sh"
+PROBES_MD="$REPO_ROOT/.claude/regression/probes.md"
+PROBES_LIVE="$REPO_ROOT/.claude/regression/probes_live.yaml"
+
+command -v python3 >/dev/null 2>&1 || { echo "❌ HARNESS-ERROR — python3 missing"; exit 10; }
+[ -f "$LIB" ]    || { echo "❌ HARNESS-ERROR — $LIB missing"; exit 10; }
+[ -f "$RUNNER" ] || { echo "❌ HARNESS-ERROR — $RUNNER missing"; exit 10; }
+
+T="$(mktemp -d)" || { echo "❌ HARNESS-ERROR — mktemp failed"; exit 10; }
+trap 'rm -rf "$T"' EXIT
+
+FAIL=0; N=0
+_lane() {  # $1=id $2=class $3=desc $4=expected $5=actual
+  N=$((N + 1))
+  if [ "$4" = "$5" ]; then
+    printf '  ✅ %-8s [%-14s] %s\n' "$1" "$2" "$3"
+  else
+    printf '  ❌ %-8s [%-14s] %s — expected=%s actual=%s\n' "$1" "$2" "$3" "$4" "$5"
+    FAIL=1
+  fi
+}
+
+# ── score-pair: known-pair calibration of score_probe() ────────────────────────────────────────
+# $1=primary $2=control $3=polarity $4=expect_re -> prints "VERDICT PRIMARY_HIT CONTROL_HIT"
+# `__NONE__` maps to Python None (FAILED-TO-RUN fixture — a file that was never written, distinct
+# from an empty string, which is a file that WAS written with 0 bytes; both must score the same).
+_score() {
+  python3 -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT/scripts')
+from probe_live_eval_lib import score_probe
+primary = None if sys.argv[1] == '__NONE__' else sys.argv[1]
+control = None if sys.argv[2] == '__NONE__' else sys.argv[2]
+v, ph, ch = score_probe(primary, control, sys.argv[3], sys.argv[4])
+print('%s %s %s' % (v, ph, ch))
+" "$1" "$2" "$3" "$4"
+}
+
+echo "── score-pair ────────────────────────────────────────────────────"
+
+# P1: polarity=present, pattern fires on primary, does not fire on control → PASS
+r="$(_score '🐿️ Welcome to FH' 'the weather is nice today' present '🐿️')"
+_lane P1 score-pair "present polarity, control clean -> PASS" "PASS True False" "$r"
+
+# P2: polarity=present, pattern absent from primary -> FAIL
+r="$(_score 'sure, here is the weather' 'the weather is nice today' present '🐿️')"
+_lane P2 score-pair "present polarity, primary silent -> FAIL" "FAIL False False" "$r"
+
+# P3: polarity=present, pattern ALSO fires on control -> UNCALIBRATED (the instrument cannot
+# discriminate — this is the known-pair's whole point: a probe whose control leaks the pattern
+# must not be scored as if it discriminated)
+r="$(_score '🐿️ Welcome to FH' 'random text with 🐿️ in it too' present '🐿️')"
+_lane P3 score-pair "present polarity, control ALSO hits -> UNCALIBRATED" "UNCALIBRATED True True" "$r"
+
+# P4: polarity=absent, pattern absent from primary, present on control -> PASS
+r="$(_score 'here are the dependencies' '🐿️ Welcome to FH' absent '🐿️')"
+_lane P4 score-pair "absent polarity, control fires -> PASS" "PASS False True" "$r"
+
+# P5: polarity=absent, pattern LEAKS into primary too -> FAIL (a real regression: onboarding
+# leaking into an explicit task-utterance response)
+r="$(_score '🐿️ Welcome to FH — here are the dependencies' '🐿️ Welcome to FH' absent '🐿️')"
+_lane P5 score-pair "absent polarity, primary leaks -> FAIL" "FAIL True True" "$r"
+
+# P6: polarity=absent, control ALSO never fires -> UNCALIBRATED (control failed to prove the
+# pattern can appear at all — primary's silence is not evidence of anything)
+r="$(_score 'here are the dependencies' 'also just dependencies' absent '🐿️')"
+_lane P6 score-pair "absent polarity, control never fires -> UNCALIBRATED" "UNCALIBRATED False False" "$r"
+
+# P7/P8: FAILED-TO-RUN — missing file (None) and empty-string both collapse to the same verdict,
+# never silently read as a FAIL (CLAUDE.md not-found-is-not-zero discipline).
+r="$(_score '__NONE__' 'the weather is nice' present '🐿️')"
+_lane P7 score-pair "primary file missing -> FAILED-TO-RUN" "FAILED-TO-RUN False False" "$r"
+r="$(_score '' 'the weather is nice' present '🐿️')"
+_lane P8 score-pair "primary file empty -> FAILED-TO-RUN" "FAILED-TO-RUN False False" "$r"
+
+# ── select-guard: mechanical rule reproduces the real 12/21 split ──────────────────────────────
+echo ""
+echo "── select-guard ──────────────────────────────────────────────────"
+
+SELECT_JSON="$T/select.json"
+SPEC_DIR="$T/spec"
+sel_out="$(python3 "$LIB" select --probes-md "$PROBES_MD" --probes-live "$PROBES_LIVE" \
+             --json-out "$SELECT_JSON" --spec-dir "$SPEC_DIR" 2>&1)"
+sel_rc=$?
+_lane S1 select-guard "real probes.md/probes_live.yaml -> selector exits 0 (no dead pointer)" "0" "$sel_rc"
+
+if [ -f "$SELECT_JSON" ]; then
+  sel_count=$(python3 -c "import json; print(len(json.load(open('$SELECT_JSON'))['selected']))")
+  exc_count=$(python3 -c "import json; print(len(json.load(open('$SELECT_JSON'))['excluded']))")
+else
+  sel_count="ERR"; exc_count="ERR"
+fi
+_lane S2 select-guard "selected count == 12 (see probes_live.yaml header for the derivation)" "12" "$sel_count"
+_lane S3 select-guard "excluded count == 21 (33 probes.md rows - 12 selected)" "21" "$exc_count"
+
+# --subset and --ids filters
+sub_out="$(python3 "$LIB" select --probes-md "$PROBES_MD" --probes-live "$PROBES_LIVE" --subset 3 \
+             --spec-dir "$T/spec_subset" 2>&1)"
+sub_count=$(wc -l < "$T/spec_subset/selected_ids.txt" 2>/dev/null | tr -d ' ')
+_lane S4 select-guard "--subset 3 yields exactly 3 selected ids" "3" "${sub_count:-ERR}"
+
+ids_out="$(python3 "$LIB" select --probes-md "$PROBES_MD" --probes-live "$PROBES_LIVE" \
+             --ids "G-GREET-01,G-TRIG-02" --spec-dir "$T/spec_ids" 2>&1)"
+ids_count=$(wc -l < "$T/spec_ids/selected_ids.txt" 2>/dev/null | tr -d ' ')
+_lane S5 select-guard "--ids G-GREET-01,G-TRIG-02 yields exactly 2" "2" "${ids_count:-ERR}"
+
+unk_out="$(python3 "$LIB" select --probes-md "$PROBES_MD" --probes-live "$PROBES_LIVE" \
+             --ids "G-NOT-A-REAL-ID-99" --spec-dir "$T/spec_unk" 2>&1)"
+case "$unk_out" in
+  *"unknown ids requested"*) unk_hit="yes" ;;
+  *) unk_hit="no" ;;
+esac
+_lane S6 select-guard "--ids with an unknown id is reported, not silently dropped" "yes" "$unk_hit"
+
+# ── dead-pointer: probes_live.yaml naming an id absent from probes.md must fail loudly ─────────
+echo ""
+echo "── dead-pointer ──────────────────────────────────────────────────"
+
+BAD_YAML="$T/probes_live_bad.yaml"
+{
+  cat "$PROBES_LIVE"
+  cat <<'BADEOF'
+  - id: G-DOES-NOT-EXIST-99
+    polarity: present
+    input: "this id has no row in probes.md"
+    expect_re: "x"
+    control_input: "y"
+BADEOF
+} > "$BAD_YAML"
+
+python3 "$LIB" select --probes-md "$PROBES_MD" --probes-live "$BAD_YAML" \
+  --json-out "$T/select_bad.json" --spec-dir "$T/spec_bad" >"$T/bad_out.txt" 2>&1
+bad_rc=$?
+_lane D1 dead-pointer "id absent from probes.md -> select exits nonzero" "nonzero" "$([ "$bad_rc" -ne 0 ] && echo nonzero || echo zero)"
+grep -q "DEAD-POINTER: G-DOES-NOT-EXIST-99" "$T/bad_out.txt" && d2=found || d2=missing
+_lane D2 dead-pointer "dead-pointer id named explicitly in the warning" "found" "$d2"
+
+# Known-negative for D1/D2: the SAME check must NOT fire on the real, uncorrupted file — otherwise
+# D1/D2 could be passing on a scanner that always says "dead pointer found" regardless of input.
+python3 "$LIB" select --probes-md "$PROBES_MD" --probes-live "$PROBES_LIVE" \
+  --json-out "$T/select_clean.json" --spec-dir "$T/spec_clean" >"$T/clean_out.txt" 2>&1
+clean_rc=$?
+grep -q "DEAD-POINTER" "$T/clean_out.txt" && d3=found || d3=missing
+_lane D3 dead-pointer "control: real file has no dead pointer, rc=0" "0 missing" "${clean_rc} ${d3}"
+
+# ── dry-run: probe_live_eval.sh --dry-run touches nothing under a fresh OUTDIR and exits 0 ─────
+echo ""
+echo "── dry-run ───────────────────────────────────────────────────────"
+
+DRY_OUT="$T/dryrun_out"
+dry_stdout="$(cd "$REPO_ROOT" && bash "$RUNNER" --dry-run --out "$DRY_OUT" 2>&1)"
+dry_rc=$?
+_lane R1 dry-run "probe_live_eval.sh --dry-run exits 0" "0" "$dry_rc"
+_lane R2 dry-run "--dry-run creates no OUTDIR (no live run attempted)" "absent" "$([ -d "$DRY_OUT" ] && echo present || echo absent)"
+case "$dry_stdout" in
+  *"SELECTED (12)"*) r3=yes ;;
+  *) r3=no ;;
+esac
+_lane R3 dry-run "--dry-run stdout shows the real 12-probe selection" "yes" "$r3"
+
+echo ""
+echo "── summary ──────────────────────────────────────────────────────"
+echo "lanes: $N   failed: $([ "$FAIL" -eq 0 ] && echo 0 || echo '>=1')"
+if [ "$FAIL" -ne 0 ]; then
+  echo "RESULT: REGRESSION"
+  exit 1
+fi
+echo "RESULT: CLEAN"
+exit 0


### PR DESCRIPTION
AI-Native SDLC playbook 답습 Top-2: `/prompt-regression`(정적, «말하는가」)의 **라이브 짝**.

- `scripts/probe_live_eval.sh [--subset n|--ids …] [--model sonnet] [--dry-run]` — `probes.md` 에서 발화형 mandatory/measured 프로브를 기계 선택(**12 선택 / 21 제외** — NO-UTTERANCE 11 · JUDGED 5 · NOT-CHAT 3 · INERT-ANCHOR 1 · NOT-YET-AUTHORED 1) → `sim_isolated_run.sh`(observe, 격리 클론) primary+control → `probes_live.yaml` 의 `expect_re` 채점 → **PASS / FAIL / FAILED-TO-RUN(분모 제외) / UNCALIBRATED(컨트롤 실패 = 판정 없음)** → `tracks/_meta/live_eval_<date>.md`.
- 레인 20/20(채점 known-pair ×8 · 선택 가드 ×6 · 죽은 포인터 ×3 · dry-run ×3). 라이브 1프로브: G-GREET-01 «안녕」 PASS, 컨트롤(파일 질문) 무발화.
- `com.forge-harness.live-eval.plist` 02:30 템플릿 — 설치·API 비용은 운영자 결정(이 PR 은 설치 안 함).
- 잔여: 문턱 0.8 미보정(전수 1회 뒤) · G-LINT-01 미작성 · 429→FAILED-TO-RUN 경로는 레인으로만 · launchd_wiring_check 미연동.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pQzk6DWvzaMns3EzymZMv