### PR TITLE
feat(gate): push-zone — 비-소유 github.com 원격 push 를 pre-push 에서 차단 + 마감 ①-f 열거(카운트) + 출하·레인 (⑫-②)

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,8 @@
     "scripts/prepush_guard_check.sh",
     "templates/predelete_check.test.sh",
     "scripts/test_prepush_destructive_lanes.sh",
+    "scripts/push_zone_check.sh",
+    "scripts/test_push_zone_lanes.sh",
     "scripts/fixture_guard_lib.sh",
     "scripts/shell_name_boundary_scan.sh",
     "scripts/test_verdict_watermark_lanes.sh",

--- a/scripts/caller_zero_baseline.txt
+++ b/scripts/caller_zero_baseline.txt
@@ -36,7 +36,6 @@
 
 exempt:
   - scripts/activity_log.sh   # on-demand chronological assembler, invoked by an operator/session when a trail is wanted — its own header says on-demand
-  - scripts/push_zone_check.sh   # human-run enumerate tool, same class as templates/predelete_check.sh: "run it BEFORE a multi-repo push round"
   - scripts/docker_phase0_verify.sh   # one-shot Docker Track 2 proof, needs a running Docker/OrbStack daemon — auto-running it in CI would fail-closed on every consumer
   - scripts/docker_phase1_verify.sh   # same Docker Track 2 one-shot; additionally spends live codex calls, so it must stay operator-initiated
   - scripts/docker_phase1b_verify.sh   # same Docker Track 2 one-shot; needs a local Ollama endpoint that exists on one machine only

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -606,6 +606,9 @@ for _pair in \
   "scripts/destructive_pre_gate.sh|scripts/test_destructive_pre_gate_lanes.sh" \
   "templates/.git-hooks/pre-push|scripts/test_prepush_destructive_lanes.sh" \
   "templates/.git-hooks/pre-push|scripts/test_prepush_destructive_liveness.sh" \
+  "templates/.git-hooks/pre-push|scripts/test_push_zone_lanes.sh" \
+  "scripts/push_zone_check.sh|scripts/test_push_zone_lanes.sh" \
+  "scripts/session_close_check.sh|scripts/test_push_zone_lanes.sh" \
   "scripts/session_close_check.sh|scripts/test_peer_worktree_detect_lanes.sh" \
   "scripts/env_purity_scan.sh|scripts/test_env_purity_lanes.sh" \
   "scripts/frontier_digest_daily.sh|scripts/test_frontier_digest_retry.sh" \

--- a/scripts/session_close_check.sh
+++ b/scripts/session_close_check.sh
@@ -704,5 +704,38 @@ else
   echo "⚠️  ①-e stray_path_scan.sh 없음 — skipped, not passed"
 fi
 
+# ── ①-f PUSH-ZONE advisory (surface-not-block; mirrors the pre-push hook's own zone check) ────
+# WHY: templates/.git-hooks/pre-push blocks a single push whose remote sits outside the owner-
+# account list, but it only ever sees the ONE push in front of it. The 2026-07-26 miss this whole
+# axis exists for was a multi-repo ROUND — CLAUDE.local.md §REST API push 계정규칙 was applied
+# correctly to one org repo and forgotten on another in the SAME round. `scripts/push_zone_check.sh`
+# is the hand-run ENUMERATE tool for that round; wiring it here means it runs at least once per
+# close without the operator separately remembering to ask for it — same shape as the ①-b open-PR
+# sweep above. Advisory only: it lists, it never blocks (CLAUDE.md §Surface-Class Degrade Invariant,
+# reversible half — a session-close check is not the irreversible boundary; that is the pre-push
+# hook's job). Applicability is mechanical: both the script and an owner-account list must exist,
+# or this reports UNCALIBRATED rather than guessing.
+_PZ_SCRIPT="$FH/scripts/push_zone_check.sh"
+_PZ_OWNERS="${PUSH_ZONE_OWNERS:-$FH/.claude/rules/.push-zone-owners}"
+if [ -x "$_PZ_SCRIPT" ] && [ -f "$_PZ_OWNERS" ]; then
+  if _pz_out=$(bash "$_PZ_SCRIPT" 2>&1); then
+    # Counts only — the enumerator prints owner-account names and per-repo owners, and this close
+    # output lands in transcripts and session cards. The pre-push block never prints the list; this
+    # advisory must not either (codex #9, 2026-09-05). The names are one command away for the operator.
+    _pz_n=$(printf '%s\n' "$_pz_out" | grep -cE '^(✅|🔶) ' 2>/dev/null || true)
+    _pz_rest=$(printf '%s\n' "$_pz_out" | grep -cE '^🔶 ' 2>/dev/null || true)
+    echo "⚠️  ①-f push-zone: ${_pz_n:-0} repo(s) enumerated · ${_pz_rest:-0} outside the owner accounts (REST channel) — names withheld here; run: bash scripts/push_zone_check.sh"
+  else
+    # Verified 2026-09-05: push_zone_check.sh does not exit non-zero merely because `gh` is
+    # missing (its own `active="(unknown)"` fallback absorbs that) — the only documented non-zero
+    # exit is UNCALIBRATED for a missing owner list, already excluded by the `-f "$_PZ_OWNERS"`
+    # guard above. A non-zero exit reaching here is therefore an unanticipated failure; report it
+    # as UNMEASURED rather than silently treating empty/partial output as "nothing to enumerate".
+    echo "⚠️  ①-f push-zone: UNMEASURED — push_zone_check.sh exited non-zero, could not enumerate"
+  fi
+else
+  echo "⏭️  ①-f push-zone UNCALIBRATED — script or owner-account list absent"
+fi
+
 echo "── close check: $([ "$FAIL" -eq 0 ] && echo CONSISTENT || echo VIOLATIONS) ──"
 exit "$FAIL"

