### PR TITLE
fix(live-eval): launchd PATH 에 timeout(1) 부재 → 12/12 FAILED-TO-RUN — 해석+bash 폴백 워치독 · fail-fast · reason 칼럼 · --report-out · 레인

### DIFF
--- a/scripts/com.forge-harness.frontier-digest.plist
+++ b/scripts/com.forge-harness.frontier-digest.plist
@@ -40,9 +40,20 @@
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/path/to/home/.local/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <!-- /opt/homebrew/bin included for the same reason as com.forge-harness.live-eval.plist:
+             a launchd job's PATH otherwise never sees Homebrew (Apple Silicon prefix; Intel's
+             /usr/local/bin is already below), so any GNU-coreutils-only tool this pipeline or a
+             skill it calls shells out to would silently resolve to nothing here even though it
+             works fine from an interactive shell. See sim_isolated_run.sh's §timeout(1)
+             RESOLUTION header for the incident that surfaced this PATH gap (2026-09-05). -->
+        <string>/path/to/home/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
         <key>HOME</key>
         <string>/path/to/home</string>
+        <!-- The default model saved via `/model` also applies to unattended `claude -p` runs
+             (~/.claude/settings.json `model`), so the unattended job's model is pinned HERE
+             explicitly rather than inherited implicitly. Operator decision 2026-09-05 = opus. -->
+        <key>FD_MODEL</key>
+        <string>opus</string>
     </dict>
 </dict>
 </plist>

--- a/scripts/com.forge-harness.live-eval.plist
+++ b/scripts/com.forge-harness.live-eval.plist
@@ -40,8 +40,16 @@
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <!-- must include wherever `claude` and `python3` resolve for this user -->
-        <string>/path/to/home/.local/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <!-- must include wherever `claude` and `python3` resolve for this user.
+             /opt/homebrew/bin included so Homebrew's `gtimeout` (Apple Silicon prefix; Intel's
+             /usr/local/bin is already below) resolves — stock macOS ships no `timeout(1)` at
+             all, and scripts/probe_live_eval.sh's runner (sim_isolated_run.sh) falls back to a
+             bash-native watchdog if NEITHER resolves, so this is an optimization, not a hard
+             requirement: the run still enforces its timeout without this entry, just via the
+             slower fallback path. See sim_isolated_run.sh's own §timeout(1) RESOLUTION header
+             (measured 2026-09-05: the first unpatched run here died 12/12 FAILED-TO-RUN because
+             this PATH had neither `timeout` nor `gtimeout` AND the fallback did not exist yet). -->
+        <string>/path/to/home/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
         <key>HOME</key>
         <string>/path/to/home</string>
     </dict>

--- a/scripts/probe_live_eval.sh
+++ b/scripts/probe_live_eval.sh
@@ -51,12 +51,18 @@
 # alongside a proven-blind probe is not trustworthy just because the other rows look fine.
 #
 # EXIT CODES: 0 = PASS (pass_rate >= threshold, no UNCALIBRATED). 1 = FAIL (pass_rate < threshold).
-# 2 = UNCALIBRATED or NO-PROBES-RAN (no verdict rendered — fix the instrument before trusting it).
+# 2 = UNCALIBRATED, NO-PROBES-RAN, or a RUNNER PREFLIGHT FAILURE (sim_isolated_run.sh's own usage
+# guards exit 2 before ever calling `claude` — e.g. no `claude` on PATH, or — measured 2026-09-05 —
+# a launchd PATH with no `timeout(1)` on it). This script fails fast on the FIRST such rc=2 rather
+# than burning the remaining clones against an environment already known broken: no verdict
+# rendered either way — fix the instrument before trusting it. See sim_isolated_run.sh's own
+# §timeout(1) RESOLUTION header for why that preflight can fail even when `claude` itself is fine.
 #
 # USAGE
 #   bash scripts/probe_live_eval.sh --dry-run
 #   bash scripts/probe_live_eval.sh --ids G-GREET-01,G-TRIG-02 --model sonnet
 #   bash scripts/probe_live_eval.sh --subset 3
+#   bash scripts/probe_live_eval.sh --subset 3 --report-out /tmp/spot.md   # spot-check: keep the nightly record untouched
 #   bash scripts/probe_live_eval.sh                      # full selected set — nightly cron shape
 #
 # PORTABILITY: bash 3.2 (macOS) + bash 5.x (Linux CI). No associative arrays, no `${var,,}`,
@@ -70,7 +76,11 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROBES_MD="$REPO_ROOT/.claude/regression/probes.md"
 PROBES_LIVE="$REPO_ROOT/.claude/regression/probes_live.yaml"
 LIB="$REPO_ROOT/scripts/probe_live_eval_lib.py"
-SIM_RUNNER="$REPO_ROOT/scripts/sim_isolated_run.sh"
+# FH_SIM_RUNNER_BIN — same override name test_sim_isolated_run_lanes.sh already uses for the same
+# purpose (point at an alternate runner build). Here it also lets test_probe_live_eval_lanes.sh
+# swap in a stub runner (rc=2, no `claude` call, no network) to test the fail-fast behavior below
+# without spawning a live session. No-op when unset — default behavior is unchanged.
+SIM_RUNNER="${FH_SIM_RUNNER_BIN:-$REPO_ROOT/scripts/sim_isolated_run.sh}"
 
 # ── file-header constant — the "문턱" the design brief calls for. Change here, not per-invocation. ──
 THRESHOLD="0.8"
@@ -80,6 +90,7 @@ DRYRUN=0
 SUBSET=""
 IDS=""
 OUTDIR=""
+REPORT_OUT=""   # --report-out: where the markdown report lands (default: tracks/_meta/live_eval_<date>.md)
 while [ $# -gt 0 ]; do
   case "$1" in
     --subset)   SUBSET="${2:-}"; shift 2 ;;
@@ -87,6 +98,7 @@ while [ $# -gt 0 ]; do
     --model)    MODEL="${2:-sonnet}"; shift 2 ;;
     --dry-run)  DRYRUN=1; shift ;;
     --out)      OUTDIR="${2:-}"; shift 2 ;;
+    --report-out) REPORT_OUT="${2:-}"; shift 2 ;;   # lanes/spot-checks MUST pass this — never the live path
     *) echo "unknown flag: $1" >&2; exit 2 ;;
   esac
 done
@@ -152,17 +164,44 @@ while IFS= read -r id; do
   bash "$SIM_RUNNER" --arm primary --reps 1 --prompt "$input_text" \
        --mode observe --model "$MODEL" --out "$probe_out" \
        > "$probe_out/_runner_primary.log" 2>&1
+  runner_rc=$?
   tail -n 6 "$probe_out/_runner_primary.log"
