### PR TITLE
feat(action): ship fh-gate as a GitHub Action — the typed verdict survives the wrapper, unknown exit codes fail closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,23 @@ npx --package @chrono-meta/fh-gate fh-gate          # nothing to install
 brew tap chrono-meta/forge-harness && brew install forge-harness   # or this
 ```
 
+**In GitHub Actions** — the same gate as a step, with the verdict kept typed:
+
+```yaml
+- uses: chrono-meta/forge-harness@v3.1.0
+  with:
+    files: ${{ steps.changed.outputs.files }}
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+The step exposes `verdict` (PASS · PENDING · BLOCKED · ESCALATE · HARNESS_ERROR · ARG_ERROR · DRY_RUN · UNKNOWN)
+and `reviewed`. **`reviewed: false` is not a pass** — a backend that never answered, a dry run, or an exit
+code this wrapper does not know all land there, and all of them fail the step by default. That default is
+the point: a check that did not run must never read green. Change it with `fail-on:` if you want a softer
+policy, and know what you are trading.
+
+
 **What you get**
 
 - A change is judged **before** it merges, and the verdict names what the change **lost** — not that

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,116 @@
+# fh-gate — GitHub Action wrapper around the shipped CLI (@chrono-meta/fh-gate).
+#
+# 🟥 WHY THIS FILE IS MOSTLY A MAPPING TABLE: the gate's whole point is a *typed* verdict.
+# `scripts/fh-gate.sh` documents seven exit codes and they do not collapse into
+# success/failure without losing the thing the gate exists to carry:
+#   0 PASS · 1 PENDING(B) · 2 BLOCKED(A) · 3 ESCALATE(human) · 10 HARNESS_ERROR
+#   · 11 ARG_ERROR · 12 DRY_RUN(prompt emitted, NO review performed)
+# Two of those are traps a naive wrapper walks into:
+#   · 12 is deliberately outside the verdict range — «a check that did not run must never be
+#     readable as PASS». A wrapper that treats "non-zero = fail, zero = pass" is fine here, but
+#     one that adds `continue-on-error` and reads the step as green is not.
+#   · an UNKNOWN exit code (a future version adding one) must land on HARNESS_ERROR, never on
+#     PASS. That is the fail-closed default below, and `scripts/test_action_yml_lanes.sh` pins it.
+name: 'fh-gate — typed AI code-review verdict'
+description: 'Run forge-harness fh-gate on a diff and get a typed verdict (PASS · PENDING · BLOCKED · ESCALATE · HARNESS_ERROR) as a step output, fail-closed by default.'
+author: 'chrono-meta'
+branding:
+  icon: 'shield'
+  color: 'purple'
+
+inputs:
+  files:
+    description: 'Space-separated files to review. Empty = the gate derives them itself from the working tree.'
+    required: false
+    default: ''
+  level:
+    description: 'Review level passed through to the gate (e.g. standard, full).'
+    required: false
+    default: 'standard'
+  backend:
+    description: 'AI backend: claude | codex | auto. Needs the matching credential in env.'
+    required: false
+    default: 'claude'
+  model:
+    description: 'Model override. Empty = the backend default.'
+    required: false
+    default: ''
+  timeout:
+    description: 'Seconds before the backend is killed. A timeout is a HARNESS_ERROR, not a pass.'
+    required: false
+    default: '120'
+  dry-run:
+    description: 'true = emit the prompt and do NOT review (exit 12). Never reported as PASS.'
+    required: false
+    default: 'false'
+  fail-on:
+    description: 'Comma-separated verdicts that fail the step. Default is fail-closed: everything except PASS and PENDING.'
+    required: false
+    default: 'BLOCKED,ESCALATE,HARNESS_ERROR,ARG_ERROR,DRY_RUN,UNKNOWN'
+  version:
+    description: 'npm version spec of @chrono-meta/fh-gate to run (default: latest).'
+    required: false
+    default: 'latest'
+  working-directory:
+    description: 'Directory to run the gate in.'
+    required: false
+    default: '.'
+
+outputs:
+  verdict:
+    description: 'PASS | PENDING | BLOCKED | ESCALATE | HARNESS_ERROR | ARG_ERROR | DRY_RUN | UNKNOWN'
+    value: ${{ steps.gate.outputs.verdict }}
+  exit-code:
+    description: "The gate's raw exit code, unmapped."
+    value: ${{ steps.gate.outputs.exit_code }}
+  reviewed:
+    description: "true only when a review actually ran (PASS · PENDING · BLOCKED · ESCALATE). false for DRY_RUN, HARNESS_ERROR, ARG_ERROR, UNKNOWN — «did not run» is never «passed»."
+    value: ${{ steps.gate.outputs.reviewed }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: gate
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        FH_BACKEND: ${{ inputs.backend }}
+        FH_MODEL: ${{ inputs.model }}
+        FH_TIMEOUT: ${{ inputs.timeout }}
+        FH_CALLER: github-action
+      run: |
+        set -uo pipefail   # NOT -e: a non-zero exit is the payload, not a crash
+        [ "${{ inputs.dry-run }}" = "true" ] && export FH_DRY_RUN=1
+        rc=0
+        npx --yes --package "@chrono-meta/fh-gate@${{ inputs.version }}" fh-gate "${{ inputs.files }}" "${{ inputs.level }}" github-action || rc=$?
+        # ── the mapping table. UNKNOWN is fail-closed on purpose (see header). ──
+        case "$rc" in
+          0)  verdict=PASS;          reviewed=true  ;;
+          1)  verdict=PENDING;       reviewed=true  ;;
+          2)  verdict=BLOCKED;       reviewed=true  ;;
+          3)  verdict=ESCALATE;      reviewed=true  ;;
+          10) verdict=HARNESS_ERROR; reviewed=false ;;
+          11) verdict=ARG_ERROR;     reviewed=false ;;
+          12) verdict=DRY_RUN;       reviewed=false ;;
+          *)  verdict=UNKNOWN;       reviewed=false ;;
+        esac
+        {
+          echo "verdict=$verdict"
+          echo "exit_code=$rc"
+          echo "reviewed=$reviewed"
+        } >> "$GITHUB_OUTPUT"
+        echo "fh-gate: exit $rc → $verdict (reviewed=$reviewed)"
+        {
+          echo "### fh-gate — \`$verdict\`"
+          echo ""
+          echo "| field | value |"
+          echo "|---|---|"
+          echo "| verdict | \`$verdict\` |"
+          echo "| exit code | \`$rc\` |"
+          echo "| a review actually ran | \`$reviewed\` |"
+          [ "$reviewed" = "false" ] && echo "" && echo "> 🟥 No review ran. This is **not** a pass — see the exit-code contract in the action's README."
+        } >> "$GITHUB_STEP_SUMMARY"
+        case ",${{ inputs.fail-on }}," in
+          *",$verdict,"*) echo "::error title=fh-gate::verdict $verdict is in fail-on"; exit 1 ;;
+        esac
+        exit 0

