### PR TITLE
fix(sync-to-be): destination guard fail-closed (rc=12) + recoverable-conflict grade (rc=2) — root identity · physical/git-identity pins · GIT_* unset · lanes 36→155 · codex ×5 converged

### DIFF
--- a/knowledge/shared/learnings/subagent_invocations_log.yaml
+++ b/knowledge/shared/learnings/subagent_invocations_log.yaml
@@ -3447,3 +3447,53 @@
   evidence: "mechanism = app HTTP PermissionRequest hook layer (src/permission-automation-policy.js:387 → src/permission.js:2246); L1 prototype feat/auto-approve-irreversible-guard 56d64f3d→99f262a1, npm test 9423/0 fail, fail-before 20/24 red → green; maintainer-persona codex review S0/A2/B2 all fixed (shell-alias tools were outside the badge allowlist → contract test 13 rows); integration test 8/8 (fake HTTP → real server.js → real permission.js, unattended + force-push → DEFER observed); Electron live run correctly REFUSED (single-instance lock bound to userData, would collide with the production app). Operator's «FH gate 가 지켜줍니다» wording rejected as over-promise; honest 7-language notice instead. Wall-clock 14:40→16:40 KST; sidecar 1"
   tokens_subagent: n/a (Orca session; sidecar codex ×1 unreported)
   notes: "phase 2: maintainer-persona codex review S0/A2/B2 all fixed (99f262a1) + isolated integration test 8/8; PR_DRAFT.md in contributor voice (#888 style, no internal vocabulary). Live run on a second machine (operator's MacBook Air, Claude session over Remote Control, mixed human/AI driving): 10 rows as expected, 0 false positives, known-pair controls, reps=1 — the private companion store handoff/LIVE_TEST_RESULT_2026-09-05.md; three runbook defects found there and folded back. Outward PR submission = operator decision ㉓"
