### PR TITLE
feat(preprep): diagrams baked from typed JSON — archify validate gate, standalone-SVG PNG with receipt, lane L12, anchor K1~K7; first real use on a 121-slide deck (v1.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -316,6 +316,7 @@
     "plugins/fh-qp/skills",
     "plugins/fh-qp/scripts",
     "plugins/fh-qp/fixtures",
-    "scripts/test_fh_qp_lanes.sh"
+    "scripts/test_fh_qp_lanes.sh",
+    "scripts/test_preprep_diagram_lanes.sh"
   ]
 }

--- a/plugins/fh-commons/skills/preprep/README.md
+++ b/plugins/fh-commons/skills/preprep/README.md
@@ -6,7 +6,7 @@
 
 ```bash
 mkdir -p ~/preprep && cd ~/preprep
-cp <이 디렉터리>/{preprep.py,interslide_deps.py,lane_progression.py,lane_adjacent_dup.py,lane_promise.py} .
+cp <이 디렉터리>/{preprep.py,interslide_deps.py,lane_progression.py,lane_adjacent_dup.py,lane_promise.py,lane_diagram.py,diagram_from_json.py} .
 cp -r <이 디렉터리>/ooxml .          # 덱(pptx)을 다룬다면. 아니면 생략
 cp <이 디렉터리>/surfaces.example.yaml   surfaces.yaml
 cp <이 디렉터리>/canon_terms.example.yaml  canon_terms.yaml
@@ -16,6 +16,9 @@ python3 preprep.py
 ```
 
 의존: `pyyaml` · `python-pptx` 둘뿐이다(나머지는 표준 라이브러리). FH 도, 네트워크도 필요 없다.
+도해를 JSON 에서 굽는 갈래(`diagram_from_json.py`)만 **선택 의존**이 둘 더 있다 — node ≥ 18 + 로컬 설치한
+archify(`npx -y skills add tt-a1i/archify --skill archify --agent claude-code --copy --yes`, MIT) · headless Chrome.
+없으면 그 스크립트만 exit 10 으로 죽고 레인 L12 는 영수증 없음을 UNMEASURED 로 낸다 — 나머지 레인은 그대로 돈다.
 
 ## 드리프트를 막는 법
 

--- a/plugins/fh-commons/skills/preprep/SKILL.md
+++ b/plugins/fh-commons/skills/preprep/SKILL.md
@@ -131,6 +131,16 @@ model: sonnet
               텍스트 소실 · 부연-본문 밝기 경쟁 넷 다 렌더 없이는 구조적으로 안 보였다(§방법론 ⓒ).
               🟥 **장을 뺄 때는 뒤 장의 전제인지 먼저 본다** — 지운 장이 다음 장 부제의
               접속사(「그러나」 류)가 받는 말이었던 실사고가 있다(§방법론 ⓔ)