--- a/scripts/test_push_zone_lanes.sh
+++ b/scripts/test_push_zone_lanes.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# test_push_zone_lanes.sh — known-pair anchor for the pre-push hook's Push-Zone verdict, and for
+# the session-close ①-f advisory that mirrors it.
+#
+# ── WHY THIS FILE EXISTS ───────────────────────────────────────────────────────────────────────
+# 2026-09-05: templates/.git-hooks/pre-push gained a new verdict path and scripts/session_close_
+# check.sh gained a new ①-f advisory, both implementing CLAUDE.local.md §REST API push 계정규칙
+# mechanically — a push to a github.com remote whose owner is NOT on the operator's owner-account
+# list needs the REST Contents API channel, not plain git push. Before this suite the new code had
+# no known-pair anchor at all. Per CLAUDE.md §Instrument Calibration, a gate is not trusted until
+# calibrated on at least one known-positive and one known-negative, hand-verified.
+#
+# ── DISCIPLINE INHERITED FROM THE SIBLING SUITE (test_prepush_destructive_lanes.sh) ────────────
+#  (a) Run the hook FOR REAL — `bash -n` is not an instrument (a runtime fault can parse clean,
+#      abort the hook, and still exit 0).
+#  (b) A runtime fault is checked BEFORE the verdict, else an aborted hook scores as a clean pass.
+#  (c) "It blocked" is NOT "it blocked correctly" — a block must be ATTRIBUTED to a named FH gate.
+#  (d) NEVER read or assert on the operator's real owner-account list
+#      (.claude/rules/.push-zone-owners). Every lane below builds its own throwaway fixture list
+#      via the PUSH_ZONE_OWNERS override, with fictitious account names. The real file, if present
+#      on this machine, is never opened by this suite in either direction.
+#
+# Runs entirely in mktemp throwaway repos: never touches this repo's index, worktree, refs, or its
+# real .claude/rules/.push-zone-owners.
+#
+# Usage: bash scripts/test_push_zone_lanes.sh
+#   FH_PUSH_ZONE_HOOK_SRC=<path>  → test a DIFFERENT copy of the pre-push hook (fail-before proof).
+#   FH_PUSH_ZONE_SCC_SRC=<path>   → same, for session_close_check.sh.
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/fixture_guard_lib.sh"
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+HOOK_SRC="${FH_PUSH_ZONE_HOOK_SRC:-$REPO_ROOT/templates/.git-hooks/pre-push}"
+SCC_SRC="${FH_PUSH_ZONE_SCC_SRC:-$REPO_ROOT/scripts/session_close_check.sh}"
+DEF_SRC="$REPO_ROOT/.claude/rules/.public-surface-patterns.defaults"
+ZERO="0000000000000000000000000000000000000000"
+
+if [ ! -f "$HOOK_SRC" ]; then
+  echo "HARNESS_ERROR — pre-push hook not found at $HOOK_SRC (subject absent; NOT a pass)"; exit 1
+fi
+
+WORK="$(fh_fixture_root "$(mktemp -d)")" || exit 1
+: "${WORK:?fixture root unset — refusing to run git in cwd}"
+trap 'rm -rf "$WORK"' EXIT
+cp "$HOOK_SRC" "$WORK/hook" || exit 1
+HOOK="$WORK/hook"
+
+# Fictitious owner-account fixture — NEVER the operator's real list. The second entry
+# (acme-shared-org) is asserted to never appear in any captured output — it is a decoy for the
+# "list content is never printed" requirement, not used by any URL in this suite.
+OWNERS_OK="$WORK/owners-ok.txt"
+printf '# fixture owner list — test only, not the operator real list\nknown-owner\nacme-shared-org\n' > "$OWNERS_OK"
+
+PASSED=0; FAILED=0; ALL_OUT=""
+
+# ── fixture: same shape as test_prepush_destructive_lanes.sh's newrepo() ───────────────────────
+newrepo() {
+  local d; d="$(fh_fixture_root "$(mktemp -d)")" || return 1
+  : "${d:?fixture root unset — refusing to run git in cwd}"
+  mkdir -p "$d/.claude/rules" "$d/templates/.git-hooks" "$d/tracks/_meta" "$d/scripts" || return 1
+  [ -f "$DEF_SRC" ] && cp "$DEF_SRC" "$d/.claude/rules/.public-surface-patterns.defaults"
+  [ -f "$REPO_ROOT/scripts/psa_scan_lib.sh" ] && cp "$REPO_ROOT/scripts/psa_scan_lib.sh" "$d/scripts/psa_scan_lib.sh"
+  printf '.claude/rules/.public-surface-patterns\n' > "$d/.gitignore"
+  cp "$HOOK" "$d/templates/.git-hooks/pre-push" || return 1
+  printf 'base\n' > "$d/a.txt"
+  (
+    cd "$d" || exit 1
+    git init -q                                  || exit 1
+    git symbolic-ref HEAD refs/heads/main        || exit 1
+    git config user.email t@example.com          || exit 1
+    git config user.name t                       || exit 1
+    git add -A >/dev/null 2>&1                   || exit 1
+    git commit -qm base >/dev/null 2>&1          || exit 1
+    git update-ref refs/remotes/origin/main HEAD || exit 1
+  ) || return 1
+  printf '%s' "$d"
+}
+
+require_repo() {   # $1 = candidate repo path, $2 = lane name
+  if [ -z "${1:-}" ] || [ ! -d "$1/.git" ]; then
+    echo "HARNESS_ERROR — fixture repo not built for $2 (setup failed; NOT a pass)"
+    exit 1
+  fi
+}
+
+# check_zone <name> <repo> <owners-file|""> <url> <push_zone_ok:0|1> <expect:block|pass> <cause-regex|""> <refline>
+check_zone() {
+  local name="$1" repo="$2" owners="$3" url="$4" pzok="$5" expect="$6" cause="$7"; shift 7
+  local out rc got _pzsrc
+  require_repo "$repo" "$name"
+  _pzsrc="${owners:-$WORK/nonexistent-owners-file-for-zone-test}"
+  out=$(printf '%s\n' "$@" | ( cd "$repo" && PUSH_ZONE_OWNERS="$_pzsrc" PUSH_ZONE_OK="$pzok" \
+        bash templates/.git-hooks/pre-push origin "$url" 2>&1 )); rc=$?
+  ALL_OUT="$ALL_OUT
+$out"
+
+  if printf '%s' "$out" | grep -qiE 'bad substitution|unbound variable|syntax error|command not found'; then
+    echo "  ❌ $name — RUNTIME FAULT in the hook (aborted, not passed)"
+    printf '%s\n' "$out" | grep -iE 'bad substitution|unbound|syntax error|command not found' | sed 's/^/       /' | head -3
+    FAILED=$((FAILED+1)); return
+  fi
+
+  if [ "$rc" -ne 0 ]; then
+    if printf '%s' "$out" | grep -qE 'FH (Push-Zone Gate|Destructive-Op Gate)'; then
+      got=block
+    else
+      echo "  ❌ $name — blocked, but NOT by a named FH gate (harness reason ≠ finding)"
+      printf '%s\n' "$out" | sed 's/^/       | /' | head -8
+      FAILED=$((FAILED+1)); return
+    fi
+  else
+    got=pass
+  fi
+
+  if [ "$got" != "$expect" ]; then
+    echo "  ❌ $name — expected $expect, got $got"
+    printf '%s\n' "$out" | sed 's/^/       | /' | head -10
+    FAILED=$((FAILED+1)); return
+  fi
+
+  if [ -n "$cause" ] && ! printf '%s' "$out" | grep -qE "$cause"; then
+    echo "  ❌ $name — verdict $got is correct but UNATTRIBUTED (missing: $cause)"
+    printf '%s\n' "$out" | sed 's/^/       | /' | head -10
+    FAILED=$((FAILED+1)); return
+  fi
+
+  echo "  ✅ $name (expected $expect)"
+  PASSED=$((PASSED+1))
+}
+
+echo "[push-zone] known-pair anchor for the pre-push Push-Zone verdict (hook: $HOOK_SRC)"
+echo ""
+
+# Z0 — no owner-account list at all → UNCALIBRATED, plain push allowed.
+R=$(newrepo); require_repo "$R" "Z0"
+BASESHA=$(cd "$R" && git rev-parse HEAD)
+NEWSHA=$(cd "$R" && printf 'x\n' >> a.txt && git commit -qam ff >/dev/null && git rev-parse HEAD)
+check_zone "Z0 no owner-account list         → PASS " "$R" "" \
+  "https://github.com/known-owner/repo.git" 0 pass 'push-zone: UNCALIBRATED' \
+  "refs/heads/feat $NEWSHA refs/heads/feat $BASESHA"
+rm -rf "$R"
+
+# Z1 — owner IN the list, https → silent pass; the rest of the hook (confidentiality) still runs.
+R=$(newrepo); require_repo "$R" "Z1"
+BASESHA=$(cd "$R" && git rev-parse HEAD)
+NEWSHA=$(cd "$R" && printf 'x\n' >> a.txt && git commit -qam ff >/dev/null && git rev-parse HEAD)
+check_zone "Z1 owner IN list, https          → PASS " "$R" "$OWNERS_OK" \
+  "https://github.com/known-owner/repo.git" 0 pass 'FH Pre-Publish' \
+  "refs/heads/feat $NEWSHA refs/heads/feat $BASESHA"
+rm -rf "$R"
+
+# Z2 — owner OUT of the list, https → BLOCK, attributed, names the URL's (fictitious) owner.
+R=$(newrepo); require_repo "$R" "Z2"
+BASESHA=$(cd "$R" && git rev-parse HEAD)
+NEWSHA=$(cd "$R" && printf 'x\n' >> a.txt && git commit -qam ff >/dev/null && git rev-parse HEAD)
+check_zone "Z2 owner OUT of list, https      → BLOCK" "$R" "$OWNERS_OK" \
+  "https://github.com/someone-else/repo.git" 0 block 'FH Push-Zone Gate' \
+  "refs/heads/feat $NEWSHA refs/heads/feat $BASESHA"
+if printf '%s' "$ALL_OUT" | grep -qF 'github.com/someone-else'; then
+  echo "  ✅ Z2b block message names the URL's owner"; PASSED=$((PASSED+1))
+else
+  echo "  ❌ Z2b — block message did not name the URL's owner (someone-else)"; FAILED=$((FAILED+1))
+fi
+rm -rf "$R"
+
+# Z3 — owner OUT of the list, scp-like ssh (git@github.com:owner/repo) → BLOCK.
+R=$(newrepo); require_repo "$R" "Z3"
+BASESHA=$(cd "$R" && git rev-parse HEAD)
+NEWSHA=$(cd "$R" && printf 'x\n' >> a.txt && git commit -qam ff >/dev/null && git rev-parse HEAD)
+check_zone "Z3 owner OUT of list, ssh scp    → BLOCK" "$R" "$OWNERS_OK" \
+  "git@github.com:someone-else/repo.git" 0 block 'FH Push-Zone Gate' \
+  "refs/heads/feat $NEWSHA refs/heads/feat $BASESHA"
+rm -rf "$R"
+
+# Z4 — remote host is not github.com → out of scope for this axis, pass allowed, says so.
+R=$(newrepo); require_repo "$R" "Z4"
+BASESHA=$(cd "$R" && git rev-parse HEAD)
+NEWSHA=$(cd "$R" && printf 'x\n' >> a.txt && git commit -qam ff >/dev/null && git rev-parse HEAD)
+check_zone "Z4 non-github host              → PASS " "$R" "$OWNERS_OK" \
+  "https://ghe.example.com/x/y" 0 pass 'not github.com' \
+  "refs/heads/feat $NEWSHA refs/heads/feat $BASESHA"
+rm -rf "$R"
+
+# Z5 — PUSH_ZONE_OK=1 override on an out-of-list push → allowed, conscious, LOGGED.
+R=$(newrepo); require_repo "$R" "Z5"
+BASESHA=$(cd "$R" && git rev-parse HEAD)
+NEWSHA=$(cd "$R" && printf 'x\n' >> a.txt && git commit -qam ff >/dev/null && git rev-parse HEAD)
+check_zone "Z5 PUSH_ZONE_OK=1 override       → PASS " "$R" "$OWNERS_OK" \
+  "https://github.com/someone-else/repo.git" 1 pass 'PUSH_ZONE_OK=1' \
+  "refs/heads/feat $NEWSHA refs/heads/feat $BASESHA"
+LOG="$R/tracks/_meta/.push_zone_override_log"
+if [ -f "$LOG" ] && grep -qF 'owner:someone-else' "$LOG"; then
+  echo "  ✅ Z5b override logged to tracks/_meta/.push_zone_override_log"; PASSED=$((PASSED+1))
+else
+  echo "  ❌ Z5b override NOT logged (wanted a line inside $LOG)"; FAILED=$((FAILED+1))
+fi
+rm -rf "$R"
+
+# Z6 — existing destructive verdict (branch DELETE, unique paths → REVIEW → BLOCK) still stands
+#      AFTER a silent zone PASS. Same shape as the sibling suite's P2, through an owner-matching
+#      github.com URL — proves the zone block, inserted near the TOP of the hook, does not shadow
+#      or reorder the destructive checks further down.
+R=$(newrepo); require_repo "$R" "Z6"
+( cd "$R" && git checkout -q -b unique-work && printf 'only here\n' > unique.txt \
+   && git add unique.txt && git commit -qm unique >/dev/null && git checkout -q main )
+TIP=$(cd "$R" && git rev-parse unique-work)
+check_zone "Z6 zone PASS, then BRANCH DELETE → BLOCK" "$R" "$OWNERS_OK" \
+  "https://github.com/known-owner/repo.git" 0 block 'REVIEW: .* unique path' \
+  "(delete) $ZERO refs/heads/unique-work $TIP"
+rm -rf "$R"
+
+# ── Residency: the owner-list's OTHER entries must never appear in any captured output ─────────
+if printf '%s' "$ALL_OUT" | grep -qF 'acme-shared-org'; then
+  echo "  ❌ RESIDENCY — the fixture owner-list's second entry leaked into hook output"
+  FAILED=$((FAILED+1))
+else
+  echo "  ✅ RESIDENCY — owner-list content never appears in any captured hook output"
+  PASSED=$((PASSED+1))
+fi
+
+echo ""
+# ── Z7–Z14 (cross-family codex gpt-5.5, 2026-09-05): the first draft accepted three literal URL
+# prefixes and read every other github.com shape as "unrecognized → allow" — four real shapes were
+# failing OPEN; an inline comment in the owner list authorised pushes; CRLF / trailing slash blocked
+# the operator's own remotes. Each lane below is one of those exact inputs.
+OWNERS_CRLF="$WORK/owners-crlf.txt";   printf 'known-owner\r\nacme-shared-org\r\n' > "$OWNERS_CRLF"
+OWNERS_COMMENT="$WORK/owners-comment.txt"; printf 'known-owner   # someone-else is NOT allowed\nacme-shared-org\n' > "$OWNERS_COMMENT"
+OWNERS_SLASH="$WORK/owners-slash.txt"; printf 'known-owner/\nacme-shared-org\n' > "$OWNERS_SLASH"
+
+_zone_ff_lane() {  # $1=id $2=desc $3=owners $4=url $5=expect $6=cause
+  local R BASESHA NEWSHA
+  R=$(newrepo); require_repo "$R" "$1"
+  BASESHA=$(cd "$R" && git rev-parse HEAD)
+  NEWSHA=$(cd "$R" && printf 'x\n' >> a.txt && git commit -qam ff >/dev/null && git rev-parse HEAD)
+  check_zone "$1 $2" "$R" "$3" "$4" 0 "$5" "$6" "refs/heads/feat $NEWSHA refs/heads/feat $BASESHA"
+  rm -rf "$R"
+}
+_zone_ff_lane Z7  "userinfo https (user@github.com), owner OUT → BLOCK" "$OWNERS_OK" "https://user@github.com/someone-else/repo.git" block 'FH Push-Zone Gate'
+_zone_ff_lane Z8  "https with :443 port, owner OUT → BLOCK"           "$OWNERS_OK" "https://github.com:443/someone-else/repo.git" block 'FH Push-Zone Gate'
+_zone_ff_lane Z9  "ssh:// with :22 port, owner OUT → BLOCK"           "$OWNERS_OK" "ssh://git@github.com:22/someone-else/repo.git" block 'FH Push-Zone Gate'
+_zone_ff_lane Z10 "scp form with leading slash (git@github.com:/o/r), owner OUT → BLOCK" "$OWNERS_OK" "git@github.com:/someone-else/repo.git" block 'FH Push-Zone Gate'
+_zone_ff_lane Z11 "inline comment in owner list must NOT authorise the commented name → BLOCK" "$OWNERS_COMMENT" "https://github.com/someone-else/repo.git" block 'FH Push-Zone Gate'
+_zone_ff_lane Z12 "CRLF owner list, owner IN → pass (no over-block)"  "$OWNERS_CRLF" "https://github.com/known-owner/repo.git" pass ''
+_zone_ff_lane Z13 "trailing-slash owner entry, owner IN → pass"       "$OWNERS_SLASH" "https://github.com/known-owner/repo.git" pass ''
+_zone_ff_lane Z13b "uppercase host/owner in URL, owner IN → pass (case-insensitive)" "$OWNERS_OK" "https://GitHub.com/Known-Owner/repo.git" pass ''
+# Z14 — $2 is a bare remote NAME (alias/insteadOf edge): the hook must resolve it, not read it as a host.
+R=$(newrepo); require_repo "$R" "Z14"
+( cd "$R" && git remote add origin https://github.com/someone-else/repo.git ) 2>/dev/null
+BASESHA=$(cd "$R" && git rev-parse HEAD)
+NEWSHA=$(cd "$R" && printf 'x\n' >> a.txt && git commit -qam ff >/dev/null && git rev-parse HEAD)
+check_zone "Z14 \$2 is the remote NAME → resolved via git remote get-url → BLOCK" "$R" "$OWNERS_OK" \
+  "origin" 0 block 'FH Push-Zone Gate' "refs/heads/feat $NEWSHA refs/heads/feat $BASESHA"
+rm -rf "$R"
+
+echo "── session-close ①-f wiring (scripts/session_close_check.sh) ──"
+if [ ! -f "$SCC_SRC" ]; then
+  echo "HARNESS_ERROR — session_close_check.sh not found at $SCC_SRC"; FAILED=$((FAILED+1))
+else
+  SR="$(fh_fixture_root "$(mktemp -d)")" || exit 1
+  mkdir -p "$SR/tracks/_meta" "$SR/scripts" "$SR/.claude/rules"
+  cp "$REPO_ROOT/scripts/push_zone_check.sh" "$SR/scripts/push_zone_check.sh" 2>/dev/null
+  chmod +x "$SR/scripts/push_zone_check.sh" 2>/dev/null
+  ( cd "$SR" && git init -q && git symbolic-ref HEAD refs/heads/main \
+      && git config user.email t@example.com && git config user.name t \
+      && git commit -q --allow-empty -m base >/dev/null ) >/dev/null 2>&1
+
+  if [ -x "$SR/scripts/push_zone_check.sh" ]; then
+    SC_OUT=$(PUSH_ZONE_OWNERS="$OWNERS_OK" bash "$SCC_SRC" "$SR" 2>&1)
+    if printf '%s' "$SC_OUT" | grep -qE '①-f push-zone: '; then
+      echo "  ✅ ①-f prints advisory-prefixed push_zone_check.sh output when both files exist"
+      PASSED=$((PASSED+1))
+    else
+      echo "  ❌ ①-f did not print the expected advisory prefix"; FAILED=$((FAILED+1))
+    fi
+    # RESIDENCY (codex #9, 2026-09-05): the enumerator prints owner-account names, and a close's
+    # output lands in transcripts and session cards. ①-f therefore prints COUNTS only — the decoy
+    # list entry must never appear, and the summary line must.
+    if printf '%s' "$SC_OUT" | grep -qF 'acme-shared-org'; then
+      echo "  ❌ ①-f leaked an owner-account list entry into the close output"; FAILED=$((FAILED+1))
+    else
+      echo "  ✅ ①-f withholds owner-account names (counts only)"; PASSED=$((PASSED+1))
+    fi
+    if printf '%s' "$SC_OUT" | grep -qE '①-f push-zone: [0-9]+ repo\(s\) enumerated'; then
+      echo "  ✅ ①-f prints the enumeration summary (repo count · outside-list count)"; PASSED=$((PASSED+1))
+    else
+      echo "  ❌ ①-f summary line missing"; FAILED=$((FAILED+1))
+    fi
+  else
+    echo "  ❌ Z-SC setup — fixture push_zone_check.sh not executable"; FAILED=$((FAILED+1))
+  fi
+
+  # Owner-account list absent → UNCALIBRATED, one line, never silent.
+  SC_OUT2=$(PUSH_ZONE_OWNERS="$SR/no-such-owners-file" bash "$SCC_SRC" "$SR" 2>&1)
+  if printf '%s' "$SC_OUT2" | grep -qE '①-f push-zone UNCALIBRATED'; then
+    echo "  ✅ ①-f UNCALIBRATED when the owner-account list is absent"; PASSED=$((PASSED+1))
+  else
+    echo "  ❌ ①-f did not report UNCALIBRATED with no owner-account list"; FAILED=$((FAILED+1))
+  fi
+  rm -rf "$SR"
+fi
+
+echo ""
+echo "[push-zone] $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/templates/.git-hooks/pre-push
+++ b/templates/.git-hooks/pre-push
@@ -42,6 +42,97 @@ REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
 [ -z "$REPO_ROOT" ] && { echo "  ❌ pre-push: not in a git repo — fail-closed (block)"; exit 1; }
 ZERO="0000000000000000000000000000000000000000"
 PUSH_REMOTE="${1:-origin}"   # git passes the remote NAME as $1; ranges are scoped to it (see below)
+
+# ── Push zone: a non-owner github.com remote is not a plain-push channel ─────────────────────
+# CLAUDE.local.md §REST API push 계정규칙: a push under a non-owner account goes through the REST
+# Contents API (new files only, never overwrite/delete) — plain `git push` is not that channel.
+# That rule was correctly applied to ONE org repo and missed on ANOTHER org repo in the SAME round
+# (2026-07-26) — not from ignorance, but because it was applied at the point of discovery instead
+# of enumerated across every remote in play (the half-fix / propagation-boundary class).
+# `scripts/push_zone_check.sh` closes the ENUMERATE half by hand, before a push round, and it
+# explicitly does not block. This block closes the other half mechanically: it cannot see the whole
+# round, but it CAN refuse the one push in front of it when THIS push's own remote sits outside the
+# owner list — exactly the "forgot on this one" shape of the 2026-07-26 miss.
+#
+# Degrade direction (Surface-Class Degrade Invariant): applicability is mechanical, never guessed.
+#   • no owner-account list         → UNCALIBRATED, plain push allowed (a guessed verdict could
+#     authorise the wrong channel, which is worse than no verdict at all)
+#   • remote host is not github.com → out of scope for this axis (the account rule is a github.com
+#     personal-account axis; a GHE / other host remote says so and is allowed, not silently risky)
+#   • remote URL does not parse into a known shape → UNMEASURED, allowed (a harness gap, not a
+#     policy decision — NOT the destructive-branch UNCLASSIFIABLE case below, which fails closed
+#     because a delete is irreversible; blocking every unfamiliar remote-URL shape here would just
+#     train --no-verify on this same hook's real, irreversible guards)
+#   • owner ∈ list → silent (the common, expected case)
+#   • owner ∉ list → BLOCK. Never prints the owner list itself — only the single non-matching
+#     owner already public in the URL being pushed to.
+#
+# Override (explicit, logged — same shape as DESTRUCTIVE_OP_OK / PUBLIC_SURFACE_OK):
+#   PUSH_ZONE_OK=1 git push …
+PUSH_ZONE_SRC="${PUSH_ZONE_OWNERS:-$REPO_ROOT/.claude/rules/.push-zone-owners}"
+if [ ! -f "$PUSH_ZONE_SRC" ]; then
+  echo "  ⏭️  push-zone: UNCALIBRATED — no owner-account list at $PUSH_ZONE_SRC, plain push allowed"
+else
+  # One owner per line. Inline comments (`owner # note`), CR line endings, surrounding whitespace and a
+  # trailing slash are stripped BEFORE tokenizing — cross-family (codex gpt-5.5, 2026-09-05) showed an
+  # inline-comment word being read as an ALLOWED owner (fail-open) and a CRLF list blocking its own owner.
+  _pz_owners="$(sed -e 's/#.*$//' -e 's/\r$//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's#/*$##' "$PUSH_ZONE_SRC" 2>/dev/null | grep -v '^$' | tr '[:upper:]' '[:lower:]')"
+  _pz_url="${2:-}"
+  # git passes the destination's URL as $2. A bare remote NAME (no ':' and no '/') means the URL was
+  # not resolved for us (alias / insteadOf edge) — resolve it here rather than reading a name as a host
+  # and quietly landing in the "not github.com" allow branch (codex #5).
+  case "$_pz_url" in
+    *:*|*/*|"") ;;
+    *) _pz_url="$(git remote get-url --push "$_pz_url" 2>/dev/null || printf '%s' "$_pz_url")" ;;
+  esac
+  if [ -z "$_pz_url" ]; then
+    echo "  ⏭️  push-zone: UNMEASURED — remote URL not supplied to the hook (\$2 empty), plain push allowed"
+  else
+    # Normalise before parsing: lowercase, trim, drop the scheme, drop userinfo (`user@`). The HOST is then
+    # everything up to the first ':' or '/'. This accepts every github.com shape git itself accepts —
+    # `https://user@github.com/o/r`, `https://github.com:443/o/r`, `git@github.com:o/r`, `git@github.com:/o/r`,
+    # `ssh://git@github.com:22/o/r` — instead of an allowlist of three literal prefixes that read the rest as
+    # "unrecognized → allow" (codex #1–#4: four real github.com shapes were failing OPEN).
+    _pz_url_lc="$(printf '%s' "$_pz_url" | tr '[:upper:]' '[:lower:]' | sed -e 's/[[:space:]]*$//' -e 's/^[[:space:]]*//')"
+    _pz_norm="$(printf '%s' "$_pz_url_lc" | sed -E 's#^[a-z][a-z0-9+.-]*://##; s#^[^@/]*@##')"
+    _pz_host="$(printf '%s' "$_pz_norm" | sed -E 's#[:/].*$##')"
+    if [ "$_pz_host" = "github.com" ]; then
+      _pz_path="$(printf '%s' "$_pz_norm" | sed -E 's#^github\.com(:[0-9]+)?[:/]+##')"
+      _pz_owner="${_pz_path%%/*}"
+      if [ -z "$_pz_owner" ] || [ "$_pz_path" = "$_pz_norm" ]; then
+        echo "  ⏭️  push-zone: UNMEASURED — github.com remote in an unrecognized URL shape, plain push allowed"
+      else
+        _pz_hit=0
+        for _pz_o in $_pz_owners; do
+          [ "$_pz_owner" = "$_pz_o" ] && { _pz_hit=1; break; }
+        done
+        if [ "$_pz_hit" -eq 0 ]; then
+          echo ""
+          echo "══════════════════════════════════════════════"
+          echo " ⛔ FH Push-Zone Gate — remote is outside the owner-account list"
+          echo "══════════════════════════════════════════════"
+          echo "  remote '$PUSH_REMOTE' → github.com/$_pz_owner"
+          echo "  Plain git push is not this remote's channel — CLAUDE.local.md §REST API push"
+          echo "  계정규칙 (a non-owner account pushes via the REST Contents API instead)."
+          echo "  Deliberate exception (explicit, logged):  PUSH_ZONE_OK=1 git push …"
+          echo "══════════════════════════════════════════════"
+          if [ "${PUSH_ZONE_OK:-0}" = "1" ]; then
+            echo "  ⚠️  FH Push-Zone: allowed by PUSH_ZONE_OK=1 (conscious, gated intent)"
+            mkdir -p "$REPO_ROOT/tracks/_meta" 2>/dev/null || true
+            printf '%s PUSH_ZONE_OK override — remote:%s owner:%s\n' \
+              "$(date +%Y-%m-%dT%H:%M:%S)" "$PUSH_REMOTE" "$_pz_owner" \
+              >> "$REPO_ROOT/tracks/_meta/.push_zone_override_log" 2>/dev/null || true
+          else
+            exit 1
+          fi
+        fi
+      fi
+    else
+      echo "  ⏭️  push-zone: remote host is not github.com — outside this axis's scope, plain push allowed"
+    fi
+  fi
+fi
+
 BASE="${FH_DESTRUCTIVE_BASE:-origin/main}"
 # All ancestry/reachability checks below must ignore local `git replace`/graft objects — a graft can
 # falsify merge-base/rev-list/ls-tree to make a divergent force look fast-forward or an unmerged branch


### PR DESCRIPTION
## 무엇 (카드 ⑫ — 만들고 배선 안 한 게이트 3종 중 ②)
계정 규칙 «비-소유 github.com 원격은 plain git push 채널이 아니다」 는 2026-07-26 에 한 org 레포엔 적용되고 같은 라운드의 다른 레포엔 빠졌다 — 사람이 기억하는 자리를 **push 시점의 기계**로 옮긴다. `scripts/push_zone_check.sh`(열거 도구, 호출자 0)도 마감 ①-f 와 files[] 에 배선한다.

## 훅 degrade 표 (설계 승인 그대로)
| 상태 | 동작 |
|---|---|
| owner 목록 파일 없음(깨끗한 클론·소비자) | `UNCALIBRATED` 한 줄, plain push 허용 |
| 원격 호스트 ≠ github.com | 축 밖 한 줄, 허용 |
| URL 파싱 불가 | `UNMEASURED` 한 줄, 허용 |
| owner ∈ 목록 | 무음 |
| owner ∉ 목록 | **BLOCK** — 원격 이름 + URL 의 owner 만 출력(목록 내용은 절대 미출력). `PUSH_ZONE_OK=1` 로그 오버라이드 |

## 증거(캡슐)
- 레인 `test_push_zone_lanes.sh` **23/23** — Z0~Z6 + ①-f(에이전트, fail-before 3/13) + **Z7~Z14**(거버너, codex 소견에서).
- **cross-family(codex gpt-5.5) 11건**: S 6 진짜·수리 — `https://user@github.com/`·`github.com:443`·`ssh://…:22/`·`git@github.com:/o` 네 형태가 «미인식 → 허용」으로 fail-open, `$2` 가 원격 이름이면 비-github 로 읽혀 허용, 목록 인라인 주석 낱말이 허용 owner 로 토큰화 → URL 정규화(스킴·userinfo·포트·구분자) + `git remote get-url --push` 해석 + 목록 파싱(주석·CR·공백·끝 `/`). A 3 수리 — CRLF·끝 슬래시 과차단, **①-f 가 owner 이름을 그대로 출력**(잔여 유출) → 카운트만. B 1 잔여(zone 차단이 삭제 게이트 분류보다 먼저 exit — fail-closed 가 앞서는 설계) · B 1 → 레인. 에이전트판 훅으로 Z7~Z14+①-f = **10 적색** → 수리본 23/23.
- 인접 스위트 초록: prepush destructive 12/12 · stdin integrity · session_close_chain 55 · session_close_lanes · package_coverage PASS · bash -n 3.2/5.3.
- **첫 실사용**: (i) 에이전트 — 일회용 클론에서 실 `git push` 로 훅 발화·UNCALIBRATED·비-github 분기·삭제 게이트 공존 확인(github.com BLOCK 은 GitHub 인증층이 먼저 막아 실 dispatch 로는 미도달 — 레인이 같은 호출 규약) (ii) **이 PR 의 push 자체** — 이 노드의 실물 owner 목록 아래서 새 훅이 돌았고 owner ∈ 목록이라 무음 통과했다.
- 출하: `files[]` += `push_zone_check.sh` + 레인 · `caller_zero_baseline` 면제 줄 제거(호출자 2 생김) · selfcheck 등록.
- standpoint: `DEGRADED_NOT_RUN` — 소비자 표면이나 목록 없는 install 은 UNCALIBRATED 허용이라 기본 행동 무변경; 깨끗한 install arm 미실행.
- crossfamily: `panel(codex) — residency=CLEAN(files=6, stripped=0) · …`(토큰 채널 두 번째 실물).

## 잔여
`push_zone_check.sh` 자체는 대소문자 구분(훅과 비대칭) · GHE 호스트 원격은 축 밖(의도) · 이 노드 실물 목록으로의 ∉ dry-run 은 미실행(레인 대체).
