### PR TITLE
feat(gate): 판정을 «둘»로 — 합성 PASS 가 acceptance-evidence 를 가리지 않게 (SWE-Gate 답습)

### DIFF
--- a/knowledge/shared/harness-core/measurement-integrity-checklist.md
+++ b/knowledge/shared/harness-core/measurement-integrity-checklist.md
@@ -198,6 +198,26 @@ Mechanization Boundary — 이 칸도 **존재만** 요구한다: 파일럿 횟�
 2. **Hand-verify one sample before publishing.** Open the single case the instrument is *most* confident
    about and confirm by eye. Do this **before** the number enters a report.
 
+### 외부 근거 — 이 규율은 우리 도그푸드에만 얹혀 있지 않다 (2026-09-06 추가)
+
+🟢 **published known-pair, 외부 그룹, 우리 사건과 무관하게**: `arXiv:2609.03267` —
+*Refusing the Impossible: A Taxonomy and Benchmark for Code Hallucination in Large Language Models*
+(Dasu, Kundu, Tan · 2026-09-03 · `cs.SE`). 그들은 «모델이 불가능한 요구에 코드를 지어낸다」는
+헤드라인(불가능 프롬프트에서 **약 60%** 가 근거 없는 코드, **27%** 만 거절)을 **내기 전에**
+계기가 아는 답을 가르는지부터 보였다: **91 개의 짝지은 «풀 수 있는» 컨트롤**에서 오거부
+**0%**, 그리고 두 단계 판정 프로토콜을 사람 라벨과 대조해 **82% 일치, κ=0.73**. (초록에서 직접
+확인 — 이 문단은 digest 요약이 아니라 원문 인용이다.)
+
+**왜 여기 적나**: 위 §The rule 의 1번(known-pair)·2번(사람이 한 건 확인)이 이 저장소 안에서는
+**전부 자체 사건**(77건→3건 붕괴 등)으로만 근거를 갖고 있었다 — 규율이 옳다는 주장의 유일한
+증인이 그 규율을 쓴 우리 자신이었다는 뜻이고, 그건 이 문서가 다른 자리에서 금지하는 형태다.
+이 논문은 **같은 절차를 밟은 외부의 공개 사례**라 그 자기참조를 끊는다.
+
+⚠️ **이식되는 것은 계기 설계이지 숫자가 아니다.** 60%/27%/κ=0.73 은 12개 open-weight 모델의
+코드 환각 벤치마크 수치이지 하네스에 대한 측정이 아니다. FH 가 인용하는 것은 «헤드라인을 내기
+전에 아는 답으로 계기를 갈랐다»는 **순서**뿐이다. 우리 수치에 대한 근거로 쓰면 그 자체가
+이 문서 §계기 보정이 금지하는 «남의 숫자 수입»이다.
+
 **Publish-order asymmetry (why step 2 is not optional):** verification is cheap *before* publication and
 expensive *after*. A number written into a report, a session card, and a signal file must then be
 corrected in **all three**, and every downstream reader who already consumed it is not recalled.

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "scripts/test_marker_soul_check_lanes.sh",
     "scripts/test_marker_affected_lanes.sh",
     "scripts/test_marker_oracle_lanes.sh",
+    "scripts/test_gate_two_verdicts_lanes.sh",
     "scripts/test_heavy_classifier_lanes.sh",
     "scripts/residency_admission_check.sh",
     "scripts/test_residency_admission_lanes.sh",

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -623,6 +623,8 @@ for _pair in \
   "templates/.git-hooks/pre-commit|scripts/test_marker_soul_tenet_lanes.sh" \
   "templates/.git-hooks/pre-commit|scripts/test_marker_affected_lanes.sh" \
   "templates/.git-hooks/pre-commit|scripts/test_marker_oracle_lanes.sh" \