+              🔷 **도해는 타입 있는 JSON 에서 굽는다**(2026-09-05 신설, 5단계 안의 갈래이지 6단계가
+              아니다). `python3 diagram_from_json.py <spec.json> --out <png> --css <덱 토큰.css>
+              --no-legend` — 외부 렌더러 archify(MIT, 로컬 설치·소스 복사 0)의 showcase validate 를
+              **못 통과하면 굽기를 거부**하고, 통과하면 deliver → 뷰어 크롬 없는 SVG 단독 PNG(≥3840px)
+              → 굽기 영수증. 덱 자기 규약(배경·강조색·폰트)은 archify CSS 변수 override 로 꽂는다 —
+              archify 색을 덱에 가져오는 게 아니라 **덱 규약을 렌더러에 꽂는다**(§방법론 ⓓ). 가이드 뷰
+              인터랙션은 장표에 없으므로 `--focus id,…` 빌드 프레임으로 번역한다(§B3 좌표 고정).
+              🟥 archify 는 글자 크기 토큰이 없어 **viewBox 폭이 글자 pt 를 정한다**(720 → 라벨 29pt·
+              부제 19pt / 1137 → 12pt) — 그래서 폭 상한이 굽기 거부 조건이다. 대응표·차이·취향 판정
+              항목: `tracks-meta/dispatch/2026-09-05_archify-preprep/DESIGN_TOKENS.md`(운영자 로컬)
 ─────────────────────────────────────────────────────────────────
 바닥         `python3 preprep.py` — 아래 레인. 걸리면 ⑤ 로 되돌아간다
 ```
@@ -171,6 +181,7 @@ python3 "$SKILL/preprep.py"
 | **L11 promise** | **앞에서 예고한 것이 뒤에서 상환되나** — 후보를 나열하고 «예고 N 회 vs 뒤에서 M 회»를 센다. 실사고: 「세 번」 예고에 상환 1건 | 🟥 advisory · **판정은 사람** |
 | **L10 adjacent-dup** | **인접 장이 같은 문장을 다시 읽나** — 쪼갤 때 뒤 프레임에 원본을 통째로 남기면 앞 장에서 읽은 문장을 또 읽는다. 실측 117자 중 82자(70%) | 차단 (임계는 사람이 적는다. 미기재면 측정만) |
 | **L9 progression** | **선언된 단계 중 하나가 화면에서 빠졌나** — 실사고: ①②③④ 중 ①이 화면에서 떨어져 리뷰어가 논지를 **정반대로** 읽었다. 개별 문장은 전부 옳았다 | 차단 (선언된 것만 본다) |
+| **L12 diagram** | **타입 JSON 도해가 «지금 JSON» 에서 validate 를 거쳐 구워졌나** — `kind: diagram_source` 표면의 굽기 영수증(`*.receipt.json`)으로 JSON 지문 일치 · showcase validate ok · PNG 실제 폭(IHDR 직독) ≥ 3840 · viewBox 폭 ≤ 720 · 여백. 실사고 후보 셋: JSON 고치고 PNG 안 구움 · 미검증 JSON 손렌더 · 픽셀은 충분한데 글자 12pt | 차단 (선언된 표면만 · 영수증 없는 손그림은 **UNMEASURED**, 0 아님) |
 | **G ooxml** | pptx 구조 9종 — 관계 참조 무결성 · 죽은 Content_Types Override · **화면 밖 도형** · 열린 도형 채움 · 선 굵기 토큰 래칫 | 차단 (`python3 ooxml/gate.py <풀린 pptx 트리>`) |
 | **R1 orphan-connective** | 선두 줄이 «그러나/그래서»로 뒤집는데 그 문장의 주어가 **직전 장 어디에도 없다** | 🟥 advisory · **실물 known-positive**(실제 백업에서 뜬 결함) |
 | **R2 enum-dropped** | 앞 장이 ①②③ 으로 센 것을, 이 장이 «이 셋 중…» 이라 부르며 **번호 없이** 재편한다 — 1:1 대응이 안 보인다 | 🟥 advisory · **실물 known-positive** |

--- a/plugins/fh-commons/skills/preprep/diagram_from_json.py
+++ b/plugins/fh-commons/skills/preprep/diagram_from_json.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""diagram_from_json.py — 타입 있는 JSON 한 장 → 검증된 다이어그램 PNG(장표용) + 굽기 영수증.
+
+⑤ 제작·퇴고 단계의 «도해» 갈래. 도해를 영점부터 그리는 시행착오를 줄이는 자리다(SKILL.md §제작 흐름).
+
+파이프라인 (한 번에, 중간 산출은 전부 남긴다):
+  JSON ──archify validate(showcase)──▶ 못 통과 = **굽기 거부(exit 1)**, PNG 를 안 만든다
+       ──archify deliver───────────▶ <out>.html (뷰어 포함 정본 산출)
+       ──SVG 단독 추출 + 토큰 CSS──▶ headless Chrome 스크린샷 <out>.png (뷰어 크롬 0)
+       ──해상도 하한·여백·viewBox 폭 검사──▶ <out>.receipt.json (레인 L12 가 읽는 채널)
+
+🟥 archify 소스는 복사하지 않는다 — 외부 렌더러(MIT)를 **쓴다**. 위치는 --archify 또는
+   $PREPREP_ARCHIFY_BIN, 없으면 cwd 기준 .claude/skills/archify/bin/archify.mjs.
+🟥 해상도 하한: 장표 폭 26.67in(1920pt) 기준 2× = 3840px. 미달이면 굽기 거부.
+🟥 viewBox 폭 상한(기본 720): archify 는 글자 크기 토큰이 없어 **viewBox 폭이 pt 를 정한다**
+   (pt = unit × 1728/viewBox폭). 720 이면 라벨 29pt·부제 19pt, 1137 이면 12pt 로 안 읽힌다
+   (tracks-meta/dispatch/2026-09-05_archify-preprep/DESIGN_TOKENS.md §3). 넘으면 거부 — --max-viewbox-w 로 조정.
+🟥 여백(--pad): 그림 가장자리 비율. 0 이면 장표 가장자리와 선이 붙는다.
+
+exit 0 굽음 · 1 거부(validate 실패 · 해상도 · viewBox · deliver 실패) · 10 계기 오류(node/archify/Chrome 부재)
+usage: diagram_from_json.py <spec.json> --out <name.png> [--css tokens.css] [--theme dark|light]
+       [--focus id,id] [--no-legend] [--size 3840x2160] [--pad 0.03] [--min-px 3840] [--max-viewbox-w 720] [--archify BIN]
+"""
+import argparse, hashlib, json, os, re, shutil, struct, subprocess, sys, tempfile, zlib
+
+def sha256_file(p):
+    h = hashlib.sha256()
+    with open(p, 'rb') as f: h.update(f.read())
+    return h.hexdigest()
+
+def png_size(p):
+    with open(p, 'rb') as f: head = f.read(24)
+    if head[:8] != b'\x89PNG\r\n\x1a\n': raise ValueError('PNG 아님')
+    w, h = struct.unpack('>II', head[16:24]); return w, h
+
+def run_json(cmd, env):
+    r = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    try: return json.loads(r.stdout), r
+    except Exception: return None, r
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('spec'); ap.add_argument('--out', required=True, help='산출 PNG 경로(.png). HTML·영수증은 같은 이름으로 옆에')
+    ap.add_argument('--css', default=None, help='디자인 토큰 override CSS(archify CSS 변수 재정의)')
+    ap.add_argument('--theme', default='dark', choices=['dark', 'light'])
+    ap.add_argument('--focus', default=None, help='빌드 프레임: 켤 노드 id(콤마). 나머지는 흐림 — 좌표는 불변(§B3)')
+    ap.add_argument('--dim', type=float, default=0.22)
+    ap.add_argument('--opaque', action='store_true', help='배경을 칠한다(기본은 투명 — 장표 배경이 그대로 비친다. 색 관리 차이로 «패널»이 보이던 실측 결함의 처방)')
+    ap.add_argument('--strip-lane-prefix', action='store_true', help='레인 제목의 «01 / »·«EX / » 접두를 뺀다(archify 고정 어휘 — 장표에선 뜻이 없다). 글자만 짧아지고 기하는 불변')
+    ap.add_argument('--no-crop', action='store_true', help='내용 경계로 자르지 않는다(기본은 자른다 — archify 가 범례 행·채널 여백을 남겨 장표에서 그림이 작아진다)')
+    ap.add_argument('--no-legend', action='store_true', help='SVG 범례 행 숨김(영어 고정이라 D1 위반)')
+    ap.add_argument('--size', default='auto', help="'auto' = 폭 3840 · 높이는 SVG 비율대로(레터박스 0 — 장표에 넣을 때 글자 배율이 안 죽는다) 또는 WxH"); ap.add_argument('--pad', type=float, default=0.03)
+    ap.add_argument('--min-px', type=int, default=3840); ap.add_argument('--max-viewbox-w', type=int, default=720)
+    ap.add_argument('--archify', default=os.environ.get('PREPREP_ARCHIFY_BIN', '.claude/skills/archify/bin/archify.mjs'))
+    ap.add_argument('--chrome', default=os.environ.get('PREPREP_CHROME', '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'))
+    a = ap.parse_args()
+
+    if not os.path.exists(a.spec): print('HARNESS ERROR: spec 없음', a.spec); return 10
+    if not os.path.exists(a.archify): print('HARNESS ERROR: archify 없음 —', a.archify, '(npx -y skills add tt-a1i/archify --skill archify --agent claude-code --copy --yes)'); return 10
+    if shutil.which('node') is None: print('HARNESS ERROR: node 없음'); return 10
+    if not os.path.exists(a.chrome) and shutil.which(a.chrome) is None: print('HARNESS ERROR: Chrome 없음 —', a.chrome); return 10
+    env = dict(os.environ, ARCHIFY_UPDATE_CHECK_DISABLED='1')   # 외부 통신 차단
+    spec = json.load(open(a.spec, encoding='utf-8'))
+    dtype = spec.get('diagram_type')
+    if dtype not in ('architecture', 'workflow', 'sequence', 'dataflow', 'lifecycle'):
+        print('REFUSE: diagram_type 없음/미지원:', dtype); return 1
+    out_png = os.path.abspath(a.out); stem = re.sub(r'\.png$', '', out_png)
+    out_html, out_receipt = stem + '.html', stem + '.receipt.json'
+
+    # ① validate — showcase 9 검사 전부. 못 통과하면 여기서 끝(PNG 안 만든다)
+    v, r = run_json(['node', a.archify, 'validate', dtype, a.spec, '--quality', 'showcase', '--json'], env)
+    if not v or not v.get('ok'):
+        print('REFUSE: archify validate 실패 — 굽지 않는다')
+        for d in (v or {}).get('diagnostics') or (((v or {}).get('composition') or {}).get('diagnostics') or []):
+            print('   ·', d.get('code'), d.get('message', '')[:300])
+        if not v: print('   ·', (r.stderr or r.stdout)[-600:])
+        return 1
+    comp = v.get('composition') or {}
+    if (comp.get('summary') or {}).get('errors', 0) or (comp.get('summary') or {}).get('warnings', 0):
+        print('REFUSE: showcase 구성 오류/경고 있음', comp.get('summary')); return 1
+    # ② deliver
+    d, r = run_json(['node', a.archify, 'deliver', dtype, a.spec, out_html, '--quality', 'showcase', '--json'], env)
+    if not d or not d.get('ok'):
+        print('REFUSE: deliver 실패', (r.stderr or r.stdout)[-600:]); return 1
+    html = open(out_html, encoding='utf-8').read()
+    svgs = re.findall(r'<svg[\s\S]*?</svg>', html)
+    if len(svgs) != 1: print('REFUSE: <svg> 블록이 1개가 아님:', len(svgs)); return 1
+    vb = re.search(r'viewBox="([^"]+)"', svgs[0]); vbw = float(vb.group(1).split()[2]) if vb else None
+    if vbw is None or vbw > a.max_viewbox_w:
+        print(f'REFUSE: viewBox 폭 {vbw} > 상한 {a.max_viewbox_w} — 글자가 {12*1728/(vbw or 1):.0f}pt 로 떨어진다. 노드/레인을 줄이거나 --max-viewbox-w 를 근거와 함께 올려라')
+        return 1
+    # ③ SVG 단독 PNG
+    styles = ''.join(re.findall(r'<style[^>]*>[\s\S]*?</style>', html))
+    svg_out = svgs[0]
+    if a.strip_lane_prefix:
+        # 레인 제목 <text …font-size="10"…>01 / 사람</text> — 접두만 지운다. 텍스트가 짧아질 뿐 어떤 좌표도 안 바뀐다.
+        svg_out = re.sub(r'(<text[^>]*font-size="10"[^>]*>)(?:\d{2}|EX) / ', r'\1', svg_out)
+    vbh = float(vb.group(1).split()[3])
+    if a.size.lower() == 'auto':
+        # 🟥 16:9 고정 캔버스에 1.9:1 도해를 넣으면 레터박스가 생겨 장표에서 그림이 작아진다(실측:
+        #    후보 1차가 라벨 18pt 로 떨어졌다). 캔버스를 SVG 비율에 맞춰 여백 0 으로 굽는다.
+        W = max(a.min_px, 3840); H = int(round(W * vbh / vbw))
+    else:
+        W, H = map(int, a.size.lower().split('x'))
+    focus_css = ''
+    if a.no_legend: focus_css += '[data-legend],[data-legend-kind]{display:none !important}\n'
+    if a.focus:
+        ids = [x.strip() for x in a.focus.split(',') if x.strip()]
+        keep_n = ','.join(f'g[data-node-id="{i}"]' for i in ids)
+        keep_e = ','.join(f'[data-edge-from="{x}"][data-edge-to="{y}"]' for x in ids for y in ids if x != y)
+        focus_css += f'g[data-node-id],[data-edge-from]{{opacity:{a.dim}}}\n{keep_n}{{opacity:1}}\n' + (f'{keep_e}{{opacity:1}}\n' if keep_e else '')
+    token_css = ('<style>' + open(a.css, encoding='utf-8').read() + '</style>') if a.css else ''
+    bg_css = '' if a.opaque else 'html,body{background:transparent !important}'
+    doc = (f'<!doctype html><html lang="ko" data-theme="{a.theme}" data-preset="classic"><head><meta charset="utf-8">{styles}'
+           f'<style>{focus_css}html,body{{margin:0;padding:0;width:{W}px;height:{H}px;overflow:hidden}}{bg_css}'
+           f'body{{display:flex;align-items:center;justify-content:center}}'
+           f'.stage{{width:{W*(1-2*a.pad):.0f}px;height:{H*(1-2*a.pad):.0f}px;display:flex;align-items:center;justify-content:center}}'
+           f'.stage>svg{{width:100%;height:100%;max-width:100%;max-height:100%}}</style>{token_css}</head>'
+           f'<body><div class="stage">{svg_out}</div></body></html>')
+    tmpd = tempfile.mkdtemp(prefix='preprep_diagram_'); src = os.path.join(tmpd, 'svg_only.html')
+    open(src, 'w', encoding='utf-8').write(doc)
+    subprocess.run([a.chrome, '--headless=new', '--disable-gpu', '--hide-scrollbars', '--no-first-run'] +
+                   ([] if a.opaque else ['--default-background-color=00000000']) +
+                   [f'--window-size={W},{H}', f'--screenshot={out_png}', 'file://' + src], capture_output=True, text=True, timeout=180)
+    shutil.rmtree(tmpd, ignore_errors=True)
+    if not os.path.exists(out_png): print('HARNESS ERROR: Chrome 스크린샷 없음'); return 10
+    cropped = None
+    if not a.no_crop and not a.opaque:
+        try:
+            from PIL import Image
+            im = Image.open(out_png).convert('RGBA'); bb = im.getbbox()   # 알파 0 이 아닌 픽셀의 경계
+            if bb:
+                m = int(round(a.pad * W)); bb2 = (max(0, bb[0]-m), max(0, bb[1]-m), min(W, bb[2]+m), min(H, bb[3]+m))
+                im.crop(bb2).save(out_png); cropped = bb2
+        except ImportError:
+            cropped = 'PIL 없음 — 자르지 못함(UNMEASURED)'
+    pw, ph = png_size(out_png)
+    if pw < a.min_px and not cropped:
+        os.remove(out_png); print(f'REFUSE: PNG 폭 {pw} < 하한 {a.min_px} — 지웠다'); return 1
+    if cropped and W < a.min_px:
+        os.remove(out_png); print(f'REFUSE: 캔버스 폭 {W} < 하한 {a.min_px} — 지웠다'); return 1
+    # ④ 영수증 — L12 가 읽는 채널. JSON 지문으로 «지금 JSON 의 그림인가»를 묶는다
+    receipt = {'schema': 'preprep.diagram.receipt/1', 'spec': os.path.abspath(a.spec), 'spec_sha256': sha256_file(a.spec),
+               'diagram_type': dtype, 'validate': {'ok': True, 'profile': 'showcase', 'checks': len(v.get('checks', [])),
+               'composition': comp.get('summary')}, 'deliver': {'artifact_sha256': (d.get('artifact') or {}).get('sha256')},
+               'html': out_html, 'png': out_png, 'png_size': [pw, ph], 'viewbox_w': vbw, 'viewbox_h': vbh, 'canvas': a.size, 'transparent': not a.opaque, 'crop': cropped, 'pad': a.pad, 'theme': a.theme,
+               'css': os.path.abspath(a.css) if a.css else None, 'focus': a.focus, 'legend_hidden': bool(a.no_legend), 'lane_prefix_stripped': bool(a.strip_lane_prefix),
+               'text_pt_estimate': {'label12': round(12*1728/vbw, 1), 'sublabel8': round(8*1728/vbw, 1)}}
+    json.dump(receipt, open(out_receipt, 'w', encoding='utf-8'), ensure_ascii=False, indent=2)
+    print(f'OK {out_png} {pw}x{ph} viewBox_w={vbw:.0f} (라벨≈{receipt["text_pt_estimate"]["label12"]}pt · 부제≈{receipt["text_pt_estimate"]["sublabel8"]}pt) 영수증 {out_receipt}')
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/plugins/fh-commons/skills/preprep/lane_diagram.py
+++ b/plugins/fh-commons/skills/preprep/lane_diagram.py
@@ -1,0 +1,95 @@
+"""L12 diagram — **도해가 «지금 JSON» 에서 검증을 거쳐 구워졌나.**
+
+## 존재 근거 (2026-09-05, archify × preprep 결합 실측)
+
+도해를 타입 있는 JSON → 외부 렌더러(archify) → PNG → pptx 로 넣는 경로가 뚫렸다. 그 경로의 사각은
+셋이고, 셋 다 «PNG 가 있다»로는 안 보인다:
+  ① JSON 을 고쳤는데 PNG 는 옛 것(재생성 안 함)         — 빌드는 성공, 그림은 거짓
+  ② validate 를 못 통과한 JSON 을 손으로 렌더해 넣음      — 겹침·라벨 마스킹이 화면에
+  ③ 픽셀은 충분한데 viewBox 가 넓어 글자가 12pt 로 떨어짐 — «해상도 OK» 인데 못 읽는다
+
+## 무엇을 재고 무엇을 안 재나
+
+- 잰다 — `kind: diagram_source` 표면마다 `render:` PNG 옆의 **굽기 영수증**(`*.receipt.json`,
+  `diagram_from_json.py` 가 쓴다)을 읽어: 영수증 존재 · JSON sha 일치 · validate ok(showcase) ·
+  PNG 실제 폭(IHDR 을 직접 읽는다 — 영수증 자기신고가 아니다) ≥ min_px · viewBox 폭 ≤ max ·
+  pad ≥ min.
+- 안 잰다 — 그림이 «좋은가». 그건 §방법론 ⓒ «도해를 건드렸으면 렌더한다» 의 사람 몫이다.
+- 🟥 영수증이 없는 PNG(손으로 넣은 그림)는 **UNMEASURED 로 낸다** — 0 이 아니고, 통과도 아니다.
+  이 레인은 «생성기를 거친 그림»만 본다. 사각은 좁아지지 좁아지지 닫히지 않는다(SKILL.md §갈라 적는 것).
+
+## 차단인 이유
+선언된 표면에 한해 «지문이 다르다 / validate 가 아니다 / 폭이 모자란다» 는 애매하지 않은 사실이다.
+오탐의 최저비용 무마는 «다시 굽는 것»이라 원고를 망가뜨리는 방향이 아니다.
+"""
+import hashlib, json, os, struct
+
+
+def _sha(p):
+    h = hashlib.sha256(); h.update(open(p, 'rb').read()); return h.hexdigest()
+
+
+def _png_w(p):
+    with open(p, 'rb') as f: head = f.read(24)
+    if head[:8] != b'\x89PNG\r\n\x1a\n': raise ValueError('PNG 아님')
+    return struct.unpack('>II', head[16:24])[0]
+
+
+def _resolve(root, p):
+    return os.path.normpath(os.path.join(root, os.path.expanduser(p)))
+
+
+def scan(cfg, root):
+    """(findings, notes). findings 튜플 = (sid, kind, ref, lit, why) — preprep.py 의 USE 계열."""
+    surfs = [s for s in cfg.get('surfaces', []) if s.get('kind') == 'diagram_source']
+    if not surfs:
+        return [], ['L12 diagram : diagram_source 표면 없음 — NOT_CONFIGURED (0 아님)']
+    spec = cfg.get('diagram') or {}
+    min_px = int(spec.get('min_px', 3840)); max_vb = float(spec.get('max_viewbox_w', 720)); min_pad = float(spec.get('min_pad', 0.02))
+    findings, notes = [], []
+    n_ok = n_unm = 0
+    for s in surfs:
+        sid = s['id']; jp = _resolve(root, s['path'])
+        if not os.path.exists(jp):
+            notes.append(f'L12 diagram : {sid} JSON 없음({jp}) — UNMEASURED (0 아님)'); n_unm += 1; continue
+        rp_png = s.get('render')
+        if not rp_png:
+            notes.append(f'L12 diagram : {sid} render(PNG) 미선언 — UNMEASURED (0 아님)'); n_unm += 1; continue
+        png = _resolve(root, rp_png); rec = png[:-4] + '.receipt.json' if png.endswith('.png') else png + '.receipt.json'
+        if not os.path.exists(png):
+            findings.append((sid, 'diagram', 'render', os.path.basename(png), 'L12 선언된 PNG 가 디스크에 없다 — 굽지 않았거나 경로가 틀렸다')); continue
+        if not os.path.exists(rec):
+            notes.append(f'L12 diagram : {sid} 굽기 영수증 없음({os.path.basename(rec)}) — 손으로 넣은 그림은 이 레인이 못 본다. UNMEASURED (0 아님)'); n_unm += 1; continue
+        try: r = json.load(open(rec, encoding='utf-8'))
+        except Exception as e:
+            findings.append((sid, 'diagram', 'receipt', os.path.basename(rec), f'L12 영수증 파싱 실패({type(e).__name__}) — 채널이 깨졌다')); continue
+        bad = False
+        if r.get('spec_sha256') != _sha(jp):
+            findings.append((sid, 'diagram', 'stale', os.path.basename(png), 'L12 JSON 지문이 영수증과 다르다 — JSON 을 고친 뒤 다시 굽지 않았다')); bad = True
+        if not (r.get('validate') or {}).get('ok') or (r.get('validate') or {}).get('profile') != 'showcase':
+            findings.append((sid, 'diagram', 'validate', os.path.basename(png), 'L12 showcase validate 통과 기록이 없다 — 검증 안 된 그림')); bad = True
+        try: w = _png_w(png)
+        except Exception as e:
+            findings.append((sid, 'diagram', 'png', os.path.basename(png), f'L12 PNG 헤더 읽기 실패({e})')); continue
+        if w < min_px:
+            # 자른(crop) PNG 는 캔버스보다 좁다 — 영수증의 png_size 가 아니라 «crop 전 캔버스»가 하한을 넘겼는지 본다.
+            # 🟥 캔버스 폭은 영수증 자기신고다. IHDR 실측(w)과 함께 둘 다 적어 감사자가 가르게 한다.
+            canvas_w = None
+            cv = r.get('canvas')
+            if isinstance(cv, str) and 'x' in cv.lower() and cv.lower() != 'auto':
+                canvas_w = int(cv.lower().split('x')[0])
+            elif r.get('crop'):
+                canvas_w = min_px if r.get('png_size') else None   # auto 캔버스는 스크립트가 하한 이상으로만 만든다
+            if not (r.get('crop') and canvas_w and canvas_w >= min_px):
+                findings.append((sid, 'diagram', 'resolution', os.path.basename(png), f'L12 PNG 폭 {w} < 하한 {min_px} (장표 2×)')); bad = True
+            else:
+                notes.append(f'L12 diagram : {sid} 자른 PNG 폭 {w}(IHDR) — 캔버스 {canvas_w}(영수증 자기신고) 로 하한 판정')
+        vbw = r.get('viewbox_w')
+        if vbw is None or float(vbw) > max_vb:
+            findings.append((sid, 'diagram', 'viewbox', os.path.basename(png), f'L12 viewBox 폭 {vbw} > 상한 {max_vb:.0f} — 글자 배율 미달(라벨≈{12*1728/float(vbw or 1):.0f}pt)')); bad = True
+        if float(r.get('pad', 0)) < min_pad:
+            findings.append((sid, 'diagram', 'pad', os.path.basename(png), f'L12 여백 {r.get("pad")} < 하한 {min_pad}')); bad = True
+        if not bad: n_ok += 1
+    notes.append(f'L12 diagram : 표면 {len(surfs)} · 통과 {n_ok} · UNMEASURED {n_unm} · 발견 {len(findings)} '
+                 f'(하한 {min_px}px · viewBox≤{max_vb:.0f} · pad≥{min_pad})')
+    return findings, notes

--- a/plugins/fh-commons/skills/preprep/preprep.py
+++ b/plugins/fh-commons/skills/preprep/preprep.py
@@ -9,6 +9,7 @@
   L2 unit-ref   — 표면 쌍의 단위 참조 정합 (대상의 «은퇴 선언 어휘»를 존중 — 안 하면 20% FP)
   L3 inventory  — 선언된 표면이 실물로 있나 (부재 = UNMEASURED, **0 이 아니다**)
   L4 getput     — 왕복 no-op 컨트롤. **v0.1 미배선 → NOT_WIRED 로 말한다**(거짓 초록 금지)
+  L12 diagram   — 타입 JSON 도해가 «지금 JSON» 에서 validate 를 거쳐 구워졌나 (lane_diagram.py · 2026-09-05)
 
 exit 0 = 전 레인 통과 · 1 = 발견 있음 · 2 = 계기 오류/미측정으로 판정 불가 (PASS 아님)
 
@@ -89,6 +90,31 @@ def read_text(path, kind):
         src = open(path, encoding='utf-8', errors='replace').read()
         lits = re.findall(r'"([^"\n]{2,})"|\'([^\'\n]{2,})\'', src)
         return '\n'.join(a or b for a, b in lits)
+    if kind == 'diagram_source':
+        # 🟥 2026-09-05 신설 — 타입 있는 도해 JSON(archify 스키마). figure_source 와 같은 이유로
+        #   «그림은 못 읽지만 그림을 그리는 소스는 읽는다». 노드 label/sublabel/tag · 간선 label ·
+        #   레인/구간/그룹 label · 카드 문장만 뽑는다(id·type 같은 기계 낱말은 L1/L5 에 안 태운다).
+        #   굽기 정합(지금 JSON 의 그림인가 · validate · 해상도)은 L12(lane_diagram.py) 몫이다.
+        import json as _json
+        d = _json.load(open(path, encoding='utf-8'))
+        out = []
+        for key in ('lanes', 'phases', 'groups', 'nodes', 'edges', 'participants', 'messages', 'states', 'transitions', 'components', 'relationships', 'stages', 'flows'):
+            for it in d.get(key) or []:
+                if isinstance(it, dict):
+                    for f in ('label', 'sublabel', 'tag', 'note'):
+                        if it.get(f): out.append(str(it[f]))
+        for c in d.get('cards') or []:
+            if isinstance(c, dict):
+                if c.get('title'): out.append(str(c['title']))
+                out += [str(x) for x in (c.get('items') or [])]
+        m = d.get('meta') or {}
+        for f in ('title', 'subtitle'):
+            if m.get(f): out.append(str(m[f]))
+        for v in m.get('views') or []:
+            if isinstance(v, dict):
+                for f in ('label', 'note'):
+                    if v.get(f): out.append(str(v[f]))
+        return '\n'.join(out)
     if kind == 'keynote':
         raise RuntimeError('keynote: 사람만 읽는 면 — 기계 어댑터 없음')
     raise RuntimeError(f'unknown kind: {kind}')
@@ -748,7 +774,7 @@ def main():
     #    [[feedback_rule_misdescribes_its_own_machine]] · [[feedback_instrument_vs_target_and_budget]]
     _lanes = sorted(n[5:] for n in globals() if n.startswith('lane_') and callable(globals()[n]))
     _mods = sorted(m for m in ('lane_promise', 'lane_adjacent_dup', 'lane_progression',
-                                'lane_slide_relations', 'lane_geometry')
+                                'lane_slide_relations', 'lane_geometry', 'lane_diagram')
                    if os.path.exists(os.path.join(HERE, m + '.py')))
     # 🟥 2026-09-04 신설 — `--lane R1,R2,...` 로 **새 모듈 레인(R1-R5·P1/P3)만** 골라 끈다/켠다.
     #    L1~L11 은 아직 이 필터를 안 탄다(usage 줄의 --lane 은 그쪽엔 미배선인 채 남아 있다 —
@@ -830,6 +856,15 @@ def main():
         except Exception as _e:
             notes.append('R1-R5 slide-relations : 계기 미실행 — NOT_WIRED (%s: %s) (0 아님)'
                          % (type(_e).__name__, _e))
+    # L12 diagram — 타입 JSON 도해가 «지금 JSON» 에서 validate 를 거쳐 구워졌나(2026-09-05 신설).
+    #   차단: 선언된 diagram_source 표면에 한해 지문·validate·해상도·viewBox 폭·여백을 본다.
+    #   영수증 없는 PNG(손그림)는 UNMEASURED 노트로만 — 0 이 아니다.
+    try:
+        import lane_diagram
+        _f12, _n12 = lane_diagram.scan(cfg, root)
+        findings += _f12; notes += _n12
+    except Exception as _e:
+        notes.append('L12 diagram : 계기 미실행 — NOT_WIRED (%s: %s) (0 아님)' % (type(_e).__name__, _e))
     if _lane_on('P1', 'P3', 'P'):
         try:
             import lane_geometry

--- a/plugins/fh-commons/skills/preprep/surfaces.example.yaml
+++ b/plugins/fh-commons/skills/preprep/surfaces.example.yaml
@@ -44,6 +44,15 @@ surfaces:
     path: "../scripts/gen_fig_s13b.py"
     kind: figure_source
     canonical_for: [도해 문구]
+  # 🟥 2026-09-05 신설 — 타입 있는 도해 JSON(archify 스키마)을 표면으로 세운다. figure_source 처럼
+  #   그림 «소스»의 문자열이 L1/L5 에 잡히고, 추가로 L12 가 옆의 굽기 영수증(*.receipt.json,
+  #   diagram_from_json.py 가 쓴다)으로 «지금 JSON 의 그림인가 · validate 통과 · 해상도 · viewBox 폭»을 본다.
+  #   render 를 안 적으면 UNMEASURED(0 아님). 손으로 넣은 PNG(영수증 없음)도 UNMEASURED.
+  - id: fig_s44
+    path: "figures/s44_methods_make_gate.workflow.json"
+    kind: diagram_source
+    render: "figures/s44_methods_make_gate.png"
+    canonical_for: [도해 문구]
   - id: wiring
     path: "../scripts/ifkakao_build_deck.py"
     kind: note_map
@@ -138,6 +147,15 @@ progressions:
       - anchor: "그래도 남는"
       - anchor: "더 늘려도"
       - anchor: "입장을 바꾸면"
+
+# ── L12 diagram — 타입 JSON 도해의 굽기 정합 (2026-09-05) ─────────────────────────
+# 값의 근거: 장표 26.67in = 1920pt → 2× = 3840px. viewBox 폭은 archify 글자 배율을 정한다
+# (pt = unit × 1728/폭: 720 이면 라벨 29pt·부제 19pt, 덱 최소 18pt 충족 / 845 면 부제 16pt 미달).
+# 🟥 덱이 다르면 min_px 는 그 덱 폭의 2× 로, max_viewbox_w 는 그 덱 최소 글자로 다시 정한다.
+diagram:
+  min_px: 3840
+  max_viewbox_w: 720
+  min_pad: 0.02
 
 # ── L10 adjacent-dup — 인접 장이 같은 문장을 다시 읽나 ────────────────────────
 # 🟥 구조는 범용이고 **임계는 발표마다 다르다** — 그래서 갈라 놓는다.

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -625,6 +625,7 @@ for _pair in \
   "templates/.git-hooks/pre-commit|scripts/test_marker_oracle_lanes.sh" \
   `# ── fh-qp (QP) — chamber run #18 EMIT 2026-09-05: qp_tools.sh known-pair + residency lanes ──` \
   "plugins/fh-qp/scripts/qp_tools.sh|scripts/test_fh_qp_lanes.sh" \