--- a/package.json
+++ b/package.json
@@ -317,6 +317,7 @@
     "plugins/fh-qp/scripts",
     "plugins/fh-qp/fixtures",
     "scripts/test_fh_qp_lanes.sh",
-    "scripts/test_preprep_diagram_lanes.sh"
+    "scripts/test_preprep_diagram_lanes.sh",
+    "scripts/test_action_yml_lanes.sh"
   ]
 }

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -626,6 +626,8 @@ for _pair in \
   `# ── fh-qp (QP) — chamber run #18 EMIT 2026-09-05: qp_tools.sh known-pair + residency lanes ──` \
   "plugins/fh-qp/scripts/qp_tools.sh|scripts/test_fh_qp_lanes.sh" \
   "plugins/fh-commons/skills/preprep/diagram_from_json.py|scripts/test_preprep_diagram_lanes.sh" \
+  `# ── action.yml — the GitHub Action wrapper: its exit-code mapping is where a typed verdict could become a boolean ──` \
+  "action.yml|scripts/test_action_yml_lanes.sh" \
   "scripts/sim_isolated_run.sh|scripts/test_sim_path_isolation_lanes.sh" \
   `# ── live-eval — the live twin of the static /prompt-regression probe check (2026-09-04) ──` \
   "scripts/probe_live_eval.sh|scripts/test_probe_live_eval_lanes.sh" \

