### PR TITLE
chore(chamber): archify-recon verdict witness — run #19 CURATED

### DIFF
--- a/knowledge/shared/learnings/chamber_ordering_witness.yaml
+++ b/knowledge/shared/learnings/chamber_ordering_witness.yaml
@@ -187,3 +187,7 @@
   artifact: EMISSION_VERDICT.md
   sha256: cbad21dba6de165da9792e5ef025f26978f607c97ffb73c86607943b3247ec3c
   recorded: 2026-09-05T11:38:21Z
+- run: archify-recon
+  artifact: EMISSION_VERDICT.md
+  sha256: 6e103aaa8b8fd6090644262159fe195f00bf3f0bd08538abf0dbf85365b3ffae
+  recorded: 2026-09-05T23:48:07Z


### PR DESCRIPTION
Chamber run `archify-recon` closed as **CURATED** (operator decision 2026-09-06): archify is MIT prior art and already a product; what this run produced that is new is the *measurement protocol* for reverse-engineering capability (sealed oracle, no-copy scan, verdict parity, fail-before), not a renderer to ship.

Recorded honestly alongside it: the expedition's actual emission — preprep's «bake the diagram from typed JSON» branch (#654) — did **not** go through the chamber's formal flow, so it is not written into the ledger as an EMIT row; a verdict created after the fact would land behind its own witnesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ydpJiBa7trEToGcDgaFAF