+  "plugins/fh-commons/skills/preprep/diagram_from_json.py|scripts/test_preprep_diagram_lanes.sh" \
   "scripts/sim_isolated_run.sh|scripts/test_sim_path_isolation_lanes.sh" \
   `# ── live-eval — the live twin of the static /prompt-regression probe check (2026-09-04) ──` \
   "scripts/probe_live_eval.sh|scripts/test_probe_live_eval_lanes.sh" \

--- a/scripts/test_preprep_diagram_lanes.sh
+++ b/scripts/test_preprep_diagram_lanes.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# test_preprep_diagram_lanes.sh — L12 diagram 레인 + diagram_from_json.py 거부 경로의 known-pair.
+#
+# 재는 것:
+#   K1 known-negative  영수증·지문·validate·폭·viewBox·pad 전부 맞으면 findings 0
+#   K2 stale          JSON 을 한 글자 고치면 «지문 다름» 1건을 이름으로 짚나
+#   K3 resolution     PNG 실제 폭(IHDR)이 하한 미달이면 1건 — 영수증 자기신고(png_size)가 아니라 헤더를 읽나
+#   K4 viewbox        viewBox 폭 > 상한이면 1건(글자 배율)
+#   K5 unmeasured     영수증 없는 PNG 는 findings 0 + UNMEASURED 노트(0 으로 안 접나)
+#   K6 not-configured diagram_source 표면이 없으면 NOT_CONFIGURED(통과 아님)
+#   K7 refuse         diagram_from_json.py 가 validate 실패 JSON 을 **굽지 않나** — archify 는 스텁으로 대체
+#                     (실물 archify·Chrome 없이 도는 레인이어야 CI 에서 앵커다)
+# 🟥 archify·Chrome 이 없어도 돌아야 한다 — 그래서 K7 은 스텁 archify(ok:false)로 «거부»만 잰다.
+#    «굽힘» 쪽 실사용은 tracks-meta/dispatch/2026-09-05_archify-preprep/REPORT.md 가 기록한다.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILL="$HERE/plugins/fh-commons/skills/preprep"
+PASS=0; FAIL=0
+ok(){ echo "  ✅ $1"; PASS=$((PASS+1)); }
+ng(){ echo "  ❌ $1"; FAIL=$((FAIL+1)); }
+command -v python3 >/dev/null 2>&1 || { echo "  ⚠️  UNMEASURED — python3 unavailable (not a pass)"; echo "diagram lanes: SKIPPED (not passed)"; exit 0; }
+
+out=$(cd "$SKILL" && python3 - <<'PY' 2>&1
+import sys, os, json, hashlib, struct, zlib, tempfile, subprocess
+sys.path.insert(0, '.')
+import lane_diagram as LD
+def sha(p): return hashlib.sha256(open(p,'rb').read()).hexdigest()
+def png(path, w, h=2):
+    # 순수 표준 라이브러리 PNG(회색 1바이트/픽셀) — 폭만 의미 있다
+    raw = b''.join(b'\x00' + b'\x80'*w for _ in range(h))
+    def chunk(t, d): return struct.pack('>I', len(d)) + t + d + struct.pack('>I', zlib.crc32(t+d) & 0xffffffff)
+    open(path,'wb').write(b'\x89PNG\r\n\x1a\n' + chunk(b'IHDR', struct.pack('>IIBBBBB', w, h, 8, 0, 0, 0, 0)) + chunk(b'IDAT', zlib.compress(raw)) + chunk(b'IEND', b''))
+d = tempfile.mkdtemp(prefix='l12_')
+spec = os.path.join(d, 'fig.workflow.json'); json.dump({'diagram_type':'workflow','nodes':[{'id':'a','label':'개발'}]}, open(spec,'w'))
+def receipt(pngp, **kw):
+    r = {'spec_sha256': sha(spec), 'validate': {'ok': True, 'profile': 'showcase'}, 'viewbox_w': 720, 'pad': 0.03, 'png_size': [3840, 2]}
+    r.update(kw); json.dump(r, open(pngp[:-4] + '.receipt.json', 'w'))
+def run(surfs, extra=None):
+    cfg = {'surfaces': surfs, 'diagram': {'min_px': 3840, 'max_viewbox_w': 720, 'min_pad': 0.02}}
+    return LD.scan(cfg, d)
+R = {}
+# K1 negative
+p1 = os.path.join(d, 'ok.png'); png(p1, 3840); receipt(p1)
+f, n = run([{'id':'fig','path':'fig.workflow.json','kind':'diagram_source','render':'ok.png'}]); R['K1'] = len(f)
+# K2 stale: JSON 고침
+open(spec,'a').write('\n'); f, n = run([{'id':'fig','path':'fig.workflow.json','kind':'diagram_source','render':'ok.png'}])
+R['K2'] = [x[2] for x in f]
+receipt(p1)  # 다시 맞춤
+# K3 resolution: 영수증은 3840 이라 «말하지만» 실제 헤더는 1000
+p3 = os.path.join(d, 'small.png'); png(p3, 1000); receipt(p3, png_size=[3840, 2])
+f, n = run([{'id':'fig','path':'fig.workflow.json','kind':'diagram_source','render':'small.png'}]); R['K3'] = [x[2] for x in f]
+# K4 viewbox
+p4 = os.path.join(d, 'wide.png'); png(p4, 3840); receipt(p4, viewbox_w=1137)
+f, n = run([{'id':'fig','path':'fig.workflow.json','kind':'diagram_source','render':'wide.png'}]); R['K4'] = [x[2] for x in f]
+# K5 unmeasured (영수증 없음)
+p5 = os.path.join(d, 'hand.png'); png(p5, 3840)
+f, n = run([{'id':'fig','path':'fig.workflow.json','kind':'diagram_source','render':'hand.png'}]); R['K5'] = {'n': len(f), 'unm': any('UNMEASURED' in s for s in n)}
+# K6 not configured
+f, n = run([]); R['K6'] = {'n': len(f), 'nc': any('NOT_CONFIGURED' in s for s in n)}
+# K7 refuse — 스텁 archify(항상 ok:false) + 가짜 chrome. PNG 가 «안 생겨야» 한다
+stub = os.path.join(d, 'archify_stub.mjs'); open(stub,'w').write('console.log(JSON.stringify({ok:false,diagnostics:[{code:"stub/fail",message:"stub"}]}))')
+fake_chrome = os.path.join(d, 'chrome'); open(fake_chrome,'w').write('#!/bin/sh\nexit 0\n'); os.chmod(fake_chrome, 0o755)
+outp = os.path.join(d, 'refused.png')
+import shutil
+if shutil.which('node'):
+    r = subprocess.run([sys.executable, 'diagram_from_json.py', spec, '--out', outp, '--archify', stub, '--chrome', fake_chrome], capture_output=True, text=True)
+    R['K7'] = {'rc': r.returncode, 'png': os.path.exists(outp), 'msg': 'REFUSE' in r.stdout}
+else:
+    R['K7'] = {'rc': 'NO_NODE'}
+print(json.dumps(R, ensure_ascii=False))
+PY
+); rc=$?
+[ $rc -eq 0 ] || { echo "  ❌ INSTRUMENT ERROR — lane_diagram 실행 실패 (rc=$rc): $out"; exit 1; }
+g(){ python3 -c "import json,sys;v=json.loads(sys.argv[1]);exec('r=v'+sys.argv[2]);print(r)" "$out" "$1"; }
+[ "$(g "['K1']")" = "0" ] && ok "K1 known-negative: 다 맞으면 0건" || ng "K1 오탐 $(g "['K1']")건"
+[ "$(g "['K2']")" = "['stale']" ] && ok "K2 stale: JSON 고치면 «stale» 1건을 이름으로" || ng "K2 실패: $(g "['K2']")"
+[ "$(g "['K3']")" = "['resolution']" ] && ok "K3 resolution: 영수증이 3840 이라 해도 IHDR 1000 을 잡는다(자기신고 아님)" || ng "K3 실패: $(g "['K3']")"
+[ "$(g "['K4']")" = "['viewbox']" ] && ok "K4 viewbox: 1137 > 720 을 잡는다(글자 배율)" || ng "K4 실패: $(g "['K4']")"
+[ "$(g "['K5']['n']")" = "0" ] && [ "$(g "['K5']['unm']")" = "True" ] && ok "K5 영수증 없는 손그림 = UNMEASURED(0 아님·통과 아님)" || ng "K5 실패: $(g "['K5']")"
+[ "$(g "['K6']['n']")" = "0" ] && [ "$(g "['K6']['nc']")" = "True" ] && ok "K6 표면 없음 = NOT_CONFIGURED" || ng "K6 실패: $(g "['K6']")"
+k7=$(g "['K7']")
+case "$k7" in
+  *NO_NODE*) echo "  ⏭  K7 거부 경로 — node 부재라 UNMEASURED (통과 아님)";;
+  *) [ "$(g "['K7']['rc']")" = "1" ] && [ "$(g "['K7']['png']")" = "False" ] && [ "$(g "['K7']['msg']")" = "True" ] && ok "K7 refuse: validate 실패면 exit 1 + PNG 미생성 + REFUSE 표기" || ng "K7 실패: $k7";;
+esac
+echo "diagram lanes: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/test_preprep_drift_anchor.sh
+++ b/scripts/test_preprep_drift_anchor.sh
@@ -33,7 +33,7 @@ sk(){ echo "  ⏭  $1 — SKIPPED (**통과 아님**)"; SKIP=$((SKIP+1)); }
 
 # D1 — 단일 소스
 missing=""