+
+- date: 2026-09-05
+  agent: fh-meta:hub-persona-auditor (opus) — pre-publication audit of an external-facing issue draft
+  invoked_by: FH governor session (Fable 5.1 max)
+  task: "audit ISSUE_DRAFT_external-gate.md (proposal to an external Electron app repo: optional external review command, downgrade-only) as maintainer / unattended power user / first-time contributor (+ a security reader it added), 4-axis per section, 3-tier revisions; judge length; list sentences a maintainer would quote back as over-claims; how to name our tool once without turning it into a pitch"
+  context_card: yes
+  outcome: accepted
+  evidence: "SHIP_AFTER_MANDATORY — mandatory 3 (complete the exit-code table incl. 124/126/127/128+n → ask; name the tool and drop 'exactly'; say what happens to an unanswered card), strong 6 (move the bypass-mode limitation to the opening, plain vocabulary, we→I, 7 over-claims softened, sessionId for sequence state, blast radius, 0/non-zero minimum), recommended 6 — all applied; final issue posted as rullerzhou-afk/clawd-on-desk#995 (816 words)"
+  tokens_subagent: 116852
+  notes: "auditor could not read the target repo's issue list (length verdict reasoned, not calibrated) — stated up front; one reader persona (security) added by the auditor itself"
+
+- date: 2026-09-05
+  agent: codex exec (gpt-5.5, read-only) — cross-family adversarial review, round 2, of the sync-to-be destination guard
+  invoked_by: FH governor session (Fable 5.1 max) — prompt via stdin (payload > ARG_MAX), residency-scanned first
+  task: "re-attack the R2 patch (root identity · physical paths · atomic --init · COUNT anchoring · timeout): any path where a wrong destination still receives a write, any write before refusal, COUNT-line spoofing, --no-git existence, timeout portability, bash 3.2/BSD"
+  context_card: yes (R1 findings + author's disposition per finding, R2 diff, post-patch lines 1-200, sync-from-be arg parser/COUNT site)
+  outcome: accepted
+  evidence: "NOT-CONVERGED — 7 findings: S1 guard validates _be_phys once but writes through mutable $BE (symlink retarget TOCTOU) · S2 default BE derived from the LOGICAL $FH · A3 old git's --show-superproject-working-tree swallowed · A4 independent nested repo inside a foreign tree passes · B5 COUNT line spoofable by a newline-bearing file name · B6 mid-run 'not a git repo' belt exits 0 after writes · B7 lane gaps. Disposition: S1/S2/A3/B6 fixed, A4 declined with grounds (lane B8m pins it), B5 named residual, B7 → lanes B8k~B8o; mutants m1~m4 each red only on the predicted lane. 59,799 tokens, 265s"
+  tokens_subagent: 59799
+  notes: "A3's direction was wrong in detail — measured: `git rev-parse --<unknown option>` ECHOES the option with rc=0 (git 2.50), so the old code refused with a nonsense reason rather than passing; both variants now fail closed with the real reason. The finding was still right that the branch was unexamined"
+
+- date: 2026-09-05
+  agent: codex exec (gpt-5.5, read-only) — cross-family adversarial review, round 3, same subject
+  invoked_by: FH governor session (Fable 5.1 max) — stdin payload (R3-only deltas + full post-R3 script + lane helpers), username scrubbed before send (2 hits → 0)
+  task: "verify each R2 closure against the code; attack the pin's coverage, the lock-wait injection lanes for flakiness/wrong-reason passes, the git shim, the A4 decline, new set -e interactions, bash 3.2/BSD"
+  context_card: yes
+  outcome: accepted
+  evidence: "NOT-CONVERGED — S1 the mid-run belt checked only --is-inside-work-tree, so a nested independent repo (accepted by A4) that loses its .git is still 'inside' the ENCLOSING repo and git add/commit/push would land the private half there (real hole, opened by the A4 decision) · A2 `_fh_phys0=$(_phys \"$FH\")` under set -e kills the script silently (rc=1) for a nonexistent HUB_DIR before the rc=10 hub refusal · B3 lane for the nested-repo mid-run case. All three taken into R4 (belt re-runs _be_root_ok; `|| true`; lanes B8o2/B8p; mutants m5/m6). 54,009 tokens, 190s"
+  tokens_subagent: 54009
+  notes: "the S1 here is a direct consequence of declining A4 in R3 — accepting the nested-repo layout created a belt that could pass for the wrong repo; the fix keeps the decision and tightens the belt to the same ROOT check the guard uses"
+
+- date: 2026-09-05
+  agent: codex exec (gpt-5.5, read-only) — cross-family adversarial review, round 4, same subject (sync-to-be destination guard)
+  invoked_by: FH governor session (Fable 5.1 max) — stdin payload (R4-only deltas + full post-R4 script), username scrubbed
+  task: "verify the R4 closures (belt re-runs the ROOT check; set -e safe derivation; lanes B8o2/B8p); attack the belt's re-check, the lock-wait lanes, bash 3.2 `cd -P \"\"` semantics, portability"
+  context_card: yes
+  outcome: accepted
+  evidence: "NOT-CONVERGED — S1 `.git` swapped mid-run for a gitfile pointing at another repo whose toplevel is still $BE passes the path-only re-check · S2 repo-selecting GIT_* env (a git hook exports GIT_DIR) makes a plain directory pass the root check · B3 lane for the swap. Also settled two of the author's own questions with measurements: bash 3.2.57 and 5.3.15 both FAIL `cd -P \"\"` (no no-op hazard), and A2's `|| true` reaches rc=10. Taken into R5: `unset GIT_*` first line + git identity pin (absolute-git-dir · common-dir) compared at the belt + threat model in the header + lanes B8q/B8r + mutants m7/m8 (m8 measured: without the unset the run mirrors into the plain dir and exits 4 from the hub-equality belt — wrong reason, after the write). 53,241 tokens"
+  tokens_subagent: 53241
+  notes: "S2 is the realistic one (hook environments); S1 needs an actor rewriting the store mid-run — accepted as a cheap non-over-blocking belt, and the header now states the threat model so later rounds grade against it instead of escalating the adversary each round"
+
+- date: 2026-09-05
+  agent: codex exec (gpt-5.5, read-only) — cross-family adversarial review, round 5, same subject (sync-to-be destination guard)
+  invoked_by: FH governor session (Fable 5.1 max) — stdin payload (R5-only deltas + full post-R5 script), username scrubbed; prompt now carries the THREAT MODEL so severity is graded against it
+  task: "verify R5 closures (GIT_* unset; git identity pin compared at the belt; lanes B8q/B8r; mutants m7/m8); attack the unset list's completeness, --git-common-dir comparability (relative vs linked worktree vs separate-git-dir), legitimate concurrent ops that change identity mid-run, bash 3.2 quoting, B8q's symlinked-tmp comparison"
+  context_card: yes
+  outcome: accepted
+  evidence: "CONVERGED — S0 · A0 · B1 (lane race: B8q waits for the 'destination:' line, which was printed BEFORE the identity pin, so a fast swap could be recorded as the baseline). Explicitly cleared: unset list covers repo selection (GIT_PREFIX does not redirect; CEILING/DISCOVERY vars only push toward fail-closed); common-dir comparison is same-cwd on both reads and does not reject legitimate separate-git-dir stores. B1 fixed as prescribed (pins moved before the destination line; log prints BE_REQUESTED → BE), lanes re-run + mutant m7 re-run; no R6 dispatched — the fix is the reviewer's own one-liner and the re-run is the verification. 67,325 tokens"
+  tokens_subagent: 67325
+  notes: "5 rounds total (R1 worktree draft → R5): S findings 1·2·1·2·0 — the count stopped falling until the threat model was stated in the header; stating it is what let the reviewer grade the mid-run-adversary class as B instead of escalating each round"

--- a/scripts/sync-to-be.sh
+++ b/scripts/sync-to-be.sh
@@ -224,6 +224,15 @@ if [ -n "$_be_phys" ] && [ -n "$_fh_phys" ] && { [ "$_be_phys" = "$_fh_phys" ] |
   echo "   BE_DIR 을 고쳐라. (허브가 아닌 «별도» 저장소여야 한다)" >&2
   exit 4
 fi
+# --init hardening (found by CI, 2026-09-05): a store this script just created has no committer
+# identity of its own, and on a machine where git cannot auto-detect one (GitHub runners, some
+# containers — "unable to auto-detect email address") the FIRST commit dies with rc=128 after the
+# mirror already ran. A machine-local fallback identity is set in the new repo only, only when no
+# identity resolves from any scope; an operator's global identity is never overridden.
+_init_identity() {   # $1 = physical repo path
+  git -C "$1" config --get user.email >/dev/null 2>&1 || { git -C "$1" config user.email "sync-to-be@$(hostname -s 2>/dev/null || echo local)"; echo "[sync-to-be] --init: no git identity resolved — set a repo-local fallback (user.email sync-to-be@host)" >&2; }
+  git -C "$1" config --get user.name  >/dev/null 2>&1 || git -C "$1" config user.name "sync-to-be"
+}
 if [ "$INIT" = "1" ]; then
   if [ ! -e "$BE" ]; then
     # A4: atomic create — parent must already exist and be writable, ONE leaf level (`mkdir`, never
@@ -244,6 +253,7 @@ if [ "$INIT" = "1" ]; then
       echo "🚫 sync-to-be REFUSED (rc=12) — git init failed in $BE; the directory was removed again (zero trace)" >&2; exit 12
     fi
     _be_phys="$(_phys "$BE")"
+    _init_identity "$_be_phys"
     echo "[sync-to-be] --init: created companion store at $BE → $_be_phys (mkdir + git init -q)" >&2
   elif [ -d "$BE" ] && [ "$(git -C "$_be_phys" rev-parse --is-inside-work-tree 2>/dev/null || echo none)" = "none" ]; then
     # Only a directory that is inside NO work tree may be initialized — `git init` inside another
@@ -252,6 +262,7 @@ if [ "$INIT" = "1" ]; then
     if ! git -C "$_be_phys" init -q 2>/dev/null; then
       echo "🚫 sync-to-be REFUSED (rc=12) — git init failed in existing directory $BE" >&2; exit 12
     fi
+    _init_identity "$_be_phys"
     echo "[sync-to-be] --init: initialized git repo in existing directory $BE → $_be_phys" >&2
   fi
 fi

--- a/scripts/sync-to-be.sh
+++ b/scripts/sync-to-be.sh
@@ -12,7 +12,33 @@
 # list refuses (non-zero exit) rather than writing anywhere.
 # Runs from a CC Stop hook (throttled) or manually.
 # Override paths via env: HUB_DIR, BE_DIR.
-# Usage: bash scripts/sync-to-be.sh [--quiet]
+# Usage: bash scripts/sync-to-be.sh [--quiet] [--init]
+#   --init   explicitly CREATE the companion store at $BE (mkdir -p + git init -q, one log line saying
+#            what was made where). Without it a destination that is not an existing git work tree is
+#            REFUSED (rc=12) — a typo in BE_DIR / FH_COMPANION_STORE must never silently clone the
+#            private half somewhere new (fh_signal_2026-09-05_sync-guard-failopen-and-alarm-fatigue ⓐ).
+# EXIT:  0 = mirrored (or nothing to do)
+#        1 = destination-newer guard tripped and the return path does NOT recover it — or any set -e
+#            mid-run failure (fail-closed: a red wall, read it)
+#        2 = destination-newer, RECOVERABLE: another node advanced and `sync-from-be.sh --dry-run`
+#            reports review 0 — nothing was written; run the return path, then re-run (ⓑ, 2026-09-05).
+#            Nothing is recovered automatically — only the tone of the message changes.
+#        4 = companion store resolves to the hub itself (refuse to commit private content into the hub)
+#       10 = $FH is not a recognized hub ("not applicable here" — the Stop hook stamps on 0 or 10)
+#       12 = destination guard: $BE is not the ROOT of an existing git work tree (missing · not a dir ·
+#            subdirectory of another repo · bare · submodule · a git too old to rule out a submodule —
+#            compared by physical path) and --init was not given, or --init could not create it
+#            atomically (fail-closed: zero trace), or the store STOPPED being the root of its own work
+#            tree mid-run, or its git identity (git dir · common dir) changed mid-run (mirrored, nothing
+#            committed — R3 B6 · R4 S1 root re-check · R5 S1 identity pin). Repo-selecting GIT_* env is
+#            unset at start so a hook's environment cannot redirect the store (R5 S2). An independent repo whose root sits inside another
+#            repo's tree is accepted on purpose (R3 A4, lane B8m). Once validated, every write goes
+#            through the PHYSICAL path (R3 S1, lane B8n) and the default destination is derived from
+#            the physical hub (R3 S2, lane B8l).
+# 🟡 Stop-hook interaction (not testable by the lanes — the hook lives in .claude/settings.local.json,
+#    outside the repo): the hook stamps its cooldown only on rc 0/10, so rc=2 is NOT stamped → the
+#    3-line notice repeats on every Stop until the return path is run. Whether the hook should also
+#    stamp on 2 is a local decision; this script only changed a 21-line wall into 3 lines for that case.
 #
 # ── WHO TURNS THIS ON, AND ITS SIBLING ────────────────────────────────────────
 # This script is one of TWO one-way mirror modes. They differ by AUDIENCE, not mechanism, and
@@ -41,9 +67,41 @@
 
 set -euo pipefail
 
+# 🟥 R5 S2 (codex, 2026-09-05): every `git` below must address the store BY PATH. Repo-selecting
+# environment (a git hook exports GIT_DIR; a caller may carry GIT_WORK_TREE / GIT_INDEX_FILE …) makes
+# `git -C "$BE" rev-parse` answer for the ENV-selected repository — a plain directory would then pass
+# the root check and `git add/commit` would land the private half in that other repo. Unset them
+# first; nothing here legitimately needs them (lane B8r).
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE 2>/dev/null || true
+
+# THREAT MODEL (stated so severity can be graded against it): the operator's own machine, the
+# operator's own store. The guard defends against TYPOS, symlinks, logical/physical path splits,
+# stale copies and CONCURRENT LEGITIMATE processes (another hub's sync, a worktree operation, a git
+# hook's environment) — not against an adversary who can rewrite the store between two lines of this
+# script; such an adversary can rewrite the script itself. Cheap belts against mid-run change are
+# still taken where they cannot over-block (identity pin below), and named as belts, not floors.
+
 FH="${HUB_DIR:-${CLAUDE_PROJECT_DIR:-$HOME/projects/forge-harness}}"
-BE="${BE_DIR:-$FH/../fh-be}"          # companion = documented sibling of the hub (derive with $FH, not a pinned literal)
-QUIET="${1:-}"
+# Physical path of an EXISTING dir (`cd -P && pwd -P`); empty if it does not exist. Defined up here
+# because the DEFAULT destination already needs it (R3 S2); the destination guard below reuses it.
+_phys() { (cd -P "$1" 2>/dev/null && pwd -P); }
+# 🟥 R3 (codex cross-family, 2026-09-05) S2: the default companion is the sibling of the PHYSICAL hub.
+# With a symlinked HUB_DIR (`/tmp/fh-link → /real/forge-harness`) the logical form `$FH/../fh-be`
+# splits in two: the kernel resolves it to /real/fh-be for cp/mkdir/`git -C`, but bash's logical `cd`
+# takes it to /tmp/fh-be — files mirrored in one repo, `git add/commit` run in another. Deriving from
+# the physical hub keeps the whole run in one place; an explicit BE_DIR is taken as given, and is
+# pinned to its physical path once the guard has validated it (S1 below) — that pin is what closes
+# the split for every spelling; this derivation keeps the requested path sane before the guard.
+_fh_phys0="$(_phys "$FH" || true)"   # R4 A2: a nonexistent HUB_DIR must reach the hub-identity refusal (rc=10), not die here under set -e
+BE="${BE_DIR:-${_fh_phys0:-$FH}/../fh-be}"   # companion = documented sibling of the hub (derive with $FH, not a pinned literal)
+QUIET=""; INIT=0
+for _arg in "$@"; do
+  case "$_arg" in
+    --quiet) QUIET="--quiet" ;;
+    --init)  INIT=1 ;;
+    *) echo "[sync-to-be] ⚠️  unknown argument ignored: $_arg (known: --quiet --init)" >&2 ;;
+  esac
+done
 
 # Hub-identity guard (fail-closed): $FH is context-derived (CLAUDE_PROJECT_DIR), and this is the
 # WRITE/push path. Refuse to mirror if $FH is not a recognized hub — e.g. the Stop hook is
@@ -104,7 +162,125 @@ HO="hub-owner$HUB_SUFFIX"
 # `flock` would be the obvious tool but ships on neither stock macOS (this operator's platform) nor
 # BSD — `mkdir` is atomic on every POSIX filesystem and needs no external binary. Shared (unsuffixed)
 # lock path: both hubs must serialize against EACH OTHER, not just themselves.
