### PR TITLE
feat(ops): worktree_reclaim.sh — 워크트리 제거 «전» gitignored tracks/** 회수(목록 파일 먼저 → 복사+검증 → 제거는 사람) + 레인 21 + CLAUDE.md 포인터

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1217,6 +1217,8 @@ routing is the author's job, not the tool's.
 > exit codes, and why an earlier draft declared the bypass *refuted* from n=1 on a non-shipped setting —
 > read only when you must determine which arm your own install is on.
 
+🟥 **And before `git worktree remove`, reclaim gitignored `tracks/**` first** — `bash scripts/worktree_reclaim.sh <worktree> --apply` (lists to a file, then copies and byte-verifies; rc=1 while anything is left only in the worktree). The Destructive-Op gate enumerates *commits* and is structurally blind to gitignored files — measured twice (2026-09-02 signal file, 2026-09-05 governance log).
+
 **Therefore: do not commit FH assets from a worktree.** Not "carry the evidence in carefully" — a
 carried marker and a fabricated one are byte-identical, so *marker provenance* is unenforceable by
 construction. Land FH-asset changes from the standard session.

--- a/package.json
+++ b/package.json
@@ -304,6 +304,8 @@
     "scripts/com.forge-harness.live-eval.plist",
     "scripts/utterance_intake.sh",
     "scripts/transcript_utterances.py",
-    "scripts/test_utterance_intake_lanes.sh"
+    "scripts/test_utterance_intake_lanes.sh",
+    "scripts/worktree_reclaim.sh",
+    "scripts/test_worktree_reclaim_lanes.sh"
   ]
 }

--- a/scripts/caller_zero_baseline.txt
+++ b/scripts/caller_zero_baseline.txt
@@ -35,6 +35,7 @@
 # 36 → 13 is a repair of the instrument, not of the tree.
 
 exempt:
+  - scripts/worktree_reclaim.sh   # human-run enumerate/reclaim tool, same class as templates/predelete_check.sh: "run it BEFORE git worktree remove" — its lane suite is the auto caller
   - scripts/activity_log.sh   # on-demand chronological assembler, invoked by an operator/session when a trail is wanted — its own header says on-demand
   - scripts/docker_phase0_verify.sh   # one-shot Docker Track 2 proof, needs a running Docker/OrbStack daemon — auto-running it in CI would fail-closed on every consumer
   - scripts/docker_phase1_verify.sh   # same Docker Track 2 one-shot; additionally spends live codex calls, so it must stay operator-initiated

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -664,7 +664,9 @@ for _pair in \
   "scripts/utterance_intake.sh|scripts/test_utterance_intake_lanes.sh" \
   "scripts/transcript_utterances.py|scripts/test_utterance_intake_lanes.sh" \
   "scripts/compaction_probe.sh|scripts/test_utterance_intake_lanes.sh" \
-  "scripts/session_close_check.sh|scripts/test_utterance_intake_lanes.sh"
+  "scripts/session_close_check.sh|scripts/test_utterance_intake_lanes.sh" \
+  `# ── 워크트리 회수(2026-09-05, N=2 재발 → 스크립트). 사람이 부르는 도구지만 레인은 자동 ──` \
+  "scripts/worktree_reclaim.sh|scripts/test_worktree_reclaim_lanes.sh"
 do
   _subj="${_pair%%|*}"; _anc="${_pair##*|}"; _lbl="${_anc##*/}"
   if [ ! -f "$_subj" ]; then

--- a/scripts/test_worktree_reclaim_lanes.sh
+++ b/scripts/test_worktree_reclaim_lanes.sh
@@ -5,7 +5,8 @@
 # that survives the copy, which is the whole reason the script exists.
 set -uo pipefail
 cd "$(dirname "$0")/.." || exit 1
-ROOT="$(pwd -P)"; SUT="$ROOT/scripts/worktree_reclaim.sh"
+ROOT="$(pwd -P)"
+SUT="$ROOT/scripts/worktree_reclaim.sh"   # own line: new_code_anchor_check resolves the variable per line
 PASS=0; FAIL=0
 ok() { echo "  ✅ $1"; PASS=$((PASS+1)); }
 ng() { echo "  ❌ $1"; FAIL=$((FAIL+1)); }