-for f in preprep.py interslide_deps.py lane_progression.py lane_adjacent_dup.py lane_promise.py SKILL.md README.md surfaces.example.yaml; do
+for f in preprep.py interslide_deps.py lane_progression.py lane_adjacent_dup.py lane_promise.py lane_diagram.py diagram_from_json.py SKILL.md README.md surfaces.example.yaml; do
   [ -f "$SRC/$f" ] || missing="$missing $f"
 done
 if [ -n "$missing" ]; then ng "D1 단일 소스 결손:$missing"
@@ -41,10 +41,10 @@ elif ! command -v python3 >/dev/null 2>&1; then
   sk "D1 구문 검사 — python3 부재라 «돌 수 있나»를 못 쟀다(UNMEASURED)"
 else
   synerr=""
-  for f in preprep.py interslide_deps.py lane_progression.py lane_adjacent_dup.py lane_promise.py; do
+  for f in preprep.py interslide_deps.py lane_progression.py lane_adjacent_dup.py lane_promise.py lane_diagram.py diagram_from_json.py; do
     python3 -c "import ast,sys;ast.parse(open(sys.argv[1],encoding='utf-8').read())" "$SRC/$f" 2>/dev/null || synerr="$synerr $f"
   done
-  [ -z "$synerr" ] && ok "D1 단일 소스 8파일 실재 + python 5파일 구문 통과" \
+  [ -z "$synerr" ] && ok "D1 단일 소스 10파일 실재 + python 7파일 구문 통과" \
                    || ng "D1 구문 실패:$synerr"
 fi
 