+  `# ── 판정을 둘로 (2026-09-06, SWE-Gate 답습): 합성 «PASS» 가 acceptance-evidence 를 가리지 않는가 ──` \
+  "templates/.git-hooks/pre-commit|scripts/test_gate_two_verdicts_lanes.sh" \
   `# ── fh-qp (QP) — chamber run #18 EMIT 2026-09-05: qp_tools.sh known-pair + residency lanes ──` \
   "plugins/fh-qp/scripts/qp_tools.sh|scripts/test_fh_qp_lanes.sh" \
   "plugins/fh-commons/skills/preprep/diagram_from_json.py|scripts/test_preprep_diagram_lanes.sh" \

--- a/scripts/test_gate_two_verdicts_lanes.sh
+++ b/scripts/test_gate_two_verdicts_lanes.sh
@@ -78,6 +78,21 @@ lane L6-indented "  crossfamily: declined — 근거 있음" "crossfamily=declin
 lane L7-first-wins "crossfamily: UNKNOWN — 안 봤다
 crossfamily: panel(codex) — 나중 줄" "crossfamily=UNKNOWN"
 
+# L8 🟥 첫 실사용이 잡은 결함 — 괄호 «안»에 공백이 있으면 값이 잘려 문법도 깨진 문자열이 찍혔다
+#    (`thirdparty: checked(확인한 것 = …)` → `checked(확인한`). 판별자는 «괄호가 닫혔는가» 하나.
+lane L8-open-paren-trimmed "thirdparty: checked(확인한 것 = 초록 원문 대조)" "thirdparty=checked"
+# L9 반대편 — 닫힌 괄호는 값의 일부라 그대로 살아야 한다(L8 의 수리가 이걸 깨면 안 된다)
+lane L9-closed-paren-kept "crossfamily: panel(codex,gemini) — 2라운드" "crossfamily=panel(codex,gemini)"
+lane L9b-tier-paren-kept  "standpoint: tier2(qasp) — 명령과 출력" "standpoint=tier2(qasp)"
+
+# L8b 잘린 값이 «그대로» 새어나오지 않는지 직접 확인 (needle 부재를 단언)
+printf 'thirdparty: checked(확인한 것 = x)\n' > "$T/p.marker"
+if run "$T/p.marker" | grep -qF 'checked(확인한'; then
+  echo "  ❌ L8b 잘린 괄호 문자열이 아직 출력에 있다"; FAIL=1
+else
+  echo "  ✅ L8b 잘린 괄호 문자열은 출력에 없다"
+fi
+
 # ── 컨트롤 A (판별력): 값이 다르면 출력도 달라야 한다 ─────────────────────
 printf 'crossfamily: panel(codex) — x\n' > "$T/a.marker"
 printf 'crossfamily: DEGRADED_SINGLE_FAMILY — y\n' > "$T/b.marker"