--- a/scripts/test_action_yml_lanes.sh
+++ b/scripts/test_action_yml_lanes.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# test_action_yml_lanes.sh — behavioural lanes for action.yml's exit-code mapping.
+#
+# WHY: `action.yml` is the only place where the gate's SEVEN typed exit codes get turned into a
+# GitHub step outcome. That translation is exactly where a typed verdict silently becomes a
+# boolean — the failure this repo names in `[[feedback_not_found_is_not_zero_family]]`. Two
+# properties carry the weight and neither is visible by reading the YAML:
+#   A. an UNKNOWN exit code (a future gate version adding one) must land on HARNESS_ERROR-class
+#      handling, never on PASS. A `case` whose `*)` arm is missing would default to... nothing,
+#      and `verdict` would be unset — which under `set -u` is a crash, but under a careless edit
+#      could become an empty string that matches no fail-on entry and exits 0. That is the leak.
+#   B. `reviewed` must be false for every code where no review ran (10 · 11 · 12 · unknown).
+#      «did not run» reported as «passed» is the same defect class as a skipped check scored green.
+#
+# HOW: the mapping is extracted from action.yml and executed as shell — the lanes run the REAL
+# case block, not a copy. A copy would drift and every lane would stay green while the shipped
+# file rotted (that is `[[feedback_built_but_not_wired]]` wearing a test's clothes).
+#
+# USAGE: bash scripts/test_action_yml_lanes.sh   → exit 0 all pass · 1 any fail · 10 harness error
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+A="$ROOT/action.yml"
+[ -f "$A" ] || { echo "❌ HARNESS: action.yml absent at $A"; exit 10; }
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  ✅ %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  ❌ %s\n' "$1"; }
+chk(){ if [ "$1" = "0" ]; then ok "$2"; else no "$2"; fi; }
+
+# ── extract the real case block from the shipped file ────────────────────────────────────────
+MAP="$(awk '/^ *case "\$rc" in/{f=1} f{print} /^ *esac/{if(f){exit}}' "$A" | sed 's/^ *//')"
+[ -n "$MAP" ] || { echo "❌ HARNESS: could not extract the case block from action.yml"; exit 10; }
+printf '%s' "$MAP" | grep -q 'esac' || { echo "❌ HARNESS: extracted block has no esac (truncated)"; exit 10; }
+
+verdict_for(){ # $1 = rc → prints "verdict reviewed"
+  rc="$1"; verdict=""; reviewed=""
+  eval "$MAP"
+  printf '%s %s' "${verdict:-<UNSET>}" "${reviewed:-<UNSET>}"
+}
+
+echo "── L1 documented exit codes map to their documented verdict ──"
+while read -r rc want_v want_r; do
+  got="$(verdict_for "$rc")"
+  [ "$got" = "$want_v $want_r" ]; chk $? "rc=$rc → $want_v (reviewed=$want_r) [got: $got]"
+done <<'CASES'
+0 PASS true
+1 PENDING true
+2 BLOCKED true
+3 ESCALATE true
+10 HARNESS_ERROR false
+11 ARG_ERROR false
+12 DRY_RUN false
+CASES
+
+echo "── L2 KNOWN-NEGATIVE: an undocumented exit code is never PASS and never reviewed=true ──"
+for rc in 4 5 9 13 42 127 255; do
+  got="$(verdict_for "$rc")"; v="${got%% *}"; r="${got##* }"
+  { [ "$v" != "PASS" ] && [ "$v" != "PENDING" ] && [ "$v" != "<UNSET>" ] && [ "$r" = "false" ]; }
+  chk $? "rc=$rc → $v (reviewed=$r) — not a pass, not unset"
+done
+
+echo "── L3 the mapping is TOTAL: no rc leaves verdict unset (the silent-green hole) ──"
+_unset=0
+for rc in $(seq 0 20) 42 100 127 255; do
+  got="$(verdict_for "$rc")"; case "$got" in "<UNSET>"*) _unset=$((_unset+1)) ;; esac
+done
+[ "$_unset" -eq 0 ]; chk $? "0 of 28 sampled codes leave verdict unset (found $_unset)"
+
+echo "── L4 CONTROL: a mutated mapping without the catch-all IS caught (the lane can fail) ──"
+_MUT="$(printf '%s' "$MAP" | grep -v '^\*)')"
+verdict_mut(){ rc="$1"; verdict=""; reviewed=""; eval "$_MUT"; printf '%s' "${verdict:-<UNSET>}"; }
+[ "$(verdict_mut 42)" = "<UNSET>" ]; chk $? "catch-all removed → rc=42 leaves verdict unset (control is alive)"
+[ "$(verdict_mut 0)" = "PASS" ]; chk $? "…and the mutant still maps documented codes (mutation is surgical)"
+
+echo "── L5 action.yml's documented codes match scripts/fh-gate.sh's exit contract ──"
+G="$ROOT/scripts/fh-gate.sh"
+if [ -f "$G" ]; then
+  _gate_codes="$(grep -oE '^#   [0-9]+ +—' "$G" | grep -oE '[0-9]+' | sort -un | tr '\n' ' ')"
+  _act_codes="$(printf '%s' "$MAP" | grep -oE '^[0-9]+\)' | grep -oE '[0-9]+' | sort -un | tr '\n' ' ')"
+  [ -n "$_gate_codes" ]; chk $? "CONTROL: the gate's exit contract was actually parsed (got: $_gate_codes)"
+  [ "$_gate_codes" = "$_act_codes" ]; chk $? "every documented gate code has an action arm [gate: $_gate_codes | action: $_act_codes]"
+else
+  echo "  ⬜ L5 SKIPPED (not PASS) — scripts/fh-gate.sh absent, contract un-cross-checked"
+fi
+
+echo "── L6 fail-on default is fail-closed: every non-reviewed verdict is in it ──"
+_failon="$(grep -A3 "^  fail-on:" "$A" | grep "default:" | sed "s/.*default: *'//; s/'.*//")"
+[ -n "$_failon" ]; chk $? "CONTROL: fail-on default parsed (got: $_failon)"
+for v in BLOCKED ESCALATE HARNESS_ERROR ARG_ERROR DRY_RUN UNKNOWN; do
+  case ",$_failon," in *",$v,"*) ok "fail-on default contains $v" ;; *) no "fail-on default is MISSING $v — that verdict would exit 0" ;; esac
+done
+for v in PASS PENDING; do
+  case ",$_failon," in *",$v,"*) no "fail-on default contains $v (over-blocks a reviewed pass)" ;; *) ok "fail-on default correctly omits $v" ;; esac
+done
+
+echo ""
+echo "── action.yml lanes: $PASS passed · $FAIL failed ──"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
The repo had no `action.yml`. Joining the GitHub Developer Program (operator, 2026-09-06) turned out not to be a shipping path at all — «Tell us about an integration» is a contact form, not a registry — so the real route is Action → Marketplace, and that file was the gap.

