### PR TITLE
fix(digest): variadic --allowedTools 가 positional 프롬프트를 먹는 인자 순서 수리 — 프롬프트를 -p 바로 뒤로 + Stage 2 FD_MODEL 플러밍 + 레인 ⑤

### DIFF
--- a/scripts/frontier_digest_autopilot.sh
+++ b/scripts/frontier_digest_autopilot.sh
@@ -210,7 +210,10 @@ PROMPT="$(cat "$PROMPT_FILE")"
 rm -f "$PROMPT_FILE"
 
 _log "Stage 2 starting (timeout ${ATTEMPT_TIMEOUT_SECS}s)"
-"$CLAUDE_BIN" -p --permission-mode bypassPermissions "$PROMPT" >> "$LOG_FILE" 2>&1 &
+# 프롬프트는 `-p` 바로 뒤(positional-first) — Stage 1 러너와 같은 계약(2026-09-05, variadic 플래그 뒤
+# positional 은 먹힌다). FD_MODEL 은 Stage 1 과 같은 변수로 핀한다: /model 로 저장한 기본 모델이
+# `claude -p` 무인 런에도 적용되므로, 무인 잡의 모델은 plist 가 명시한다(운영자 결정 2026-09-05).
+"$CLAUDE_BIN" -p "$PROMPT" --permission-mode bypassPermissions ${FD_MODEL:+--model "$FD_MODEL"} >> "$LOG_FILE" 2>&1 &
 CLAUDE_PID=$!
 DEADLINE=$((SECONDS + ATTEMPT_TIMEOUT_SECS))
 while kill -0 "$CLAUDE_PID" 2>/dev/null && [ "$SECONDS" -lt "$DEADLINE" ]; do

--- a/scripts/frontier_digest_daily.sh
+++ b/scripts/frontier_digest_daily.sh
@@ -511,11 +511,17 @@ for ATTEMPT in $(seq 1 $MAX_ATTEMPTS); do
     #    2026-09-04: 33/35 fh-meta skills denied; the 2 that passed were exactly the 2 with a
     #    Skill(...) rule in the gitignored settings.local.json). The gitignored settings file is not
     #    a skeleton — this flag is, so the runner carries it itself.
-    "$CLAUDE_BIN" -p --permission-mode acceptEdits \
+    # 🟥 프롬프트는 항상 `-p` 바로 뒤(첫 positional)에 둔다 — 2026-09-05, 첫 무인 런 3회 전부
+    #    이 순서로 죽은 뒤 실측. `--allowedTools`(그리고 `--disallowedTools`·`--add-dir`)는
+    #    variadic 이라 다음 `-` 플래그를 만날 때까지 뒤 토큰을 전부 자기 값으로 삼킨다 —
+    #    FD_MODEL·PROFILE_SETTINGS_JSON 이 둘 다 빈 launchd 기본 조건에서 프롬프트가
+    #    allowedTools 목록으로 먹혀 `Input must be provided … as a prompt argument` 로 죽었다.
+    #    (09-04 손 테스트는 우연히 `--model` 이 사이에 있어 안 죽었다 — 순서의존은 자기고발 안 함.)
+    "$CLAUDE_BIN" -p "$(_build_prompt)" \
+        --permission-mode acceptEdits \
         --allowedTools "Skill(fh-meta:frontier-digest)" \
         ${FD_MODEL:+--model "$FD_MODEL"} \
         ${PROFILE_SETTINGS_JSON:+--settings "$PROFILE_SETTINGS_JSON"} \
-        "$(_build_prompt)" \
         >> "$LOG_FILE" 2>&1 &
     CLAUDE_PID=$!
     DEADLINE=$((SECONDS + ATTEMPT_TIMEOUT_SECS))

--- a/scripts/test_frontier_digest_retry.sh
+++ b/scripts/test_frontier_digest_retry.sh
@@ -99,5 +99,48 @@ fi
 pkill -P "$RPID" 2>/dev/null || true   # 고아 정리 (B-2)
 rm -rf "$T"
 