--- a/scripts/test_gate_two_verdicts_lanes.sh
+++ b/scripts/test_gate_two_verdicts_lanes.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# test_gate_two_verdicts_lanes.sh — pre-commit 의 `_acceptance_evidence_line` 계약을 고정한다.
+#
+# WHY (2026-09-06, frontier-digest 답습 · arXiv:2609.04167 «SWE-Gate»): 그 논문의 실측은
+# 기능 테스트를 통과한 수리 644 건 중 **221 건(34%)** 이 실제 PR 리뷰 코멘트에서 뽑은 제약을
+# 어겼다는 것이고, 처방은 «기능 정확성과 리뷰 제약 충족을 따로 채점하라» 다. 이 훅도 같은
+# 형태였다 — 축이 다 통과하면 «ALL AXES PASSED» 라는 **합성 판정 하나**만 찍혔고, 마커의
+# `crossfamily: DEGRADED_PANEL_UNUSED` 같은 값은 출력 어디에도 안 나왔다.
+#
+# SCOPE — 채널이지 판정이 아니다(§Mechanization Boundary): 이 함수는 «어떤 값이 적혔나」만
+# 찍는다. 값의 진위를 판정하지 않고, 어떤 경우에도 종료코드를 바꾸지 않는다. 그래서 레인도
+# «막나」가 아니라 «가려지나」를 잰다 — 특히 DEGRADED/UNKNOWN 이 조용히 사라지지 않는지.
+#
+# 종료코드: 0 = 계약대로 · 1 = 회귀
+set -uo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$REPO_ROOT/templates/.git-hooks/pre-commit"
+T=$(mktemp -d); trap 'rm -rf "$T"' EXIT
+[ -f "$HOOK" ] || { echo "ⓘ $HOOK absent — subject missing when we looked (NOT a pass)"; exit 2; }
+
+sed -n '/^_acceptance_evidence_line()/,/^}/p' "$HOOK" > "$T/fn.sh"
+# 계기 보정: 추출이 비면 아래 픽스처가 «아무것도 아닌 것」을 재고 전부 통과한다.
+if ! grep -q '_acceptance_evidence_line' "$T/fn.sh"; then
+  echo "❌ HARNESS-ERROR — _acceptance_evidence_line 이 $HOOK 에서 추출되지 않았다."
+  echo "   픽스처가 빈 함수를 잴 참이었다. 초록을 보고하지 않고 중단한다."
+  exit 1
+fi
+
+FAIL=0
+run() { bash -c 'set -uo pipefail; . "$1"; _acceptance_evidence_line "$2"' _ "$T/fn.sh" "${1:-}" 2>&1; }
+lane() { # $1=id  $2=marker body ('' = 마커 없음)  $3..=출력에 반드시 있어야 하는 조각들
+  local id="$1" body="$2"; shift 2
+  local path="" out n rc
+  if [ -n "$body" ]; then path="$T/m.marker"; printf '%s\n' "$body" > "$path"; fi
+  out=$(run "$path"); rc=$?
+  if [ $rc -ne 0 ]; then
+    printf '  ❌ %-34s 함수가 rc=%s — 보고 전용인데 실패했다\n     %s\n' "$id" "$rc" "$out"; FAIL=1; return
+  fi
+  for n in "$@"; do
+    if ! printf '%s' "$out" | grep -qF -- "$n"; then
+      printf '  ❌ %-34s «%s» 가 출력에 없다\n     %s\n' "$id" "$n" "$out"; FAIL=1; return
+    fi
+  done
+  printf '  ✅ %-34s %s\n' "$id" "$(printf '%s' "$out" | head -1)"
+}
+
+echo "== 수용-근거 줄: 값이 그대로 드러나는가 =="
+
+# L1 known-positive — 네 필드가 다 있으면 네 값이 다 나온다
+lane L1-all-four "crossfamily: panel(codex,gemini) — 2라운드
+standpoint: tier2(qasp) — 명령과 출력을 댔다
+thirdparty: checked — 상류 소스 독해
+oracle: known-pair — 양성/음성 픽스처" \
+  "crossfamily=panel(codex,gemini)" "standpoint=tier2(qasp)" "thirdparty=checked" "oracle=known-pair"
+
+# L2 🟥 하중 레인 — DEGRADED 가 «통과» 뒤에 숨지 않는다 (이 레인 스위트의 존재 이유)
+lane L2-degraded-visible "crossfamily: DEGRADED_PANEL_UNUSED — 패널 미사용
+standpoint: not-applicable — Q0 ⓒ
+oracle: none — 잴 값이 없다" \
+  "crossfamily=DEGRADED_PANEL_UNUSED" "standpoint=not-applicable"
+
+# L3 UNKNOWN 도 마찬가지 — «안 봤다»가 «봤는데 괜찮다»로 안 접힌다
+lane L3-unknown-visible "crossfamily: UNKNOWN — 안 봤다
+standpoint: UNKNOWN — 안 봤다" \
+  "crossfamily=UNKNOWN" "standpoint=UNKNOWN"
+
+# L4 부재는 «(없음)» 으로 — 빈 문자열이면 필드가 있었는지조차 안 보인다 (미측정≠0)
+lane L4-absent-is-typed "axis2-model: opus" \
+  "crossfamily=(없음)" "standpoint=(없음)" "thirdparty=(없음)" "oracle=(없음)"
+
+# L5 마커 자체가 없는 경로(경량 게이트) — 근거가 «있다»고 주장하지 않는다
+lane L5-no-marker "" "n/a" "경량 게이트"
+
+# L6 들여쓴 필드도 읽는다(마커는 손으로 쓰는 파일이다)
+lane L6-indented "  crossfamily: declined — 근거 있음" "crossfamily=declined"
+
+# L7 첫 줄만 — 같은 키가 둘이면 앞의 것을 찍고 조용히 합치지 않는다
+lane L7-first-wins "crossfamily: UNKNOWN — 안 봤다
+crossfamily: panel(codex) — 나중 줄" "crossfamily=UNKNOWN"
+
+# ── 컨트롤 A (판별력): 값이 다르면 출력도 달라야 한다 ─────────────────────
+printf 'crossfamily: panel(codex) — x\n' > "$T/a.marker"
+printf 'crossfamily: DEGRADED_SINGLE_FAMILY — y\n' > "$T/b.marker"
+OA=$(run "$T/a.marker"); OB=$(run "$T/b.marker")
+if [ "$OA" != "$OB" ] && printf '%s' "$OB" | grep -qF 'DEGRADED_SINGLE_FAMILY'; then
+  echo "  ✅ CTRL-A 판별력: 서로 다른 값이 서로 다른 줄을 낸다"
+else
+  echo "  ❌ CTRL-A 판별력 없음 — 두 마커가 같은 줄을 냈다(계기가 값을 안 읽는다)"; FAIL=1
+fi
+
+# ── 컨트롤 B (되돌림): 값 추출을 죽인 뮤턴트에서 L2 가 빨개지는가 ──────────
+#    이게 없으면 «필드를 안 읽는 함수»도 이 스위트를 통과한다.
+sed 's/^  for f in crossfamily.*/  for f in ; do :; done; out="";/' "$T/fn.sh" > "$T/mut.sh"
+if ! grep -q 'out=""' "$T/mut.sh"; then
+  echo "  ❌ CTRL-B 뮤턴트가 적용되지 않았다 — 되돌림 프로브가 장식이다"; FAIL=1
+else
+  MOUT=$(bash -c 'set -uo pipefail; . "$1"; _acceptance_evidence_line "$2"' _ "$T/mut.sh" "$T/b.marker" 2>&1 || true)
+  if printf '%s' "$MOUT" | grep -qF 'DEGRADED_SINGLE_FAMILY'; then
+    echo "  ❌ CTRL-B 뮤턴트인데도 값이 나온다 — 레인이 실물을 안 재고 있다"; FAIL=1
+  else
+    echo "  ✅ CTRL-B 되돌림: 추출을 죽이면 값이 사라진다(레인이 실패할 수 있음을 증명)"
+  fi
+fi
+
+# ── 컨트롤 C (배선): 훅의 PASS 배너가 이 함수를 실제로 부르는가 ───────────
+#    함수만 있고 호출부가 없으면 산문이다([[feedback_built_but_not_wired]]).
+if grep -q '_acceptance_evidence_line "\${MARKER:-}"' "$HOOK" \
+   && grep -q 'ALL AXES PASSED' "$HOOK"; then
+  echo "  ✅ CTRL-C 배선: PASS 배너가 이 함수를 부른다"
+else
+  echo "  ❌ CTRL-C 배선 없음 — 정의만 있고 PASS 배너가 안 부른다"; FAIL=1
+fi
+
+# ── 컨트롤 D (무해): 이 함수는 종료코드를 바꾸지 않는다 (채널이지 게이트가 아니다) ──
+run "" >/dev/null 2>&1; RC_NONE=$?
+run "$T/b.marker" >/dev/null 2>&1; RC_DEG=$?
+if [ "$RC_NONE" -eq 0 ] && [ "$RC_DEG" -eq 0 ]; then
+  echo "  ✅ CTRL-D 채널: 마커 부재도 DEGRADED 도 rc=0 (막지 않는다)"
+else
+  echo "  ❌ CTRL-D 이 함수가 종료코드를 바꾼다 (none=$RC_NONE degraded=$RC_DEG) — 채널이 아니라 게이트가 됐다"; FAIL=1
+fi
+
+echo "── gate-two-verdicts lanes: $([ $FAIL -eq 0 ] && echo 'all green' || echo 'FAILED')"
+exit "$FAIL"