**The mapping is the substance.** `fh-gate` documents seven exit codes and they do not survive a naive success/failure wrapper: `0 PASS · 1 PENDING · 2 BLOCKED · 3 ESCALATE · 10 HARNESS_ERROR · 11 ARG_ERROR · 12 DRY_RUN`. Two traps are closed explicitly — an **unknown** code maps to `UNKNOWN` and fails closed (never PASS), and a third output `reviewed` separates «a review ran» from «it passed», because dry-run, a dead backend and an unrecognised code are all *not* passes. The `fail-on` default lets only PASS and PENDING through.

**Lanes, 28/28** (`scripts/test_action_yml_lanes.sh`): the seven documented codes map as documented; seven undocumented codes are never PASS, PENDING or unset; the mapping is total over 28 sampled codes; a **mutant with the catch-all arm removed leaves `verdict` unset for rc=42 while still mapping the documented codes**, so the lane is shown able to fail; the action's arms are cross-checked against `scripts/fh-gate.sh`'s own exit contract (with a control asserting the contract was actually parsed); and the `fail-on` default is checked entry by entry, both directions.

🟥 The lanes execute the **real** `case` block extracted from `action.yml`, not a copy — a copy would stay green while the shipped file rotted.

**Named residuals**: this has never run on an actual GitHub runner (the mapping was measured locally in bash); Marketplace listing needs an operator click plus a release tag; a cross-family pass on the composite step's shell quoting and `${{ }}` interpolation surface is owed once it has run once for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ydpJiBa7trEToGcDgaFAF