+# ⑤ positional-first 계약 (2026-09-05, launchd 무인 런 3회 전멸의 회귀 앵커): claude 에게 넘기는
+#    argv 에서 `-p` 바로 다음 원소가 프롬프트여야 한다. `--allowedTools`(variadic) 가 다음 `-`
+#    플래그를 만날 때까지 뒤 토큰을 전부 삼키므로, FD_MODEL·PROFILE_SETTINGS_JSON 이 둘 다 빈
+#    (=launchd 기본) 조건에서 프롬프트가 그 뒤에 오면 allowedTools 값으로 먹힌다. 로그 grep 으로는
+#    "차단됐다"만 보이고 "옳게 차단됐다"는 안 보이므로, 여기는 로그가 아니라 argv 자체를 연다 —
+#    스텁이 실제로 받은 argv 를 NUL 구분으로 물질화하고, 이 레인이 그것을 기계로 확인한다.
+T=$(mk_sandbox)
+cat > "$T/bin/claude-stub" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\0' "$@" > "$FD_FH_DIR/.argv_capture"
+exit 1
+STUB
+chmod +x "$T/bin/claude-stub"
+env FD_FH_DIR="$T/fh" FD_PROFILE=.satellite-profile.md FD_CLAUDE_BIN="$T/bin/claude-stub" \
+    FD_ATTEMPT_TIMEOUT_SECS=3 FD_POLL_SECS=1 FD_RETRY_SLEEP_SECS=1 FD_MAX_ATTEMPTS=1 \
+    bash "$RUNNER" >/dev/null 2>&1
+ARGV_FILE="$T/fh/.argv_capture"
+FOUND_P=0
+NEXT_IS_PROMPT=""
+if [ -f "$ARGV_FILE" ]; then
+  while IFS= read -r -d '' tok; do
+    if [ "$FOUND_P" = 1 ]; then
+      NEXT_IS_PROMPT="$tok"
+      FOUND_P=2
+    elif [ "$FOUND_P" = 0 ] && [ "$tok" = "-p" ]; then
+      FOUND_P=1
+    fi
+  done < "$ARGV_FILE"
+fi
+case "$NEXT_IS_PROMPT" in
+  *"Run /frontier-digest"*)
+    echo "✅ ⑤ positional-first: argv[-p 다음]이 프롬프트다" ;;
+  *)
+    echo "❌ ⑤ positional-first: argv[-p 다음]이 프롬프트가 아니다 — variadic 플래그가 삼켰을 가능성"
+    if [ -f "$ARGV_FILE" ]; then
+      echo "     | -p 다음 원소(앞 80자): $(printf '%s' "$NEXT_IS_PROMPT" | head -c 80)"
+    else
+      echo "     | argv capture 파일 자체가 없다 — 스텁이 안 불렸다"
+    fi
+    FAILED=1 ;;
+esac
+rm -rf "$T"
+
 echo "── retry/watchdog harness: $([ "$FAILED" -eq 0 ] && echo "PASS — 로직 건전, 잔여 델타는 환경(라이브 계측이 판별)" || echo "FAIL — 스크립트 로직 결함") ──"
 exit "$FAILED"


### PR DESCRIPTION
## 무엇
무인 프런티어 다이제스트가 2026-09-05 09:00 launchd 런에서 3/3 `Input must be provided either through stdin or as a prompt argument when using --print` 로 죽었다. #612 가 넣은 `--allowedTools`(`<tools...>`, **variadic**) 바로 뒤에 positional 프롬프트가 왔고, launchd 에서는 `FD_MODEL`·`PROFILE_SETTINGS_JSON` 이 비어 사이에 플래그가 없어 프롬프트가 툴 이름으로 먹혔다. 09-04 손 테스트는 `--model` 이 사이에 있어 통과했다 — «내 셸에서는 됐다».

## 수리
- `scripts/frontier_digest_daily.sh`: 프롬프트를 `-p` 바로 뒤 첫 positional 로.
- `scripts/frontier_digest_autopilot.sh`: 같은 계약 + `${FD_MODEL:+--model}` 플러밍(무인 런 모델 핀 — `/model` 로 저장한 기본 모델이 `claude -p` 에도 적용되므로 plist 가 명시한다. 운영자 결정 2026-09-05).
- `scripts/test_frontier_digest_retry.sh`: 레인 ⑤ positional-first — 스텁이 argv 를 NUL 구분으로 캡처, `-p` 다음 원소가 프롬프트인지 검사.

## 증거(캡슐)
- known-pair(haiku, 변수 = 프롬프트 위치 하나): 플래그 뒤 프롬프트 → rc=1 같은 에러 / 프롬프트 우선 → rc=0 «OK».
- 레인 ⑤ fail-before/after: 패치 전 스크립트 본 → `❌ -p 다음 원소 = --permission-mode` / 패치본 → `✅`, 5/5. `/bin/bash` 3.2 런타임에서도 5/5. 레인 ①~④ 는 양쪽 초록(argv 순서를 안 본다).
- 호출부 전수 감사(scripts·bin·templates·plugins) 9행: 취약 1(원인) · 안전 8. 독립 grep 컨트롤 = 같은 집합.
- **첫 실사용 2**: 본 체크아웃 수동 런(`FD_MODEL=opus`) → Attempt 1 claude exit 0, 다이제스트 18,858B, 착지 증언 3/3. forge-wiki 위성 launchd 10:00 런(같은 러너, 패치본) → `wiki/signals/frontier_digest_2026_09_05.md` 10:04.
- Axis 1 = SKIP(pathspec 밖, 통과 아님). degrade-scan 1 히트 = 기존 lock `exit 0`(hunk 밖).
- standpoint: `tier2b(forge-wiki)` — 위성 launchd 잡을 패치본으로 실행, 산출 확인. 소비자 install 무관(러너·레인 미출하).
- crossfamily: `DEGRADED_PANEL_UNUSED` — 판별자가 argv 순서(기계). load-bearing 아님.

## defeater
내일 09:00 로그에 `Input must be provided` 재발 또는 Attempt 1 claude exit 1 · 위성 산출 중단.

## 잔여
- `ablation_calibrate.sh` 는 stdin 전용이라 안전 — positional 을 추가하면 같은 함정(주석으로 남김).
- 다이제스트 frontmatter 의 `run: automated (launchd)` 는 프롬프트 토큰이라 수동 런에도 그렇게 찍힌다 — 별도.