--- a/templates/.git-hooks/pre-commit
+++ b/templates/.git-hooks/pre-commit
@@ -3052,6 +3052,32 @@ else
   echo "  ⚠️  상주 유입 게이트 미설치 (scripts/residency_admission_check.sh) — skipped, not passed"
 fi
 
+# ── 수용-근거 한 줄 (보고 전용 — 절대 안 막는다) ────────────────────────────
+# WHY (2026-09-06, digest 답습 · arXiv:2609.04167 SWE-Gate): 그 논문은 «기능 테스트 통과»와
+# «리뷰 제약 충족»을 **따로** 채점하라고 처방한다 — 실측에서 기능 테스트를 통과한 수리 644 건 중
+# **221 건(34%)** 이 실제 PR 리뷰 코멘트에서 뽑은 제약을 어겼다. 한 숫자로 합치면 그 34% 가 안 보인다.
+# FH 도 같은 형태였다: 이 훅은 Axis 1(회귀)·레인·매니페스트가 통과하면 «ALL AXES PASSED» 라는
+# **합성 판정 하나**를 찍었고, 그동안 마커의 `crossfamily: DEGRADED_PANEL_UNUSED` 같은 값은
+# 출력 어디에도 안 나왔다. 통과는 통과인데 «무엇이 기록됐나»는 안 보이는 것이다.
+# 그래서 판정을 둘로 찍는다 — 위는 «초록인가», 아래는 «무엇이 기록됐나».
+# 🟥 §Mechanization Boundary: 이건 **채널**이다. 기록의 속성(어떤 값이 적혔나)만 찍고,
+#    그 값이 참인지는 판정하지 않으며 아무것도 막지 않는다. 차단은 기존 다리들이 그대로 한다.
+# Anchor: scripts/test_gate_two_verdicts_lanes.sh
+_acceptance_evidence_line() {   # $1 = marker path (비었거나 없으면 n/a)
+  local m="${1:-}" f v out=""
+  if [ -z "$m" ] || [ ! -f "$m" ]; then
+    printf 'acceptance-evidence: n/a (경량 게이트 — 이 경로는 마커를 읽지 않는다)\n'
+    return 0
+  fi
+  for f in crossfamily standpoint thirdparty oracle; do
+    v=$(sed -n "s/^[[:space:]]*${f}:[[:space:]]*\([^[:space:]][^[:space:]]*\).*/\1/p" "$m" | head -1)
+    [ -n "$v" ] || v='(없음)'
+    out="${out}${out:+ · }${f}=${v}"
+  done
+  printf 'acceptance-evidence: %s\n' "$out"
+}
+
+
 # ── Verdict ───────────────────────────────────────────────────────────────────
 echo ""
 echo "══════════════════════════════════════════════"