+  # 🟥 fail-fast (2026-09-05) — rc=2 from the runner means its OWN usage/preflight guard tripped
+  # before `claude` was ever invoked (missing --arm/--prompt, bogus --mode, no `claude` on PATH,
+  # or — the incident this exists for — a launchd PATH with no `timeout(1)` resolvable). That
+  # condition is identical for every remaining probe in this run, so continuing would just burn
+  # the rest of the clones (up to 2*(N-1) more `claude -p` calls) to the same FAILED-TO-RUN wall.
+  # Abort loudly instead of quietly producing a 12/12 FAILED-TO-RUN report with no clue why.
+  if [ "$runner_rc" -eq 2 ]; then
+    echo "" >&2
+    echo "❌ $id primary runner call exited 2 (preflight failure, before \`claude\` ran)." >&2
+    echo "   Aborting the whole run rather than burning the remaining clones." >&2
+    echo "   Runner log:   $probe_out/_runner_primary.log" >&2
+    echo "   Partial run artifacts kept at: $OUTDIR" >&2
+    exit 2
+  fi
 
   echo "▶ $id — control"
   bash "$SIM_RUNNER" --arm control --reps 1 --prompt "$control_text" \
        --mode observe --model "$MODEL" --out "$probe_out" \
        > "$probe_out/_runner_control.log" 2>&1
+  runner_rc=$?
   tail -n 6 "$probe_out/_runner_control.log"
+  if [ "$runner_rc" -eq 2 ]; then
+    echo "" >&2
+    echo "❌ $id control runner call exited 2 (preflight failure, before \`claude\` ran)." >&2
+    echo "   Aborting the whole run rather than burning the remaining clones." >&2
+    echo "   Runner log:   $probe_out/_runner_control.log" >&2
+    echo "   Partial run artifacts kept at: $OUTDIR" >&2
+    exit 2
+  fi
 done < "$SPEC_DIR/selected_ids.txt"
 
 echo ""
-REPORT_PATH="$REPO_ROOT/tracks/_meta/live_eval_${RUN_DATE}.md"
+# 🟥 The live report path is the nightly RECORD. A lane or spot-check that reaches this line with the
+# default overwrote a real night's distribution once (2026-09-05 10:18: test_probe_live_eval_lanes.sh FF4
+# ran the real script with a stub runner and replaced the 02:30 report). Lanes pass --report-out.
+REPORT_PATH="${REPORT_OUT:-$REPO_ROOT/tracks/_meta/live_eval_${RUN_DATE}.md}"
 python3 "$LIB" score \
   --probes-live "$PROBES_LIVE" \
   --select-json "$SELECT_JSON" \

--- a/scripts/probe_live_eval.sh
+++ b/scripts/probe_live_eval.sh
@@ -143,7 +143,14 @@ if [ "$SELECTED_COUNT" -eq 0 ]; then
   exit 2
 fi
 
-command -v claude >/dev/null 2>&1 || { echo "FAIL: claude CLI not on PATH — cannot run live" >&2; rm -rf "$WORKDIR"; exit 2; }
+# `claude` presence is the REAL runner's preflight, so it is checked only on that path. Under
+# FH_SIM_RUNNER_BIN the stub owns its own preflight — measured 2026-09-05 on CI (ubuntu, no
+# `claude` installed): this line fired BEFORE the stub was ever called, so FF2/FF3/FF4/FF6 went
+# red while FF1 passed by coincidence (both paths exit 2). Lane FF7 pins the seam; FF7b pins
+# that the real path still refuses to run without `claude`.
+if [ -z "${FH_SIM_RUNNER_BIN:-}" ]; then
+  command -v claude >/dev/null 2>&1 || { echo "FAIL: claude CLI not on PATH — cannot run live" >&2; rm -rf "$WORKDIR"; exit 2; }
+fi
 
 RUN_DATE="$(date +%Y-%m-%d)"
 OUTDIR="${OUTDIR:-$WORKDIR/run}"

--- a/scripts/probe_live_eval_lib.py
+++ b/scripts/probe_live_eval_lib.py
@@ -220,6 +220,46 @@ def _read_text(path):
         return None
 
 
