### PR TITLE
fix(sim-runner): block operator user-scope MCP from headless arms — --strict-mcp-config by default, --mcp-config explicit allow (lanes L27 ×3, mutant red)

### DIFF
--- a/scripts/sim_isolated_run.sh
+++ b/scripts/sim_isolated_run.sh
@@ -328,6 +328,7 @@ while [ $# -gt 0 ]; do
     --base-sha) BASE_SHA="${2:-}"; shift 2 ;;
     --setup)   SETUP="${2:-}"; shift 2 ;;  # shell run INSIDE each clone before the sim. See below.
     --extra-tools) EXTRA="${2:-}"; shift 2 ;;  # append tools to the mode's set. See TOOL VISIBILITY.
+    --mcp-config) MCPCFG="${2:-}"; shift 2 ;;  # the ONLY MCP servers an arm may see (see MCP ISOLATION). Default: none.
     *) echo "unknown flag: $1" >&2; exit 2 ;;
   esac
 done
@@ -588,8 +589,16 @@ for r in $(seq 1 "$REPS"); do
   #    부르며 정직하게 거부하면서도, 거부문 안에서 정답을 말한다. 채점기는 그걸 토큰으로 센다.
   #    이것이 회차 1~3 과 probe1~4 를 전부 무효로 만든 근인이고, 경로 deny·코퍼스 마스킹은
   #    **원리적으로 못 막는다**(도구 읽기가 아니라 프롬프트 조립이다).
+  # 🟥 MCP ISOLATION (measured 2026-09-05, QP chamber floor sim): a headless arm launched by this
+  #    runner saw the OPERATOR'S user-scope MCP servers (a cloud drive, a wiki, a browser bridge)
+  #    in its tool list — the clone isolates files and settings, not `~/.claude.json` MCP scope.
+  #    A blind arm with a write-capable MCP is a residency hole, not a sim. `--strict-mcp-config`
+  #    = "only the servers given by --mcp-config" (CLI --help), and with no --mcp-config that is
+  #    NONE. An arm that legitimately needs a server (e.g. Playwright for a web target) gets it
+  #    explicitly via --mcp-config <file inside the clone>; nothing is inherited.
+  MCPARGS=(--strict-mcp-config); [ -n "${MCPCFG:-}" ] && MCPARGS+=(--mcp-config "$MCPCFG")   # bash 3.2 + set -u: expanded with the ${a[@]+"${a[@]}"} idiom below
   ( cd "$WORK" && fh_timeout "$TIMEOUT" claude -p "$PROMPT" \
-        --model "$MODEL" "${TOOLS[@]}" \
+        --model "$MODEL" "${TOOLS[@]}" ${MCPARGS[@]+"${MCPARGS[@]}"} \
         < /dev/null 2>"$OUTDIR/${ARM}_r${r}.stderr.txt" ) > "$OUTDIR/${ARM}_r${r}.txt"
   rc=$?
   bytes=$(wc -c < "$OUTDIR/${ARM}_r${r}.txt" | tr -d ' ')

--- a/scripts/test_sim_isolated_run_lanes.sh
+++ b/scripts/test_sim_isolated_run_lanes.sh
@@ -378,5 +378,24 @@ else
   esac
 fi
 
+# ── L27 MCP isolation (2026-09-05) — the QP chamber floor sim saw the operator's user-scope MCP servers ─
+#    in a headless arm's tool list. The runner must pass --strict-mcp-config ALWAYS (no --mcp-config ⇒
+#    no servers), and pass through --mcp-config only when the caller names a file. Both directions.
+OUTDIR="$WORKROOT/o27"; LOG="$WORKROOT/argv27.log"; : > "$LOG"
+( cd "$SRC" && PATH="$STUBBIN:$PATH" HOME="$FAKEHOME" FH_STUB_MODE=say FH_STUB_ARGV_LOG="$LOG" \
+   bash "$SUT" --arm a --reps 1 --prompt p --out "$OUTDIR" ) >/dev/null 2>&1
+grep -q -- "--strict-mcp-config" "$LOG" \
+  && ok "L27a default passes --strict-mcp-config (user-scope MCP cannot reach a blind arm)" \
+  || no "L27a default did NOT pass --strict-mcp-config — operator MCP servers leak into headless arms"
+grep -q -- "--mcp-config" "$LOG" \
+  && no "L27b default passed --mcp-config without a file (would point at nothing)" \
+  || ok "L27b default passes no --mcp-config (strict + none = no servers)"
+OUTDIR="$WORKROOT/o27c"; LOG2="$WORKROOT/argv27c.log"; : > "$LOG2"; printf '{"mcpServers":{}}\n' > "$WORKROOT/mcp27.json"
+( cd "$SRC" && PATH="$STUBBIN:$PATH" HOME="$FAKEHOME" FH_STUB_MODE=say FH_STUB_ARGV_LOG="$LOG2" \
+   bash "$SUT" --arm a --reps 1 --prompt p --mcp-config "$WORKROOT/mcp27.json" --out "$OUTDIR" ) >/dev/null 2>&1
+grep -q -- "--mcp-config $WORKROOT/mcp27.json" "$LOG2" && grep -q -- "--strict-mcp-config" "$LOG2" \
+  && ok "L27c --mcp-config <file> reaches the CLI together with --strict-mcp-config (explicit allow, still strict)" \
+  || no "L27c --mcp-config not plumbed (or strict dropped when a file is given)"
+
 echo "sim_isolated_run lanes: $pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
The isolated-clone sim runner launched headless arms that could see the operator's user-scope MCP servers (a cloud drive, a wiki, a browser bridge) — found by the QP chamber's floor-tier sim today. The clone isolates files and settings; it never isolated MCP scope. A blind arm with a write-capable MCP is a residency hole, not a sim.

- `claude -p` now always gets `--strict-mcp-config` (CLI: only servers from `--mcp-config`; none given ⇒ none), and a new `--mcp-config <file>` runner option passes an explicit allow-list from inside the clone.
- Array expansion uses the bash-3.2 + `set -u` safe idiom (the first mutant run showed why: an empty array killed the runner at the call site).
- Lanes L27a/b/c on the stub argv log: default passes strict; default passes no `--mcp-config`; a file is plumbed together with strict. 34/34; the fail-before mutant (flag swapped) turns exactly L27a and L27c red.
- Named residual: the live effect (an arm's actual tool list) is verified by the next QP sim that passes `--mcp-config`, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ydpJiBa7trEToGcDgaFAF