@@ -3064,6 +3090,10 @@ if [ "$FAILED" -eq 1 ]; then
 fi
 
 echo " ✅ ALL AXES PASSED — commit allowed"
+echo "    functional          : PASS (Axis 1 회귀 · 레인 · 매니페스트)"
+echo "    $(_acceptance_evidence_line "${MARKER:-}")"
+echo "    🟥 둘은 한 판정이 아니다 — 위는 «초록인가», 아래는 «무엇이 기록됐나»다."
+echo "       형식이 통과했다는 뜻이지 그 값이 참이라는 뜻이 아니다 (arXiv:2609.04167)."
 echo "══════════════════════════════════════════════"
 echo ""
 exit 0

--- a/templates/.git-hooks/pre-commit
+++ b/templates/.git-hooks/pre-commit
@@ -3071,6 +3071,15 @@ _acceptance_evidence_line() {   # $1 = marker path (비었거나 없으면 n/a)
   fi
   for f in crossfamily standpoint thirdparty oracle; do
     v=$(sed -n "s/^[[:space:]]*${f}:[[:space:]]*\([^[:space:]][^[:space:]]*\).*/\1/p" "$m" | head -1)
+    # 🟥 첫 실사용(이 훅의 첫 두-판정 커밋)이 즉시 잡은 것: 값이 `checked(확인한 것 = …)` 처럼
+    #    **괄호 안에 공백**을 담으면 첫 토큰이 `checked(확인한` 으로 잘려, 값도 아니고 문법도
+    #    깨져 보이는 문자열이 찍힌다. 반면 `panel(codex,gemini)` · `tier2(qasp)` 는 괄호가 값의
+    #    일부라 살려야 한다. 판별자는 **괄호가 닫혔는가** 하나뿐이다 — 안 닫혔으면 여는 괄호
+    #    앞까지가 값이다. (마커 defeater 에 «관측될 것»으로 적어 둔 그 줄이 그대로 발화했다.)
+    case "$v" in
+      *'('*')'*) : ;;                      # panel(codex,gemini) — 괄호가 값의 일부
+      *'('*)     v="${v%%(*}" ;;           # checked(확인한 … — 잘린 괄호는 값이 아니다
+    esac
     [ -n "$v" ] || v='(없음)'
     out="${out}${out:+ · }${f}=${v}"
   done