### PR DESCRIPTION
Adds a branch inside preprep's step ⑤ (make · revise): a slide diagram is **baked from a typed JSON** document instead of hand-drawn. `diagram_from_json.py` runs archify's showcase validate first (a failing document is refused — exit 1, no PNG), delivers, extracts the SVG standalone (viewer chrome removed, ≥3840 px wide, margins), and writes a bake receipt bound to the JSON's sha. Lane **L12 diagram** (blocking) then checks receipt fingerprint, validate ok, real PNG width (IHDR), viewBox width cap and margins; a hand-drawn figure without a receipt is UNMEASURED, not a pass.

Measured rule that became a bake condition: archify has no font-size token, so **viewBox width sets the slide point size** (720 → 29/19 pt; 1137 → 12 pt).

Evidence: anchor `scripts/test_preprep_diagram_lanes.sh` K1~K7 7/7 (stubbed — runs without archify/Chrome), preprep rp tests 18 pass · 1 skip, and a first real use: a 121-slide conference deck rebaked as v1.4 (5 slides) and v1.4_record (2 slides) — preprep 0/0, L12 2/2, P1/P3 delta 0, PowerPoint opens with no repair prompt, PDF 121×2, speaker notes byte-identical; L12 caught a stale-PNG build mid-run (first real catch). Integration checks (lane runner 105/105, package coverage, files manifest, count) pass.

Named residuals: the companion deployment copy of preprep drifts until re-extracted from this single source after merge; the packed-install execution arm is not run; subtitle size stays under the deck's 18 pt minimum because archify reserves six columns (fix belongs upstream — a font/stroke token, filed in the sister-asset proposal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ydpJiBa7trEToGcDgaFAF