-mkdir -p "$BE"
+#
+# ── Destination guard (fail-closed) — BEFORE the lock mkdir, before anything touches $BE ──────────
+# Measured 2026-09-05: `BE_DIR=/tmp/__nonexistent__ bash sync-to-be.sh` created that path and mirrored
+# the private half into it — 838+93+61 files, 15 MB, rc=0, no warning. A single typo in the
+# documented `export FH_COMPANION_STORE=...` line therefore cloned tracks/_meta, memory/ and
+# CLAUDE.local.md to an arbitrary directory, silently. That is the publish direction, so it fails
+# CLOSED here: the destination must ALREADY be the root of a git work tree, or the caller must
+# say `--init` — an explicit act that logs what it makes and where. "The destination does not exist"
+# never means "it may be created" (CLAUDE.md §Irreversibility: applicable-but-missing ≠ not-applicable).
+# 🟥 R2 (codex cross-family, 2026-09-05): "inside SOME git work tree" was too weak — a typo that lands
+# in an existing subdirectory of ANOTHER repository passed, and the private half went into a foreign
+# repo (the original scenario, one level deeper). So the destination must be a git work tree's
+# ROOT ITSELF, compared by PHYSICAL path (`cd -P && pwd -P` on both sides — a symlink that displays as
+# a harmless BE= can resolve inside someone else's repo). Subdirectories, bare repos and submodules
+# are refused. Both the requested and the resolved path are logged on refuse and on pass.
+# (_phys() is defined at the top of the file — the default BE derivation already needs it.)
+_be_reason=""
+_be_root_ok() {   # $1 = physical dir. Sets _be_reason on failure.
+  local p="$1" inside top sup
+  inside="$(git -C "$p" rev-parse --is-inside-work-tree 2>/dev/null || echo none)"
+  case "$inside" in
+    true) ;;
+    false) _be_reason="a BARE repository (or its .git dir) — not a work tree"; return 1 ;;
+    *)     _be_reason="not inside any git work tree"; return 1 ;;
+  esac
+  # R3 A3 (codex): a git older than 2.13 does not know --show-superproject-working-tree. `rev-parse`
+  # then ECHOES the unknown option back on stdout with rc=0 (measured on git 2.50 with a misspelled
+  # option), so "non-empty ⇒ submodule" refused with a nonsense reason ("a SUBMODULE of --show-…"),
+  # and a git that errors instead was read as "no superproject" by the old `|| true`. Both are now
+  # refused with the real reason — fail-closed: a submodule cannot be ruled out, so it is not passed.
+  if ! sup="$(git -C "$p" rev-parse --show-superproject-working-tree 2>/dev/null)"; then
+    _be_reason="a work tree whose git could not answer --show-superproject-working-tree (git < 2.13?) — cannot rule out a submodule, refusing (fail-closed)"; return 1
+  fi
+  case "$sup" in
+    "") ;;
+    --*) _be_reason="a work tree whose git echoed --show-superproject-working-tree back instead of answering it (needs git ≥ 2.13) — cannot rule out a submodule, refusing (fail-closed)"; return 1 ;;
+    *)   _be_reason="a SUBMODULE of $sup — refusing to write into a nested repo"; return 1 ;;
+  esac
+  top="$(_phys "$(git -C "$p" rev-parse --show-toplevel 2>/dev/null)")"
+  [ "$top" = "$p" ] || { _be_reason="a SUBDIRECTORY of another repository's work tree ($top), not its root — refusing to write into a foreign repo"; return 1; }
+  # R3 A4 (codex, DECLINED with grounds): an INDEPENDENT repository whose root happens to sit inside
+  # another repository's tree (`/parent-repo/companion/.git`) passes — it IS a work tree root, and only
+  # a deliberate act creates one there (--init refuses to initialize inside an existing tree). The
+  # class this guard exists for — a typo landing in a foreign SUBDIRECTORY — never carries its own
+  # .git. Walking the parents would refuse every legitimate "all my repos live under one git-managed
+  # directory" layout to close a case no typo can produce. Lane B8m pins the accepted behavior.
+  return 0
+}
+_fh_phys="$(_phys "$FH")"
+if [ -d "$BE" ]; then _be_phys="$(_phys "$BE")"
+elif [ -d "$(dirname "$BE")" ]; then _be_phys="$(_phys "$(dirname "$BE")")/$(basename "$BE")"
+else _be_phys=""; fi
+# ORDER (A2): the self-hub check runs BEFORE the destination guard, on physical paths — `$FH/subdir`
+# must exit 4 ("you pointed the store at the hub itself"), not 12, so the operator reads the right
+# remedy. The toplevel-equality check further down stays as a second belt for the git-resolved form.
+if [ -n "$_be_phys" ] && [ -n "$_fh_phys" ] && { [ "$_be_phys" = "$_fh_phys" ] || case "$_be_phys" in "$_fh_phys"/*) true ;; *) false ;; esac; }; then
+  echo "🟥 동반 저장소가 허브 자신(또는 그 하위)을 가리킨다 — 비공개 내용을 여기 커밋하지 않는다." >&2
+  echo "   BE=$BE → $_be_phys" >&2
+  echo "   FH=$FH → $_fh_phys" >&2
+  echo "   BE_DIR 을 고쳐라. (허브가 아닌 «별도» 저장소여야 한다)" >&2
+  exit 4
+fi
+if [ "$INIT" = "1" ]; then
+  if [ ! -e "$BE" ]; then
+    # A4: atomic create — parent must already exist and be writable, ONE leaf level (`mkdir`, never
+    # -p: a missing parent under `set -e` would otherwise leave a half-made chain), and a failed
+    # `git init` rolls the leaf back so a failed --init leaves zero trace.
+    _be_parent="$(dirname "$BE")"
+    if [ ! -d "$_be_parent" ] || [ ! -w "$_be_parent" ]; then
+      echo "🚫 sync-to-be REFUSED (rc=12) — --init needs an EXISTING, writable parent directory:" >&2
+      echo "   BE=$BE   parent=$_be_parent ($([ -d "$_be_parent" ] && echo 'not writable' || echo 'does not exist'))" >&2
+      echo "   Nothing was created. Create the parent yourself, then re-run with --init." >&2
+      exit 12
+    fi
+    if ! mkdir "$BE" 2>/dev/null; then
+      echo "🚫 sync-to-be REFUSED (rc=12) — --init could not create $BE (nothing created)" >&2; exit 12
+    fi
+    if ! git -C "$BE" init -q 2>/dev/null; then
+      rmdir "$BE" 2>/dev/null || true
+      echo "🚫 sync-to-be REFUSED (rc=12) — git init failed in $BE; the directory was removed again (zero trace)" >&2; exit 12
+    fi
+    _be_phys="$(_phys "$BE")"
+    echo "[sync-to-be] --init: created companion store at $BE → $_be_phys (mkdir + git init -q)" >&2
+  elif [ -d "$BE" ] && [ "$(git -C "$_be_phys" rev-parse --is-inside-work-tree 2>/dev/null || echo none)" = "none" ]; then
+    # Only a directory that is inside NO work tree may be initialized — `git init` inside another
+    # repository's tree would create a nested repo there, which is the foreign-repo write this guard
+    # exists to refuse (that case falls through to the root check below and exits 12).
+    if ! git -C "$_be_phys" init -q 2>/dev/null; then
+      echo "🚫 sync-to-be REFUSED (rc=12) — git init failed in existing directory $BE" >&2; exit 12
+    fi
+    echo "[sync-to-be] --init: initialized git repo in existing directory $BE → $_be_phys" >&2
+  fi
+fi
+if [ ! -d "$BE" ] || [ -z "$_be_phys" ] || ! _be_root_ok "$_be_phys"; then
+  echo "" >&2
+  echo "🚫 sync-to-be REFUSED (rc=12) — destination is not the ROOT of an existing git work tree:" >&2
+  echo "   BE=$BE → ${_be_phys:-<unresolvable>}" >&2
+  if [ ! -e "$BE" ]; then echo "   → the path does not exist. Nothing was created, nothing was written." >&2
+  elif [ ! -d "$BE" ]; then echo "   → the path exists but is not a directory." >&2
+  else echo "   → it is $_be_reason." >&2; fi
+  echo "   Most likely a typo in BE_DIR / FH_COMPANION_STORE — check the spelling first." >&2
+  echo "   Creating a NEW companion store is an explicit act:  bash \"$0\" --init   (parent must exist)" >&2
+  exit 12
+fi
+# 🟥 R3 S1 (codex, 2026-09-05): from here on EVERY path below goes through the physical directory the
+# guard just validated. Keeping the requested spelling (a symlink, say) would re-resolve it on each
+# write — a link retargeted between validation and the mirror would redirect the private half into
+# whatever it points at NOW (TOCTOU). The lock dir, the mirror, the second belt and the final `cd` all
+# read $BE, so pinning it once here closes every consumer at once (lane B8n injects the retarget during
+# the lock wait and asserts the mirror still lands in the validated root).
+BE_REQUESTED="$BE"; BE="$_be_phys"
+# R5 S1 (codex): the root check compares PATHS; a `.git` swapped mid-run for a gitfile that points at
+# another repository's git dir keeps the same toplevel and would pass the belt's re-check — so the
+# git IDENTITY (absolute git dir + common dir) is pinned here and must be unchanged at the belt.
+# R5 B1 (codex): both pins happen BEFORE the "destination:" line below — the lanes wait for that line as
+# their "validated" marker, so everything the belt later compares against must already be recorded.
+_be_gitdir0="$(git -C "$BE" rev-parse --absolute-git-dir 2>/dev/null || true)"
+_be_common0="$(git -C "$BE" rev-parse --git-common-dir 2>/dev/null || true)"
+[ "$QUIET" = "--quiet" ] || echo "[sync-to-be] destination: $BE_REQUESTED → $BE (git work tree root)"
 
 # DEFINED HERE, NOT AT ITS OLD SITE ~50 LINES BELOW (fixed 2026-08-16, reproduced first).
 # The lock loop below calls `log`. Bash resolves an unknown name through PATH, and macOS ships
@@ -296,6 +472,48 @@ check_dest_newer() {   # $1 = src dir, $2 = dst dir
 # One message for two sites was right; one *remedy* for two sites was not.
 _abort_dest_newer() {   # $1 = pre-formatted hit list (one "  <path>  (newer than <path>)" per line)
   local rp="$FH/scripts/sync-from-be.sh" kind="${2:-pullable}"
+  if [ "$kind" = "pullable" ] && [ -f "$rp" ]; then
+    # ⓑ (2026-09-05) — separate the RECOVERABLE case from the red wall, using the discriminator the
+    # message below already tells the operator to run by hand. Run `sync-from-be.sh --dry-run --no-git`
+    # (read-only by construction: dry-run writes nothing, --no-git fetches nothing), capture ALL of its
+    # output (nothing leaks to stderr), and parse its COUNT line
+    #   "pulled N file(s) companion → hub  (clean C · review R)".
+    # review R == 0 → every newer file is one the return path pulls cleanly: this hub is simply the
+    # stale node. Then a 3-line notice and rc=2 instead of the wall. Anything else — R > 0, no COUNT
+    # line, dry-run rc≠0, TOTAL 0 — keeps the wall (rc=1): fail-closed direction.
+    # 🟥 The return path is NEVER run for real here. The decision "which side is canonical" stays
+    # human (CLAUDE.md §Mechanization Boundary); only the OUTPUT GRADE changes.
+    local _dr_out _dr_rc=0 _dr_n="" _dr_r="" _dr_line _dr_cnt _to=""
+    # B7: the probe is bounded. Without a timeout binary the grade split is SKIPPED and the wall kept —
+    # an unmeasured discriminator is not a "recoverable" verdict ("not measured ≠ safe").
+    if command -v timeout >/dev/null 2>&1; then _to="timeout"; elif command -v gtimeout >/dev/null 2>&1; then _to="gtimeout"; fi
+    if [ -n "$_to" ]; then
+      _dr_out="$("$_to" 30 bash "$rp" --dry-run --no-git </dev/null 2>&1)" || _dr_rc=$?
+      # B5/B6: anchor on the EXACT line sync-from-be.sh prints (its `say` prefix + literal format, see
+      # `pulled $TOTAL file(s) companion → hub  (clean $N_CLEAN · review $N_REVIEW)` there), full-line
+      # match so a stderr diagnostic mentioning "review 0" cannot pose as the COUNT line, and accept it
+      # ONLY when exactly one such line exists — 0 or 2+ lines is a parse failure → wall.
+      # R3 B5 (codex, NAMED residual, not closed): a file NAME containing a newline could print a
+      # look-alike line. It cannot coexist with the real COUNT line (2 matches → wall), so the forgery
+      # needs a run where sync-from-be.sh exits 0, prints no COUNT line (TOTAL=0) and still lists that
+      # name. Closing it properly is a machine-only output mode on the return path, not a regex here.
+      _dr_line="$(printf '%s\n' "$_dr_out" | grep -E '^\[sync-from-be\] (\(dry-run\) )?pulled [0-9]+ file\(s\) companion → hub  \(clean [0-9]+ · review [0-9]+\)$' || true)"
+      _dr_cnt="$(printf '%s' "$_dr_line" | grep -c . || true)"
+      if [ "$_dr_rc" -eq 0 ] && [ "${_dr_cnt:-0}" -eq 1 ]; then
+        _dr_n="$(printf '%s\n' "$_dr_line" | sed -E 's/.*pulled ([0-9]+) file.*/\1/')"
+        _dr_r="$(printf '%s\n' "$_dr_line" | sed -E 's/.*review ([0-9]+)\)$/\1/')"
+      fi
+    else
+      echo "ℹ️  sync-to-be: no timeout/gtimeout binary — recoverable-grade probe skipped, keeping the wall (unmeasured ≠ safe)" >&2
+    fi
+    if [ "$_dr_rc" -eq 0 ] && [ -n "$_dr_n" ] && [ -n "$_dr_r" ] && [ "$_dr_r" -eq 0 ] && [ "$_dr_n" -gt 0 ]; then
+      echo "" >&2
+      echo "ℹ️  sync-to-be: another node advanced — the mirror is ahead and the return path pulls ALL of it" >&2
+      echo "   (sync-from-be.sh --dry-run: pulled $_dr_n · review 0). The conflicting path(s) were NOT written." >&2
+      echo "   → bash \"$rp\"   then re-run this script.   (rc=2 = recoverable, not an error wall)" >&2
+      exit 2
+    fi
+  fi
   echo "" >&2
   echo "🚫 SYNC ABORTED — the destination is NEWER than the source:" >&2
   printf '%s' "$1" >&2
@@ -606,14 +824,32 @@ fi
 
 cd "$BE"
 
-# Mirror-only mode: a plain (non-git) companion directory is a valid local-only
-# setup — files are already mirrored above; just skip the commit/push half.
-# Without this guard, set -e kills the script at `git add` with a noisy error
-# on every Stop-hook run (fh_signal_2026-06-10: companion-store portability).
-git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
-  log "companion store is not a git repo — mirror-only mode ($([ "$HAVE_RSYNC" -eq 1 ] && echo "$TOTAL file(s) synced" || echo "cp-mode mirror done"), no commit/push)"
-  exit 0
-}
+# Mirror-only mode: a plain (non-git) companion directory used to be a valid local-only setup.
+# Since 2026-09-05 the destination guard above refuses a non-git $BE at rc=12 (before any write), so
+# this branch is reachable only if the work tree stopped being one MID-RUN. Kept as a belt for that
+# case — set -e would otherwise kill the script at `git add` with a noisy error
+# (fh_signal_2026-06-10: companion-store portability).
+# R3 B6 (codex): this belt used to `exit 0` — a store that lost its .git after the mirror would have
+# stamped the Stop hook's cooldown as a success while nothing was committed or pushed. It is a refusal
+# now (rc=12, the destination-guard class), printed unconditionally: --quiet must not hide it.
+# 🟥 R4 S1 (codex): "inside a work tree" is NOT the right belt. A store that is an independent repo
+# INSIDE another repo's tree (accepted on purpose, R3 A4 / lane B8m) and loses its .git mid-run is
+# still "inside a work tree" — the ENCLOSING one — and `git add/commit/push` below would land the
+# private half there. So the belt re-runs the same ROOT check the guard ran (inside ∧ no superproject
+# ∧ physical toplevel == the pinned $BE), and refuses on any mismatch (lane B8o2).
+if ! _be_root_ok "$BE"; then
+  echo "🚫 sync-to-be rc=12 — the companion store STOPPED being the root of its own git work tree mid-run ($BE): it is now $_be_reason." >&2
+  echo "   the files were mirrored ($([ "$HAVE_RSYNC" -eq 1 ] && echo "$TOTAL file(s)" || echo "cp-mode")) but NOTHING was committed or pushed — committing here could land the private half in an ENCLOSING repository. Restore the repo, then re-run." >&2
+  exit 12
+fi
+_be_gitdir1="$(git -C "$BE" rev-parse --absolute-git-dir 2>/dev/null || true)"
+_be_common1="$(git -C "$BE" rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -z "$_be_gitdir0" ] || [ "$_be_gitdir1" != "$_be_gitdir0" ] || [ "$_be_common1" != "$_be_common0" ]; then
+  echo "🚫 sync-to-be rc=12 — the companion store's git IDENTITY changed mid-run ($BE):" >&2
+  echo "   git dir ${_be_gitdir0:-<unresolved>} → ${_be_gitdir1:-<unresolved>} · common dir ${_be_common0:-<unresolved>} → ${_be_common1:-<unresolved>}" >&2
+  echo "   the files were mirrored but NOTHING was committed or pushed — the commit would have gone to a DIFFERENT repository. Restore the store, then re-run." >&2
+  exit 12
+fi
 
 # Push any commits ahead of upstream. Offline-safe: never aborts the script,
 # so a failed push just leaves commits queued for the next run to flush.