@@ -3090,7 +3099,7 @@ if [ "$FAILED" -eq 1 ]; then
 fi
 
 echo " ✅ ALL AXES PASSED — commit allowed"
-echo "    functional          : PASS (Axis 1 회귀 · 레인 · 매니페스트)"
+echo "    functional         : PASS (Axis 1 회귀 · 레인 · 매니페스트)"
 echo "    $(_acceptance_evidence_line "${MARKER:-}")"
 echo "    🟥 둘은 한 판정이 아니다 — 위는 «초록인가», 아래는 «무엇이 기록됐나»다."
 echo "       형식이 통과했다는 뜻이지 그 값이 참이라는 뜻이 아니다 (arXiv:2609.04167)."


### PR DESCRIPTION
frontier digest 2026-09-06 답습. 인용한 두 논문은 digest 요약이 아니라 **초록을 직접 열어** 대조했고, 그 과정에서 digest 요약 한 곳을 정정했다(리뷰 제약은 «저자 구성물»이 아니라 «실제 PR 코멘트에서 도출» — 초록 원문이 더 강하다).

## 무엇이 문제였나

`arXiv:2609.04167` (SWE-Gate, He 외, 09-03): 303 수리 인스턴스 / 75 Python 레포에서 **기능 테스트를 통과한 644 건 중 221 건(≈34%)** 이 실제 PR 리뷰 코멘트에서 도출한 제약을 어긴다. 처방은 «기능 정확성과 제약 충족을 **따로** 채점하라».

이 훅이 정확히 그 형태였다 — 축이 다 통과하면 `ALL AXES PASSED` 라는 **합성 판정 하나**만 찍혔고, 마커의 `crossfamily: DEGRADED_PANEL_UNUSED` 같은 값은 커밋 출력 **어디에도** 안 나왔다. 통과는 통과인데 «무엇이 기록됐나」가 안 보인다.

## 무엇을 했나 — 이 PR 자신의 커밋 출력이 그 실물이다

```
 ✅ ALL AXES PASSED — commit allowed
    functional         : PASS (Axis 1 회귀 · 레인 · 매니페스트)
    acceptance-evidence: crossfamily=DEGRADED_PANEL_UNUSED · standpoint=not-applicable · thirdparty=checked · oracle=known-pair
    🟥 둘은 한 판정이 아니다 — 위는 «초록인가», 아래는 «무엇이 기록됐나»다.
       형식이 통과했다는 뜻이지 그 값이 참이라는 뜻이 아니다 (arXiv:2609.04167).
```

