### PR TITLE
feat(close): 엔진 강화 — 운영자 발화 착지 채널(transcript_utterances.py 공용화 · utterance_intake.sh · 마감 ①-f advisory) + 레인 72 + codex 8 수리

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1335,6 +1335,9 @@ Closing phrase detected ("wrap up", "done", "good work", "end session", etc. —
        --state open` cross-repo). Classify, **surface-not-auto**: **self-mergeable** PR (own repo,
        checks green) → *propose merge now* (never auto-merge — HITL); **awaiting-external** →
        *surface for tracking only*. (Origin PR#111 + count-consistency pairing → §detail below.)
+  → ①-f 발화 착지 (advisory) — 이번 세션 전사본의 운영자 발화가 오늘자 기록에 착지했는지
+       기계로 grep 한다(`scripts/utterance_intake.sh`). **막지 않는다** — rc=1 은 «기록하라»가
+       아니라 «확인하라»다(키 낱말 프로브라 과차단 방향). ①-c~①-e 는 스크립트에만 산다.
   → ② If FH assets changed, **or `close_retro` is granted**: harvest-loop
        (후자는 Step 0-d 세션 회고 — 자산 미변경 세션에도 회고는 의미가 있다)
   → ③ Sync local/gitignored session state to your durable companion store, if you keep one

--- a/package.json
+++ b/package.json
@@ -301,6 +301,9 @@
     "scripts/probe_live_eval_lib.py",
     "scripts/test_probe_live_eval_lanes.sh",
     ".claude/regression/probes_live.yaml",
-    "scripts/com.forge-harness.live-eval.plist"
+    "scripts/com.forge-harness.live-eval.plist",
+    "scripts/utterance_intake.sh",
+    "scripts/transcript_utterances.py",
+    "scripts/test_utterance_intake_lanes.sh"
   ]
 }

--- a/scripts/compaction_probe.sh
+++ b/scripts/compaction_probe.sh
@@ -70,41 +70,15 @@ do_seal() {
 
     echo "## 운영자 발화 (이 세션)"
     if [ -f "$transcript" ]; then
-      python3 - "$transcript" <<'PY' 2>/dev/null || echo "- (전사본 파싱 실패 — 원본: $transcript)"
-import json,sys
-n=0
-skipped_tool=skipped_meta=skipped_other=0
-for line in open(sys.argv[1], errors='replace'):
-    try: d=json.loads(line)
-    except Exception: continue
-    if d.get('type')!='user': continue
-    m=d.get('message') or {}
-    c=m.get('content')
-    # ⚠️ 초판은 "실발화=str · 툴결과=list" 로 갈랐다. **틀렸다** — 이미지/파일을 첨부한 실발화는
-    # list 다(high 리뷰 실측: 전사본 25개에서 그런 발화 18건이 구조적으로 안 보였다). 더 나쁜 건
-    # self-test 픽스처가 같은 가정을 인코딩해서 **초록이 그 결함을 보증**했다는 것이다.
-    # 이제 list 는 text 블록을 꺼내 쓰고, tool_result 만 제외한다.
-    if isinstance(c,str):
-        t=c
-    elif isinstance(c,list):
-        if any(isinstance(b,dict) and b.get('type')=='tool_result' for b in c):
-            skipped_tool+=1; continue
-        parts=[b.get('text','') for b in c if isinstance(b,dict) and b.get('type')=='text']
-        if not parts:
-            skipped_other+=1; continue          # 이미지-only 등 — 셈에서 지우지 않고 센다
-        t=' '.join(parts)
-    else:
-        skipped_other+=1; continue
-    t=' '.join(t.split())
-    if not t: skipped_other+=1; continue
-    if t.startswith('<') or t.startswith('/'):   # 슬래시 커맨드·메타 봉투 제외
-        skipped_meta+=1; continue
-    n+=1
-    print(f"{n}. {t[:200]}")
-# **제외분을 반드시 인쇄한다.** 합계만 찍으면 그 원장이 완전한 것처럼 읽힌다 — `not found ≠ 0`.
-print(f"\n합계: {n}건" if n else "- (발화 0건)")
-print(f"제외: tool_result {skipped_tool} · 메타/커맨드 {skipped_meta} · 텍스트없음 {skipped_other}")
-PY
+      # 🟥 추출 로직은 `scripts/transcript_utterances.py` 가 **단일 소스**다 (2026-09-05).
+      #    인라인 heredoc 이었을 때 두 번째 소비처(`utterance_intake.sh` — 발화 착지 검사)를
+      #    붙이려면 사본이 생겼고, 전처리 두 벌은 «한쪽만 통과하는 입력이 다른 쪽에서 무음
+      #    드롭» 이다(`[[feedback_divergent_leniency_duplicate_normalizers]]`).
+      #    출력은 **바이트 동일**해야 한다 — `scripts/test_utterance_intake_lanes.sh` L10 이
+      #    골든으로 고정하고, L12/L12b 가 되돌림으로 «정말 이 파일을 통해 도는가» 를 잰다.
+      #    추출기가 없거나 죽으면 비영 종료 → 아래 폴백 문구가 그대로 뜬다(무음 아님).
+      python3 "$REPO_ROOT/scripts/transcript_utterances.py" "$transcript" --format seal 2>/dev/null \
+        || echo "- (전사본 파싱 실패 — 원본: $transcript)"
     else
       echo "- 🟥 전사본 경로 없음: $transcript"
     fi

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -659,7 +659,12 @@ for _pair in \
   "scripts/round/target_pin.sh|scripts/test_round_instruments_lanes.sh" \
   "scripts/round/instrument_manifest.sh|scripts/test_round_instruments_lanes.sh" \
   "scripts/round/eligcheck_qset.sh|scripts/test_round_instruments_lanes.sh" \
-  "scripts/round/gatecheck_qset.sh|scripts/test_round_instruments_lanes.sh"
+  "scripts/round/gatecheck_qset.sh|scripts/test_round_instruments_lanes.sh" \
+  `# ── 발화 착지(2026-09-05). 네 주체가 한 스위트로 묶인다 — 주체별로 행을 둔다 ──` \
+  "scripts/utterance_intake.sh|scripts/test_utterance_intake_lanes.sh" \
+  "scripts/transcript_utterances.py|scripts/test_utterance_intake_lanes.sh" \
+  "scripts/compaction_probe.sh|scripts/test_utterance_intake_lanes.sh" \
+  "scripts/session_close_check.sh|scripts/test_utterance_intake_lanes.sh"
 do
   _subj="${_pair%%|*}"; _anc="${_pair##*|}"; _lbl="${_anc##*/}"
   if [ ! -f "$_subj" ]; then

--- a/scripts/session_close_check.sh
+++ b/scripts/session_close_check.sh
@@ -269,6 +269,73 @@ fi
 
 fi
 
+# ── ①-f UTTERANCE LANDING (advisory) ─────────────────────────────────────────
+# WHY. 마감 체크는 **형식**만 본다 — 카드가 로그보다 새로운가, 필수 아티팩트가 있는가.
+# **운영자 발화가 기록에 착지했는지는 아무도 안 봤다.** `utterance_landing_check.sh` 가 그걸
+# 재려고 2026-08-08 에 지어졌는데 probes.tsv 를 **손으로** 짜야 해서 호출부가 0 개였다
+# (2026-09-05 실측: 이 파일에서 그 스크립트를 부르는 줄이 하나도 없었다). 그 사이의 빠진 칸이
+# `utterance_intake.sh` 다 — 전사본에서 발화를 뽑아 프로브를 자동 생성한다.
+# 근거: 같은 날 운영자의 교리·설계급 발화 6 건이 착지한 경로가 전부 **거버너의 손**이었다.
+#
+# 🟥 라벨이 `①-e` 가 아닌 이유: 그건 아래 stray-path 블록이 **이미 쓰고 있다.** 한 라벨을 두
+#    검사가 나눠 쓰면 「어느 ①-e 가 울렸나」를 아무도 못 가른다 — 이 배선을 준비한 진단은
+#    «①-e 는 비어 있다» 고 적었고, 그건 거짓이었다(레인 L13 이 «배선 전인데 초록» 으로 잡았다).
+#
+# 🟥 **advisory 다 — 막지 않는다.** 프로브는 키 낱말이라 기록이 같은 뜻을 다른 낱말로 적으면
+#    과차단이 난다(안전한 방향이지만 소음이다). 노출 사다리(shadow) 로 몇 세션 관찰한 뒤
+#    close push 차단으로 승격할지는 **운영자 결정**이고, 그때까지 FAIL 을 세우지 않는다.
+_UI_SUT="$FH/scripts/utterance_intake.sh"
+if [ -f "$_UI_SUT" ]; then
+  # 세션 id 의 정본은 `branch_claim.sh` 다 — **새 판정기를 짓지 않는다**(재발명 금지).
+  # `show` 의 `세션ID` 줄이 그 값이고, 값이 `pid-` 로 시작하면 런타임이 id 를 안 준 것이라
+  # 전사본을 특정할 수 없다. 그때는 «다른 세션 것을 대신 읽는» 대신 UNMEASURED 로 남긴다 —
+  # 남의 전사본으로 낸 착지 판정은 틀린 답이지 근사값이 아니다.
+  _UI_SID=""
+  if [ -f "$FH/scripts/branch_claim.sh" ]; then
+    _UI_SID=$(LC_ALL=C bash "$FH/scripts/branch_claim.sh" show 2>/dev/null \
+              | LC_ALL=C sed -n 's/^세션ID[[:space:]][[:space:]]*//p' | head -1)
+  fi
+  case "$_UI_SID" in pid-*|'') _UI_SID="" ;; esac
+  # 전사본 slug = 프로젝트 절대경로에서 `/` `.` `_` 를 `-` 로 (실측 2026-09-05, ~/.claude/projects 대조)
+  _UI_SLUG=$(printf '%s' "$FH" | tr '/._' '---')
+  _UI_TRDIR="${FH_TRANSCRIPT_DIR:-$HOME/.claude/projects/$_UI_SLUG}"
+  _UI_TR="$_UI_TRDIR/$_UI_SID.jsonl"
+  if [ -z "$_UI_SID" ]; then
+    echo "ℹ️  ①-f UNMEASURED — 세션 id 미상(런타임이 CLAUDE_CODE_SESSION_ID 를 안 줬다)"
+    echo "     전사본을 특정할 수 없다. «발화가 다 적혔다» 가 아니라 «못 쟀다» 다."
+  elif [ ! -f "$_UI_TR" ]; then
+    echo "ℹ️  ①-f UNMEASURED — 전사본 부재: $_UI_TR"
+    echo "     부재를 0 으로 접지 마라 — 발화가 없었다는 뜻이 아니다."
+  else
+    # 기록 대상: 오늘자 산출 + 상시 카드/UAP. 배열로 모은다(zsh word-split 함정 회피).
+    _UI_RECS=()
+    for _p in "$FH/tracks/_meta/fh_completed_$TODAY.md" \
+              "$FH/tracks/_meta/user_adaptation_profile.md" \
+              "$FH/tracks/_meta/reference_next_session_starter.md"; do
+      [ -f "$_p" ] && _UI_RECS+=("$_p")
+    done
+    for _p in "$FH"/tracks/_meta/fh_signal_"$TODAY"_*.md "$FH"/tracks/*/*_"$TODAY".md; do
+      [ -f "$_p" ] && _UI_RECS+=("$_p")
+    done
+    if [ "${#_UI_RECS[@]}" -eq 0 ]; then
+      echo "⚠️  ①-f 오늘자 기록 파일이 하나도 없다 — 발화 착지를 잴 대상이 없다(UNMEASURED)"
+      echo "     ④/⑤ 가 아직 안 돌았다는 뜻일 수 있다. 마감 순서를 확인해라."
+    else
+      _UI_OUT=$(bash "$_UI_SUT" "$_UI_TR" "${_UI_RECS[@]}" 2>&1); _UI_RC=$?
+      case "$_UI_RC" in
+        0) echo "✅ ①-f 발화 착지 — 프로브 전건 착지 (${#_UI_RECS[@]} 파일 대조)"
+           echo "     ⚠️ 발화별 최장 토큰 ⌈n/2⌉ 일치 기준(키 2 개 이하는 OR) — «제대로 적혔다» 의 증명이 아니다." ;;
+        1) echo "⚠️  ①-f 미착지 발화가 있다 — advisory, 막지 않는다. 아래를 **확인**해라(기록 강제 아님):"
+           printf '%s\n' "$_UI_OUT" | sed 's/^/     /' ;;
+        *) echo "⚠️  ①-f 발화 착지 검사 UNMEASURED/계기이상 (rc=$_UI_RC) — 0 으로 읽지 마라"
+           printf '%s\n' "$_UI_OUT" | sed 's/^/     /' ;;
+      esac
+    fi
+  fi
+else
+  echo "⚠️  ①-f utterance_intake.sh 없음 — skipped, not passed (UNMEASURED)"
+fi
+
 # ② FH assets changed today → harvest-loop owed
 # NOTE: no `grep -q` here — under `set -o pipefail`, -q's early exit SIGPIPEs git log (141),
 # masking a real match as pipeline failure so the warning NEVER fired on true positives

--- a/scripts/test_utterance_intake_lanes.sh
+++ b/scripts/test_utterance_intake_lanes.sh
@@ -1,0 +1,414 @@
+#!/usr/bin/env bash
+# test_utterance_intake_lanes.sh — known pair for the «받는 절반»(operator utterance → record) channel.
+#
+# WHAT THIS GUARDS. FH 의 «질문하기» 엔진은 묻는 절반만 배선돼 있고 **받는 절반이 산문이다**
+# (`fh_three_layer_canon.md §2`: *"이 엔진의 수용 절반이 비어 있다"*). 계기는 둘 다 이미 있었는데
+# 서로 안 이어져 있었다:
+#   · `compaction_probe.sh seal`  전사본 → 운영자 발화 축자 원장 (있음)
+#   · `utterance_landing_check.sh` 손으로 쓴 probes.tsv → 기록 파일 grep (있음, **호출부 0**)
+# probes.tsv 를 만드는 기계가 없어서 두 번째는 사람이 손으로 짜야 했고, 그래서 안 돌았다.
+# `utterance_intake.sh` 가 그 사이를 잇고 `session_close_check.sh ①-f` 가 그걸 부른다.
+#
+# 🟥 이 스위트가 지키는 불변식 넷 — 넷 다 «미측정을 0 으로 접지 마라» 의 사례다:
+#   ⓐ 미착지는 rc=1 · 계기 사망은 rc=10 — **뭉치면 「기록하라」와 「프로브를 고쳐라」가 안 갈린다**
+#   ⓑ 전사본 부재 → UNMEASURED(rc≠0). 「전부 착지」가 **아니다**
+#   ⓒ 추출 발화 0 건 → UNMEASURED. 빈 프로브 세트는 합격이 아니다
+#   ⓓ seal 출력은 리팩터 전후로 **바이트 동일**해야 한다 — 공용화가 기존 원장을 조용히 바꾸면
+#      그건 「미측정을 0 으로」의 사촌인 «재생성이 커밋된 의도를 지운다» 다
+#
+# 🟥 음성 컨트롤이 왜 필요한가. `utterance_landing_check.sh` 의 CONTROL 은 **양성만** 있다
+#   ("착지가 확실한 것이 안 잡히면 계기 사망"). 그건 「계기가 죽었나」만 재고 「계기가 아무거나
+#   다 잡나」는 못 잰다 — `[[feedback_control_presence_is_not_discrimination]]`. 그래서 이 래퍼가
+#   **없어야 마땅한 무작위 토큰**을 넣고, 그게 잡히면 rc=10 을 낸다. L5/L5b 가 그 known pair 다.
+#
+# HERMETIC: 픽스처는 전부 mktemp 아래. 실 전사본도 실 tracks/ 도 읽지 않는다.
+#
+# 종료코드는 selfcheck.sh 규약: 0 pass · 2 주체 부재 · 10 이 스위트 자신의 setup 실패.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/fixture_guard_lib.sh"
+cd "$(dirname "$0")/.." || exit 1
+ROOT="$(pwd -P)"
+SUT="$ROOT/scripts/utterance_intake.sh"
+EXTRACT="$ROOT/scripts/transcript_utterances.py"
+PROBE="$ROOT/scripts/compaction_probe.sh"
+CLOSE="$ROOT/scripts/session_close_check.sh"
+PASS=0; FAIL=0
+ok() { echo "✅ $1"; PASS=$((PASS+1)); }
+ng() { echo "❌ $1"; FAIL=$((FAIL+1)); }
+
+# 주체 부재는 «통과» 가 아니다 — skipped is not passed.
+for _s in "$SUT" "$EXTRACT"; do
+  [ -f "$_s" ] || { echo "ⓘ ${_s##*/} absent — subject missing when we looked (NOT a pass)"; exit 2; }
+done
+[ -f "$PROBE" ] || { echo "ⓘ compaction_probe.sh absent (NOT a pass)"; exit 2; }
+
+T="$(fh_fixture_root "$(mktemp -d 2>/dev/null)")" || { echo "ⓘ mktemp failed — this suite's own setup broke (NOT a pass)"; exit 10; }
+: "${T:?fixture root unset}"
+trap 'rm -rf "$T"' EXIT INT TERM
+
+TODAY="$(date +%Y-%m-%d)"
+
+# ── 픽스처 전사본 ────────────────────────────────────────────────────────────
+# 발화 4 (착지 2 · 미착지 1 · 짧음 1) + tool_result 1 + 슬래시 커맨드 1 + assistant 1
+mk_transcript() {  # $1=경로
+  cat > "$1" <<'JSONL'
+{"type":"user","timestamp":"2026-09-05T01:00:00.000Z","message":{"content":"앞으로 무인 잡은 plist 에 모델을 핀하는 걸 원칙으로 하자"}}
+{"type":"user","timestamp":"2026-09-05T01:01:00.000Z","message":{"content":[{"type":"tool_result","content":"툴출력본문 재규어호루라기"}]}}
+{"type":"user","timestamp":"2026-09-05T01:02:00.000Z","message":{"content":"/clear 슬래시커맨드본문 도롱뇽부표"}}
+{"type":"assistant","timestamp":"2026-09-05T01:03:00.000Z","message":{"content":"응답"}}
+{"type":"user","timestamp":"2026-09-05T01:04:00.000Z","message":{"content":"ㄱㄱ"}}
+{"type":"user","timestamp":"2026-09-05T01:05:00.000Z","message":{"content":[{"type":"text","text":"등급 기댓값은 분기마다 다시 세우자 이번 분기는 인큐베이터를 과녁으로"},{"type":"image","source":{"type":"base64"}}]}}
+{"type":"user","timestamp":"2026-09-05T01:06:00.000Z","message":{"content":"이폴트 추천은 세션 시작에 한 번만 띄우고 반복하지 마라 두번은 소음이다"}}
+JSONL
+}
+
+# 기록 픽스처: 1번(plist 모델 핀)과 3번(등급 기댓값)만 착지. 4번(이폴트 추천)은 미착지.
+# 양성 컨트롤(오늘 날짜)이 반드시 들어 있어야 한다.
+mk_record() {  # $1=경로
+  cat > "$1" <<REC
+# fh_completed_${TODAY}.md
+
+- ✅ 무인 잡 plist 에 모델을 핀했다 — launchd 3종 전부
+- ✅ 등급 기댓값을 분기 단위로 재정의 — 인큐베이터 과녁 선언
+REC
+}
+
+mk_transcript "$T/tr.jsonl"
+mk_record "$T/rec.md"
+
+# ── L1 착지 2 · 미착지 1 · rc=1 ──────────────────────────────────────────────
+OUT1="$(bash "$SUT" "$T/tr.jsonl" "$T/rec.md" 2>&1)"; RC1=$?
+case "$RC1" in 1) ok "L1 미착지가 있으면 rc=1" ;; *) ng "L1 rc=$RC1 (기대 1)"; echo "$OUT1" | sed 's/^/     /' ;; esac
+case "$OUT1" in *"착지 2"*) ok "L1b 착지 2 건으로 센다" ;; *) ng "L1b 착지 수가 2 가 아니다"; echo "$OUT1" | sed 's/^/     /' ;; esac
+case "$OUT1" in *"미착지 1"*) ok "L1c 미착지 1 건으로 센다" ;; *) ng "L1c 미착지 수가 1 이 아니다" ;; esac
+
+# ── L2 미착지 목록이 **정확히 그 발화**를 가리킨다 ───────────────────────────
+case "$OUT1" in *"이폴트 추천"*) ok "L2 미착지 목록에 그 발화가 나온다" ;; *) ng "L2 미착지 발화가 목록에 없다" ;; esac
+# known-negative: 착지한 발화는 미착지 목록에 없어야 한다. 목록 절만 잘라서 본다.
+LIST1="$(printf '%s\n' "$OUT1" | sed -n '/미착지 목록/,$p')"
+case "$LIST1" in *"등급 기댓값"*) ng "L2b 착지한 발화가 미착지 목록에 섞였다" ;; *) ok "L2b 착지한 발화는 목록에 없다 (known-negative)" ;; esac
+
+# ── L3 구조 제외: tool_result 본문·슬래시 커맨드는 프로브가 되지 않는다 ──────
+PT="$T/probes_dump.tsv"
+FH_INTAKE_DUMP_PROBES="$PT" bash "$SUT" "$T/tr.jsonl" "$T/rec.md" >/dev/null 2>&1
+if [ -f "$PT" ]; then
+  grep -q "재규어호루라기" "$PT" && ng "L3 tool_result 본문이 프로브가 됐다" || ok "L3 tool_result 제외 (known-negative)"
+  grep -q "도롱뇽부표" "$PT" && ng "L3b 슬래시 커맨드가 프로브가 됐다" || ok "L3b 슬래시 커맨드 제외 (known-negative)"
+  # ── L4 짧은 발화 제외 ──
+  grep -qE $'^TARGET\t.*ㄱㄱ' "$PT" && ng "L4 짧은 발화가 프로브가 됐다" || ok "L4 짧은 발화(<20자) 제외"
+  # known-positive: 덤프가 비어 있지 않다 — 위 세 줄이 «빈 파일이라 통과» 가 아님을 증명한다
+  # 🟥 `grep -c ... || echo 0` 은 무매치일 때 0 을 두 번 낸다 — 계기 자신에게 난 같은 결함이다.
+  # TARGET 은 토큰마다 한 행이다(#idx.k/n) — 발화 수는 고유 idx 로 센다
+  NT=$(grep $'^TARGET\t' "$PT" 2>/dev/null | sed -n 's/.*#\([0-9][0-9]*\)\.[0-9]*\/[0-9]* .*/\1/p' | sort -u | grep -c .); case "$NT" in ''|*[!0-9]*) NT=0 ;; esac
+  [ "${NT:-0}" -eq 3 ] && ok "L4b TARGET 발화 3 건 (덤프가 공허하지 않다 — known-positive)" \
+                       || ng "L4b TARGET 발화 $NT 건 (기대 3) — 위 known-negative 셋이 빈 집합 통과일 수 있다"
+  # known-positive: 음성 컨트롤 행이 실제로 생성된다
+  grep -q "^NEGATIVE" "$PT" && ok "L4c 음성 컨트롤 행이 생성된다" || ng "L4c 음성 컨트롤 행이 없다"
+  grep -q "^CONTROL" "$PT" && ok "L4d 양성 컨트롤 행이 생성된다" || ng "L4d 양성 컨트롤 행이 없다"
+else
+  ng "L3/L4 프로브 덤프가 안 나왔다 (FH_INTAKE_DUMP_PROBES 미지원)"
+fi
+
+# ── L5 음성 컨트롤이 기록에 있으면 rc=10 (계기 사망) ─────────────────────────
+cp "$T/rec.md" "$T/rec_neg.md"
+printf '\n무작위토큰 FHNEGZZTEST9 가 기록에 섞여 있다\n' >> "$T/rec_neg.md"
+OUT5="$(FH_INTAKE_NEG_TOKEN=FHNEGZZTEST9 bash "$SUT" "$T/tr.jsonl" "$T/rec_neg.md" 2>&1)"; RC5=$?
+case "$RC5" in 10) ok "L5 음성 컨트롤 적발 → rc=10 (계기 사망)" ;; *) ng "L5 rc=$RC5 (기대 10)"; echo "$OUT5" | sed 's/^/     /' ;; esac
+# 🟥 known-negative — 같은 토큰을 주입해도 기록에 **없으면** 10 이 아니어야 한다.
+#    이게 없으면 L5 는 「무조건 10 을 내는 계기」와 구분되지 않는다.
+OUT5B="$(FH_INTAKE_NEG_TOKEN=FHNEGZZTEST9 bash "$SUT" "$T/tr.jsonl" "$T/rec.md" 2>&1)"; RC5B=$?
+[ "$RC5B" != "10" ] && ok "L5b 토큰이 기록에 없으면 rc≠10 (known-negative)" || { ng "L5b 토큰 부재인데도 rc=10"; echo "$OUT5B" | sed 's/^/     /'; }
+
+# ── L6 양성 컨트롤 — 「날짜가 내용에 없다」로 죽으면 안 된다 (sim 이 잡은 넷째) ─────
+# 🟥 초판 컨트롤은 «오늘 날짜» 였고 «오늘자 기록엔 오늘 날짜가 있다» 를 가정했다. 거짓이다 —
+#    날짜는 파일명에 있지 내용에 있을 의무가 없다. 실측(2026-09-05 sim, WRITECTL 팔): 플로어
+#    티어가 만든 `fh_completed_2026-09-05.md` 내용은 한 줄이고 날짜 문자열이 없다.
+#    그러면 정상 마감마다 rc=10 거짓 경보가 뜨고, 그 소음이 ❌ 줄을 스킵하게 만든다.
+#    ⇒ 컨트롤을 기록 «내용»에서 뽑는다. 아래가 그 known pair 다.
+printf '오늘 날짜 문자열이 없는 기록 파일이다 이폴트 추천 등급 기댓값 무인 잡 인큐베이터\n' > "$T/rec_nodate.md"
+OUT6="$(bash "$SUT" "$T/tr.jsonl" "$T/rec_nodate.md" 2>&1)"; RC6=$?
+[ "$RC6" != "10" ] && ok "L6 날짜가 내용에 없어도 계기가 안 죽는다 (rc=$RC6, 거짓 경보 방지)" \
+                   || { ng "L6 날짜 부재만으로 rc=10 — 정상 마감에 거짓 경보"; echo "$OUT6" | sed 's/^/     /'; }
+# known-negative 짝: 기록에서 토큰을 못 뽑으면(사실상 빈 기록) **반드시** rc=10 이어야 한다.
+printf '\n' > "$T/rec_empty.md"
+OUT6B="$(bash "$SUT" "$T/tr.jsonl" "$T/rec_empty.md" 2>&1)"; RC6B=$?
+case "$RC6B" in 10) ok "L6b 컨트롤을 못 뽑으면 rc=10 (계기 사망)" ;; *) ng "L6b rc=$RC6B (기대 10)"; echo "$OUT6B" | sed 's/^/     /' ;; esac
+case "$OUT6B" in *"전부 착지"*) ng "L6c 계기 사망인데 «전부 착지» 를 인쇄했다" ;; *) ok "L6c 계기 사망일 때 착지 판정을 인쇄하지 않는다" ;; esac
+# 파생 컨트롤이 **실제로 생성**되는지 — 이름표만 있고 값이 없으면 위 셋이 공허해진다
+FH_INTAKE_DUMP_PROBES="$T/p6.tsv" bash "$SUT" "$T/tr.jsonl" "$T/rec.md" >/dev/null 2>&1
+grep -q "기록파생" "$T/p6.tsv" 2>/dev/null && ok "L6d 파생 양성 컨트롤 행이 생성된다" || ng "L6d 파생 컨트롤 행이 없다"
+
+# ── L7 전사본 부재 → UNMEASURED, rc≠0, 「전부 착지」 금지 ────────────────────
+OUT7="$(bash "$SUT" "$T/NOPE.jsonl" "$T/rec.md" 2>&1)"; RC7=$?
+[ "$RC7" -ne 0 ] && ok "L7 전사본 부재 → rc=$RC7 (0 아님)" || ng "L7 전사본 부재인데 rc=0"
+case "$OUT7" in *UNMEASURED*) ok "L7b 전사본 부재가 UNMEASURED 로 라벨된다" ;; *) ng "L7b UNMEASURED 라벨이 없다"; echo "$OUT7" | sed 's/^/     /' ;; esac
+case "$OUT7" in *"전부 착지"*) ng "L7c 부재를 «전부 착지» 로 접었다" ;; *) ok "L7c 부재를 0 으로 접지 않는다" ;; esac
+
+# ── L8 추출 발화 0 건 → UNMEASURED (빈 프로브 세트는 합격이 아니다) ─────────
+cat > "$T/tr_short.jsonl" <<'JSONL'
+{"type":"user","timestamp":"2026-09-05T01:00:00.000Z","message":{"content":"ㄱㄱ"}}
+{"type":"user","timestamp":"2026-09-05T01:01:00.000Z","message":{"content":"응 좋아"}}
+JSONL
+OUT8="$(bash "$SUT" "$T/tr_short.jsonl" "$T/rec.md" 2>&1)"; RC8=$?
+[ "$RC8" -ne 0 ] && ok "L8 발화 0 건 → rc=$RC8 (0 아님)" || ng "L8 발화 0 건인데 rc=0"
+case "$OUT8" in *UNMEASURED*) ok "L8b 발화 0 건이 UNMEASURED 로 라벨된다" ;; *) ng "L8b UNMEASURED 라벨이 없다"; echo "$OUT8" | sed 's/^/     /' ;; esac
+
+# ── L9 transcript_utterances.py --min-chars known pair ──────────────────────
+# 🟥 문턱은 실측으로 골랐다 — 설계안의 40 이 아니라 **20** 이다. 이 레포 전사본 전수
+#   (2026-09-05, 봉투/툴결과 제외 후 3191 발화)에서 30–39 자 구간에 하중 지는 발화가 산다:
+#   «그리고 입장리뷰는 정적 동적 모두 수행해야해» · «4는 초록으로 올리도록 하자» — 한글은
+#   자당 정보량이 커서 40 자 바닥은 **교리 발화를 조용히 버린다**(위험한 방향).
+#   20 = 853 건 제외 · 2338 건 보존. 아래 두 줄이 그 문턱의 known pair 다.
+N0=$(python3 "$EXTRACT" "$T/tr.jsonl" --min-chars 0  2>/dev/null | grep -c .); case "$N0" in ''|*[!0-9]*) N0=0 ;; esac
+N20=$(python3 "$EXTRACT" "$T/tr.jsonl" --min-chars 20 2>/dev/null | grep -c .); case "$N20" in ''|*[!0-9]*) N20=0 ;; esac
+[ "${N0:-0}" -eq 4 ] && ok "L9 --min-chars 0 → 4 발화 (known-positive)" || ng "L9 --min-chars 0 → $N0 (기대 4)"
+[ "${N20:-0}" -eq 3 ] && ok "L9b --min-chars 20 → 3 발화 (필터가 실제로 거른다)" || ng "L9b --min-chars 20 → $N20 (기대 3)"
+# 출력 형식: n<TAB>ts<TAB>text
+python3 "$EXTRACT" "$T/tr.jsonl" --min-chars 0 2>/dev/null | head -1 | grep -qE $'^1\t2026-09-05T01:00:00' \
+  && ok "L9c tsv 형식이 n<TAB>ts<TAB>text" || ng "L9c tsv 형식이 어긋난다"
+
+# ── L10 seal 출력 골든 — 공용화가 기존 원장을 바꾸지 않았다 ─────────────────
+bash "$PROBE" seal --transcript "$T/tr.jsonl" --dir "$T/seal" >/dev/null 2>&1
+SF="$(ls "$T/seal"/seal_*.md 2>/dev/null | head -1)"
+if [ -n "$SF" ]; then
+  sed -n '/^## 운영자 발화/,/^## 이 세션이 건드린/p' "$SF" | sed '$d' > "$T/seal_block.txt"
+  cat > "$T/seal_expect.txt" <<'GOLD'
+## 운영자 발화 (이 세션)
+1. 앞으로 무인 잡은 plist 에 모델을 핀하는 걸 원칙으로 하자
+2. ㄱㄱ
+3. 등급 기댓값은 분기마다 다시 세우자 이번 분기는 인큐베이터를 과녁으로
+4. 이폴트 추천은 세션 시작에 한 번만 띄우고 반복하지 마라 두번은 소음이다
+
+합계: 4건
+제외: tool_result 1 · 메타/커맨드 1 · 텍스트없음 0
+
+GOLD
+  if diff -u "$T/seal_expect.txt" "$T/seal_block.txt" >"$T/seal_diff.txt" 2>&1; then
+    ok "L10 seal 발화 블록이 골든과 바이트 동일"
+  else
+    ng "L10 seal 발화 블록이 골든과 다르다"; sed 's/^/     /' "$T/seal_diff.txt" | head -20
+  fi
+else
+  ng "L10 seal 파일이 안 생겼다"
+fi
+
+# ── L11 compaction_probe.sh --self-test 초록 유지 ───────────────────────────
+if bash "$PROBE" --self-test >/dev/null 2>&1; then ok "L11 compaction_probe --self-test 초록"; else ng "L11 compaction_probe --self-test 실패"; fi
+
+# ── L12 되돌림 컨트롤 — 배선이 장식이 아니다 ────────────────────────────────
+# 실레포를 안 건드리고, compaction_probe.sh 만 스크래치 트리로 복사해 REPO_ROOT 를 옮긴다.
+# 추출기가 **없으면** seal 이 파싱 실패로 떨어져야 한다 = seal 이 정말 그 파일을 통해 돈다.
+mkdir -p "$T/mirror/scripts"
+cp "$PROBE" "$T/mirror/scripts/compaction_probe.sh"
+bash "$T/mirror/scripts/compaction_probe.sh" seal --transcript "$T/tr.jsonl" --dir "$T/seal_rv" >/dev/null 2>&1
+SFR="$(ls "$T/seal_rv"/seal_*.md 2>/dev/null | head -1)"
+if [ -n "$SFR" ] && grep -q "앞으로 무인 잡은 plist" "$SFR"; then
+  ng "L12 추출기가 없는데도 발화가 실렸다 — seal 이 그 파일을 통해 돌지 않는다(배선 장식)"
+else
+  ok "L12 추출기 제거 → seal 발화 블록이 죽는다 (되돌림 컨트롤)"
+fi
+# known-positive 짝: 같은 미러에 추출기를 넣으면 살아난다
+cp "$EXTRACT" "$T/mirror/scripts/transcript_utterances.py"
+bash "$T/mirror/scripts/compaction_probe.sh" seal --transcript "$T/tr.jsonl" --dir "$T/seal_rv2" >/dev/null 2>&1
+SFR2="$(ls "$T/seal_rv2"/seal_*.md 2>/dev/null | head -1)"
+if [ -n "$SFR2" ] && grep -q "앞으로 무인 잡은 plist" "$SFR2"; then
+  ok "L12b 추출기 복원 → 발화가 다시 실린다 (복원 확인 — L12 가 미러 자체의 사망이 아님)"
+else
+  ng "L12b 추출기를 복원했는데도 발화가 안 실린다 — L12 는 미러 결함이지 되돌림 증거가 아니다"
+fi
+
+# ── L13 session_close_check.sh 가 ①-f 를 **실행**한다 (mention 아님) ────────
+# 🟥 ①-e 가 아니다 — 그 라벨은 stray-path 가 이미 쓰고 있다(session_close_check.sh:690).
+#    임무 진단이 «①-e 는 없다» 고 적었는데 거짓이었고, 이 레인이 «배선 전인데 초록» 으로 잡았다.
+if [ -f "$CLOSE" ]; then
+  # 🟥 도구를 **설치해서** 돌린다 — 없으면 «skipped, not passed» 로 빠져 배선 자체를 못 잰다.
+  #    fakerepo 는 실 전사본 slug 와 안 겹치므로 결과는 결정적으로 UNMEASURED(전사본 부재)다.
+  mkdir -p "$T/fakerepo/scripts" && ( cd "$T/fakerepo" && git init -q . 2>/dev/null && git config user.email l@example.invalid && git config user.name lane )
+  cp "$SUT" "$EXTRACT" "$ROOT/scripts/utterance_landing_check.sh" "$ROOT/scripts/branch_claim.sh" "$T/fakerepo/scripts/" 2>/dev/null
+  OUT13="$(FH_PEER_SOCK_DIR="$T/nosock" bash "$CLOSE" "$T/fakerepo" 2>&1)"
+  case "$OUT13" in *"①-f"*) ok "L13 close check 가 ①-f 를 인쇄한다 (실행 확인)" ;; *) ng "L13 close check 출력에 ①-f 가 없다" ;; esac
+  # 🟥 «utterance_intake.sh 없음 … UNMEASURED» 분기도 ①-f+UNMEASURED 를 찍는다 — 그 분기로 통과하면
+  #    «설치돼서 돌았다» 가 아니라 «없어서 건너뛰었다» 다(codex #9). 설치 분기의 문구를 요구한다.
+  case "$OUT13" in
+    *"utterance_intake.sh 없음"*) ng "L13b 스크립트를 설치했는데 «없음» 분기로 갔다 (실행이 아니라 skip)" ;;
+    *"①-f UNMEASURED"*) ok "L13b 설치 분기에서 ①-f 가 UNMEASURED 로 뜬다 (전사본 부재 / 세션 미상)" ;;
+    *) ng "L13b ①-f 가 설치 분기의 UNMEASURED 로 라벨되지 않는다" ;;
+  esac
+else
+  ng "L13 session_close_check.sh 부재"
+fi
+
+# ── L14/L15 첫 실사용이 잡은 둘 (2026-09-05) ────────────────────────────────
+# 실 전사본에 처음 돌리자 두 결함이 즉시 나왔다 — 레인 29개도 cross-family 도 못 잡던 것들이다
+# ([[feedback_adversarial_review_not_substitute_for_first_use]]):
+#   ⓐ peer 알림 · 무인 실행 · 이미지 마커가 «운영자 발화» 로 세어졌다
+#   ⓑ 라벨에 머신 고유 절대경로(`/var/folders/3h/…`)가 그대로 찍혔다 = 사설 토큰 유출 채널
+cat > "$T/tr_sys.jsonl" <<'JSONL'
+{"type":"user","timestamp":"2026-09-05T02:00:00.000Z","message":{"content":"[Cross-session delivery notice] peer 세션이 보낸 알림이지 운영자 발화가 아니다"}}
+{"type":"user","timestamp":"2026-09-05T02:01:00.000Z","message":{"content":"[automated-run: launchd] 무인 실행 프리앰블이지 운영자 발화가 아니다"}}
+{"type":"user","timestamp":"2026-09-05T02:02:00.000Z","message":{"content":"[Image: source: /var/folders/3h/deadbeefcafe/T/shot.png]"}}
+{"type":"user","timestamp":"2026-09-05T02:03:00.000Z","message":{"content":"[Image #3] 레드팀 블루팀을 나눠서 단계별로 돌리는 기법을 우리도 쓰는지 궁금하다"}}
+JSONL
+OUT14="$(FH_INTAKE_DUMP_PROBES="$T/p14.tsv" bash "$SUT" "$T/tr_sys.jsonl" "$T/rec.md" 2>&1)"
+if [ -f "$T/p14.tsv" ]; then
+  N14=$(grep $'^TARGET\t' "$T/p14.tsv" 2>/dev/null | sed -n 's/.*#\([0-9][0-9]*\)\.[0-9]*\/[0-9]* .*/\1/p' | sort -u | grep -c .); case "$N14" in ''|*[!0-9]*) N14=0 ;; esac
+  [ "$N14" -eq 1 ] && ok "L14 시스템 마커 3 건 제외 · 실발화 1 건만 프로브가 된다" \
+                   || ng "L14 TARGET $N14 건 (기대 1)"
+  grep -q "Cross-session" "$T/p14.tsv" && ng "L14b peer 알림이 프로브가 됐다" || ok "L14b peer 알림 제외 (known-negative)"
+  grep -q "automated-run\|launchd" "$T/p14.tsv" && ng "L14c 무인 실행 프리앰블이 프로브가 됐다" || ok "L14c 무인 실행 제외 (known-negative)"
+  # known-positive: 마커만 벗기고 **뒤의 실발화는 살린다** — 통째로 버리는 것과 다르다
+  grep -q "레드팀" "$T/p14.tsv" && ok "L14d [Image #N] 뒤의 실발화는 살아남는다 (known-positive)" \
+                                || ng "L14d 마커 벗기기가 실발화까지 버렸다"
+  # ── L15 사설 토큰 마스킹 ──
+  grep -q "var/folders\|deadbeefcafe" "$T/p14.tsv" && ng "L15 머신 고유 임시경로가 프로브에 남았다" \
+                                                   || ok "L15 임시경로가 마스킹된다"
+else
+  ng "L14/L15 프로브 덤프가 안 나왔다"
+fi
+# 🟥 컨트롤: 플래그를 **안 주면** 안 걸러져야 한다. 안 그러면 «원래부터 안 잡히는 입력» 을
+#    필터의 공로로 오귀속한다. seal 이 바이트 동일한 이유가 정확히 이것이다.
+NRAW=$(python3 "$EXTRACT" "$T/tr_sys.jsonl" --min-chars 20 2>/dev/null | grep -c .); case "$NRAW" in ''|*[!0-9]*) NRAW=0 ;; esac
+NSTR=$(python3 "$EXTRACT" "$T/tr_sys.jsonl" --min-chars 20 --strip-system-markers 2>/dev/null | grep -c .); case "$NSTR" in ''|*[!0-9]*) NSTR=0 ;; esac
+[ "$NRAW" -eq 4 ] && ok "L15b 플래그 없으면 4 건 전부 통과 (known-negative — 필터가 기본 OFF)" \
+                  || ng "L15b 플래그 없이 $NRAW 건 (기대 4) — seal 경로가 이미 오염됐다"
+[ "$NSTR" -eq 1 ] && ok "L15c 플래그를 주면 1 건 (필터가 실제로 거른다)" || ng "L15c 플래그 켜고 $NSTR 건 (기대 1)"
+# 🟥 홈 경로 마스킹 — HOME 은 러너마다 다르니 값이 아니라 **부재**를 잰다.
+printf '%s\n' '{"type":"user","timestamp":"2026-09-05T03:00:00.000Z","message":{"content":"'"$HOME"'/projects/secretrepo 아래 파일을 손봐야 하는데 어떻게 할까 고민이다"}}' > "$T/tr_home.jsonl"
+FH_INTAKE_DUMP_PROBES="$T/p15.tsv" bash "$SUT" "$T/tr_home.jsonl" "$T/rec.md" >/dev/null 2>&1
+if [ -f "$T/p15.tsv" ]; then
+  grep -qF -- "$HOME/projects/secretrepo" "$T/p15.tsv" && ng "L15d 홈 절대경로가 프로브에 남았다" \
+                                                       || ok "L15d 홈 절대경로가 마스킹된다"
+  grep -q "secretrepo" "$T/p15.tsv" && ok "L15e known-positive: 그 발화 자체는 잡혔다 (빈 파일 통과 아님)" \
+                                    || ng "L15e 그 발화가 아예 안 잡혔다 — L15d 는 공허한 통과다"
+else
+  ng "L15d/e 프로브 덤프가 안 나왔다"
+fi
+
+# ── L16 슬래시 커맨드 vs 절대경로 발화 (첫 실사용이 잡은 셋째) ──────────────
+# 옛 규칙 `startswith('/')` 은 «/Users/…/OT.pptx.pdf 이건 발표자 ot자료인데…» 를 커맨드로
+# 오분류해 **무음 삭제**했다. 실측: `/` 접두 28 건 중 13 건(46%)이 경로형 실발화.
+cat > "$T/tr_slash.jsonl" <<'JSONL'
+{"type":"user","timestamp":"2026-09-05T04:00:00.000Z","message":{"content":"/compact"}}
+{"type":"user","timestamp":"2026-09-05T04:01:00.000Z","message":{"content":"/install-wizard --dry-run 으로 먼저 돌려보고 결과를 보자 그 다음에 결정하면 된다"}}
+{"type":"user","timestamp":"2026-09-05T04:02:00.000Z","message":{"content":"/srv/tester/Downloads/발표자료.pdf 이건 발표자 오티 자료인데 이걸 기준으로 초안을 잡자"}}
+JSONL
+NS_OFF=$(python3 "$EXTRACT" "$T/tr_slash.jsonl" --min-chars 20 2>/dev/null | grep -c .); case "$NS_OFF" in ''|*[!0-9]*) NS_OFF=0 ;; esac
+NS_ON=$(python3 "$EXTRACT" "$T/tr_slash.jsonl" --min-chars 20 --strip-system-markers 2>/dev/null | grep -c .); case "$NS_ON" in ''|*[!0-9]*) NS_ON=0 ;; esac
+[ "$NS_OFF" -eq 0 ] && ok "L16 플래그 없으면 셋 다 커맨드로 제외 (옛 규칙 = seal 경로, 컨트롤)" \
+                    || ng "L16 플래그 없이 $NS_OFF 건 남았다 (기대 0) — seal 행동이 바뀌었다"
+[ "$NS_ON" -eq 1 ] && ok "L16b 플래그를 주면 경로형 실발화 1 건만 살아난다" || ng "L16b 플래그 켜고 $NS_ON 건 (기대 1)"
+python3 "$EXTRACT" "$T/tr_slash.jsonl" --min-chars 20 --strip-system-markers 2>/dev/null | grep -q "발표자 오티" \
+  && ok "L16c 살아난 것이 **경로형 실발화** 다 (known-positive)" || ng "L16c 엉뚱한 것이 살아났다"
+python3 "$EXTRACT" "$T/tr_slash.jsonl" --min-chars 20 --strip-system-markers 2>/dev/null | grep -q "install-wizard" \
+  && ng "L16d 진짜 슬래시 커맨드가 살아남았다" || ok "L16d 진짜 슬래시 커맨드는 여전히 제외 (known-negative)"
+
+# ── L17 압축 이어붙임 프리앰블 (첫 실사용이 잡은 다섯째) ────────────────────
+# 대괄호로 시작하지 않아 L14 규칙이 **구조적으로** 못 잡는다. 실측 21 건, 실전 미착지 목록에 등장.
+cat > "$T/tr_cont.jsonl" <<'JSONL'
+{"type":"user","timestamp":"2026-09-05T05:00:00.000Z","message":{"content":"This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion."}}
+{"type":"user","timestamp":"2026-09-05T05:01:00.000Z","message":{"content":"이건 진짜 운영자 발화다 등급 기댓값을 분기마다 다시 세우자고 했던 그 이야기"}}
+JSONL
+NC_ON=$(python3 "$EXTRACT" "$T/tr_cont.jsonl" --min-chars 20 --strip-system-markers 2>/dev/null | grep -c .); case "$NC_ON" in ''|*[!0-9]*) NC_ON=0 ;; esac
+NC_OFF=$(python3 "$EXTRACT" "$T/tr_cont.jsonl" --min-chars 20 2>/dev/null | grep -c .); case "$NC_OFF" in ''|*[!0-9]*) NC_OFF=0 ;; esac
+[ "$NC_ON" -eq 1 ] && ok "L17 압축 프리앰블 제외 · 실발화 1 건만 남는다" || ng "L17 플래그 켜고 $NC_ON 건 (기대 1)"
+[ "$NC_OFF" -eq 2 ] && ok "L17b 플래그 없으면 둘 다 통과 (컨트롤 — seal 행동 불변)" || ng "L17b 플래그 없이 $NC_OFF 건 (기대 2)"
+python3 "$EXTRACT" "$T/tr_cont.jsonl" --min-chars 20 --strip-system-markers 2>/dev/null | grep -q "등급 기댓값" \
+  && ok "L17c 남은 것이 실발화다 (known-positive)" || ng "L17c 실발화까지 버렸다"
+
+# ── L18 ①-f **행복 경로** — 전사본과 기록이 다 있을 때 실제로 판정까지 간다 ────
+# 🟥 L13/L13b 는 UNMEASURED 가지만 잰다. 그것만 있으면 «①-f 가 늘 UNMEASURED 를 내는 블록» 과
+#    구분이 안 된다 — 존재 확인이지 판별력 확인이 아니다
+#    (`[[feedback_control_presence_is_not_discrimination]]`).
+if [ -f "$CLOSE" ] && [ -d "$T/fakerepo" ]; then
+  mkdir -p "$T/fakerepo/tracks/_meta" "$T/trdir"
+  # 오늘자 기록 — 착지 1 · 미착지 1 이 되게 만든다
+  { echo "# fh_completed_$TODAY.md"; echo "- ✅ 무인 잡 plist 에 모델을 핀했다 — launchd 3종 전부"; } \
+    > "$T/fakerepo/tracks/_meta/fh_completed_$TODAY.md"
+  mk_transcript "$T/trdir/LANESESSION.jsonl"
+  OUT18="$(FH_PEER_SOCK_DIR="$T/nosock" FH_CLAIM_TEST=1 FH_CLAIM_SESSION=LANESESSION \
+           FH_TRANSCRIPT_DIR="$T/trdir" bash "$CLOSE" "$T/fakerepo" 2>&1)"; RC18=$?
+  case "$OUT18" in *"①-f 미착지 발화가 있다"*) ok "L18 ①-f 가 실제로 판정까지 간다 (미착지 분기)" ;;
+    *) ng "L18 ①-f 가 판정 분기에 도달하지 못했다"; printf '%s\n' "$OUT18" | grep -A4 "①-f" | sed 's/^/     /' ;; esac
+  case "$OUT18" in *"이폴트 추천"*) ok "L18b 미착지 발화가 마감 출력에 그대로 뜬다" ;; *) ng "L18b 미착지 목록이 마감 출력에 없다" ;; esac
+  # 🟥 advisory 다 — ①-f 때문에 close check 가 «VIOLATIONS» 로 뒤집히면 안 된다.
+  #    그러면 정상 마감이 막히고 그게 --no-verify 를 훈련시킨다.
+  case "$OUT18" in *"①-f"*) _seen=1 ;; *) _seen=0 ;; esac
+  OUT18B="$(FH_PEER_SOCK_DIR="$T/nosock" FH_CLAIM_TEST=1 FH_CLAIM_SESSION=NOSUCHSESSION \
+            FH_TRANSCRIPT_DIR="$T/trdir" bash "$CLOSE" "$T/fakerepo" 2>&1)"; RC18B=$?
+  V18=$(printf '%s\n' "$OUT18"  | grep -c '^❌'); case "$V18"  in ''|*[!0-9]*) V18=0 ;; esac
+  V18B=$(printf '%s\n' "$OUT18B" | grep -c '^❌'); case "$V18B" in ''|*[!0-9]*) V18B=0 ;; esac
+  [ "$V18" -eq "$V18B" ] && ok "L18c ①-f 는 ❌ 개수를 늘리지 않는다 (advisory — 미착지 유무로 불변)" \
+                         || ng "L18c ①-f 가 close check 판정을 바꿨다 (미착지 $V18 vs 전사본없음 $V18B)"
+  [ "$_seen" -eq 1 ] && ok "L18d known-positive: 그 실행에 ①-f 가 실제로 있었다" || ng "L18d ①-f 자체가 안 떴다 — L18c 는 공허하다"
+  # ❌ 개수만 보면 «같은 출력 + exit 1» 회귀를 못 잡는다(codex #8) — exit code 도 같아야 advisory 다
+  [ "${RC18:-x}" = "${RC18B:-y}" ] && ok "L18e ①-f 는 close check exit code 도 바꾸지 않는다 (rc $RC18 = $RC18B)" \
+                                    || ng "L18e exit code 가 달라졌다 (미착지 $RC18 vs 전사본없음 $RC18B)"
+  # L13c — 스크립트가 없으면 «없음 — skipped, not passed» 로 표시된다 (L13b 의 반대쪽)
+  rm -f "$T/fakerepo/scripts/utterance_intake.sh"
+  OUT13C="$(FH_PEER_SOCK_DIR="$T/nosock" FH_CLAIM_TEST=1 FH_CLAIM_SESSION=LANESESSION \
+            FH_TRANSCRIPT_DIR="$T/trdir" bash "$CLOSE" "$T/fakerepo" 2>&1)"
+  case "$OUT13C" in *"utterance_intake.sh 없음"*) ok "L13c 스크립트 부재 → «없음 — skipped, not passed» (known-negative)" ;; *) ng "L13c 부재를 표시하지 않는다" ;; esac
+else
+  ng "L18 fakerepo 준비 안 됨"
+fi
+
+# ── L19 발화 판정은 토큰 과반 — 주제어 하나가 겹친다고 착지가 아니다 (codex #1) ──
+cat > "$T/tr19.jsonl" <<'JSONL'
+{"type":"user","timestamp":"2026-09-05T05:00:00.000Z","message":{"content":"쿠버네티스 배포는 승인자두명 카나리지표 장애예산 셋이 모두 맞을 때만 열자"}}
+JSONL
+printf '%s\n' '- 오늘 쿠버네티스 버전만 확인했다 (주제어 하나만 겹친다 — 정책은 안 적혔다)' > "$T/rec19a.md"
+OUT19="$(bash "$SUT" "$T/tr19.jsonl" "$T/rec19a.md" 2>&1)"; RC19=$?
+[ "$RC19" -eq 1 ] && ok "L19 주제어 하나만 겹치면 미착지 (rc=1)" || { ng "L19 rc=$RC19 (기대 1) — 낱말 하나로 착지 처리"; echo "$OUT19" | sed 's/^/     /'; }
+case "$OUT19" in *"쿠버네티스 배포는"*) ok "L19b 그 발화가 미착지 목록에 있다" ;; *) ng "L19b 미착지 목록에 없다" ;; esac
+printf '%s\n' '- 배포 정책: 승인자두명 확인 + 카나리지표 통과 + 장애예산 잔여 — 셋 다 맞을 때만' > "$T/rec19b.md"
+OUT19B="$(bash "$SUT" "$T/tr19.jsonl" "$T/rec19b.md" 2>&1)"; RC19B=$?
+[ "$RC19B" -eq 0 ] && ok "L19c CONTROL 토큰 3 중 2 이상 겹치면 착지 (rc=0)" || { ng "L19c rc=$RC19B (기대 0)"; echo "$OUT19B" | sed 's/^/     /'; }
+
+# ── L20 프로브불가 발화는 «못 쟀다» — 미착지 0 이어도 rc=0 이 아니다 (codex #2) ──
+cat > "$T/tr20.jsonl" <<'JSONL'
+{"type":"user","timestamp":"2026-09-05T05:10:00.000Z","message":{"content":"그리고 그러니까 그래서 그러면 그런데 이렇게 그렇게 어떻게 하지만 그러나 마찬가지 이야기"}}
+{"type":"user","timestamp":"2026-09-05T05:11:00.000Z","message":{"content":"앞으로 무인 잡은 plist 에 모델을 핀하는 걸 원칙으로 하자"}}
+JSONL
+OUT20="$(bash "$SUT" "$T/tr20.jsonl" "$T/rec.md" 2>&1)"; RC20=$?
+[ "$RC20" -eq 1 ] && ok "L20 프로브불가 1 + 착지 1 → rc=1 (미측정은 착지가 아니다)" || { ng "L20 rc=$RC20 (기대 1)"; echo "$OUT20" | sed 's/^/     /'; }
+case "$OUT20" in *"프로브불가 1 건"*) ok "L20b 프로브불가 발화가 목록으로 뜬다" ;; *) ng "L20b 프로브불가 목록이 없다" ;; esac
+case "$OUT20" in *"착지 1 · 미착지 0"*) ok "L20c CONTROL 다른 발화는 착지로 센다 (rc=1 이 미착지 탓이 아님)" ;; *) ng "L20c 착지/미착지 계수가 기대와 다르다"; echo "$OUT20" | sed 's/^/     /' ;; esac
+
+# ── L21 라벨·프로브의 사설 토큰 마스킹은 $HOME 만이 아니다 (codex #5) ──
+cat > "$T/tr21.jsonl" <<'JSONL'
+{"type":"user","timestamp":"2026-09-05T05:20:00.000Z","message":{"content":"/srv/bob/projects/acme-secret/prod.env 에 있는 DB_HOST=db01.internal 값을 기록하지 말고 비교만 해줘"}}
+JSONL
+OUT21="$(FH_INTAKE_DUMP_PROBES="$T/p21.tsv" bash "$SUT" "$T/tr21.jsonl" "$T/rec.md" 2>&1)"
+if [ -f "$T/p21.tsv" ]; then
+  for _tok in bob acme-secret prod.env db01 internal; do
+    grep -q -- "$_tok" "$T/p21.tsv" && ng "L21 사설 토큰 '$_tok' 이 프로브/라벨에 남았다" || ok "L21 '$_tok' 마스킹"
+  done
+  printf '%s\n' "$OUT21" | grep -q -- "acme-secret\|db01" && ng "L21b 출력(미착지 목록)에 사설 토큰이 찍혔다" || ok "L21b 출력에도 없다"
+  grep -q "기록하지" "$T/p21.tsv" && ok "L21c known-positive: 그 발화 자체는 프로브가 됐다" || ng "L21c 발화가 아예 안 잡혔다 — L21 은 공허하다"
+else
+  ng "L21 프로브 덤프가 안 나왔다"
+fi
+
+# ── L22 기록이 짧아 양성 컨트롤을 못 만들면 UNMEASURED(rc=10), 착지 판정 없음 (codex #7) ──
+printf '%s\n' '하네스 배선 착지' > "$T/rec22.md"
+OUT22="$(bash "$SUT" "$T/tr.jsonl" "$T/rec22.md" 2>&1)"; RC22=$?
+[ "$RC22" -eq 10 ] && ok "L22 컨트롤 재료 없음 → rc=10" || { ng "L22 rc=$RC22 (기대 10)"; echo "$OUT22" | sed 's/^/     /'; }
+case "$OUT22" in *"양성 컨트롤 토큰을 못 뽑았다"*) ok "L22b 사유가 «컨트롤 재료 없음» 으로 명명된다 (계기 사망과 구분)" ;; *) ng "L22b 사유 문구 없음" ;; esac
+case "$OUT22" in *"전부 착지"*) ng "L22c 컨트롤 없이 «전부 착지» 를 찍었다" ;; *) ok "L22c 착지 판정을 내지 않는다" ;; esac
+
+# ── L23 런타임이 isMeta/isSidechain 으로 표시한 레코드는 발화가 아니다 (codex #4) ──
+cat > "$T/tr23.jsonl" <<'JSONL'
+{"type":"user","isMeta":true,"timestamp":"2026-09-05T05:30:00.000Z","message":{"content":"작업 큐 알림 재시도 필요 메타표시레코드 본문이다 발화가 아니다"}}
+{"type":"user","isSidechain":true,"timestamp":"2026-09-05T05:31:00.000Z","message":{"content":"사이드체인 서브에이전트 대화 본문이다 운영자 발화가 아니다"}}
+{"type":"user","timestamp":"2026-09-05T05:32:00.000Z","message":{"content":"같은 문장인데 표시가 없는 이 줄은 운영자 발화라 남아야 한다"}}
+JSONL
+N23=$(python3 "$EXTRACT" "$T/tr23.jsonl" --min-chars 20 2>/dev/null | grep -c .); case "$N23" in ''|*[!0-9]*) N23=0 ;; esac
+[ "$N23" -eq 1 ] && ok "L23 isMeta·isSidechain 레코드 제외 · 표시 없는 1 건만 남는다" || ng "L23 $N23 건 (기대 1)"
+python3 "$EXTRACT" "$T/tr23.jsonl" --min-chars 20 2>/dev/null | grep -q "표시가 없는" && ok "L23b known-positive: 남은 것이 표시 없는 발화다" || ng "L23b 표시 없는 발화까지 버렸다"
+python3 "$EXTRACT" "$T/tr23.jsonl" --min-chars 20 2>/dev/null | grep -q "메타표시레코드\|사이드체인" && ng "L23c 표시된 레코드가 살아남았다" || ok "L23c 표시된 레코드는 없다 (known-negative)"
+
+echo
+echo "── utterance-intake lanes: PASS=$PASS FAIL=$FAIL ──"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/scripts/transcript_utterances.py
+++ b/scripts/transcript_utterances.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""transcript_utterances.py — Claude Code 전사본(jsonl) → 운영자 발화.
+
+WHY THIS FILE EXISTS. 이 추출 로직은 `compaction_probe.sh` 안에 heredoc 으로 인라인돼 있었고,
+「받는 절반」(발화 → 기록 착지) 을 배선하려면 두 번째 소비처가 필요했다. 사본을 두 벌 두는 것은
+`[[feedback_divergent_leniency_duplicate_normalizers]]` — 전처리가 갈리면 **한쪽만 통과하는
+입력이 다른 쪽에서 무음 드롭된다**. 그래서 파일 하나로 꺼낸다.
+
+🟥 SEAL 출력은 바이트 동일해야 한다. `--format seal` 은 인라인 판본을 **그대로** 재현한다
+(줄 형식 · 합계/제외 문구 · 카운터 이름까지). `scripts/test_utterance_intake_lanes.sh` L10 이
+골든으로 고정하고, L12/L12b 가 «이 파일이 정말 seal 경로에 있는가» 를 되돌림으로 잰다.
+
+── 무엇을 발화로 세는가 (그리고 왜) ──────────────────────────────────────────
+`type=user` 는 **사람 발화가 아니다** — 툴 결과 · peer 메시지 · task 알림이 같은 타입으로 온다
+(`[[feedback_type_user_is_not_human_utterance.md]]`: 39 vs 실제 30). 실측(2026-09-05, 이 레포의
+전사본 전수): `<task-notification` 3791 · `<cross-session-message` 1467 · `<local-command-*` 232 —
+전부 `<` 로 시작하므로 봉투 접두 규칙이 잡는다.
+  · content 가 str          → 발화 후보
+  · content 가 list         → tool_result 블록이 하나라도 있으면 **툴 결과**(제외).
+                              아니면 text 블록만 이어붙인다. 🟥 이미지 첨부 실발화가 list 다 —
+                              「list = 툴결과」로 가르면 그런 발화가 구조적으로 안 보인다.
+  · text 블록이 없음        → 이미지 전용 등. **세되 싣지 않는다**(지우지 않는다).
+  · `<` 또는 `/` 로 시작    → 메타 봉투 · 슬래시 커맨드(제외)
+  · `--min-chars N` 미만    → 짧은 응답(«ㄱㄱ» «응» «승인»). **별도 카운터**로 센다.
+  · `--strip-system-markers` → 아래 §시스템 마커. **기본 OFF** — 켜면 seal 출력이 바뀐다.
+
+🟥 제외분을 반드시 인쇄한다. 합계만 찍으면 그 원장이 완전한 것처럼 읽힌다 —
+`[[feedback_not_found_is_not_zero_family]]`.
+
+── 사용 ──────────────────────────────────────────────────────────────────────
+  python3 scripts/transcript_utterances.py <transcript.jsonl> [--min-chars N]
+         [--format tsv|seal] [--strip-system-markers]
+    tsv  (기본) : `n<TAB>ts<TAB>text`  한 줄 한 발화. ts 가 없으면 `-`.
+    seal        : compaction_probe seal 블록 (바이트 동일)
+  종료코드: 0 정상 · 2 인자/파일 문제(호출부의 «파싱 실패» 폴백이 여기서 뜬다)
+
+이식성: 표준 라이브러리만. python3.6+ (f-string).
+"""
+import json
+import re
+import sys
+
+
+# ── 시스템 마커 (실측 2026-09-05, 이 레포 전사본 전수 — 대괄호 접두 171 건) ──────────────
+# `type=user` 로 오지만 **운영자가 친 것이 아닌** 것들. 개수를 세서 골랐다:
+#     [Cross-session delivery notice] 66 · [Request interrupted by user] 45 ·
+#     [automated-run: launchd] 31 · [Image #N] 17 · [Cross-session idle notice] 4
+# 정책 두 갈래 — ⓐ **통째로 버릴 것**(발신자가 사람이 아니다) ⓑ **마커만 벗길 것**(뒤에 실발화가 온다).
+# 🟥 `[자율 루프 …]` 8 건은 **일부러 안 넣었다** — 운영자가 쓴 무인 실행 프롬프트라 과포함(안전)
+#    쪽에 둔다. 과소포함은 무음 손실이라 방향이 다르다.
+# 🟥 기본 OFF. 켜면 seal 출력이 바뀌므로 `--strip-system-markers` 를 준 소비처(intake)만 받는다.
+# 🟥 압축 이어붙임 프리앰블도 `type=user` 로 온다 — 실측 21 건, 그리고 **첫 실사용에서
+#    미착지 목록에 그대로 떴다**(2026-09-05). 런타임이 주입한 요약이지 운영자 발화가 아니다.
+#    괄호로 시작하지 않아 앞의 대괄호 규칙이 구조적으로 못 잡는다 — 별도 접두로 센다.
+_DROP_PREFIXES = ('[Cross-session delivery notice]', '[Cross-session idle notice]',
+                  '[automated-run:',
+                  'This session is being continued from a previous conversation')
+_STRIP_MARKER = re.compile(r'^\[(?:Image|Request interrupted by user)[^\]]*\]\s*')
+
+
+def _is_slash_command(t):
+    """슬래시 커맨드인가, 절대경로로 시작하는 실발화인가.
+
+    🟥 실측 2026-09-05, 이 레포 전사본 전수: `<` 봉투가 아닌 `/` 접두 발화 **28 건 중 13 건**
+    (46%)이 **절대경로로 시작하는 진짜 발화**였다 — «/Users/…/OT.pptx.pdf 이건 발표자 ot자료인…»
+    처럼 지시가 통째로 딸려 있다. 옛 규칙(`startswith('/')` → 커맨드)은 그 13 건을 무음 삭제했다.
+    판별자: **첫 낱말의 `/` 개수**. `/compact` `/install-wizard --dry-run` = 1 개(커맨드) ·
+    `/Users/<name>/…` = 2 개 이상(경로). 이 코퍼스에서 15/13 으로 깨끗이 갈린다.
+
+    🟥 이 규칙은 `--strip-system-markers` 를 준 소비처에만 적용된다. seal 은 안 준다 —
+    바꾸면 기존 원장 출력이 달라지고, 그건 리팩터가 아니라 **행동 변경**이라 운영자 판단이다.
+    즉 seal 쪽에는 이 결함이 **아직 남아 있다**(보고서에 이름으로 남긴다).
+    """
+    return t.split(' ', 1)[0].count('/') == 1
+
+
+def _apply_system_markers(t):
+    """→ (text, dropped).  dropped=True 면 이 레코드는 발화가 아니다."""
+    for pref in _DROP_PREFIXES:
+        if t.startswith(pref):
+            return '', True
+    prev = None
+    while prev != t:
+        prev = t
+        t = _STRIP_MARKER.sub('', t)
+    if not t.strip():
+        return '', True
+    return t, False
+
+
+def _iter_records(path):
+    with open(path, errors='replace') as fh:
+        for line in fh:
+            try:
+                yield json.loads(line)
+            except Exception:
+                continue
+
+
+def extract(path, min_chars=0, strip_system=False):
+    """→ (utterances, counters).  utterances = [(n, ts, text), ...] (1-based n)."""
+    out = []
+    n = 0
+    c = {'tool': 0, 'meta': 0, 'other': 0, 'short': 0, 'sys': 0}
+    for d in _iter_records(path):
+        if d.get('type') != 'user':
+            continue
+        # Runtime-flagged provenance: isMeta (harness-injected — command expansions, caveats,
+        # image placeholders) and isSidechain (a sub-agent's conversation) are not operator
+        # utterances. A channel property of the record itself, not a content judgment. Measured on
+        # a live transcript 2026-09-05: 1 of 379 user records is isMeta with plain text (the image
+        # placeholder), 0 isSidechain — so the seal ledger loses exactly that line. (codex finding 4)
+        if d.get('isMeta') or d.get('isSidechain'):
+            c['meta'] += 1
+            continue
+        m = d.get('message') or {}
+        content = m.get('content')
+        if isinstance(content, str):
+            t = content
+        elif isinstance(content, list):
+            if any(isinstance(b, dict) and b.get('type') == 'tool_result' for b in content):
+                c['tool'] += 1
+                continue
+            parts = [b.get('text', '') for b in content
+                     if isinstance(b, dict) and b.get('type') == 'text']
+            if not parts:
+                c['other'] += 1          # 이미지 전용 등 — 셈에서 지우지 않고 센다
+                continue
+            t = ' '.join(parts)
+        else:
+            c['other'] += 1
+            continue
+        t = ' '.join(t.split())
+        if not t:
+            c['other'] += 1
+            continue
+        if t.startswith('<'):                        # 메타 봉투
+            c['meta'] += 1
+            continue
+        if t.startswith('/'):
+            # strip_system 이 꺼져 있으면 옛 규칙 그대로 — seal 출력 바이트 동일의 근거다.
+            if not (strip_system and not _is_slash_command(t)):
+                c['meta'] += 1
+                continue
+        if strip_system:
+            t, dropped = _apply_system_markers(t)
+            if dropped:
+                c['sys'] += 1
+                continue
+        if min_chars and len(t) < min_chars:
+            c['short'] += 1
+            continue
+        n += 1
+        out.append((n, d.get('timestamp') or '-', t))
+    return out, c
+
+
+def _seal(utterances, c):
+    # 🟥 인라인 판본과 **바이트 동일**. 문구·구두점·카운터 이름을 바꾸지 마라 (L10 골든).
+    for n, _ts, t in utterances:
+        print(f"{n}. {t[:200]}")
+    total = len(utterances)
+    print(f"\n합계: {total}건" if total else "- (발화 0건)")
+    print(f"제외: tool_result {c['tool']} · 메타/커맨드 {c['meta']} · 텍스트없음 {c['other']}")
+
+
+def _tsv(utterances, c):
+    for n, ts, t in utterances:
+        # 탭·개행은 위에서 이미 접혔다. 그래도 방어적으로 한 번 더 — 한 줄 = 한 발화가 계약이다.
+        print(f"{n}\t{ts}\t" + t.replace('\t', ' '))
+    # 제외분은 stderr 로. stdout 은 «한 줄 한 발화» 계약이라 소비처가 `wc -l` 로 세도 안전해야 한다.
+    sys.stderr.write(
+        f"제외: tool_result {c['tool']} · 메타/커맨드 {c['meta']} · "
+        f"텍스트없음 {c['other']} · 짧음 {c['short']} · 시스템마커 {c['sys']}\n")
+
+
+def main(argv):
+    if len(argv) < 2:
+        sys.stderr.write("usage: transcript_utterances.py <transcript.jsonl> "
+                         "[--min-chars N] [--format tsv|seal]\n")
+        return 2
+    path = argv[1]
+    min_chars = 0
+    fmt = 'tsv'
+    strip_system = False
+    i = 2
+    while i < len(argv):
+        a = argv[i]
+        if a == '--min-chars' and i + 1 < len(argv):
+            try:
+                min_chars = int(argv[i + 1])
+            except ValueError:
+                sys.stderr.write(f"transcript_utterances: --min-chars 값이 정수가 아니다: {argv[i+1]}\n")
+                return 2
+            i += 2
+        elif a == '--format' and i + 1 < len(argv):
+            fmt = argv[i + 1]
+            if fmt not in ('tsv', 'seal'):
+                sys.stderr.write(f"transcript_utterances: --format 은 tsv|seal: {fmt}\n")
+                return 2
+            i += 2
+        elif a == '--strip-system-markers':
+            strip_system = True
+            i += 1
+        else:
+            sys.stderr.write(f"transcript_utterances: 알 수 없는 인자: {a}\n")
+            return 2
+    try:
+        utterances, counters = extract(path, min_chars, strip_system)
+    except OSError as e:
+        # 호출부(compaction_probe seal)의 «파싱 실패» 폴백이 이 비영 종료로 뜬다.
+        sys.stderr.write(f"transcript_utterances: 전사본을 열 수 없다: {e}\n")
+        return 2
+    if fmt == 'seal':
+        _seal(utterances, counters)
+    else:
+        _tsv(utterances, counters)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/scripts/utterance_intake.sh
+++ b/scripts/utterance_intake.sh
@@ -1,0 +1,424 @@
+#!/usr/bin/env bash
+# utterance_intake.sh — 전사본의 운영자 발화를 **자동으로** 프로브로 만들어 기록 착지를 검증한다.
+#
+# ── 왜 (진단, 2026-09-05) ────────────────────────────────────────────────────
+# FH 의 «질문하기» 엔진은 external-grounding 엔진인데 **수용 절반이 산문이다**
+# (`fh_three_layer_canon.md §2`: *"묻는 경로는 있고 들어온 통찰을 자산화하는 경로가 약하다"*).
+# 계기는 이미 둘 다 있었다:
+#     compaction_probe.sh seal        전사본 → 운영자 발화 축자 원장        (돈다)
+#     utterance_landing_check.sh      probes.tsv → 기록 파일 grep          (돈다, 호출부 0)
+# 그런데 **probes.tsv 를 만드는 기계가 없었다.** 손으로 짜야 하니 아무도 안 짰고,
+# `session_close_check.sh` 어디에서도 두 번째가 호출되지 않았다(grep 0). 두 계기 사이의
+# 한 칸이 비어 있어서 채널이 아니라 산문으로 남아 있던 것 — 이 스크립트가 그 칸이다.
+#
+# 실측 근거(같은 날): 운영자가 세션 중 던진 교리·설계급 발화 6 건이 착지한 경로는 전부
+# **거버너의 손**이었다(signal 파일 2 · UAP 블록 2 · fh_completed). 기계는 한 건도 안 잡았다.
+#
+# ── 이 스크립트가 하는 것 / 안 하는 것 ──────────────────────────────────────
+#   한다   : 발화 추출 → 키 낱말 프로브 생성 → 컨트롤 2 종 삽입 → 착지 검증 → 미착지 목록
+#   안 한다: 기록을 **쓰지 않는다.** 무엇을 어디에 적을지는 판단이고, 판단을 코드로 굳히면
+#            그게 천장이 된다(`CLAUDE.md §Mechanization Boundary`). 이건 «채널이 값을
+#            나르는가» 만 본다 — «그 값이 옳은가» 는 사람 몫이다.
+#
+# ── 🟥 명명된 잔여 셋. 인용하기 전에 읽어라 ─────────────────────────────────
+# ⓐ **이름표는 측정이 아니다** — 프로브는 «키 낱말» 이라서, 기록이 같은 뜻을 **다른 낱말로**
+#    적었으면 착지했는데 미착지로 뜬다. 상속: `utterance_landing_check.sh` 헤더의
+#    *"rc=1 은 «기록하라»가 아니라 «확인하라»로 읽어야 한다"*. 이 방향은 **과차단이라 안전**하다.
+# ⓑ **토큰마다 한 행, 발화는 과반으로 판정한다.** 초판은 한 행 `(낱말1|낱말2|낱말3)` 이라
+#    **하나만 겹쳐도** 착지였다 — 같은 주제어 하나(«쿠버네티스»)가 든 기록이 정책 발화를 «착지»
+#    로 렌더했다(cross-family codex, 2026-09-05). 이제 발화의 최장 토큰(≤3)을 **각각 한 행**으로
+#    내고, 발화는 착지 행이 ⌈n/2⌉ 이상일 때만 착지다(3 키 → 2 · 2 키 → 1 · 1 키 → 1).
+#    🟥 남은 fail-open: 키가 2 개뿐인 발화는 여전히 하나만 겹쳐도 착지다(OR). rc=0 은 여전히
+#    «제대로 적혔다» 의 증명이 아니다. 발화 단위 계상은 map 의 n_keys 로 이 스크립트가 집계한다.
+# ⓒ **advisory 다** — `session_close_check.sh ①-f` 는 이걸 차단으로 쓰지 않는다. 노출 사다리
+#    (`fh_three_layer_canon §1-a-2 ⓔ` shadow) 로 몇 세션 관찰한 뒤 승격 여부는 운영자 결정.
+#
+# ── 컨트롤 두 종 (한 종이 아니다) ───────────────────────────────────────────
+# `utterance_landing_check.sh` 의 CONTROL 은 **양성만** 있다 — 「계기가 죽었나」는 재고
+# 「계기가 아무거나 다 잡나」는 못 잰다(`[[feedback_control_presence_is_not_discrimination]]`).
+#   POSITIVE  **기록 내용에서 뽑은 최장 토큰.** 거기 실제로 있으니 정의상 잡혀야 하고,
+#             안 잡히면 파이프라인이 죽은 것이다(word-split · 경로 · 인코딩) → rc=10.
+#             🟥 초판은 «오늘 날짜» 였는데 **날짜는 파일명에 있지 내용에 있을 의무가 없다** —
+#             그러면 정상 마감마다 거짓 경보가 뜬다. 실측 근거는 아래 `_control_rows` 주석.
+#             날짜는 «있을 때만» 보조 컨트롤로 더한다.
+#   NEGATIVE  무작위 토큰 — **없어야 마땅하다.** 잡히면 계기가 아무거나 잡는 것이므로 역시 rc=10
+# NEGATIVE 는 이 래퍼가 직접 검사한다(하위 도구가 모르는 종류라 그 행은 무시하고 지나간다).
+#
+# ── 사용 ────────────────────────────────────────────────────────────────────
+#   bash scripts/utterance_intake.sh <transcript.jsonl> <record-file> [<record-file>...]
+#   env:
+#     FH_INTAKE_MIN_CHARS    기본 20 — 아래 §문턱 참조
+#     FH_INTAKE_NEG_TOKEN    음성 컨트롤 토큰 고정(레인용). 미설정이면 매 실행 무작위
+#     FH_INTAKE_DUMP_PROBES  생성된 probes.tsv 를 이 경로로도 남긴다(레인/디버그용)
+#
+# ── §문턱: 왜 40 이 아니라 20 인가 (실측 2026-09-05) ────────────────────────
+# 이 레포 전사본 전수 3191 발화(봉투·툴결과 제외)의 길이 분포:
+#     00-09  524  ·  10-19  329  ·  20-29  284  ·  30-39  187  ·  40+  1867
+# 30–39 구간 표본에 하중 지는 발화가 산다 — «그리고 입장리뷰는 정적 동적 모두 수행해야해» ·
+# «4는 초록으로 올리도록 하자». 한글은 자당 정보량이 커서 **40 자 바닥은 교리 발화를 조용히
+# 버린다**(위험한 방향). 20 = 853 제외 · 2338 보존. 과포함은 소음(안전), 과소포함은 무음 손실.
+#
+# ── 종료코드 ────────────────────────────────────────────────────────────────
+#   0   전건 착지            1   미착지 있음 (목록 인쇄)
+#  10   HARNESS-ERROR / UNMEASURED — **PASS 도 FAIL 도 아니다**
+#       (전사본 부재 · 추출 발화 0 · 기록 파일 0 · 컨트롤 사망 · 프로브 오류 · rc↔목록 불일치)
+#
+# 이식성: bash 3.2 · 백틱 없음 · heredoc 은 함수 안 + 인용 구분자. python3 표준 라이브러리만.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXTRACTOR="$REPO_ROOT/scripts/transcript_utterances.py"
+LANDING="$REPO_ROOT/scripts/utterance_landing_check.sh"
+MIN_CHARS="${FH_INTAKE_MIN_CHARS:-20}"
+
+_die10() { echo "$1"; exit 10; }
+
+# 🟥 `grep -c x f || echo 0` 은 무매치일 때 «0» 을 **두 번** 낸다 — grep 이 0 을 찍고 rc=1 을
+#    내므로 폴백까지 붙는다. `[ "0\n0" -eq 0 ]` 은 «integer expression expected» 로 죽고,
+#    그 죽음이 계기 사망으로 렌더된다(레인이 L1/L4b/L8b 에서 잡았다).
+#    `[[feedback_pipefail_fallback_disarms_guard]]` 의 사촌 — 폴백이 값을 오염시키는 형태.
+_num() { case "${1:-}" in ''|*[!0-9]*) echo 0 ;; *) printf '%s' "$1" ;; esac; }
+
+# ── 양성 컨트롤 ───────────────────────────────────────────
+# 🟥 초판은 «오늘 날짜» 를 양성 컨트롤로 썼다 — «오늘자 기록 파일에는 오늘 날짜가
+#    반드시 있다» 는 가정이었고, **거짓이다.** 날짜는 파일명에 있지 내용에 있을 의무가 없다.
+#    실측(2026-09-05 sim): 플로어 티어 세션이 만든 `fh_completed_2026-09-05.md` 내용은
+#    «- ✅ 계기 확인 — 클론 안 쓰기 가능» 한 줄뿐이다. 그러면 컨트롤이 죽어 rc=10 이 나고,
+#    정상 마감에 거짓 경보가 뜬다 — 그것이 바로 스키밍을 훈련시키는 소음이다.
+#    ⇒ 컨트롤을 **기록 내용에서 뽑는다**: 거기 실제로 있는 긴 토큰은 정의상 잡혀야 하므로,
+#    안 잡히면 **파이프라인이 죽은 것**(word-split · 경로 · 인코딩)이다 — 원래 재려던 바로 그 실패다.
+#    날짜는 «있을 때만» 두 번째 컨트롤로 더한다(있으면 더 강하고, 없어도 치명적이지 않다).
+_control_rows() {  # $1=오늘날짜  $2=스크래치  $3...=기록 파일들
+  local _today="$1" _scratch="$2"; shift 2
+  local _py="$_scratch/mkcontrol.py"
+  cat > "$_py" <<'CTLPY'
+import re, sys
+
+today = sys.argv[1]
+best = ''
+seen_today = False
+for path in sys.argv[2:]:
+    try:
+        txt = open(path, errors='replace').read()
+    except OSError:
+        continue
+    # degrade-scan C2(substring-boolean) 대응: 이 포함검사는 **가산적**이다 — 맞으면 보조
+    # 컨트롤이 하나 늘고, 틀리면 안 늘 뿐이다. 하중은 아래 `best`(파생 컨트롤)가 진다.
+    # 어느 방향으로 틀려도 PASS 로 기울지 않으므로 정확 일치로 좁힐 이유가 없다.
+    if today in txt:  # noqa: degrade — additive only: ADDS a secondary control row, never grounds a verdict
+        seen_today = True
+    for tok in re.findall(r'[\uac00-\ud7a3]{4,}|[A-Za-z0-9_]{5,}', txt):
+        if len(tok) > len(best):
+            best = tok
+if best:
+    print("CONTROL\t%s\t기록파생(양성컨트롤)" % best)
+if seen_today:
+    print("CONTROL\t%s\t오늘날짜(보조컨트롤)" % today)
+CTLPY
+  python3 "$_py" "$_today" "$@"
+}
+
+# ── 키 낱말 프로브 생성 ──────────────────────────────────────────────────────
+# 한글/영숫자 토큰 중 **가장 긴** 것 3 개. 조사를 벗기고, 불용어와 짧은 토큰을 뺀다.
+# 정규식 메타문자가 섞이지 않도록 토큰 문자군을 [\uac00-\ud7a3]·[A-Za-z0-9_] 로 **닫아 둔다** —
+# `.` `-` 를 허용하면 ERE 에서 각각 와일드카드/범위로 새고, 이스케이프를 손으로 하는 순간
+# 「관대함 갈린 중복 정규화」가 시작된다.
+# 🟥 `python3 - <<'PY'` 를 쓰면 **heredoc 이 python 의 stdin 이 되어** 발화 tsv 가 통째로
+#    안 읽힌다(첫 판본이 그랬고, 레인 L4b 가 « TARGET 0 건 » 으로 잡았다). 프로그램은 파일로
+#    떨어뜨리고 stdin 은 호출부의 리다이렉트가 그대로 나르게 둔다.
+_build_probes() {  # stdin: n<TAB>ts<TAB>text   stdout: probes rows   $1=map 경로  $2=스크래치 디렉터리
+  local _py="$2/mkprobes.py"
+  cat > "$_py" <<'PY'
+import os, re, sys
+
+MAP = open(sys.argv[1], 'w')
+
+# 🟥 사설 토큰 마스킹 — **토큰화 전에** 한다. 이 출력은 마감 화면에 찍히고 사람이 카드에
+#    붙여넣는다. 첫 실사용(2026-09-05)에서 실제로 `[Image: source: /var/folders/3h/…]` 가
+#    라벨로 나왔다 — 머신 고유 임시경로다. 마스킹을 라벨에만 걸면 키 낱말 쪽으로 새므로
+#    (사용자명 같은 것이 그대로 토큰이 된다) 앞단에서 지운다.
+# 🟥 한글 범위를 `[\uac00-\ud7a3]` 로 적는다 — `[가-힣]` 과 **의미는 같지만**
+#    (파이썬 `re` 에서 동치, known-pair 로 확인), 이 파일은 `.sh` 라
+#    `test_card_drift_probe.sh` 의 locale-range 린트가 스캔한다. 그 린트는 셸의 `grep` 을
+#    겨냥한 것이고(C 로케일에서 비ASCII 범위는 exit 2 → «무매치» 로 읽힌다), heredoc 안의
+#    python 인지 구분하지 못한다. 린트를 끄는 대신 **표기를 바꾼다** — 로케일 함정에 대한
+#    그 경계는 살아 있어야 한다.
+#    (`transcript_utterances.py` 는 `.sh` 가 아니라 스캔 대상이 아니므로 가독성 표기를 쓴다.)
+_HOME = os.environ.get('HOME', '')
+_TMP_RE = re.compile(r'/(?:var/folders|private/var/folders)/[^\s\]\)]*')
+
+
+_PATH_RE = re.compile(r'(?<![\w])/(?:[\w.@+-]+/)+[\w.@+-]*')          # any absolute path, 2+ segments
+_KV_RE   = re.compile(r'\b([A-Z][A-Z0-9_]{2,})=[^\s]+')                 # KEY=value → KEY=<v>
+_HOST_RE = re.compile(r'\b[a-z0-9-]+(?:\.[a-z0-9-]+)*\.(?:internal|local|corp|lan|intra)\b')
+def mask(t):
+    # Labels and probe tokens are an OUTPUT surface (close-check stdout, pasted into cards) — so
+    # the masking is not "the operator's own paths" but every absolute path, every KEY=value and
+    # every host-like name (codex finding 5, 2026-09-05). The suffix list is a small frozen
+    # judgment; it fails loud (an unmasked host shows up in a label), not silent.
+    t = _TMP_RE.sub('<tmp>', t)
+    if _HOME and len(_HOME) > 4:
+        t = t.replace(_HOME, '$HOME')
+    t = _PATH_RE.sub('<path>', t)
+    t = _KV_RE.sub(r'\1=<v>', t)
+    t = _HOST_RE.sub('<host>', t)
+    return t
+
+# 조사/어미 — 토큰 끝에서 벗긴다. 긴 것부터 시도한다(짧은 게 먼저 맞으면 덜 벗겨진다).
+PARTICLES = ['으로는', '에서는', '에게는', '이라고', '으로도', '까지는', '부터는',
+             '으로', '에서', '에게', '한테', '처럼', '보다', '라고', '하고', '까지',
+             '부터', '이나', '든지', '마다', '조차', '밖에', '이란', '이든',
+             '은', '는', '이', '가', '을', '를', '에', '의', '로', '도', '만', '과', '와']
+
+# 불용어 — 이 코퍼스에서 흔해서 «우연 일치» 를 만드는 것들. OR 결합이라 여기가 fail-open 의
+# 주된 입구다(§명명된 잔여 ⓑ). 길이 규칙만으로는 안 걸러진다.
+STOP = set('''그리고 그러니까 그래서 그러면 그런데 이렇게 그렇게 어떻게 하지만 그러나
+마찬가지 이야기 생각 경우 부분 내용 확인 진행 작업 파일 세션 지금 다음 이번 정도
+사람 방법 이유 상태 결과 문제 대해 위해 통해 우리 너는 나는 것을 것이 거기 여기 저기
+해줘 하자 하는 되는 있는 없는 같은 같이 좋은 다시 먼저 아직 이제 조금 그냥 바로
+this that with from have been will your about would should could there which their
+path host tmp home HOME
+then than when what where because those these into over under more most only just'''.split())
+
+def strip_particle(tok):
+    if not re.match(r'^[\uac00-\ud7a3]+$', tok):
+        return tok
+    for p in PARTICLES:
+        if tok.endswith(p) and len(tok) - len(p) >= 2:
+            return tok[:-len(p)]
+    return tok
+
+n_rows = 0
+n_unprobeable = 0
+for line in sys.stdin:
+    line = line.rstrip('\n')
+    if not line:
+        continue
+    parts = line.split('\t', 2)
+    if len(parts) < 3:
+        continue
+    idx, _ts, text = parts
+    text = mask(text)
+    toks = re.findall(r'[\uac00-\ud7a3]+|[A-Za-z0-9_]+', text)
+    cand = []
+    seen = set()
+    for t in toks:
+        s = strip_particle(t)
+        if s in seen or s in STOP or s.lower() in STOP:
+            continue
+        if re.match(r'^[\uac00-\ud7a3]+$', s):
+            if len(s) < 3:
+                continue
+        else:
+            if len(s) < 4 or s.isdigit():
+                continue
+        seen.add(s)
+        cand.append(s)
+    # 가장 긴 것부터 3 개. 동률은 먼저 나온 것(발화 앞쪽이 대개 주제어).
+    cand.sort(key=lambda s: -len(s))
+    keys = cand[:3]
+    if not keys:
+        # 프로브를 만들 수 없는 발화 — **버리지 않고 센다**(not found != 0).
+        n_unprobeable += 1
+        MAP.write("%s\tUNPROBEABLE\t%s\t0\n" % (idx, text[:60]))
+        continue
+    label = "#%s %s" % (idx, text[:40])
+    # One TARGET row per key: `#<idx>.<k>/<n> <text>` — the wrapper re-aggregates per utterance
+    # (codex finding 1). Keys are bare tokens ([가-힣]+ / [A-Za-z0-9_]+): no ERE metacharacters,
+    # never dash-first, so the landing checker reads them as literals.
+    for k_i, key in enumerate(keys, 1):
+        print("TARGET\t%s\t#%s.%d/%d %s" % (key, idx, k_i, len(keys), text[:36]))
+    MAP.write("%s\t%s\t%s\t%d\n" % (idx, label, text[:60], len(keys)))
+    n_rows += 1
+MAP.close()
+sys.stderr.write("probe utterances=%d · 프로브불가=%d\n" % (n_rows, n_unprobeable))
+PY
+  python3 "$_py" "$1"
+}
+
+# ── 인자 ────────────────────────────────────────────────────────────────────
+if [ "$#" -lt 2 ]; then
+  echo "usage: $0 <transcript.jsonl> <record-file> [<record-file>...]" >&2
+  exit 10
+fi
+TRANSCRIPT="$1"; shift
+RECORDS=()                       # 배열 — zsh word-split 에 의존하지 않는다
+MISSING_RECORDS=0
+for f in "$@"; do
+  if [ -f "$f" ]; then RECORDS+=("$f"); else MISSING_RECORDS=$((MISSING_RECORDS+1)); fi
+done
+
+[ -f "$EXTRACTOR" ] || _die10 "🟥 HARNESS-ERROR: 추출기 없음: $EXTRACTOR"
+[ -f "$LANDING" ]   || _die10 "🟥 HARNESS-ERROR: 착지 검사기 없음: $LANDING"
+
+if [ ! -f "$TRANSCRIPT" ]; then
+  echo "ℹ️  UNMEASURED — 전사본 부재: $TRANSCRIPT"
+  # 🟥 성공 판정 리터럴(«전부 착지»)을 **부정문 안에도** 쓰지 마라 — grep 하는 쪽이
+  #    성공으로 읽는다(Grep-Collision Treadmill). 레인 L7c 가 실제로 그렇게 오독했다.
+  echo "    부재를 0 으로 접지 마라 — 발화가 없었다는 뜻도, 다 적혔다는 뜻도 아니다."
+  exit 10
+fi
+if [ "${#RECORDS[@]}" -eq 0 ]; then
+  echo "ℹ️  UNMEASURED — 검사할 기록 파일이 하나도 없다 (인자 $# 건 중 $MISSING_RECORDS 건 부재)"
+  echo "    기록이 없는 것과 발화가 안 적힌 것은 다른 명제다."
+  exit 10
+fi
+
+WORK="$(mktemp -d 2>/dev/null)" || _die10 "🟥 HARNESS-ERROR: mktemp -d 실패 (환경 부재이지 계기 결함이 아니다)"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+# ── 1. 발화 추출 ────────────────────────────────────────────────────────────
+# `--strip-system-markers`: peer 알림 · 무인 실행 · 이미지 마커는 **운영자 발화가 아니다**.
+# seal 은 이 플래그를 안 주므로 기존 원장 출력은 그대로다(레인 L10 골든이 그걸 고정한다).
+python3 "$EXTRACTOR" "$TRANSCRIPT" --min-chars "$MIN_CHARS" --strip-system-markers \
+  > "$WORK/utts.tsv" 2> "$WORK/extract.err"
+_erc=$?
+if [ "$_erc" -ne 0 ]; then
+  echo "🟥 HARNESS-ERROR: 발화 추출 실패 (rc=$_erc)"; sed 's/^/    /' "$WORK/extract.err"; exit 10
+fi
+N_UTT=$(_num "$(grep -c . "$WORK/utts.tsv" 2>/dev/null)")
+if [ "${N_UTT:-0}" -eq 0 ]; then
+  echo "ℹ️  UNMEASURED — 추출된 발화 0 건 (min-chars=$MIN_CHARS)"
+  sed 's/^/    /' "$WORK/extract.err"
+  echo "    빈 프로브 세트는 합격이 아니다 — «아무것도 안 쟀다» 다."
+  exit 10
+fi
+
+# ── 2. 프로브 생성 (컨트롤 2 종 먼저) ───────────────────────────────────────
+TODAY="$(date +%Y-%m-%d)"
+NEG_TOKEN="${FH_INTAKE_NEG_TOKEN:-}"
+if [ -z "$NEG_TOKEN" ]; then
+  # 무작위. `date +%N` 은 BSD 에 없으므로 쓰지 않는다.
+  NEG_TOKEN="FHNEG$(od -An -N6 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n' | tr 'a-f' 'A-F')"
+  case "$NEG_TOKEN" in FHNEG) NEG_TOKEN="FHNEG$$X$(date +%s)" ;; esac
+fi
+{
+  _control_rows "$TODAY" "$WORK" "${RECORDS[@]}"
+  printf 'NEGATIVE\t%s\t무작위토큰(음성컨트롤)\n' "$NEG_TOKEN"
+} > "$WORK/probes.tsv"
+_build_probes "$WORK/probes.map" "$WORK" < "$WORK/utts.tsv" >> "$WORK/probes.tsv" 2> "$WORK/build.err"
+[ -n "${FH_INTAKE_DUMP_PROBES:-}" ] && cp "$WORK/probes.tsv" "$FH_INTAKE_DUMP_PROBES" 2>/dev/null
+N_TARGET=$(_num "$(grep -c "^TARGET$(printf '\t')" "$WORK/probes.tsv" 2>/dev/null)")
+N_PROBED=$(_num "$(LC_ALL=C awk -F'\t' '$2!="UNPROBEABLE"' "$WORK/probes.map" 2>/dev/null | grep -c .)")
+UNPROBE=$(_num "$(LC_ALL=C awk -F'\t' '$2=="UNPROBEABLE"' "$WORK/probes.map" 2>/dev/null | grep -c .)")
+if [ "${N_TARGET:-0}" -eq 0 ]; then
+  echo "ℹ️  UNMEASURED — 발화 $N_UTT 건에서 프로브를 하나도 못 만들었다"
+  sed 's/^/    /' "$WORK/build.err"
+  exit 10
+fi
+# 양성 컨트롤이 하나도 안 나왔으면(기록이 짧아 4자+ 한글 / 5자+ 영숫자 토큰이 없다) 계기를 돌리지
+# 않는다 — 착지 검사기도 CONTROL 부재에 rc=10 을 내지만, 그 메시지는 «계기 사망» 이고 여기 원인은
+# «컨트롤을 만들 재료가 없다» 라 다르다(codex finding 7). 둘 다 UNMEASURED 다.
+N_CTL=$(_num "$(grep -c "^CONTROL$(printf '\t')" "$WORK/probes.tsv" 2>/dev/null)")
+if [ "${N_CTL:-0}" -eq 0 ]; then
+  echo "ℹ️  UNMEASURED — 기록에서 양성 컨트롤 토큰을 못 뽑았다(4자+ 한글 · 5자+ 영숫자 토큰 부재, 오늘 날짜도 없음)"
+  echo "    컨트롤 없는 착지 판정은 근거가 아니다 — 기록이 너무 짧다."
+  exit 10
+fi
+
+# ── 3. 음성 컨트롤 — 하위 도구가 모르는 종류라 여기서 검사한다 ─────────────
+# `grep -F` : 토큰을 리터럴로 본다. 정규식으로 해석되면 «없어야 할 것» 의 의미가 바뀐다.
+if grep -qF -- "$NEG_TOKEN" "${RECORDS[@]}" 2>/dev/null; then
+  echo "🟥 HARNESS-ERROR: 음성 컨트롤이 기록에서 잡혔다 — [$NEG_TOKEN]"
+  echo "    없어야 마땅한 토큰이 잡힌다 = 계기가 아무거나 잡고 있다. 타깃 결과는 인쇄하지 않는다."
+  exit 10
+fi
+
+# ── 4. 착지 검증 (양성 컨트롤은 하위 도구가 본다) ───────────────────────────
+LAND_OUT="$WORK/land.txt"
+bash "$LANDING" "$WORK/probes.tsv" "${RECORDS[@]}" > "$LAND_OUT" 2>&1
+LRC=$?
+
+# 🟥 판정은 **종료코드**로 낸다. 아래 파싱은 «사람이 읽을 목록» 을 만들 뿐이고, 둘이 어긋나면
+#    그 자체가 신호다(`[[feedback_summary_parsing_hides_failure]]` · 두 신호의 어긋남).
+ROW_MISS=$(_num "$(grep -c '미착지$' "$LAND_OUT" 2>/dev/null)")
+# 발화 단위 집계 — 행(토큰)의 착지/미착지를 `#idx.k/n` 라벨로 발화에 되돌리고, ⌈n/2⌉ 이상 착지면
+# 그 발화는 착지다. 출력: LANDED / UNLANDED 개수 + 미착지 발화 idx 목록.
+_AGG="$WORK/agg.py"
+cat > "$_AGG" <<'AGGPY'
+import re, sys
+land, mapf = sys.argv[1], sys.argv[2]
+n_keys = {}
+for line in open(mapf, errors='replace'):
+    parts = line.rstrip('\n').split('\t')
+    if len(parts) >= 4 and parts[1] != 'UNPROBEABLE':
+        n_keys[parts[0]] = int(parts[3])
+hits = {}
+row_re = re.compile(r'^\s*(✅|🟥)\s+#(\d+)\.(\d+)/(\d+)\s')
+for line in open(land, errors='replace'):
+    m = row_re.match(line)
+    if not m:
+        continue
+    idx = m.group(2)
+    n_keys.setdefault(idx, int(m.group(4)))
+    if m.group(1) == '✅':
+        hits[idx] = hits.get(idx, 0) + 1
+landed, unlanded = [], []
+for idx in sorted(n_keys, key=int):
+    n = n_keys[idx]
+    need = (n + 1) // 2
+    (landed if hits.get(idx, 0) >= need else unlanded).append(idx)
+print("LANDED=%d" % len(landed))
+print("UNLANDED=%d" % len(unlanded))
+print("UNLANDED_IDX=%s" % " ".join(unlanded))
+AGGPY
+_AGG_OUT="$(python3 "$_AGG" "$LAND_OUT" "$WORK/probes.map" 2>/dev/null)"
+HIT_N=$(_num "$(printf '%s\n' "$_AGG_OUT" | sed -n 's/^LANDED=//p')")
+MISS_N=$(_num "$(printf '%s\n' "$_AGG_OUT" | sed -n 's/^UNLANDED=//p')")
+MISS_IDX="$(printf '%s\n' "$_AGG_OUT" | sed -n 's/^UNLANDED_IDX=//p')"
+
+echo "── 발화 착지 검사 ──"
+echo "   전사본   : $TRANSCRIPT"
+echo "   기록 대상: ${#RECORDS[@]} 파일$([ "$MISSING_RECORDS" -gt 0 ] && printf ' (부재 %s 건 제외)' "$MISSING_RECORDS")"
+echo "   추출     : 발화 $N_UTT 건 (min-chars=$MIN_CHARS) → 프로브 발화 $N_PROBED 건 (토큰 행 $N_TARGET) · 프로브불가 $UNPROBE 건"
+sed 's/^/   /' "$WORK/build.err" 2>/dev/null
+sed 's/^/   /' "$WORK/extract.err" 2>/dev/null
+
+case "$LRC" in
+  10)
+    echo
+    sed 's/^/   /' "$LAND_OUT"
+    echo "   🟥 계기 사망 — 착지 판정을 내지 않는다(죽은 계기의 출력은 데이터가 아니다)."
+    exit 10 ;;
+esac
+
+if [ "$LRC" -eq 0 ] && [ "$ROW_MISS" -ne 0 ]; then
+  echo "🟥 HARNESS-ERROR: rc=0 인데 미착지 행이 $ROW_MISS 개 — 두 신호가 어긋난다. 원문:"
+  sed 's/^/   /' "$LAND_OUT"; exit 10
+fi
+if [ "$LRC" -eq 1 ] && [ "$ROW_MISS" -eq 0 ]; then
+  echo "🟥 HARNESS-ERROR: rc=1 인데 미착지 행이 0 개 — 두 신호가 어긋난다. 원문:"
+  sed 's/^/   /' "$LAND_OUT"; exit 10
+fi
+if [ $((HIT_N + MISS_N)) -ne "$N_PROBED" ]; then
+  echo "🟥 HARNESS-ERROR: 발화 집계 $HIT_N+$MISS_N ≠ 프로브 발화 $N_PROBED — 집계기가 행을 잃었다. 원문:"
+  sed 's/^/   /' "$LAND_OUT"; exit 10
+fi
+
+echo "   착지 $HIT_N · 미착지 $MISS_N · 프로브불가 $UNPROBE   (행: 착지 $((N_TARGET - ROW_MISS)) · 미착지 $ROW_MISS · 판정 = 발화 토큰 ⌈n/2⌉ 이상)"
+if [ "$MISS_N" -gt 0 ]; then
+  echo
+  echo "   미착지 목록 (발화 앞 60자):"
+  # 라벨의 `#<n>` 으로 map 을 되짚는다. 숫자 비교라 비ASCII 동등성 함정에 안 걸린다
+  # (`[[feedback_locale_string_equality_breaks_nonascii]]`).
+  for _k in $MISS_IDX; do
+    LC_ALL=C awk -F'\t' -v k="$_k" '$1==k{printf "     · %s\n", $3}' "$WORK/probes.map"
+  done
+fi
+# 프로브불가 발화는 «못 쟀다» 지 «착지» 가 아니다 — 미착지와 별개로 세되 rc 에는 같이 든다
+# (codex finding 2: MISS_N=0 이면 조용히 rc=0 이던 것을 닫음). 사람이 확인할 목록으로 낸다.
+if [ "${UNPROBE:-0}" -gt 0 ]; then
+  echo
+  echo "   프로브불가 $UNPROBE 건 (키 낱말을 못 뽑은 발화 — 미측정, 착지 아님. 눈으로 확인):"
+  LC_ALL=C awk -F'\t' '$2=="UNPROBEABLE"{printf "     · %s\n", $3}' "$WORK/probes.map"
+fi
+if [ "$MISS_N" -gt 0 ] || [ "${UNPROBE:-0}" -gt 0 ]; then
+  echo
+  echo "   ⚠️ rc=1 은 «기록하라» 가 아니라 «확인하라» 다 — 프로브 노후가 첫 번째 의심 대상이다."
+  echo "      가장 잘 빠지는 것은 잊은 발화가 아니라 **행동으로 대응한 발화**다."
+  exit 1
+fi
+echo "   ✅ 프로브 발화 $N_PROBED 건 전부 착지 (발화별 최장 토큰 ≤3 중 ⌈n/2⌉ 이상 일치)"
+echo "   ⚠️ 키 2 개 이하 발화는 하나만 겹쳐도 착지다 — «제대로 적혔다» 의 증명이 아니다."
+exit 0


### PR DESCRIPTION
## 무엇 (엔진 강화 — 질문하기 «받는 절반»)
ENGINE_REVIEW_2026-09-05 판정: 4대 엔진은 동급이 아니고, 얇은 곳은 «운영자 발화 → 기록 착지»(산문 규율만, 계기 0). 이미 있던 두 계기(`compaction_probe seal` · `utterance_landing_check`)를 잇는 빠진 칸을 짓고 마감 체인에 **advisory** 로 붙인다.

- `scripts/transcript_utterances.py` — 전사본 JSONL → 사람이 친 `type=user` 만(tool_result 봉투 · 슬래시 커맨드 · 시스템 마커 제외) · seal 과 공용
- `scripts/utterance_intake.sh` — 발화(≥20자)마다 최장 토큰 프로브 → 오늘자 `tracks/_meta/**` 기록에 grep · 양성(기록 파생 토큰)/음성 컨트롤 · 사설 토큰 마스킹 · rc 0/1/2/10
- `scripts/session_close_check.sh` **①-f** (advisory — ❌ 개수 불변, 차단 안 함) · `compaction_probe.sh` 는 공용 추출기로 리팩터(**seal 출력 바이트 동일**, 되돌림 컨트롤 L12)
- CLAUDE.md 마감 체인에 ①-f 3줄 · files[] +3 · selfcheck 등록

## 검증
- 레인 `test_utterance_intake_lanes.sh` **51/51** — fail-before rc=2(subject absent) · 구현 1차 21/8(실결함 4: heredoc 이 python stdin 을 먹음 · `grep -c || echo 0` 이중 출력 · 성공 리터럴을 부정문에 · ①-e 선점) · L18 이 행복 경로 전체를 **실행**(①-f 분기 + 미착지 목록) · L18c 가 advisory 성질(❌ 불변) 고정
- **sim 사전등록 봉인**(sha256 a14a678d…, 첫 팔보다 9초 앞) — ARM 0/3 · CTRL 0/3. 🟥 **귀속 보류**: 세 팔 전부 착지 지점으로 `memory/`(레포 밖)를 골랐고 러너의 경로 격리가 막았다(WRITECTL 1/1 로 클론 안 `tracks/` 쓰기는 가능 확인). 성립하는 것 = «플로어 티어 3/3 이 레포 기록면에 안 적었다 · 3/3 이 레포 밖을 골랐다». 2단계(계기가 그 발화를 미착지로 잡는가) 3/3
- **첫 실사용**(라이브 전사본): 미착지 **2 건 진짜 적발**(플랫폼 층위 발화 · 레드/블루팀 질문) → 거버너가 fh_completed 에 착지 처분. 첫 실사용이 레인·적대검증이 못 잡은 결함 3 종을 즉시 잡음(이미지 플레이스홀더 계상+절대경로 유출 · 압축 프리앰블 계상 · 날짜 양성 컨트롤 거짓 경보) → 레인으로 굳힘
- 임무 진단 오류 정정: ①-e 는 STRAY PATH 가 이미 선점 → 새 블록은 ①-f
- **cross-family codex(gpt-5.5) 11건 → 수리 8 · 반박 3** — S: OR 프로브가 «주제어 하나만 겹쳐도 착지» → **토큰마다 한 행 + 발화 ⌈n/2⌉ 과반**(키 2개는 OR 잔여 명시) · 프로브불가 발화가 rc=0 에 묻힘 → 목록 + rc=1 · 컨트롤 재료 없음 → 별도 UNMEASURED(rc=10) · A: isMeta/isSidechain 레코드 계상 → 제외(라이브 전사본 실측 1/379 = 이미지 플레이스홀더; seal 원장이 정확히 그 한 줄 달라짐) · 마스킹이 $HOME 뿐 → 모든 절대경로·KEY=value·host 형 · L18c exit code 미비교 → L18e · L13b 가 «없음» 분기로도 통과 → 설치 분기 문구 + L13c · B: 주석 ①-e→①-f. 반박: tool_result+text 혼합(라이브 0/379, 인터럽트 마커 오계상 위험) · 한글 n-gram(판단 기계, 과차단 방향 잔여) · selfcheck 백틱 캐리어(선재 관용구)
- 레인 **72/72** — 수리 전(에이전트판) 스크립트 위에 새 레인 **15 적색**(L4b·L14·L19~L23) → 수리본 72/72 · 복원 byte-identical
- 거버너 첫 실사용(수리본, 라이브 전사본 vs 오늘 기록 7 파일): 과반 규칙 미착지 3 = 전부 «의역으로 착지» 한 발화(붙여쓰기 «가속화하기위한» vs «가속화하기 위한» = R-4) → 축자 인용으로 착지 → 재실행 4/4. 🟥 R-8 신설: 턴 도중 도착한 운영자 메시지는 전사본에 user 레코드가 아니라 tool_result 봉투 안 텍스트라 추출기 시야 밖
- selfcheck 전수(rebased) · pkgcov · lane_runner · degrade 0 · residency CLEAN(files=8, `intranet` 접미가 패턴에 걸려 마스크 목록에서 제거) · pre-commit 1차 차단 3(claim 기록 · 픽스처 `/Users/…` MED · CLAUDE.md +3줄 상주 유입 → `residency: disambiguator`) 해소

## 잔여(이름으로)
R-8 턴 도중 메시지는 tool_result 봉투 안이라 추출기가 못 본다 · R-3 키 2 개 이하 발화는 OR · R-1 기록면이 `tracks/**` 뿐 — `memory/`·컴패니언 스토어 착지는 미착지로 뜬다(과차단 방향, 소음의 주 출처 후보; env 확장은 운영자 결정) · R-2 seal 쪽 `/` 접두 오분류 잔존(고치면 바이트 동일이 깨져 운영자 판단) · R-3 OR 결합 프로브는 fail-open 방향(rc=0 ≠ «제대로 적혔다») · R-5 `claude -p` 는 한 턴이라 실세션 충실도 한계 · R-6 sim 귀속 보류 · R-7 불용어 목록은 작은 굳은 판단
## 노출 사다리
①-f 는 advisory · 3 세션 관찰 후 close push 차단 승격 여부 = 운영자 결정