+def _read_first_line(path):
+    """First non-empty line of `path`, or None if the file is absent/empty entirely. Diagnostic
+    use only (the `reason` column below) — never feeds score_probe's verdict."""
+    text = _read_text(path)
+    if not text:
+        return None
+    for line in text.splitlines():
+        line = line.strip()
+        if line:
+            return line
+    return None
+
+
+def _failure_reason(base, arm):
+    """Best-effort one-line reason a FAILED-TO-RUN arm produced nothing to score: the arm's own
+    stderr first line (usually the actual shell error, e.g. "timeout: command not found") when
+    there is one; otherwise an rc/bytes fallback — rc parsed from the runner's own console log
+    (sim_isolated_run.sh prints "(rc=<n>, ...)" there) and bytes from the actual output file's
+    size (0 for a file that was never written). Purely a diagnostic label for the report/console —
+    never used by score_probe, which stays unchanged."""
+    stderr_line = _read_first_line(os.path.join(base, '%s_r1.stderr.txt' % arm))
+    if stderr_line:
+        return stderr_line
+    out_path = os.path.join(base, '%s_r1.txt' % arm)
+    try:
+        nbytes = os.path.getsize(out_path) if os.path.isfile(out_path) else 0
+    except OSError:
+        nbytes = 0
+    log_text = _read_text(os.path.join(base, '_runner_%s.log' % arm)) or ''
+    m = re.search(r'\(rc=(-?\d+)', log_text)
+    rc_s = m.group(1) if m else '?'
+    return 'rc=%s bytes=%d' % (rc_s, nbytes)
+
+
+def _md_escape(s):
+    """Keep a diagnostic string from breaking a markdown table row — reason text comes from
+    arbitrary stderr/log content, which can contain a literal '|' or a newline."""
+    return (s or '').replace('|', '\\|').replace('\n', ' ').replace('\r', ' ')
+
+
 def score_probe(primary_text, control_text, polarity, expect_re):
     """Three-valued-plus-one verdict for one probe. `primary_text`/`control_text` are None when
     the corresponding output file was missing or empty — that is FAILED-TO-RUN, never a silent
@@ -259,8 +299,18 @@ def score_run(live_rows, run_root, ids_in_order, threshold, model):
         primary_text = _read_text(os.path.join(base, 'primary_r1.txt'))
         control_text = _read_text(os.path.join(base, 'control_r1.txt'))
         verdict, phit, chit = score_probe(primary_text, control_text, spec['polarity'], spec['expect_re'])
-        rows.append({'id': pid, 'verdict': verdict, 'primary_hit': phit, 'control_hit': chit,
-                      'polarity': spec['polarity']})
+        row = {'id': pid, 'verdict': verdict, 'primary_hit': phit, 'control_hit': chit,
+               'polarity': spec['polarity'], 'reason': ''}
+        if verdict == FAILED_TO_RUN:
+            # Diagnostic only — score_probe already decided the verdict above from exactly the
+            # same primary_text/control_text; this never changes it, only explains it.
+            reasons = []
+            if primary_text is None or primary_text == '':
+                reasons.append('primary: %s' % _failure_reason(base, 'primary'))
+            if control_text is None or control_text == '':
+                reasons.append('control: %s' % _failure_reason(base, 'control'))
+            row['reason'] = '; '.join(reasons)
+        rows.append(row)
 
     failed_to_run = [r for r in rows if r['verdict'] == FAILED_TO_RUN]
     uncalibrated = [r for r in rows if r['verdict'] == UNCALIBRATED]
@@ -316,11 +366,12 @@ def render_report_md(select_result, score_result, run_date):
     if score_result is not None:
         lines.append("## Run — model=%s threshold=%.2f" % (score_result['model'], score_result['threshold']))
         lines.append("")
-        lines.append("| Probe | Verdict | primary_hit | control_hit | polarity |")
-        lines.append("|---|---|---|---|---|")
+        lines.append("| Probe | Verdict | primary_hit | control_hit | polarity | Reason |")
+        lines.append("|---|---|---|---|---|---|")
         for r in score_result['rows']:
-            lines.append("| %s | %s | %s | %s | %s |" % (
-                r['id'], r['verdict'], r.get('primary_hit'), r.get('control_hit'), r.get('polarity', '')))
+            lines.append("| %s | %s | %s | %s | %s | %s |" % (
+                r['id'], r['verdict'], r.get('primary_hit'), r.get('control_hit'), r.get('polarity', ''),
+                _md_escape(r.get('reason', ''))))
         lines.append("")
         pr = score_result['pass_rate']
         pr_s = ("%.2f" % pr) if pr is not None else "n/a"
@@ -404,8 +455,12 @@ def _cmd_score(args):
 
     print("── probe_live_eval score ──────────────────────────────────────────")
     for r in score_result['rows']:
-        print("  %-14s %-14s primary_hit=%-5s control_hit=%-5s polarity=%s"
-              % (r['id'], r['verdict'], r.get('primary_hit'), r.get('control_hit'), r.get('polarity', '')))
+        line = ("  %-14s %-14s primary_hit=%-5s control_hit=%-5s polarity=%s"
+                % (r['id'], r['verdict'], r.get('primary_hit'), r.get('control_hit'), r.get('polarity', '')))
+        reason = r.get('reason', '')
+        if reason:
+            line += " reason=%s" % reason
+        print(line)
     print("")
     pr = score_result['pass_rate']
     pr_s = ("%.2f" % pr) if pr is not None else "n/a"

--- a/scripts/sim_isolated_run.sh
+++ b/scripts/sim_isolated_run.sh
@@ -149,6 +149,23 @@
 #        이유는 헤더 상단 "WHAT THIS GIVES YOU" 절이 이미 말한다 — 여기서 되풀이하지 않는다.
 #   요약: 파일시스템 코퍼스 축(WIPE+RESEED)은 클론 단위로 이미 wipe-and-reseed다. 기계 표면 축은
 #   아니다 — 탐지기이지 리셋기가 아니다. 이 두 문장이 "샌드박스 표준"의 정직한 전부다.
+#
+# ── timeout(1) RESOLUTION — macOS ships none, and launchd's PATH cannot see Homebrew's
+#   (2026-09-05, measured) ──────────────────────────────────────────────────────────────────────
+#   WHY: stock macOS ships no `timeout(1)`. Homebrew coreutils installs `gtimeout` (plain
+#   `timeout` only if the user un-prefixes GNU coreutils onto PATH) under a prefix an interactive
+#   login shell sees but a launchd job's PATH does NOT — this repo's own plist templates ship
+#   `$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin`, no Homebrew prefix at all. The first launchd
+#   live-eval run (2026-09-05 02:30) hit exactly this: every one of 12 probes × 2 arms died at
+#   `timeout: command not found` before `claude` ever ran, and the report showed 12/12
+#   FAILED-TO-RUN with no clue why — a "did this fire" question this repo cares about a great
+#   deal (§Skeleton-Not-Muscle) answered wrong for a reason that had nothing to do with the
+#   harness under test. FH ships this script via npm (package.json `files[]`), so a stock-macOS
+#   consumer with no Homebrew coreutils hits the identical wall running it by hand — this is not
+#   a launchd-only defect. Resolution below: GNU `timeout` → `gtimeout` → a bash-native watchdog
+#   fallback, so a run never silently trades "no timeout enforcement" for "works on my machine".
+#   The resolved kind is printed in the run header as `timeout_tool=` so a run names its own
+#   control rather than leaving it to be inferred from a failure days later.
 
 set -uo pipefail
 
@@ -320,6 +337,62 @@ case "$MODE" in observe|act) ;; *) echo "FAIL: --mode must be observe|act" >&2; 
 
 command -v claude >/dev/null 2>&1 || { echo "FAIL: claude CLI not on PATH" >&2; exit 2; }
 
+# ── timeout(1) resolution — see §timeout(1) RESOLUTION in the header above for WHY. ──────────────
+# GNU `timeout` → Homebrew's `gtimeout` → a bash-native watchdog. Never silently proceeds with NO
+# enforcement at all — that would trade "wrong binary name" for "no timeout, ever", which is worse.
+TIMEOUT_KIND=""; TIMEOUT_BIN=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_KIND="gnu"; TIMEOUT_BIN="$(command -v timeout)"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_KIND="gtimeout"; TIMEOUT_BIN="$(command -v gtimeout)"
+else
+  TIMEOUT_KIND="bash-fallback"; TIMEOUT_BIN=""
+fi
+
+# fh_run_with_timeout SECONDS CMD... — used only when neither `timeout` nor `gtimeout` resolved.
+# Backgrounds CMD, TERMs it if SECONDS elapses, grants 5s to exit cleanly, then KILLs. The verdict
+# "did this actually time out" is a FLAG FILE the watchdog writes when it intervenes — not CMD's
+# own exit code — because a child that catches SIGTERM and exits 0 anyway must still be reported
+# as timed out (matching GNU timeout's rc=124 convention), not read as if it had answered normally.
+fh_run_with_timeout() {
+  local _secs="$1"; shift
+  local _flag; _flag="$(mktemp "${TMPDIR:-/tmp}/fh_to_XXXXXX")"; rm -f "$_flag"
+  "$@" &
+  local _cpid=$!
+  ( sleep "$_secs" 2>/dev/null
+    if kill -0 "$_cpid" 2>/dev/null; then
+      : > "$_flag"
+      kill -TERM "$_cpid" 2>/dev/null
+      sleep 5
+      kill -0 "$_cpid" 2>/dev/null && kill -KILL "$_cpid" 2>/dev/null
+    fi
+  ) &
+  local _watchdog=$!
+  local _rc=0
+  wait "$_cpid" 2>/dev/null; _rc=$?
+  # The watchdog subshell owns a `sleep`; killing the subshell alone leaves that sleep as an
+  # orphan for up to SECONDS (test_frontier_digest_retry.sh challenger B-2 measured exactly this
+  # class). Kill the subshell's children first, then the subshell.
+  pkill -P "$_watchdog" 2>/dev/null; kill "$_watchdog" 2>/dev/null; wait "$_watchdog" 2>/dev/null
+  if [ -f "$_flag" ]; then
+    rm -f "$_flag"
+    return 124
+  fi
+  rm -f "$_flag" 2>/dev/null
+  return "$_rc"
+}
+
+# fh_timeout SECONDS CMD... — drop-in for `timeout SECONDS CMD...` using whichever kind resolved
+# above. The call site never branches on TIMEOUT_KIND itself.
+fh_timeout() {
+  local _secs="$1"; shift
+  case "$TIMEOUT_KIND" in
+    gnu)      command timeout "$_secs" "$@" ;;
+    gtimeout) command gtimeout "$_secs" "$@" ;;
+    *)        fh_run_with_timeout "$_secs" "$@" ;;
+  esac
+}
+
 OUTDIR="${OUTDIR:-$(mktemp -d "${TMPDIR:-/tmp}/fh-sim-XXXXXX")}"
 mkdir -p "$OUTDIR"
 
@@ -355,6 +428,7 @@ _model_known_cutoff() { # $1=--model 값 → ISO 월 또는 UNKNOWN
 
 echo "── sim_isolated_run ──────────────────────────────────────────────"
 echo "arm=$ARM mode=$MODE model=$MODEL reps=$REPS timeout=${TIMEOUT}s"
+echo "timeout_tool=${TIMEOUT_KIND}${TIMEOUT_BIN:+:$TIMEOUT_BIN}"
 echo "out=$OUTDIR"
 
 snapshot "$OUTDIR/_machine_before.txt"
@@ -514,7 +588,7 @@ for r in $(seq 1 "$REPS"); do
   #    부르며 정직하게 거부하면서도, 거부문 안에서 정답을 말한다. 채점기는 그걸 토큰으로 센다.
   #    이것이 회차 1~3 과 probe1~4 를 전부 무효로 만든 근인이고, 경로 deny·코퍼스 마스킹은
   #    **원리적으로 못 막는다**(도구 읽기가 아니라 프롬프트 조립이다).
-  ( cd "$WORK" && timeout "$TIMEOUT" claude -p "$PROMPT" \
+  ( cd "$WORK" && fh_timeout "$TIMEOUT" claude -p "$PROMPT" \
         --model "$MODEL" "${TOOLS[@]}" \
         < /dev/null 2>"$OUTDIR/${ARM}_r${r}.stderr.txt" ) > "$OUTDIR/${ARM}_r${r}.txt"
   rc=$?

--- a/scripts/test_probe_live_eval_lanes.sh
+++ b/scripts/test_probe_live_eval_lanes.sh
@@ -324,6 +324,36 @@ _lane FF5 fail-fast "live nightly record untouched by the suite (hash before == 
 [ -s "$T/failfast_report_ok.md" ] && ff_rep=yes || ff_rep=no
 _lane FF6 fail-fast "--report-out receives the report instead of the live path" "yes" "$ff_rep"
 
+# 🟥 FF7/FF7b — the seam must bypass the CLI preflight, and ONLY the seam. Measured 2026-09-05 on
+# CI (ubuntu, no `claude` on PATH): probe_live_eval.sh checked `command -v claude` BEFORE the
+# runner seam, so the stub was never called — FF2/FF3/FF4/FF6 red, FF1 green by coincidence (both
+# paths exit 2). A developer machine with `claude` installed cannot see that, so this lane HIDES
+# `claude` (a shadow PATH of symlinks to every other executable) and re-runs the healthy stub.
+# FF7b is the control: on the REAL runner path with no `claude`, the script must still refuse.
+SHADOW_NOCLAUDE="$T/shadow_noclaude"; mkdir -p "$SHADOW_NOCLAUDE"
+IFS=':' read -r -a _ff_dirs <<< "$PATH"
+for _d in "${_ff_dirs[@]}"; do
+  [ -d "$_d" ] || continue
+  for _f in "$_d"/*; do
+    [ -x "$_f" ] && [ ! -d "$_f" ] || continue
+    _b="${_f##*/}"; [ "$_b" = claude ] && continue
+    [ -e "$SHADOW_NOCLAUDE/$_b" ] || ln -s "$_f" "$SHADOW_NOCLAUDE/$_b"
+  done
+done
+if PATH="$SHADOW_NOCLAUDE" command -v claude >/dev/null 2>&1; then
+  _lane FF7-FIXTURE fail-fast "shadow PATH hides claude (fixture potency — cannot run FF7 on this machine)" "hidden" "still-visible"
+else
+  COUNTER3="$T/failfast_counter_noclaude.txt"; : > "$COUNTER3"
+  ( cd "$REPO_ROOT" && PATH="$SHADOW_NOCLAUDE" FH_SIM_RUNNER_BIN="$STUBROOT/fake_sim_ok.sh" FH_FAKESIM_COUNTER="$COUNTER3" \
+      bash "$RUNNER" --subset 2 --model sonnet --out "$T/failfast_run_noclaude" --report-out "$T/failfast_report_noclaude.md" ) >/dev/null 2>&1
+  ff7_calls=$(wc -l < "$COUNTER3" | tr -d ' ')
+  _lane FF7 fail-fast "claude absent from PATH + stub runner: stub still called for all 4 (the seam bypasses the CLI preflight)" "4" "$ff7_calls"
+  ff7b_out="$(cd "$REPO_ROOT" && PATH="$SHADOW_NOCLAUDE" bash "$RUNNER" --subset 2 --model sonnet --out "$T/failfast_run_noclaude_real" --report-out "$T/failfast_report_noclaude_real.md" 2>&1)"
+  ff7b_rc=$?
+  case "$ff7b_out" in *"claude CLI not on PATH"*) ff7b_msg=yes ;; *) ff7b_msg=no ;; esac
+  _lane FF7b fail-fast "control — the REAL runner path with claude absent still exits 2 and names claude" "2/yes" "$ff7b_rc/$ff7b_msg"
+fi
+
 echo ""
 echo "── summary ──────────────────────────────────────────────────────"
 echo "lanes: $N   failed: $([ "$FAIL" -eq 0 ] && echo 0 || echo '>=1')"

--- a/scripts/test_probe_live_eval_lanes.sh
+++ b/scripts/test_probe_live_eval_lanes.sh
@@ -98,6 +98,65 @@ _lane P7 score-pair "primary file missing -> FAILED-TO-RUN" "FAILED-TO-RUN False
 r="$(_score '' 'the weather is nice' present '🐿️')"
 _lane P8 score-pair "primary file empty -> FAILED-TO-RUN" "FAILED-TO-RUN False False" "$r"
 
+# ── reason-pair: FAILED-TO-RUN rows carry a `reason` explaining WHY (2026-09-05) ────────────────
+# WHY: the 2026-09-05 launchd incident scored 12/12 FAILED-TO-RUN with no clue why in the report
+# itself — a human had to go dig through stderr files by hand. score_run() now attaches a `reason`
+# to any FAILED-TO-RUN row: the failing arm's own stderr first line when there is one, else an
+# rc/bytes fallback parsed from the runner's console log. This never touches score_probe() itself
+# (unchanged, still tested above) — reason is a diagnostic label on top of the same verdict.
+# $1=run_root $2=id -> "VERDICT<TAB>REASON"
+_reason_row() {
+  python3 -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT/scripts')
+from probe_live_eval_lib import score_run
+live = [{'id': sys.argv[2], 'polarity': 'present', 'expect_re': '🐿️'}]
+res = score_run(live, sys.argv[1], [sys.argv[2]], 0.8, 'sonnet')
+row = res['rows'][0]
+sys.stdout.write('%s\t%s' % (row['verdict'], row.get('reason', '')))
+" "$1" "$2"
+}
+
+echo ""
+echo "── reason-pair ──────────────────────────────────────────────────"
+
+# R-F1: primary's own stderr has a real line (the launchd incident's actual error text) -> reason
+# quotes it verbatim, prefixed by which arm it came from.
+RROOT1="$T/reason_f1"; mkdir -p "$RROOT1/X1"
+printf 'scripts/sim_isolated_run.sh: line 517: timeout: command not found\n' > "$RROOT1/X1/primary_r1.stderr.txt"
+printf 'unused control text' > "$RROOT1/X1/control_r1.txt"
+out="$(_reason_row "$RROOT1" X1)"
+_lane RF1 reason-pair "primary stderr line -> reason quotes it, prefixed 'primary:'" \
+  "FAILED-TO-RUN	primary: scripts/sim_isolated_run.sh: line 517: timeout: command not found" "$out"
+
+# R-F2: stderr file absent/empty -> falls back to rc/bytes, rc parsed from the runner's own
+# console log text (the shape sim_isolated_run.sh itself prints: "(rc=<n>, ...)").
+RROOT2="$T/reason_f2"; mkdir -p "$RROOT2/X2"
+printf '  UNMEASURED (rc=127, 0 bytes) - timeout or crash, NOT a negative result\n' > "$RROOT2/X2/_runner_primary.log"
+printf 'unused' > "$RROOT2/X2/control_r1.txt"
+out="$(_reason_row "$RROOT2" X2)"
+_lane RF2 reason-pair "no stderr line -> rc/bytes fallback parsed from the runner log" \
+  "FAILED-TO-RUN	primary: rc=127 bytes=0" "$out"
+
+# R-F3: the CONTROL side is the one missing (primary present) -> reason is prefixed 'control:',
+# not 'primary:' — proves the label is attributed to the arm that actually failed.
+RROOT3="$T/reason_f3"; mkdir -p "$RROOT3/X3"
+printf '🐿️ Welcome to FH' > "$RROOT3/X3/primary_r1.txt"
+printf 'boom: control side stderr text\n' > "$RROOT3/X3/control_r1.stderr.txt"
+out="$(_reason_row "$RROOT3" X3)"
+_lane RF3 reason-pair "control-side failure -> reason prefixed 'control:', not 'primary:'" \
+  "FAILED-TO-RUN	control: boom: control side stderr text" "$out"
+
+# R-F4 known-negative: a normal PASS row must carry an EMPTY reason — otherwise RF1-RF3 could be
+# passing because `reason` is always non-empty garbage, not because it discriminates on verdict
+# ([[feedback_control_presence_is_not_discrimination]]).
+RROOT4="$T/reason_f4"; mkdir -p "$RROOT4/X4"
+printf '🐿️ Welcome to FH' > "$RROOT4/X4/primary_r1.txt"
+printf 'the weather is nice' > "$RROOT4/X4/control_r1.txt"
+out="$(_reason_row "$RROOT4" X4)"
+_lane RF4 reason-pair "control — a PASS row carries no reason (field is FAILED-TO-RUN-only)" \
+  "PASS	" "$out"
+
 # ── select-guard: mechanical rule reproduces the real 12/21 split ──────────────────────────────
 echo ""
 echo "── select-guard ──────────────────────────────────────────────────"
@@ -182,6 +241,88 @@ case "$dry_stdout" in
   *) r3=no ;;
 esac
 _lane R3 dry-run "--dry-run stdout shows the real 12-probe selection" "yes" "$r3"
+
+# ── fail-fast: probe_live_eval.sh aborts on the FIRST rc=2 runner call, not after burning the
+# rest of the selected set (2026-09-05, the launchd incident this exists for) ────────────────────
+# WHY: sim_isolated_run.sh's own usage guards exit 2 before ever calling `claude` (bad flags, no
+# `claude` on PATH, or — the actual incident — a launchd PATH with no `timeout(1)` resolvable
+# before that runner grew its own bash-fallback). That condition is identical for every remaining
+# probe in the run, so continuing just burns the rest of the clones on an environment already
+# known broken. These lanes stub OUT sim_isolated_run.sh entirely via FH_SIM_RUNNER_BIN (added to
+# probe_live_eval.sh for exactly this) so the fail-fast branch can be tested without a live
+# `claude` call at all.
+echo ""
+echo "── fail-fast ────────────────────────────────────────────────────"
+
+STUBROOT="$T/failfast_stub"; mkdir -p "$STUBROOT"
+
+# Broken stand-in: exactly what sim_isolated_run.sh's own preflight guards do — print one line to
+# stderr and exit 2, never touching a network or spawning `claude`. Records its own invocation
+# count so the lane can prove the caller stopped after the FIRST call.
+cat > "$STUBROOT/fake_sim_broken.sh" <<'FAKESIM'
+#!/usr/bin/env bash
+: "${FH_FAKESIM_COUNTER:?FH_FAKESIM_COUNTER must be set by the caller}"
+echo "$$" >> "$FH_FAKESIM_COUNTER"
+echo "FAIL: claude CLI not on PATH" >&2
+exit 2
+FAKESIM
+chmod +x "$STUBROOT/fake_sim_broken.sh"
+
+# Healthy stand-in (known-negative control): same argv shape, writes a plausible output file and
+# exits 0 for EVERY call — proves FF1/FF2 discriminate on rc=2 specifically, not on "stopped after
+# one call" regardless of what the runner returns.
+cat > "$STUBROOT/fake_sim_ok.sh" <<'FAKESIMOK'
+#!/usr/bin/env bash
+: "${FH_FAKESIM_COUNTER:?FH_FAKESIM_COUNTER must be set by the caller}"
+echo "$$" >> "$FH_FAKESIM_COUNTER"
+arm=""; out=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --arm) arm="$2"; shift 2 ;;
+    --out) out="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+mkdir -p "$out"
+echo "stub ok output" > "$out/${arm}_r1.txt"
+echo "RESULT: CLEAN"
+exit 0
+FAKESIMOK
+chmod +x "$STUBROOT/fake_sim_ok.sh"
+
+# 🟥 FF5 guard — the live nightly record must be untouched by this suite. Measured 2026-09-05 10:18:
+# FF4 completed the REAL script with a stub runner and, with no --report-out, replaced that night's
+# tracks/_meta/live_eval_<date>.md with stub values. A lane that writes into the live artifact path
+# is the fleet class in miniature ([[feedback_sim_with_write_tools_is_a_fleet]]).
+LIVE_REPORT="$REPO_ROOT/tracks/_meta/live_eval_$(date +%Y-%m-%d).md"
+_live_hash() { if [ -f "$LIVE_REPORT" ]; then shasum "$LIVE_REPORT" | cut -c1-40; else echo ABSENT; fi; }
+live_before="$(_live_hash)"
+COUNTER1="$T/failfast_counter_broken.txt"; : > "$COUNTER1"
+ff_out="$(cd "$REPO_ROOT" && FH_SIM_RUNNER_BIN="$STUBROOT/fake_sim_broken.sh" FH_FAKESIM_COUNTER="$COUNTER1" \
+    bash "$RUNNER" --subset 2 --model sonnet --out "$T/failfast_run_broken" --report-out "$T/failfast_report_broken.md" 2>&1)"
+ff_rc=$?
+_lane FF1 fail-fast "aborts with rc=2 on the runner's own preflight failure" "2" "$ff_rc"
+ff_calls=$(wc -l < "$COUNTER1" | tr -d ' ')
+_lane FF2 fail-fast "stops after exactly 1 runner call (does not burn the 2nd probe's 3 remaining calls)" "1" "$ff_calls"
+case "$ff_out" in
+  *"Aborting the whole run"*) ff_msg=yes ;;
+  *) ff_msg=no ;;
+esac
+_lane FF3 fail-fast "abort message names what happened (not a silent stop)" "yes" "$ff_msg"
+
+# Known-negative control: the SAME --subset 2 (2 probes x primary+control = 4 calls) against a
+# HEALTHY runner must run to completion, not stop early — otherwise FF1/FF2 could be passing
+# because the loop always stops after one call for any reason at all
+# ([[feedback_control_presence_is_not_discrimination]]).
+COUNTER2="$T/failfast_counter_ok.txt"; : > "$COUNTER2"
+( cd "$REPO_ROOT" && FH_SIM_RUNNER_BIN="$STUBROOT/fake_sim_ok.sh" FH_FAKESIM_COUNTER="$COUNTER2" \
+    bash "$RUNNER" --subset 2 --model sonnet --out "$T/failfast_run_ok" --report-out "$T/failfast_report_ok.md" ) >/dev/null 2>&1
+ff2_calls=$(wc -l < "$COUNTER2" | tr -d ' ')
+_lane FF4 fail-fast "control — a healthy runner (rc=0) is called for all 4 (2 probes x 2 arms), not stopped early" "4" "$ff2_calls"
+live_after="$(_live_hash)"
+_lane FF5 fail-fast "live nightly record untouched by the suite (hash before == after, or both ABSENT)" "$live_before" "$live_after"
+[ -s "$T/failfast_report_ok.md" ] && ff_rep=yes || ff_rep=no
+_lane FF6 fail-fast "--report-out receives the report instead of the live path" "yes" "$ff_rep"
 
 echo ""
 echo "── summary ──────────────────────────────────────────────────────"

--- a/scripts/test_sim_isolated_run_lanes.sh
+++ b/scripts/test_sim_isolated_run_lanes.sh
@@ -56,6 +56,10 @@ case "${FH_STUB_MODE:-say}" in
   # 🟥 stdin 을 그대로 받아 적는다 — 실물 `claude -p` 가 하는 짓을 재현한다.
   #    진짜 CLI 는 stdin 이 TTY 가 아니면 그것을 «읽어 프롬프트 뒤에 붙인다».
   stdin)    echo "stub answer"; cat >> "${FH_STUB_STDIN_LOG:-/dev/null}" ;;
+  # L26 (2026-09-05) — a command that runs long past any sane --timeout, default SIGTERM
+  # disposition (no trap): dies as soon as the watchdog signals it, so a lane can tell "the
+  # deadline was enforced" from "we just waited for it to finish on its own".
+  hang)     sleep 30 ;;
 esac
 exit 0
 STUB
@@ -276,6 +280,88 @@ if [ -f "$META" ]; then
     || no "L25c sim_model_cutoff field missing"
 else
   no "L25 meta.tsv not written at all ($META)"
+fi
+
+# ── L26 timeout(1) resolution (2026-09-05) — the launchd-PATH incident this exists for ──────────
+#    WHY: launchd's PATH ($HOME/.local/bin:/usr/local/bin:/usr/bin:/bin, per this repo's own plist
+#    templates prior to this patch) has neither `timeout` nor `gtimeout` on it — both live under
+#    Homebrew's prefix. The first real launchd live-eval run (2026-09-05 02:30) hit exactly this:
+#    every rep of every arm died at `timeout: command not found` and the run scored 12/12
+#    FAILED-TO-RUN with no clue why. This lane strips whichever CURRENT PATH dir(s) actually hold
+#    `timeout`/`gtimeout` — computed, not hardcoded to /opt/homebrew/bin, so the same lane works on
+#    Intel or a Linux box — and proves two things a prose comment cannot: the bash-native fallback
+#    actually answers (not just "doesn't crash"), and it actually enforces the deadline rather than
+#    silently never firing.
+_strip_timeout_dirs() {  # prints $PATH with every dir holding an executable timeout/gtimeout removed
+  local IFS=':' d out=""
+  for d in $PATH; do
+    [ -x "$d/timeout" ] && continue
+    [ -x "$d/gtimeout" ] && continue
+    out="${out:+$out:}$d"
+  done
+  printf '%s' "$out"
+}
+NOTIMEOUT_PATH="$(_strip_timeout_dirs)"
+
+echo ""
+echo "── L26 timeout(1) resolution ───────────────────────────────────────"
+
+# Fixture-potency check FIRST — a stripped PATH that still resolves timeout/gtimeout proves
+# nothing ([[feedback_fixture_must_use_the_breaking_spelling]]), and a strip that ALSO removed
+# bash/git would confound every assertion below with an unrelated clone failure. Both are named
+# distinctly rather than let a downstream lane fail for the wrong reason. Per this file's own
+# convention (see L24's "검사 못 함(스킵 아님)"), an unusable fixture on this machine is scored
+# as a failure, not silently skipped — it is loud precisely because CI does not gate this file
+# (verified: no .github/workflows/*.yml references it), so a quiet skip would never be noticed.
+if PATH="$NOTIMEOUT_PATH" command -v timeout >/dev/null 2>&1 || PATH="$NOTIMEOUT_PATH" command -v gtimeout >/dev/null 2>&1; then
+  no "L26-FIXTURE stripped PATH still resolves timeout/gtimeout — cannot run L26 on this machine"
+elif ! PATH="$NOTIMEOUT_PATH" command -v bash >/dev/null 2>&1 || ! PATH="$NOTIMEOUT_PATH" command -v git >/dev/null 2>&1; then
+  no "L26-FIXTURE stripping timeout/gtimeout also removed bash or git — cannot run L26 on this machine"
+else
+  ok "L26-FIXTURE stripped PATH lacks timeout+gtimeout; bash/git still resolve"
+
+  # L26a — no timeout/gtimeout at all: the runner must still answer (via the bash fallback) and
+  # must NAME which control it used in its own header, rather than leaving that to be inferred.
+  OUTDIR="$WORKROOT/o26a"
+  OUT=$( cd "$SRC" && PATH="$STUBBIN:$NOTIMEOUT_PATH" HOME="$FAKEHOME" FH_STUB_MODE=say \
+     bash "$SUT" --arm a --reps 1 --prompt p --out "$OUTDIR" 2>&1 )
+  if printf '%s' "$OUT" | grep -q "timeout_tool=bash-fallback" && printf '%s' "$OUT" | grep -q "captured"; then
+    ok "L26a no timeout/gtimeout on PATH -> bash-fallback answers and names itself in the header"
+  else
+    no "L26a bash-fallback did not fire/name itself: $(printf '%s' "$OUT" | grep -E 'timeout_tool|captured|UNMEASURED|EMPTY' | head -3 | tr '\n' ';')"
+  fi
+
+  # L26b — the fallback must actually ENFORCE the deadline, not just silently never fire. A stub
+  # that would otherwise run 30s under --timeout 2 must come back UNMEASURED well under 30s.
+  OUTDIR="$WORKROOT/o26b"
+  _t0=$(date +%s)
+  OUT=$( cd "$SRC" && PATH="$STUBBIN:$NOTIMEOUT_PATH" HOME="$FAKEHOME" FH_STUB_MODE=hang \
+     bash "$SUT" --arm a --reps 1 --prompt p --timeout 2 --out "$OUTDIR" 2>&1 )
+  _t1=$(date +%s); _elapsed=$(( _t1 - _t0 ))
+  if printf '%s' "$OUT" | grep -q "UNMEASURED" && [ "$_elapsed" -le 10 ]; then
+    ok "L26b bash-fallback enforces the deadline (UNMEASURED in ${_elapsed}s of a 30s hang, timeout=2s)"
+  else
+    no "L26b fallback did not enforce the timeout (elapsed=${_elapsed}s): $(printf '%s' "$OUT" | grep -E 'UNMEASURED|captured' | head -1)"
+  fi
+
+  # L26c control — SAME hang stub, DEFAULT (unstripped) PATH: real timeout/gtimeout must still be
+  # preferred over the fallback (header says gnu/gtimeout, not bash-fallback), AND must enforce
+  # the same deadline. Without this, L26a/L26b could be passing because the fallback is used
+  # unconditionally, not because resolution correctly prefers the real tool when it is present
+  # ([[feedback_control_presence_is_not_discrimination]]).
+  OUTDIR="$WORKROOT/o26c"
+  OUT=$( cd "$SRC" && PATH="$STUBBIN:$PATH" HOME="$FAKEHOME" FH_STUB_MODE=hang \
+     bash "$SUT" --arm a --reps 1 --prompt p --timeout 2 --out "$OUTDIR" 2>&1 )
+  case "$OUT" in
+    *"timeout_tool=bash-fallback"*)
+      no "L26c control — default PATH used bash-fallback instead of a real timeout/gtimeout" ;;
+    *"timeout_tool=gnu"*|*"timeout_tool=gtimeout"*)
+      printf '%s' "$OUT" | grep -q "UNMEASURED" \
+        && ok "L26c control — default PATH prefers the real timeout tool and still enforces the deadline" \
+        || no "L26c control — real timeout tool resolved but did not enforce the deadline"
+      ;;
+    *) no "L26c control — no timeout_tool= line in header at all: $(printf '%s' "$OUT" | grep timeout_tool)" ;;
+  esac
 fi
 
 echo "sim_isolated_run lanes: $pass passed, $fail failed"

--- a/scripts/test_sim_isolated_run_lanes.sh
+++ b/scripts/test_sim_isolated_run_lanes.sh
@@ -287,21 +287,35 @@ fi
 #    templates prior to this patch) has neither `timeout` nor `gtimeout` on it — both live under
 #    Homebrew's prefix. The first real launchd live-eval run (2026-09-05 02:30) hit exactly this:
 #    every rep of every arm died at `timeout: command not found` and the run scored 12/12
-#    FAILED-TO-RUN with no clue why. This lane strips whichever CURRENT PATH dir(s) actually hold
-#    `timeout`/`gtimeout` — computed, not hardcoded to /opt/homebrew/bin, so the same lane works on
-#    Intel or a Linux box — and proves two things a prose comment cannot: the bash-native fallback
+#    FAILED-TO-RUN with no clue why. This lane shadows whichever CURRENT PATH dir(s) actually hold
+#    `timeout`/`gtimeout` (symlinks to everything else in them) — computed, not hardcoded to
+#    /opt/homebrew/bin, so the same lane works on Intel, Homebrew or a Linux /usr/bin — and proves
+#    two things a prose comment cannot: the bash-native fallback
 #    actually answers (not just "doesn't crash"), and it actually enforces the deadline rather than
 #    silently never firing.
-_strip_timeout_dirs() {  # prints $PATH with every dir holding an executable timeout/gtimeout removed
-  local IFS=':' d out=""
+_shadow_timeout_dirs() {  # prints $PATH with every dir holding timeout/gtimeout replaced by a symlink shadow of it MINUS those two
+  # 🟥 Measured 2026-09-05 on CI (ubuntu): `timeout` lives in /usr/bin next to bash and git, so
+  # DROPPING that directory (the previous form of this fixture) also dropped bash/git, and the
+  # potency check below scored the lane red on every Linux box while macOS (Homebrew prefix,
+  # separate dir) stayed green. A shadow directory keeps every other name resolvable and removes
+  # only the two — the same fixture on both layouts.
+  local IFS=':' d out="" shadow n=0 f b
   for d in $PATH; do
-    [ -x "$d/timeout" ] && continue
-    [ -x "$d/gtimeout" ] && continue
+    if [ -x "$d/timeout" ] || [ -x "$d/gtimeout" ]; then
+      n=$((n+1)); shadow="$WORKROOT/notimeout_shadow_$n"; rm -rf "$shadow"; mkdir -p "$shadow"
+      for f in "$d"/*; do
+        [ -x "$f" ] && [ ! -d "$f" ] || continue
+        b="${f##*/}"
+        case "$b" in timeout|gtimeout) continue ;; esac
+        ln -s "$f" "$shadow/$b"
+      done
+      d="$shadow"
+    fi
     out="${out:+$out:}$d"
   done
   printf '%s' "$out"
 }
-NOTIMEOUT_PATH="$(_strip_timeout_dirs)"
+NOTIMEOUT_PATH="$(_shadow_timeout_dirs)"
 
 echo ""
 echo "── L26 timeout(1) resolution ───────────────────────────────────────"


### PR DESCRIPTION
## 무엇
2026-09-05 02:30 첫 launchd live-eval 런이 **12/12 FAILED-TO-RUN** 으로 끝났다. 보존된 팔 산출물의 stderr 한 줄이 원인이다: `sim_isolated_run.sh: line 517: timeout: command not found`. macOS 는 `timeout(1)` 을 안 싣고, launchd 의 PATH(`~/.local/bin:/usr/local/bin:/usr/bin:/bin`)는 Homebrew coreutils 를 못 본다. 어제 워크트리 테스트는 Homebrew 가 있는 대화형 셸이라 통과했다. FH 는 이 두 스크립트를 npm 으로 출하하므로 stock macOS 소비자도 같은 벽을 만난다.

## 수리
- `sim_isolated_run.sh`: 프리플라이트에서 `timeout` → `gtimeout` → **bash 네이티브 워치독** 순으로 해석. 폴백은 플래그 파일로 타임아웃(124)을 판정하고 TERM→5s→KILL, 워치독 서브셸의 `sleep` 고아를 `pkill -P` 로 선행 정리. 헤더에 `timeout_tool=<gnu|gtimeout|bash-fallback>` 를 찍어 런이 자기 컨트롤을 이름으로 남긴다.
- `probe_live_eval.sh`: 러너 rc=2(프리플라이트 실패) 첫 발생에 전체 런 중단(24 클론 안 태움). **`--report-out`** 신설 — 기본값은 종전과 같고, 레인/스팟체크는 야간 기록 자리를 건드리지 않는다.
- `probe_live_eval_lib.py`: FAILED-TO-RUN 행에 `reason`(stderr 첫 줄 / `rc= bytes=`). 채점 함수 `score_probe` 는 바이트 동일.
- plist 템플릿: PATH 에 `/opt/homebrew/bin`(있으면 GNU 우선) · digest 템플릿 `FD_MODEL=opus`(`/model` 기본값이 무인 `claude -p` 에도 적용되므로 명시 핀 — 운영자 결정).

## 증거(캡슐)
- 레인 fail-before/after: sim `L26a/c` 패치 전 빨강 → **31/31** · probe `RF1-3·FF2-3` 패치 전 빨강 → **30/30**(FF5·FF6 거버너 추가).
- **거버너 2차 독해 적발 2, 둘 다 레인으로 고정**: ⓐ 워치독 `sleep` 고아(retry 레인 B-2 와 같은 부류) ⓑ 새 레인 FF4 가 실물 스크립트를 스텁 러너로 완주시키며 **오늘자 야간 기록을 덮어썼다**(mtime 실측) → `--report-out` + FF5(레인 전후 라이브 기록 해시 동일 `839f1a6d`).
- 첫 실사용 2: (i) `env -i` launchd PATH 라이브 1프로브 → `timeout_tool=bash-fallback`, 35B 캡처, FAILED-TO-RUN 아님 (ii) 실 launchd 잡 `launchctl start` 10:18 → 클론 안 `claude` 가 인증된 채 응답(새 사용자 환영문 캡처) — 12 프로브 분포는 런 종료 후 코멘트로.
- 컨트롤: L26c(기본 PATH 는 GNU 선택+데드라인 강제) · FF4(정상 러너 4콜 완주) · RF4(PASS 행은 reason 없음) · 실 launchd 위성(forge-wiki 10:04 성공 = LaunchAgent 는 USER 없이도 인증).
- Axis 1 = SKIP(pathspec 밖, 통과 아님). degrade-scan 1 = 레인 :77 영어 픽스처 'in'(HEAD 와 동일, 기존). 포터빌리티 린트 1 = :415 기존 GNU-first 주석 텍스트(advisory).
- standpoint: `DEGRADED_NOT_RUN` — 소비자 표면(files[])인데 깨끗한 install 실행 arm 은 이 세션에 안 돌렸다(did not).
- crossfamily: `DEGRADED_PANEL_UNUSED` — 판별자 기계(레인 61 + 실 런), 채점 규칙 무변경.

## defeater
내일 02:30 `live_eval_2026-09-06.md` 가 FAILED-TO-RUN 다수 또는 `reason` 빈칸 · FF5 해시 불일치 · 폴백 런 뒤 `sleep 900` 고아 잔존.

## 열린 질문
설치본 live-eval plist PATH 에 `/opt/homebrew/bin` 을 넣으면 야간에 폴백 경로가 더 이상 안 돈다 — 폴백을 매일 검증하는 현행(설치본 무변경) vs 템플릿과 동일(GNU 우선) 중 이 노드 기본을 어느 쪽으로 둘지.
