### PR TITLE
chore(chamber): archify-recon SIM_NOTES ordering witness (before verdict)

### DIFF
--- a/knowledge/shared/learnings/chamber_ordering_witness.yaml
+++ b/knowledge/shared/learnings/chamber_ordering_witness.yaml
@@ -179,3 +179,7 @@
   artifact: SIM_NOTES.md
   sha256: ea417c681e8f1be3b59fddaa86ca4356ab6ae36816ee15c996a51af212f84e2a
   recorded: 2026-09-05T11:06:36Z
+- run: archify-recon
+  artifact: SIM_NOTES.md
+  sha256: 781b3632fe3e500d73917d02815607cac1291f59d43096905d88ee3f26eb8f73
+  recorded: 2026-09-05T11:21:12Z


### PR DESCRIPTION
Chamber run `archify-recon` step-4 (three blind personas via the reverse-engineering workflow) — SIM_NOTES.md ordering witness, committed before any verdict per `ship_readiness_gate §② P1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ydpJiBa7trEToGcDgaFAF