🟥 **채널이지 판정이 아니다** (`§Mechanization Boundary`): 기록의 속성만 찍고 값의 진위는 판정하지 않으며, **아무것도 새로 막지 않는다**. 차단 집합·종료코드·마커 규칙 전부 무변경이라 `BREAKING (gate):` 없음.

## 🟥 첫 실사용이 defeater 를 즉시 발화시켰다 (커밋 2)

첫 커밋의 배너가 스스로 결함을 냈다 — `thirdparty=checked(확인한`. 값이 `checked(확인한 것 = …)` 라 **괄호 안의 공백**에서 잘려, 값도 아니고 문법도 깨진 문자열이 찍혔다. 반면 `panel(codex,gemini)` · `tier2(qasp)` 는 괄호가 값의 일부라 살려야 한다. **판별자는 «괄호가 닫혔는가» 하나.**

fail-before 실행 증명(수리 블록만 제거한 함수 vs 수리본, 같은 픽스처):

```
pre-fix : thirdparty=checked(확인한
post-fix: thirdparty=checked
```

앞 커밋의 마커가 이 실패를 defeater ⓑ 로 «관측될 것»이라 **미리 적어 뒀고**, 첫 실사용이 그 자리에서 발화했다. 정적 독해로는 안 나왔을 자리다.

## 레인 15/15 — `scripts/test_gate_two_verdicts_lanes.sh`

| | |
|---|---|
| L2 | **DEGRADED 가시성** — 이 스위트의 존재 이유 |
| L3 | UNKNOWN 가시성 (안 봤다 ≠ 봤는데 괜찮다) |
| L4 | 부재는 `(없음)` — 빈 문자열이면 필드 유무조차 안 보인다 |
| L5 | 마커 없는 경로는 «근거 있다»고 주장하지 않는다 |
| L8 · L8b | 잘린 괄호가 다듬어지는가 / **잘린 문자열이 출력에 «없는가»(부재 단언)** |
| L9 · L9b | 닫힌 괄호는 보존 — 수리가 반대편을 깨지 않는지 |
| CTRL-A | 판별력 — 다른 값이 다른 줄을 낸다 |
| CTRL-B | 되돌림 뮤턴트 — 추출을 죽이면 값이 사라진다(레인이 실패할 수 있음) |
| CTRL-C | 배선 — 정의만 있고 PASS 배너가 안 부르는 형태 차단 |
| CTRL-D | 무해 — 마커 부재도 DEGRADED 도 rc=0 |

스위트 앞단에 추출 보정: 함수가 훅에서 안 뽑히면 HARNESS-ERROR 로 중단한다(빈 함수를 재고 초록을 보고하지 않는다).

## 두 번째: known-pair 규율의 외부 근거

`measurement-integrity-checklist.md §Instrument-Calibration` 의 증인이 지금까지 **전부 우리 자신의 사건**이었다(77건→3건 붕괴 등) — 규율이 옳다는 유일한 증인이 그 규율을 쓴 우리 자신인 형태다. `arXiv:2609.03267`(Dasu, Kundu, Tan, 09-03)은 헤드라인(불가능 프롬프트에서 ≈60% 가 근거 없는 코드, 27%만 거절)을 **내기 전에** **91개 짝지은 «풀 수 있는» 컨트롤**에서 오거부 **0%**, 사람 라벨 대조 **82% 일치 κ=0.73** 을 보였다.

⚠️ 이식되는 것은 **계기 설계(순서)** 이지 60%/27%/κ 숫자가 아니라고 문단이 스스로 적는다.

## 안 닫힌 것

- `crossfamily: DEGRADED_PANEL_UNUSED` — 패널 미사용. 이 변경의 위험은 판정 로직이 아니라 문자열 추출이라 레인이 직접 잡는다. 열린 것 = `sed` 표기 전수를 codex 1라운드로.
- 이 줄이 실제로 다음 세션의 DEGRADED 처리에 영향을 주는지는 **미측정**이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ydpJiBa7trEToGcDgaFAF