### PR TITLE
chore(chamber): fh-qa-generic verdict witness — run #18 EMIT (QP, plugins/fh-qp)

### DIFF
--- a/knowledge/shared/learnings/chamber_ordering_witness.yaml
+++ b/knowledge/shared/learnings/chamber_ordering_witness.yaml
@@ -183,3 +183,7 @@
   artifact: SIM_NOTES.md
   sha256: 781b3632fe3e500d73917d02815607cac1291f59d43096905d88ee3f26eb8f73
   recorded: 2026-09-05T11:21:12Z
+- run: fh-qa-generic
+  artifact: EMISSION_VERDICT.md
+  sha256: cbad21dba6de165da9792e5ef025f26978f607c97ffb73c86607943b3247ec3c
+  recorded: 2026-09-05T11:38:21Z


### PR DESCRIPTION
Chamber run `fh-qa-generic` closed: **EMIT** (operator decision 2026-09-05) — QP (Quality Platform), the generic edition of qasp's PAR as an FH plugin. This commit carries the ordering-witness row for EMISSION_VERDICT.md; the plugin scaffold itself lands in a separate PR under the New-Skill gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ydpJiBa7trEToGcDgaFAF