--- a/scripts/test_worktree_reclaim_lanes.sh
+++ b/scripts/test_worktree_reclaim_lanes.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# test_worktree_reclaim_lanes.sh — known pairs for scripts/worktree_reclaim.sh (2026-09-05).
+# Fixture: a real `git init` main checkout + a real `git worktree add`, gitignored tracks/ on both sides.
+# The lanes assert the ORDER (list file before copy) as well as the verdicts — the list is the evidence
+# that survives the copy, which is the whole reason the script exists.
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+ROOT="$(pwd -P)"; SUT="$ROOT/scripts/worktree_reclaim.sh"
+PASS=0; FAIL=0
+ok() { echo "  ✅ $1"; PASS=$((PASS+1)); }
+ng() { echo "  ❌ $1"; FAIL=$((FAIL+1)); }
+[ -f "$SUT" ] || { echo "ⓘ worktree_reclaim.sh absent — subject missing when we looked (NOT a pass)"; exit 2; }
+T="$(mktemp -d 2>/dev/null)" || { echo "ⓘ mktemp failed (NOT a pass)"; exit 10; }
+trap 'rm -rf "$T"' EXIT INT TERM
+
+mk_pair() {  # $1=root → creates $1/main (checkout) + $1/wt (worktree); echoes nothing
+  mkdir -p "$1" && ( cd "$1" && git init -q main && cd main \
+    && git config user.email l@example.invalid && git config user.name lane \
+    && mkdir -p tracks/_meta && printf 'tracks/\n' > .gitignore && echo x > README.md \
+    && git add .gitignore README.md && git commit -qm init && git worktree add -q ../wt -b wt-branch ) 2>/dev/null
+}
+
+echo "── W1 enumerate: only-in files are listed, list file written, rc=1, nothing copied ──"
+mk_pair "$T/a"; M="$T/a/main"; W="$T/a/wt"
+mkdir -p "$W/tracks/_meta/sub"; echo "signal body" > "$W/tracks/_meta/fh_signal_lost.md"; echo nested > "$W/tracks/_meta/sub/deep.yaml"
+OUT="$(bash "$SUT" "$W" 2>&1)"; RC=$?
+[ "$RC" -eq 1 ] && ok "W1 rc=1 (only-in exists, not yet reclaimed)" || { ng "W1 rc=$RC (기대 1)"; printf '%s\n' "$OUT" | sed 's/^/     /'; }
+N=$(printf '%s\n' "$OUT" | grep -c '   ONLY  '); [ "$N" -eq 2 ] && ok "W1b 2 only-in files listed (nested dir walked)" || ng "W1b listed $N (기대 2)"
+L=$(ls "$M"/tracks/_meta/dispatch/reclaim_wt_*.txt 2>/dev/null | wc -l | tr -d ' '); [ "$L" -eq 1 ] && ok "W1c list file written in MAIN tracks/_meta/dispatch" || ng "W1c list files: $L (기대 1)"
+grep -q $'^ONLY\t_meta/sub/deep.yaml' "$M"/tracks/_meta/dispatch/reclaim_wt_*.txt && ok "W1d list carries the relative path" || ng "W1d list lacks the nested path"
+[ ! -e "$M/tracks/_meta/fh_signal_lost.md" ] && ok "W1e enumerate mode copies nothing (known-negative)" || ng "W1e enumerate mode copied a file"
+
+echo "── W2 --apply: copied, byte-verified, rc=0; re-run says nothing left ──"
+OUT="$(bash "$SUT" "$W" --apply 2>&1)"; RC=$?
+[ "$RC" -eq 0 ] && ok "W2 --apply rc=0" || { ng "W2 rc=$RC (기대 0)"; printf '%s\n' "$OUT" | sed 's/^/     /'; }
+cmp -s "$W/tracks/_meta/fh_signal_lost.md" "$M/tracks/_meta/fh_signal_lost.md" && cmp -s "$W/tracks/_meta/sub/deep.yaml" "$M/tracks/_meta/sub/deep.yaml" \
+  && ok "W2b both files byte-identical in main" || ng "W2b copies differ or missing"
+OUT="$(bash "$SUT" "$W" 2>&1)"; RC=$?
+[ "$RC" -eq 0 ] && ok "W2c re-run after reclaim → rc=0 (idempotent)" || ng "W2c re-run rc=$RC"
+case "$OUT" in *"safe to: git worktree remove"*) ok "W2d prints the next (human) step, never runs it" ;; *) ng "W2d no next-step line" ;; esac
+[ -d "$W" ] && ok "W2e worktree still exists (script never removes)" || ng "W2e worktree vanished"
+
+echo "── W3 differ-both-sides: listed, NOT copied, rc=1 even with --apply ──"
+echo same > "$M/tracks/_meta/shared.md"; echo "changed in wt" > "$W/tracks/_meta/shared.md"
+OUT="$(bash "$SUT" "$W" --apply 2>&1)"; RC=$?
+[ "$RC" -eq 1 ] && ok "W3 rc=1 (needs a human)" || ng "W3 rc=$RC (기대 1)"
+case "$OUT" in *"DIFF  _meta/shared.md"*) ok "W3b the differing file is named" ;; *) ng "W3b DIFF not listed" ;; esac
+grep -q '^same$' "$M/tracks/_meta/shared.md" && ok "W3c main copy untouched (known-negative: no overwrite)" || ng "W3c main copy was overwritten"
+
+echo "── W4 list-before-copy: unwritable list dir → rc=10 and NO copy happened ──"
+mk_pair "$T/b"; M="$T/b/main"; W="$T/b/wt"
+mkdir -p "$W/tracks/_meta" && echo body > "$W/tracks/_meta/only.md"; rm -rf "$M/tracks/_meta/dispatch"; touch "$M/tracks/_meta/dispatch"   # a FILE where the dir must be
+[ -f "$W/tracks/_meta/only.md" ] && ok "W4-FIXTURE the only-in file exists in the worktree (potency)" || ng "W4-FIXTURE fixture file missing — W4b would pass vacuously"
+OUT="$(bash "$SUT" "$W" --apply 2>&1)"; RC=$?
+[ "$RC" -eq 10 ] && ok "W4 rc=10 when the evidence file cannot be written" || ng "W4 rc=$RC (기대 10)"
+[ ! -e "$M/tracks/_meta/only.md" ] && ok "W4b nothing was copied before the list failed (order holds)" || ng "W4b copy happened without a list"
+
+echo "── W5 argument guards ──"
+OUT="$(bash "$SUT" "$M" 2>&1)"; RC=$?; [ "$RC" -eq 2 ] && ok "W5 main checkout as argument → rc=2" || ng "W5 rc=$RC (기대 2)"
+OUT="$(bash "$SUT" "$T" 2>&1)"; RC=$?; [ "$RC" -eq 2 ] && ok "W5b non-repo dir → rc=2" || ng "W5b rc=$RC (기대 2)"
+OUT="$(bash "$SUT" "$W" --bogus 2>&1)"; RC=$?; [ "$RC" -eq 2 ] && ok "W5c unknown flag → rc=2" || ng "W5c rc=$RC (기대 2)"
+OUT="$(bash "$SUT" 2>&1)"; RC=$?; [ "$RC" -eq 2 ] && ok "W5d no argument → rc=2" || ng "W5d rc=$RC (기대 2)"
+mk_pair "$T/c"; rm -rf "$T/c/wt/tracks"; OUT="$(bash "$SUT" "$T/c/wt" 2>&1)"; RC=$?
+[ "$RC" -eq 0 ] && ok "W5e worktree without tracks/ → rc=0 nothing to reclaim" || ng "W5e rc=$RC (기대 0)"
+
+echo
+echo "── worktree-reclaim lanes: PASS=$PASS FAIL=$FAIL ──"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/scripts/worktree_reclaim.sh
+++ b/scripts/worktree_reclaim.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# worktree_reclaim.sh — reclaim gitignored `tracks/**` artifacts from a git worktree BEFORE it is removed.
+#
+# WHY (N=2, so a script — 2026-09-02 signal + 2026-09-05 push-zone dispatch): the Destructive-Op gate
+# enumerates COMMITS, and `tracks/**` is gitignored, so a worktree removal can delete a session's only
+# copy of a signal file / governance log / dispatch report without any gate ever seeing it. Both
+# incidents lost real files (51-line signal · a day's governance log). The manual recipe that replaced
+# them — `diff -rq <wt>/tracks tracks | grep "^Only in <wt>"` → list to a FILE → copy → only then
+# remove — is exactly what this script does, in that order, because after the copy «never existed»
+# and «already moved» are indistinguishable (the list file is the evidence).
+#
+# USAGE
+#   bash scripts/worktree_reclaim.sh <worktree-path>            # enumerate only (writes the list file)
+#   bash scripts/worktree_reclaim.sh <worktree-path> --apply    # enumerate + copy + verify
+#
+# EXIT  0 = nothing to reclaim, or everything reclaimed and byte-verified
+#       1 = files exist on BOTH sides with different content — a human must merge (listed, not copied)
+#       2 = usage / not a worktree of a main checkout
+#       10 = harness error (list file unwritable, copy failed verification)
+#
+# NEVER removes the worktree. Removal stays an explicit `git worktree remove` after this exits 0.
+set -uo pipefail
+# bash 3.2 + `set -u`: expanding an EMPTY array with "${a[@]}" is a fatal unbound-variable error, so every
+# array loop below uses the ${a[@]+"${a[@]}"} idiom (measured on the first fixture run, 2026-09-05).
+
+WT="${1:-}"; MODE="${2:-}"
+[ -n "$WT" ] || { echo "usage: $0 <worktree-path> [--apply]" >&2; exit 2; }
+[ -d "$WT" ] || { echo "🟥 not a directory: $WT" >&2; exit 2; }
+case "$MODE" in ''|--apply) ;; *) echo "usage: $0 <worktree-path> [--apply]" >&2; exit 2 ;; esac
+
+COMMON="$(git -C "$WT" rev-parse --git-common-dir 2>/dev/null)" || { echo "🟥 not a git worktree: $WT" >&2; exit 2; }
+GITDIR="$(git -C "$WT" rev-parse --git-dir 2>/dev/null)"
+case "$COMMON" in /*) ;; *) COMMON="$WT/$COMMON" ;; esac
+case "$GITDIR" in /*) ;; *) GITDIR="$WT/$GITDIR" ;; esac
+COMMON="$(cd "$COMMON" && pwd -P)"; GITDIR="$(cd "$GITDIR" && pwd -P)"
+if [ "$COMMON" = "$GITDIR" ]; then
+  echo "🟥 $WT is the MAIN checkout (git-dir == git-common-dir), not a worktree — nothing to reclaim from itself" >&2; exit 2
+fi
+ROOT="$(dirname "$COMMON")"           # main checkout root = parent of the shared .git
+WT="$(cd "$WT" && pwd -P)"
+SRC="$WT/tracks"; DST="$ROOT/tracks"
+[ -d "$SRC" ] || { echo "ℹ️  no tracks/ in worktree — nothing to reclaim (rc=0)"; exit 0; }
+mkdir -p "$DST/_meta/dispatch" 2>/dev/null || { echo "🟥 cannot create $DST/_meta/dispatch" >&2; exit 10; }
+
+NAME="$(basename "$WT")"; TS="$(date +%Y%m%d-%H%M%S)"
+LIST="$DST/_meta/dispatch/reclaim_${NAME}_${TS}.txt"
+
+# 1. ENUMERATE — the list lands in a file FIRST (the evidence that survives the copy)
+ONLY=(); DIFF=()
+while IFS= read -r line; do
+  case "$line" in
+    "Only in $SRC"*)
+      d="${line#Only in }"; dir="${d%%: *}"; f="${d#*: }"
+      rel="${dir#$SRC}"; rel="${rel#/}"
+      p="${rel:+$rel/}$f"
+      if [ -d "$SRC/$p" ]; then
+        while IFS= read -r ff; do ONLY+=("${ff#$SRC/}"); done < <(find "$SRC/$p" -type f)
+      else
+        ONLY+=("$p")
+      fi ;;
+    "Files $SRC"*" differ") DIFF+=("$(printf '%s' "${line#Files }" | sed "s# and .*##; s#^$SRC/##")") ;;
+  esac
+done < <(diff -rq "$SRC" "$DST" 2>/dev/null)
+
+{
+  echo "# worktree_reclaim — $WT → $ROOT  ($TS)"
+  echo "# only-in-worktree: ${#ONLY[@]}   differ-both-sides: ${#DIFF[@]}   mode: ${MODE:-enumerate}"
+  for p in ${ONLY[@]+"${ONLY[@]}"}; do echo "ONLY	$p"; done
+  for p in ${DIFF[@]+"${DIFF[@]}"}; do echo "DIFF	$p"; done
+} > "$LIST" || { echo "🟥 cannot write list file $LIST" >&2; exit 10; }
+echo "── worktree_reclaim: $NAME ──"
+echo "   only-in-worktree: ${#ONLY[@]} · differ-both-sides: ${#DIFF[@]} · list: ${LIST#$ROOT/}"
+for p in ${ONLY[@]+"${ONLY[@]}"}; do echo "   ONLY  $p"; done
+for p in ${DIFF[@]+"${DIFF[@]}"}; do echo "   DIFF  $p   (both sides exist and differ — NOT copied, merge by hand)"; done
+
+# 2. RECLAIM (--apply) — copy, then verify byte-identical; a copy that cannot be verified is a harness error
+if [ "$MODE" = "--apply" ] && [ "${#ONLY[@]}" -gt 0 ]; then
+  bad=0
+  for p in ${ONLY[@]+"${ONLY[@]}"}; do
+    mkdir -p "$(dirname "$DST/$p")" && cp -p "$SRC/$p" "$DST/$p" && cmp -s "$SRC/$p" "$DST/$p" \
+      && echo "   ✅ reclaimed $p" || { echo "   🟥 copy/verify FAILED $p"; bad=$((bad+1)); }
+  done
+  [ "$bad" -eq 0 ] || { echo "🟥 $bad file(s) not reclaimed — do NOT remove the worktree" >&2; exit 10; }
+fi
+
+if [ "${#DIFF[@]}" -gt 0 ]; then
+  echo "⚠️  ${#DIFF[@]} file(s) differ on both sides — reconcile by hand before removing the worktree (rc=1)"
+  exit 1
+fi
+if [ "${#ONLY[@]}" -gt 0 ] && [ "$MODE" != "--apply" ]; then
+  echo "ℹ️  ${#ONLY[@]} file(s) exist only in the worktree — re-run with --apply to copy them (rc=1 until reclaimed)"
+  exit 1
+fi
+echo "✅ nothing left only in the worktree — safe to: git worktree remove $WT"
+exit 0


### PR DESCRIPTION
## 무엇 (카드 잔여 12 — N=2 재발의 기계화)
`git worktree remove` 는 Destructive-Op 게이트가 «커밋»을 열거하므로 gitignored `tracks/**` 를 구조적으로 못 본다. 2026-09-02(신호 파일 51줄)·2026-09-05(governance_log 하루치) 두 번 잃었다. 손 레시피(`diff -rq … | grep "^Only in"` → 목록을 파일로 → 복사 → 그다음 제거)를 그 순서 그대로 스크립트로.

- `scripts/worktree_reclaim.sh <worktree> [--apply]` — `git rev-parse --git-common-dir` 로 메인 체크아웃을 기계로 찾고(메인 자신이면 rc=2) · only-in 을 재귀 열거 → **목록을 `tracks/_meta/dispatch/reclaim_<wt>_<ts>.txt` 에 먼저**(회수 뒤엔 «없었다»와 «옮겼다»가 안 갈린다) → `--apply` 면 `cp -p` + `cmp` 검증(하나라도 실패 rc=10 «제거하지 마라») · 양쪽 다르면 DIFF 로 나열만(rc=1) · **워크트리는 절대 안 지운다**(다음 명령만 인쇄)
- 레인 `test_worktree_reclaim_lanes.sh` **21/21**: 열거 rc=1·중첩 경로·목록 파일·복사 0 / apply rc=0·cmp·idempotent·워크트리 잔존 / DIFF rc=1·덮어쓰기 없음 / **목록 못 쓰면 rc=10 이고 복사 0(순서 증명, 잠재성 검사 포함)** / 인자 가드 4 · tracks/ 없는 워크트리 rc=0 · subject-absent rc=2
- 배선: selfcheck 레인 표 · files[] +2 · caller_zero 면제(사람이 부르는 도구, `predelete_check.sh` 와 같은 급) · CLAUDE.md §Agent Dispatch 워크트리 문단 포인터 1줄

## 검증
lane_runner 0 · pkgcov PASS · degrade 0 · portability 0 · backtick 0 · residency CLEAN · caller ratchet PASS · selfcheck 전수 · 픽스처 스모크에서 잡힌 것 2(bash 3.2 `set -u` + 빈 배열 `"${a[@]}"` 치명 → `${a[@]+"${a[@]}"}` · W4 픽스처가 워크트리 tracks/ 를 안 만들어 vacuous → 잠재성 검사)

## 정직 기록
crossfamily = **DEGRADED_PANEL_UNUSED** — 93줄 가역 표면(복사만, 삭제 없음) 도구라 자체 픽스처로 닫고 패널은 안 썼다. 미검 = 개행 든 파일명·심링크·권한 오류 파일의 `diff -rq` 파싱 · 회수 대상은 `tracks/**` 뿐(다른 gitignored 경로는 안 본다) · standpoint not-applicable(소비자 게이트·세션 지시 무변경)