--- a/scripts/sync_to_be_lanes.sh
+++ b/scripts/sync_to_be_lanes.sh
@@ -176,6 +176,360 @@ chk $? "the abort says the return path is NOT PRESENT instead of printing a dead
 printf '%s' "$out" | grep -q -- '--dry-run'; [ $? -ne 0 ]
 chk $? "it does NOT hand out a --dry-run command that cannot run here"
 
+# ══ A · destination guard — fail-closed (fh_signal_2026-09-05_sync-guard-failopen-and-alarm-fatigue ⓐ) ══
+# The probe that found the defect was "rc=0 AND 15 MB appeared at a path that did not exist". So every
+# lane below checks the FILESYSTEM, not only the exit code — an rc alone would have passed the old code
+# too (it exited 0) and would pass a future regression that refuses *after* writing.
+count_files(){ [ -e "$1" ] && find "$1" -type f 2>/dev/null | wc -l | tr -d ' ' || echo 0; }
+
+echo "── A1 a NON-EXISTENT destination is refused (rc=12) and NOTHING is created ──"
+new_env a1
+printf 'private\n' > "$HUB/tracks/_meta/secret_card.md"
+BEX="$ENV_DIR/does-not-exist/companion"
+[ ! -e "$BEX" ]; chk $? "CONTROL: destination really is absent before the run"
+out="$(MID=lanea run 2>&1)"; rc=$?
+[ "$rc" -eq 12 ]; chk $? "KNOWN-NEGATIVE: refused with rc=12 (got $rc)"
+[ ! -e "$BEX" ]; chk $? "destination path still does not exist after the run (mkdir -p did NOT fire)"
+[ "$(count_files "$ENV_DIR/does-not-exist")" = "0" ]; chk $? "0 files anywhere under the absent parent (the 15 MB probe, closed)"
+printf '%s' "$out" | grep -q 'REFUSED (rc=12)'; chk $? "the refusal names its code"
+printf '%s' "$out" | grep -q -- '--init'; chk $? "the remedy for a genuinely new store (--init) is printed"
+printf '%s' "$out" | grep -qi 'typo'; chk $? "the message suspects a typo first (the measured failure mode)"
+
+echo "── A2 an EXISTING directory that is not a git work tree is refused (rc=12), contents unchanged ──"
+new_env a2
+BEX="$ENV_DIR/plain-dir"; mkdir -p "$BEX"; printf 'pre-existing\n' > "$BEX/keep.txt"
+printf 'private\n' > "$HUB/tracks/_meta/secret_card.md"
+before="$(count_files "$BEX")"
+[ "$before" = "1" ]; chk $? "CONTROL: fixture holds exactly 1 file before the run"
+MID=lanea run >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 12 ]; chk $? "KNOWN-NEGATIVE: non-git directory refused with rc=12 (got $rc)"
+[ "$(count_files "$BEX")" = "$before" ]; chk $? "file count unchanged ($before → $(count_files "$BEX")) — nothing mirrored, no lock dir left"
+[ ! -d "$BEX/.git" ]; chk $? "no git repo was created implicitly"
+
+echo "── A3 --init creates the store EXPLICITLY (mkdir + git init, logged) and then syncs ──"
+new_env a3
+BEX="$ENV_DIR/fresh/companion"; mkdir -p "$ENV_DIR/fresh"   # parent EXISTS — --init creates exactly one leaf level
+printf 'private\n' > "$HUB/tracks/_meta/secret_card.md"
+[ ! -e "$BEX" ]; chk $? "CONTROL: destination absent before --init"
+out="$(MID=lanea run --init 2>&1)"; rc=$?
+[ "$rc" -eq 0 ]; chk $? "--init run completes rc=0 (got $rc)"
+[ "$(git -C "$BEX" rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; chk $? "destination is now a git work tree"
+[ -f "$BEX/tracks-meta/secret_card.md" ]; chk $? "and the sync actually proceeded after creation"
+printf '%s' "$out" | grep -q -- '--init: created companion store at'; chk $? "creation is LOGGED with what and where (not silent)"
+
+echo "── A4 an existing git work tree passes the guard unchanged (the ordinary path — regression control) ──"
+new_env a4
+printf 'private\n' > "$HUB/tracks/_meta/secret_card.md"
+MID=lanea run >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 0 ]; chk $? "KNOWN-POSITIVE: ordinary git-worktree destination still syncs rc=0 (got $rc)"
+[ -f "$BEX/tracks-meta/secret_card.md" ]; chk $? "file landed — the guard did not over-block the valid case"
+
+# ══ B · destination-newer: recoverable vs wall (ⓑ) ══
+# HUB_DIR is a temp hub, so `rp="$FH/scripts/sync-from-be.sh"` resolves to a FAKE return path that
+# prints a CONTROLLED COUNT line — the exact line the real script prints — and nothing else.
+fake_rp(){ # $1 = body of the fake sync-from-be.sh
+  mkdir -p "$HUB/scripts"; printf '#!/usr/bin/env bash\n%s\n' "$1" > "$HUB/scripts/sync-from-be.sh"
+}
+seed_newer(){ # first sync, then make the companion copy newer + divergent
+  printf 'hub-v1\n' > "$HUB/tracks/_meta/card.md"
+  MID=lanea run >/dev/null 2>&1
+  [ -f "$BEX/tracks-meta/card.md" ]; chk $? "CONTROL: first sync landed the file (fixture is live)"
+  sleep 2
+  printf 'peer-node-added-this\n' >> "$BEX/tracks-meta/card.md"
+  [ "$BEX/tracks-meta/card.md" -nt "$HUB/tracks/_meta/card.md" ]; chk $? "CONTROL: companion copy is newer + divergent"
+}
+
+echo "── B1 destination newer AND review>0 → the red wall stays (rc=1) — KNOWN-POSITIVE for the wall ──"
+new_env b1
+fake_rp 'echo "[sync-from-be] (dry-run) pulled 4 file(s) companion → hub  (clean 3 · review 1)"; exit 0'
+seed_newer
+out="$(MID=lanea run 2>&1)"; rc=$?
+[ "$rc" -eq 1 ]; chk $? "rc=1 (got $rc)"
+printf '%s' "$out" | grep -q 'SYNC ABORTED'; chk $? "the wall is printed when the return path cannot cover everything"
+printf '%s' "$out" | grep -q 'recoverable, not an error wall'; [ $? -ne 0 ]; chk $? "the soft notice is NOT printed here"
+
+echo "── B2 destination newer AND review==0 → 3-line notice instead of the wall, rc=2, nothing recovered ──"
+new_env b2
+fake_rp 'echo "[sync-from-be] (dry-run) pulled 3 file(s) companion → hub  (clean 3 · review 0)"; exit 0'
+seed_newer
+out="$(MID=lanea run 2>&1)"; rc=$?
+[ "$rc" -eq 2 ]; chk $? "rc=2 (got $rc)"
+printf '%s' "$out" | grep -q 'SYNC ABORTED'; [ $? -ne 0 ]; chk $? "the red wall is NOT printed"
+printf '%s' "$out" | grep -q 'another node advanced'; chk $? "the notice names the cause (peer ahead, recoverable)"
+printf '%s' "$out" | grep -q 'pulled 3 · review 0'; chk $? "the notice cites the parsed COUNT (N=3, review 0)"
+printf '%s' "$out" | grep -q 'sync-from-be.sh"'; chk $? "the notice hands over the return-path command (quoted)"
+[ "$(cat "$HUB/tracks/_meta/card.md")" = "hub-v1" ]; chk $? "hub file UNCHANGED — no automatic recovery happened"
+grep -q 'peer-node-added-this' "$BEX/tracks-meta/card.md"; chk $? "companion copy UNCHANGED — the stale hub did not overwrite it"
+
+echo "── B3 dry-run fails or prints no COUNT line → the wall stays (fail-closed) ──"
+new_env b3
+fake_rp 'echo "[sync-from-be] something unrelated"; exit 1'
+seed_newer
+out="$(MID=lanea run 2>&1)"; rc=$?
+[ "$rc" -eq 1 ]; chk $? "dry-run rc≠0 → wall, rc=1 (got $rc)"
+printf '%s' "$out" | grep -q 'SYNC ABORTED'; chk $? "wall printed"
+printf '%s' "$out" | grep -q 'something unrelated'; [ $? -ne 0 ]; chk $? "the dry-run's own output did NOT leak into ours (captured)"
+new_env b3b
+fake_rp 'echo "[sync-from-be] hub is current with the companion store — nothing to pull"; exit 0'
+seed_newer
+out="$(MID=lanea run 2>&1)"; rc=$?
+[ "$rc" -eq 1 ]; chk $? "dry-run rc=0 but NO COUNT line → wall, rc=1 (parse failure is not recovery) (got $rc)"
+printf '%s' "$out" | grep -q 'SYNC ABORTED'; chk $? "wall printed"
+
+# ══ B8 · codex R2 — root identity · physical paths · atomic --init · COUNT anchoring · timeout ══
+echo "── B8a destination = a SUBDIRECTORY of another repo → rc=12, that repo untouched ──"
+new_env b8a
+OTHER="$ENV_DIR/other-repo"; mkdir -p "$OTHER/docs"; git -C "$OTHER" init -q; printf 'theirs\n' > "$OTHER/docs/readme.md"
+BEX="$OTHER/docs"; before="$(count_files "$OTHER")"
+printf 'private\n' > "$HUB/tracks/_meta/secret_card.md"
+out="$(MID=lanea run 2>&1)"; rc=$?
+[ "$rc" -eq 12 ]; chk $? "KNOWN-NEGATIVE: inside-a-worktree-but-not-its-root is refused rc=12 (got $rc) — the R1 hole"
+[ "$(count_files "$OTHER")" = "$before" ]; chk $? "the foreign repo's file count is unchanged ($before)"
+printf '%s' "$out" | grep -q 'SUBDIRECTORY of another repository'; chk $? "the reason names the foreign-repo case"
+
+echo "── B8b destination = \$FH/subdir → rc=4 (self-hub), decided BEFORE the rc=12 guard ──"
+new_env b8b
+mkdir -p "$HUB/companion"; git -C "$HUB" init -q
+BEX="$HUB/companion"
+MID=lanea run >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 4 ]; chk $? "a store inside the hub exits 4, not 12 (got $rc) — the operator reads the self-hub remedy"
+
+echo "── B8c destination = SYMLINK whose target is inside another repo → rc=12, log shows the REAL path ──"
+new_env b8c
+OTHER="$ENV_DIR/other-repo"; mkdir -p "$OTHER/inner"; git -C "$OTHER" init -q
+ln -s "$OTHER/inner" "$ENV_DIR/harmless-looking"
+BEX="$ENV_DIR/harmless-looking"; before="$(count_files "$OTHER")"
+out="$(MID=lanea run 2>&1)"; rc=$?
+[ "$rc" -eq 12 ]; chk $? "symlink into a foreign repo is refused rc=12 (got $rc)"
+printf '%s' "$out" | grep -q "harmless-looking → .*other-repo/inner"; chk $? "the refusal logs requested → resolved path"
+[ "$(count_files "$OTHER")" = "$before" ]; chk $? "nothing written through the symlink"
+
+echo "── B8d destination = BARE repo → rc=12 ──"
+new_env b8d
+BEX="$ENV_DIR/bare.git"; git init -q --bare "$BEX"; before="$(count_files "$BEX")"
+out="$(MID=lanea run 2>&1)"; rc=$?
+[ "$rc" -eq 12 ]; chk $? "bare repo refused rc=12 (got $rc)"
+printf '%s' "$out" | grep -q 'BARE repository'; chk $? "reason names the bare case"
+[ "$(count_files "$BEX")" = "$before" ]; chk $? "bare repo untouched"
+
+echo "── B8e destination = a work tree ROOT reached via symlink → passes (physical comparison, not string) ──"
+new_env b8e
+ln -s "$BEX" "$ENV_DIR/be-link"; REAL="$BEX"; BEX="$ENV_DIR/be-link"
+printf 'private\n' > "$HUB/tracks/_meta/secret_card.md"
+MID=lanea run >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 0 ]; chk $? "KNOWN-POSITIVE: a symlink TO a work tree root still passes rc=0 (got $rc) — no over-block"
+[ -f "$REAL/tracks-meta/secret_card.md" ]; chk $? "file landed in the real root"
+
+echo "── B8f --init with a MISSING parent → rc=12 and zero trace ──"
+new_env b8f
+BEX="$ENV_DIR/no-such-parent/companion"
+out="$(MID=lanea run --init 2>&1)"; rc=$?
+[ "$rc" -eq 12 ]; chk $? "--init without an existing parent is refused rc=12 (got $rc), not mkdir -p'd"
+[ ! -e "$ENV_DIR/no-such-parent" ]; chk $? "the parent chain was NOT created (zero trace)"
+printf '%s' "$out" | grep -q 'EXISTING, writable parent'; chk $? "the remedy says to create the parent first"
+
+echo "── B8g --init inside another repo's subdirectory → rc=12, no nested .git created ──"
+new_env b8g
+OTHER="$ENV_DIR/other-repo"; mkdir -p "$OTHER/sub"; git -C "$OTHER" init -q
+BEX="$OTHER/sub"
+MID=lanea run --init >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 12 ]; chk $? "--init does not git-init inside a foreign work tree (rc=$rc)"
+[ ! -e "$OTHER/sub/.git" ]; chk $? "no nested repository was created"
+
+echo "── B8h COUNT line appears TWICE → parse failure → wall (fail-closed), not rc=2 ──"
+new_env b8h
+fake_rp 'echo "[sync-from-be] (dry-run) pulled 3 file(s) companion → hub  (clean 3 · review 0)"; echo "[sync-from-be] (dry-run) pulled 3 file(s) companion → hub  (clean 3 · review 0)"; exit 0'
+seed_newer
+out="$(MID=lanea run 2>&1)"; rc=$?
+[ "$rc" -eq 1 ]; chk $? "two COUNT lines → wall rc=1 (got $rc)"
+printf '%s' "$out" | grep -q 'SYNC ABORTED'; chk $? "wall printed"
+
+echo "── B8i a stderr diagnostic that MENTIONS 'review 0' is not mistaken for the COUNT line ──"
+new_env b8i
+# The diagnostic below CONTAINS the whole COUNT phrase (with a "hint:" prefix) and there is NO real
+# COUNT line — a substring anchor would accept it and grade the run recoverable; the full-line anchor
+# must not. This is the fixture that distinguishes "anchored" from "contains".
+fake_rp 'echo "[sync-from-be] hint: last run pulled 3 file(s) companion → hub  (clean 3 · review 0)" >&2; echo "[sync-from-be] hub is current with the companion store — nothing to pull"; exit 0'
+seed_newer
+out="$(MID=lanea run 2>&1)"; rc=$?
+[ "$rc" -eq 1 ]; chk $? "a prefixed look-alike line is NOT the COUNT line → wall rc=1 (got $rc)"
+printf '%s' "$out" | grep -q 'SYNC ABORTED'; chk $? "wall printed"
+new_env b8i2
+fake_rp 'echo "[sync-from-be] warning: peer said review 0 earlier, ignore" >&2; echo "[sync-from-be] (dry-run) pulled 2 file(s) companion → hub  (clean 1 · review 1)"; exit 0'
+seed_newer
+out="$(MID=lanea run 2>&1)"; rc=$?
+[ "$rc" -eq 1 ]; chk $? "real COUNT says review 1 → wall rc=1 despite a 'review 0' diagnostic (got $rc)"
+
+echo "── B8j no timeout/gtimeout on PATH → grade split skipped, wall kept (unmeasured ≠ safe) ──"
+new_env b8j
+SHIM="$ENV_DIR/shim"; mkdir -p "$SHIM"
+for d in $(printf '%s' "$PATH" | tr ':' ' '); do
+  [ -d "$d" ] || continue
+  for b in "$d"/*; do [ -e "$b" ] || continue; n="$(basename "$b")"; case "$n" in timeout|gtimeout) continue;; esac; [ -e "$SHIM/$n" ] || ln -s "$b" "$SHIM/$n" 2>/dev/null; done  # portability-noqa: the [ -e "$b" ] || continue guard is on this same line
+done
+PATH="$SHIM" command -v timeout >/dev/null 2>&1; [ $? -ne 0 ]; chk $? "CONTROL: timeout really is absent on the shimmed PATH"
+PATH="$SHIM" command -v git >/dev/null 2>&1; chk $? "CONTROL: git still resolves on the shimmed PATH (shim is live)"
+fake_rp 'echo "[sync-from-be] (dry-run) pulled 3 file(s) companion → hub  (clean 3 · review 0)"; exit 0'
+seed_newer
+out="$(PATH="$SHIM" MID=lanea run 2>&1)"; rc=$?
+[ "$rc" -eq 1 ]; chk $? "review 0 but no timeout binary → wall rc=1 (got $rc)"
+printf '%s' "$out" | grep -q 'no timeout/gtimeout'; chk $? "the skip is announced, not silent"
+printf '%s' "$out" | grep -q 'SYNC ABORTED'; chk $? "wall printed"
+
+# ══ B8k~B8o · codex R3 (2026-09-05) — old-git fail-closed · physical default BE · nested-repo decision · symlink retarget (S1) · mid-run .git loss (B6) ══
+# B8n/B8o inject a state change BETWEEN validation and mirror deterministically: the lane HOLDS the sync
+# lock, starts the script (which validates, then polls the lock every 1s), waits for its "destination:"
+# line (printed right before the lock loop), mutates the world, then releases the lock. No sleep-and-hope.
+wait_for_line(){ # $1 = file  $2 = pattern  → 0 when seen within ~20s
+  local i=0; while [ "$i" -lt 40 ]; do grep -q "$2" "$1" 2>/dev/null && return 0; sleep 0.5; i=$((i+1)); done; return 1
+}
+run_loud(){ HOME="$ENV_DIR/home" HUB_DIR="$HUB" BE_DIR="$BEX" FH_MACHINE_ID="${MID:-lanea}" bash "$SCRIPT" "$@"; }   # no --quiet: the lane reads the destination line
+
+echo "── B8k a git that cannot answer --show-superproject-working-tree → rc=12 fail-closed with the REAL reason ──"
+new_env b8k
+printf 'private\n' > "$HUB/tracks/_meta/secret_card.md"
+SHIM="$ENV_DIR/shim"; mkdir -p "$SHIM"
+REAL_GIT="$(command -v git)"
+# variant 1: an old git ERRORS on the option (what `|| true` used to swallow as "no superproject")
+{ printf '#!/usr/bin/env bash\n'
+  printf 'for a in "$@"; do case "$a" in --show-superproject-working-tree) echo "error: unknown option" >&2; exit 129;; esac; done\n'
+  printf 'exec "%s" "$@"\n' "$REAL_GIT"; } > "$SHIM/git"
+chmod +x "$SHIM/git"
+out="$(PATH="$SHIM:$PATH" MID=lanea run 2>&1)"; rc=$?
+[ "$rc" -eq 12 ]; chk $? "old git (errors on the option) → rc=12 (got $rc)"
+printf '%s' "$out" | grep -q 'could not answer --show-superproject-working-tree'; chk $? "the reason names the git capability gap, not a phantom submodule"
+[ ! -e "$BEX/tracks-meta" ]; chk $? "nothing was mirrored before the refusal"
+# variant 2: an old git ECHOES the unknown option back with rc=0 (what rev-parse actually does)
+{ printf '#!/usr/bin/env bash\n'
+  printf 'for a in "$@"; do case "$a" in --show-superproject-working-tree) echo "--show-superproject-working-tree"; exit 0;; esac; done\n'
+  printf 'exec "%s" "$@"\n' "$REAL_GIT"; } > "$SHIM/git"
+out="$(PATH="$SHIM:$PATH" MID=lanea run 2>&1)"; rc=$?
+[ "$rc" -eq 12 ]; chk $? "old git (echoes the option back, rc=0) → rc=12 (got $rc)"
+printf '%s' "$out" | grep -q 'echoed --show-superproject-working-tree back'; chk $? "the echo-back is named as such, not reported as 'a SUBMODULE of --show-…'"
+MID=lanea run >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 0 ]; chk $? "CONTROL: real git, same fixture → rc=0 (got $rc) — the shim, not the fixture, caused the refusals"
+
+echo "── B8l symlinked HUB_DIR, BE_DIR unset → the default store is the PHYSICAL hub's sibling, and the commit lands THERE ──"
+new_env b8l
+mkdir -p "$ENV_DIR/real" "$ENV_DIR/link"
+mv "$HUB" "$ENV_DIR/real/hubx"; HUB="$ENV_DIR/real/hubx"
+ln -s "$ENV_DIR/real/hubx" "$ENV_DIR/link/hubx"
+for d in "$ENV_DIR/real/fh-be" "$ENV_DIR/link/fh-be"; do   # physical sibling + logical decoy — BOTH valid repo roots
+  mkdir -p "$d"; git -C "$d" init -q; git -C "$d" config user.email "lane@test.local"; git -C "$d" config user.name "lane-test"
+done
+printf 'private\n' > "$HUB/tracks/_meta/secret_card.md"
+[ -L "$ENV_DIR/link/hubx" ] && [ -d "$ENV_DIR/link/hubx/tracks/_meta" ]; chk $? "CONTROL: the symlinked hub resolves and carries the fixture"
+out="$(HOME="$ENV_DIR/home" HUB_DIR="$ENV_DIR/link/hubx" FH_MACHINE_ID=lanea bash "$SCRIPT" 2>&1)"; rc=$?
+[ "$rc" -eq 0 ]; chk $? "run through the symlinked HUB_DIR completed rc=0 (got $rc)"
+REAL_BE_PHYS="$(cd -P "$ENV_DIR/real/fh-be" && pwd -P)"   # mktemp dirs can themselves sit under a symlink (/var → /private/var on macOS)
+printf '%s' "$out" | grep -qF "→ $REAL_BE_PHYS (git work tree root)"; chk $? "the destination line resolves to the PHYSICAL sibling"
+[ -f "$ENV_DIR/real/fh-be/tracks-meta/secret_card.md" ]; chk $? "the file landed in the PHYSICAL sibling"
+[ "$(git -C "$ENV_DIR/real/fh-be" log --oneline 2>/dev/null | grep -c .)" -ge 1 ]; chk $? "…and was COMMITTED there (a logical-path cd would have committed in the decoy instead)"
+[ ! -e "$ENV_DIR/link/fh-be/tracks-meta" ] && [ "$(git -C "$ENV_DIR/link/fh-be" log --oneline 2>/dev/null | grep -c .)" -eq 0 ]; chk $? "the logical decoy sibling got neither files nor commits"
+
+echo "── B8m an INDEPENDENT repo whose root sits inside another repo's tree is ACCEPTED (R3 A4 declined — decision pinned); the same path without its own .git is refused ──"
+new_env b8m
+OUTER="$ENV_DIR/outer"; mkdir -p "$OUTER"; git -C "$OUTER" init -q
+BEX="$OUTER/companion"; mkdir -p "$BEX"
+printf 'private\n' > "$HUB/tracks/_meta/secret_card.md"
+MID=lanea run >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 12 ]; chk $? "KNOWN-NEGATIVE: a plain subdirectory of a foreign repo → rc=12 (got $rc)"
+[ ! -e "$BEX/tracks-meta" ]; chk $? "…and nothing was mirrored into the foreign tree"
+git -C "$BEX" init -q; git -C "$BEX" config user.email "lane@test.local"; git -C "$BEX" config user.name "lane-test"
+MID=lanea run >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 0 ]; chk $? "KNOWN-POSITIVE: the same path as its OWN repo root → rc=0 (got $rc)"
+[ -f "$BEX/tracks-meta/secret_card.md" ]; chk $? "file landed in the nested independent repo"
+[ ! -e "$OUTER/tracks-meta" ]; chk $? "nothing leaked into the enclosing repo's root"
+
+echo "── B8n symlink retargeted BETWEEN validation and mirror → the mirror still lands in the VALIDATED root (S1 TOCTOU) ──"
+new_env b8n
+GOOD="$ENV_DIR/good-be"; FOREIGN="$ENV_DIR/foreign"
+mv "$BEX" "$GOOD"; mkdir -p "$FOREIGN"; git -C "$FOREIGN" init -q
+BEX="$ENV_DIR/be"; ln -s "$GOOD" "$BEX"
+printf 'private\n' > "$HUB/tracks/_meta/secret_card.md"
+mkdir "$GOOD/.sync.lock.d"                                   # hold the lock: the run validates, then polls
+( MID=lanea run_loud > "$ENV_DIR/out" 2>&1; echo "$?" > "$ENV_DIR/rc" ) &
+_pid=$!
+wait_for_line "$ENV_DIR/out" 'destination: '; chk $? "CONTROL: the run passed validation and is waiting on the lock"
+rm "$BEX"; ln -s "$FOREIGN" "$BEX"                           # retarget the REQUESTED path to a different valid repo root
+sleep 1.5                                                    # ≥1 poll cycle on the retargeted spelling
+[ ! -e "$FOREIGN/tracks-meta" ]; chk $? "while the validated root is still locked, nothing has been written to the retargeted repo"
+rmdir "$GOOD/.sync.lock.d"                                   # release the lock in the VALIDATED root only
+wait "$_pid"
+rc="$(cat "$ENV_DIR/rc" 2>/dev/null || echo none)"
+[ "$rc" = "0" ]; chk $? "run completed rc=0 after the lock was released (got $rc) — the loop waited on the PHYSICAL lock"
+[ -f "$GOOD/tracks-meta/secret_card.md" ]; chk $? "the private file landed in the VALIDATED root"
+[ ! -e "$FOREIGN/tracks-meta" ] && [ ! -d "$FOREIGN/.sync.lock.d" ]; chk $? "the retargeted repo got neither files nor a lock — the requested spelling was never re-resolved"
+
+echo "── B8o the store loses its .git MID-RUN (after validation) → rc=12, never a 'mirrored' exit 0 (B6) ──"
+new_env b8o
+printf 'private\n' > "$HUB/tracks/_meta/secret_card.md"
+mkdir "$BEX/.sync.lock.d"
+( MID=lanea run_loud --quiet > "$ENV_DIR/out" 2>&1; echo "$?" > "$ENV_DIR/rc" ) &
+_pid=$!
+sleep 2                                                      # --quiet prints no destination line; the guard takes well under 2s
+mv "$BEX/.git" "$BEX/.git.gone"                              # the work tree stops being one, after the guard passed
+rmdir "$BEX/.sync.lock.d"
+wait "$_pid"
+rc="$(cat "$ENV_DIR/rc" 2>/dev/null || echo none)"
+[ "$rc" = "12" ]; chk $? "mid-run loss of git identity → rc=12 (got $rc), not 0"
+grep -q 'STOPPED being the root of its own git work tree' "$ENV_DIR/out"; chk $? "the refusal is printed even under --quiet"
+[ -f "$BEX/tracks-meta/secret_card.md" ]; chk $? "CONTROL: the mirror itself had run — the belt fires AFTER the write, which is why rc must not be 0"
+
+echo "── B8o2 a NESTED independent repo loses its .git mid-run → rc=12 and NOTHING is committed into the ENCLOSING repo (R4 S1) ──"
+new_env b8o2
+OUTER="$ENV_DIR/outer"; mkdir -p "$OUTER"; git -C "$OUTER" init -q; git -C "$OUTER" config user.email "lane@test.local"; git -C "$OUTER" config user.name "lane-test"
+BEX="$OUTER/companion"; mkdir -p "$BEX"; git -C "$BEX" init -q; git -C "$BEX" config user.email "lane@test.local"; git -C "$BEX" config user.name "lane-test"
+printf 'private\n' > "$HUB/tracks/_meta/secret_card.md"
+mkdir "$BEX/.sync.lock.d"
+( MID=lanea run_loud > "$ENV_DIR/out" 2>&1; echo "$?" > "$ENV_DIR/rc" ) &
+_pid=$!
+wait_for_line "$ENV_DIR/out" 'destination: '; chk $? "CONTROL: the nested repo root passed validation (B8m's accepted case) and the run is waiting on the lock"
+mv "$BEX/.git" "$BEX/.git.gone"          # now a plain subdirectory INSIDE the enclosing repo — still 'inside a work tree'
+rmdir "$BEX/.sync.lock.d"
+wait "$_pid"
+rc="$(cat "$ENV_DIR/rc" 2>/dev/null || echo none)"
+[ "$rc" = "12" ]; chk $? "mid-run loss inside an enclosing repo → rc=12 (got $rc) — 'inside a work tree' alone would have passed"
+grep -q 'ENCLOSING' "$ENV_DIR/out"; chk $? "the refusal names the enclosing-repo hazard"
+[ "$(git -C "$OUTER" log --oneline 2>/dev/null | grep -c .)" -eq 0 ]; chk $? "the enclosing repo received NO commit"
+[ -z "$(git -C "$OUTER" diff --cached --name-only 2>/dev/null)" ]; chk $? "…and nothing was staged there either"
+[ -f "$BEX/tracks-meta/secret_card.md" ]; chk $? "CONTROL: the mirror itself had run (the belt fires after the write)"
+
+echo "── B8p HUB_DIR that does not exist → the hub-identity refusal (rc=10) is reached, not a silent set -e death in the physical-path derivation (R4 A2) ──"
+new_env b8p
+out="$(HOME="$ENV_DIR/home" HUB_DIR="$ENV_DIR/does-not-exist" BE_DIR="$BEX" FH_MACHINE_ID=lanea bash "$SCRIPT" --quiet 2>&1)"; rc=$?
+[ "$rc" -eq 10 ]; chk $? "nonexistent HUB_DIR → rc=10 (got $rc), not a bare set -e exit 1"
+printf '%s' "$out" | grep -qi 'recognized hub'; chk $? "the refusal is printed (the guard was reached)"
+[ ! -e "$BEX/tracks-meta" ]; chk $? "nothing was mirrored"
+
+echo "── B8q .git swapped mid-run for a gitfile pointing at ANOTHER repo (same toplevel) → rc=12, nothing committed there (R5 S1) ──"
+new_env b8q
+OTHER="$ENV_DIR/other"; mkdir -p "$OTHER"; git -C "$OTHER" init -q; git -C "$OTHER" config user.email "lane@test.local"; git -C "$OTHER" config user.name "lane-test"
+printf 'private\n' > "$HUB/tracks/_meta/secret_card.md"
+mkdir "$BEX/.sync.lock.d"
+( MID=lanea run_loud > "$ENV_DIR/out" 2>&1; echo "$?" > "$ENV_DIR/rc" ) &
+_pid=$!
+wait_for_line "$ENV_DIR/out" 'destination: '; chk $? "CONTROL: validated, waiting on the lock"
+mv "$BEX/.git" "$BEX/.git.orig"; printf 'gitdir: %s/.git\n' "$OTHER" > "$BEX/.git"   # same work tree top, DIFFERENT repository
+[ "$(git -C "$BEX" rev-parse --show-toplevel 2>/dev/null)" = "$(cd -P "$BEX" && pwd -P)" ]; chk $? "CONTROL: after the swap the toplevel is STILL \$BE — a path-only re-check would pass"
+rmdir "$BEX/.sync.lock.d"
+wait "$_pid"
+rc="$(cat "$ENV_DIR/rc" 2>/dev/null || echo none)"
+[ "$rc" = "12" ]; chk $? "identity switch → rc=12 (got $rc)"
+grep -q 'git IDENTITY changed' "$ENV_DIR/out"; chk $? "the refusal names the identity change"
+[ "$(git -C "$OTHER" log --oneline 2>/dev/null | grep -c .)" -eq 0 ] && [ -z "$(git --git-dir="$OTHER/.git" --work-tree="$BEX" diff --cached --name-only 2>/dev/null)" ]; chk $? "the other repository received neither a commit nor staged files"
+
+echo "── B8r repo-selecting GIT_* env in the caller (a git hook's environment) cannot redirect the store (R5 S2) ──"
+new_env b8r
+PUBLIC="$ENV_DIR/public"; mkdir -p "$PUBLIC"; git -C "$PUBLIC" init -q; git -C "$PUBLIC" config user.email "lane@test.local"; git -C "$PUBLIC" config user.name "lane-test"
+rm -rf "$BEX"; mkdir -p "$BEX"                                 # a PLAIN directory — must be refused
+printf 'private\n' > "$HUB/tracks/_meta/secret_card.md"
+[ "$(GIT_DIR="$PUBLIC/.git" GIT_WORK_TREE="$BEX" git -C "$BEX" rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; chk $? "CONTROL: with the env set, git itself reports the plain dir as a work tree (the leak is real)"
+out="$(GIT_DIR="$PUBLIC/.git" GIT_WORK_TREE="$BEX" MID=lanea run 2>&1)"; rc=$?
+[ "$rc" -eq 12 ]; chk $? "plain dir + leaked GIT_DIR/GIT_WORK_TREE → rc=12 (got $rc)"
+[ ! -e "$BEX/tracks-meta" ]; chk $? "nothing was mirrored"
+[ "$(git -C "$PUBLIC" log --oneline 2>/dev/null | grep -c .)" -eq 0 ] && [ -z "$(git -C "$PUBLIC" diff --cached --name-only 2>/dev/null)" ]; chk $? "the env-selected repository received neither a commit nor staged files"
+
 echo ""
 echo "════ lanes: $PASS passed · $FAIL failed ════"
 [ "$FAIL" -eq 0 ]

--- a/scripts/sync_to_be_lanes.sh
+++ b/scripts/sync_to_be_lanes.sh
@@ -211,8 +211,12 @@ new_env a3
 BEX="$ENV_DIR/fresh/companion"; mkdir -p "$ENV_DIR/fresh"   # parent EXISTS — --init creates exactly one leaf level
 printf 'private\n' > "$HUB/tracks/_meta/secret_card.md"
 [ ! -e "$BEX" ]; chk $? "CONTROL: destination absent before --init"
-out="$(MID=lanea run --init 2>&1)"; rc=$?
+# CI 2026-09-05: the runner had no committer identity and the FIRST commit of the just-created store died with
+# rc=128 (mirror already done). user.useConfigOnly makes that condition deterministic on every machine, so this
+# lane asserts the script's own repo-local fallback identity, not the host's auto-detection.
+out="$(GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=user.useConfigOnly GIT_CONFIG_VALUE_0=true MID=lanea run --init 2>&1)"; rc=$?
 [ "$rc" -eq 0 ]; chk $? "--init run completes rc=0 (got $rc)"
+[ "$(git -C "$BEX" log --oneline 2>/dev/null | grep -c .)" -ge 1 ]; chk $? "…and the new store's FIRST commit exists (no host identity: the script's repo-local fallback was used)"
 [ "$(git -C "$BEX" rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; chk $? "destination is now a git work tree"
 [ -f "$BEX/tracks-meta/secret_card.md" ]; chk $? "and the sync actually proceeded after creation"
 printf '%s' "$out" | grep -q -- '--init: created companion store at'; chk $? "creation is LOGGED with what and where (not silent)"


### PR DESCRIPTION
## What

`scripts/sync-to-be.sh` — the hub-local → private companion-store mirror — now **refuses** any destination that is not the root of an existing git work tree (`rc=12`, nothing created, nothing written), grades a recoverable destination-newer conflict as `rc=2` with a 3-line notice instead of the 21-line wall, and holds the validated store identity through the whole run.

Origin: `fh_signal_2026-09-05_sync-guard-failopen-and-alarm-fatigue` — a typo in `BE_DIR` / `FH_COMPANION_STORE` used to `mkdir -p` a fresh directory and mirror the private half into it in mirror-only mode with `exit 0` (fail-open on an irreversible surface), and every legitimate «another node advanced» conflict printed the same red wall as a real corruption (alarm fatigue).

## Rounds (cross-family, codex gpt-5.5 × 5)

| round | verdict | what it found → what changed |
|---|---|---|
| R1 (worktree draft) | NOT-CONVERGED | «inside SOME git work tree» was too weak: a typo landing in a subdirectory of another repo passed → root identity (`_be_root_ok`: inside ∧ no superproject ∧ physical toplevel == physical `$BE`), physical paths both sides, atomic `--init`, COUNT-line anchoring, 30 s timeout |
| R2 | NOT-CONVERGED | S1 symlink retargeted between validation and write (TOCTOU) → `BE` pinned to the validated physical path · S2 default store derived from the logical `$FH` → derived from the physical hub · A3 old git's `--show-superproject-working-tree` (measured: `rev-parse` echoes an unknown option back with rc=0) → fail-closed both ways · A4 independent repo nested in another repo's tree → **declined with grounds**, pinned by lane B8m · B6 mid-run belt `exit 0` → `rc=12` |
| R3 | NOT-CONVERGED | S1 the belt checked only `--is-inside-work-tree`, so a nested independent repo that loses its `.git` is still «inside» the enclosing repo → belt re-runs the root check · A2 nonexistent `HUB_DIR` died silently under `set -e` before the `rc=10` hub refusal → `\|\| true` |
| R4 | NOT-CONVERGED | S1 `.git` swapped mid-run for a gitfile pointing at another repo (same toplevel) → git identity (absolute git dir · common dir) pinned after validation and compared at the belt · S2 repo-selecting `GIT_*` env (a git hook exports `GIT_DIR`) made a plain directory pass → `unset GIT_DIR GIT_WORK_TREE …` first line |
| R5 | **CONVERGED** (S0 · A0 · B1) | B1 lane race: the lanes wait for the `destination:` line, which was printed *before* the identity pin → both pins moved ahead of that line (the reviewer's own one-liner; lanes and mutant m7 re-run, no further round). Explicitly cleared: the `GIT_*` unset list covers repo selection; `--git-common-dir` is compared same-cwd on both reads and does not reject a legitimate separate-git-dir store |

The header now states the **threat model** (the operator's own machine and store; typos · symlinks · logical/physical splits · stale copies · concurrent legitimate processes — not an adversary rewriting the store between two lines of the script), so later reviews grade against it instead of escalating the adversary each round.

## Evidence

- Lanes `scripts/sync_to_be_lanes.sh`: 36 → **155/155** (A1~A4 guard · B1~B3 grade split · B8a~B8r: root identity, physical paths, atomic `--init`, COUNT anchoring, timeout absence, old-git shim, symlinked hub, nested repo decision, symlink retarget during the lock wait, mid-run `.git` loss, gitfile swap, `GIT_*` leak). B8n/B8o/B8o2/B8q inject the mid-run change deterministically: hold the sync lock → wait for the script's `destination:` line → mutate → release.
- Fail-before mutants, each red **only** on its predicted lane: m1 drop the pin → B8n · m2 drop pin+derivation → B8l+B8n · m3 old `sup` line → B8k · m4 belt `exit 0` → B8o · m5 belt inside-only → B8o2 · m6 drop `|| true` → B8p · m7 drop identity compare → B8q · m8 drop `unset` → B8r (measured: without the unset the run mirrors into the plain dir, then exits 4 from the hub-equality belt — wrong reason, after the write).
- Standpoint (`tier2b`): the new script run with the sibling hub's real directory as `HUB_DIR` against a temp store → rc=0, suffixed dirs landed, 1 commit; the FH hub → rc=0; a plain dir → rc=12, 0 files. First real use against the real companion store → rc=0, committed and pushed.
- `selfcheck.sh` SELFCHECK: PASS rc=0 on the final tree (FAIL 0; forward-path lanes 155/155 inside it) · degrade scan 3 smells = the 3 pre-existing ones (lines moved, 0 new) · portability lint 1 = pre-existing.

## Behavior change for hub owners (this script does not ship in the npm package)

**BREAKING (gate)**: an existing **non-git** directory, a **subdirectory of another repository**, a bare repo or a submodule as the companion store is now refused with `rc=12` — it used to be `mkdir -p`'d and mirrored in mirror-only mode with `exit 0`. Remedy: point `BE_DIR` at the root of an existing git work tree, or run `bash scripts/sync-to-be.sh --init` (parent must exist) to create one explicitly. `rc=2` (recoverable: run `sync-from-be.sh`, then re-run) is new and is **not** stamped by the Stop hook's cooldown — whether it should be is a local hook decision, unchanged here.

## Named residuals

- B5 (codex R2): a file name containing a newline could forge the COUNT line only in a run where the return path exits 0, prints no COUNT line and still lists that name — closing it properly is a machine-only output mode on `sync-from-be.sh`, not a regex here.
- The sibling hub's copy of this script (2026-08-14) is already behind FH `main`; syncing it is a separate one-way PR.
- Stop-hook stamping policy for rc=2 / rc=12 (`.claude/settings.local.json`, outside the repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ydpJiBa7trEToGcDgaFAF
