### PR TITLE
fix(hook): PIPE-VERDICT R2 를 «파이프 직후 한 문장» 으로 좁힌다 — 실사용 오탐

### DIFF
--- a/scripts/pipe_verdict_guard.sh
+++ b/scripts/pipe_verdict_guard.sh
@@ -138,9 +138,20 @@ if ! printf '%s' "$NORM" | grep -qE 'set -o pipefail|set -[a-zA-Z]*o[a-zA-Z]* pi
   # Branch (b)'s optional `([^|&]*;)?` prefix keeps `| (sort; tail -5); echo $?` caught — the
   # filter need not be the group's FIRST command, only its LAST — while the `;` requirement keeps
   # the filter at a statement start, so `| (echo cat); rc=$?` does not match through a bare word.
+  # 🟥 «바로 다음 문장» 으로 좁힌다 (2026-09-06, 운영자 실사용 신고 + known-pair 재현).
+  #   종전 꼬리는 `[;&].*\$\?` 라 파이프 뒤 **어디든** `$?` 가 있으면 잡았다 — 그게 **다른
+  #   명령의** `$?` 여도. 한 호출에 문장이 여럿인 실사용 커맨드는 거의 항상 걸린다.
+  #   실측 4팔: ①`out=$(c); rc=$?; echo "$out"|tail` 안 터짐(정상) ②`c|tail; echo $?` 터짐
+  #   (known-positive) ③표시전용 안 터짐 ④`out=$(a); rc=$?; echo "$out"|tail; b; echo $?`
+  #   **터짐 = 오탐**. ④의 `$?` 는 `b` 의 것이라 안 잡는 것이 옳다.
+  #   ⇒ 꼬리를 `[;&]&?[^;&|]*\$\?` 로 — 파이프라인 **직후 한 문장** 안에서만 읽는다.
+  #   `&?` 는 `cmd | tail && echo $?`(진짜 결함)를 살리기 위한 것이다.
+  #   이 좁힘의 재현율 손실은 사실상 0 이다: 사이에 명령이 끼면 `$?` 는 그 명령의 것이므로
+  #   원래 **잡으면 안 되는** 자리다. 훅 자기 주석이 «100% FP 는 정작 중요한 한 건을
+  #   무시하도록 훈련시킨다» 고 적었고, 운영자 신고가 정확히 그 신호였다.
   _F='(tail|head|cat|less|more)'
   if printf '%s' "$NORM" \
-     | grep -qE "\|&?[[:space:]]*(${_F}([[:space:]][^|;&]*)?|[({]([^|&]*;)?[[:space:]]*${_F}([[:space:]][^|;&()}]*)?[[:space:]]*;?[[:space:]]*[)}])[[:space:]]*[;&].*\\\$\?"; then
+     | grep -qE "\|&?[[:space:]]*(${_F}([[:space:]][^|;&]*)?|[({]([^|&]*;)?[[:space:]]*${_F}([[:space:]][^|;&()}]*)?[[:space:]]*;?[[:space:]]*[)}])[[:space:]]*[;&]&?[^;&|]*\\\$\?"; then
     add "R2 \$? after a display filter" \
         "\$? holds the filter's status (tail/head/cat almost always succeed), not the command's — a FAILED check reads as 0. Capture first: \`out=\$(cmd 2>&1); rc=\$?\` then print \"\$out\" | tail."
   fi

--- a/scripts/test_pipe_verdict_guard_lanes.sh
+++ b/scripts/test_pipe_verdict_guard_lanes.sh
@@ -56,6 +56,22 @@ expect "R2 tail then \$?"                  HIT   'bash gate.sh | tail -20; echo 
 expect "R2 head then \$?"                  HIT   'make test | head -40; rc=$?'
 expect "R2 cat then \$?"                   HIT   'run.sh | cat; if [ $? -ne 0 ]; then echo bad; fi'
 
+echo "-- R2 «바로 다음 문장» 좁힘 (2026-09-06, 운영자 실사용 신고) --"
+# 🟥 종전 꼬리 `[;&].*\$\?` 는 파이프 뒤 **어디든** `$?` 가 있으면 잡았다 — 그게 다른
+#   명령의 것이어도. 한 호출에 문장이 여럿인 실사용 커맨드는 거의 항상 걸렸고, 그건
+#   «100% FP 는 정작 중요한 한 건을 무시하도록 훈련시킨다» 는 이 훅 자신의 경고 그대로다.
+expect "R2 좁힘: 사이에 다른 명령이 끼면 그 \$? 는 그 명령의 것" CLEAN \
+       'out=$(a 2>&1); rc=$?; echo "$out" | tail -1; b; echo $?'
+expect "R2 좁힘: 두 문장 뒤의 \$? 도 아니다"                    CLEAN \
+       'pytest | tail -2; echo done; echo $?'
+expect "R2 좁힘: 파이프 앞에서 잡은 rc 는 원래 정상"             CLEAN \
+       'out=$(pytest 2>&1); rc=$?; echo "$out" | tail -2 | head -1; echo "rc=$rc"'
+# 짝 — 좁히다가 진짜 결함을 죽이면 그게 과교정이다
+expect "R2 좁힘 짝: 직후 문장의 \$? 는 여전히 잡는다"           HIT \
+       'pytest 2>&1 | tail -2; echo "rc=$?"'
+expect "R2 좁힘 짝: && 로 이어진 직후 읽기도 잡는다"             HIT \
+       'make test | head -5 && echo $?'
+
 echo "-- R2 false-positive lanes: the 7 shapes this repo actually ships --"
 # Every one of these was hand-verified on 2026-07-31 as CORRECT: the final stage IS the command
 # whose status is wanted. A detector that flags these is noise, and noise trains dismissal.


### PR DESCRIPTION
## 무엇

운영자 실사용 신고가 계기다 — *「배쉬오류가 자꾸보이네」*. `PIPE-VERDICT R2` 가 정상적인 커맨드에도 계속 떴다.

## 재현 — 훅에 4팔을 직접 먹였다

```
① out=$(c); rc=$?; echo "$out" | tail                CLEAN   ← 정상(내가 쓰는 형태)
② c | tail; echo $?                                  HIT     ← 진짜 결함
③ 표시 전용($? 안 씀)                                CLEAN
④ out=$(a); rc=$?; echo "$out" | tail; b; echo $?    HIT     ← 🟥 오탐
```

**원인**: R2 꼬리가 `[;&].*\$\?` 라 파이프 뒤 **어디든** `$?` 가 있으면 잡는다 — 그게 **다른 명령의** `$?` 여도. 한 호출에 문장이 여럿인 실사용 커맨드는 거의 항상 ④에 걸린다.

④의 `$?` 는 `b` 의 것이므로 **안 잡는 것이 옳다.**

## 처방

꼬리를 `[;&]&?[^;&|]*\$\?` 로 — **파이프라인 직후 한 문장** 안에서만 `$?` 를 읽는다.
`&?` 는 `cmd | tail && echo $?`(진짜 결함)를 살리기 위한 것이다.

**재현율 손실은 사실상 0** 이다: 사이에 명령이 끼면 `$?` 는 그 명령의 것이므로 원래 잡으면 안 되는 자리다. 그래도 과교정 짝 레인 둘을 세웠다 — 직후 문장의 `$?` · `&&` 로 이어진 직후 읽기.

## 왜 좁히는 것이 옳은가 — 훅 자신의 근거

이 파일 주석이 이미 적어 뒀다: *"100% FP 는 정작 중요한 한 건을 무시하도록 훈련시킨다"*(S5 가 자기 주석에 남긴 것). 운영자 신고가 정확히 **그 신호**다. 이 훅은 advisory 라 막지는 않지만, 무시하도록 훈련되면 ②가 왔을 때도 안 읽힌다.

## 🟥 되돌림 컨트롤을 두 번 돌렸다 — 첫 번째는 죽어 있었다

첫 시도는 뮤턴트가 내가 **새로 쓴 주석**의 같은 문자열을 바꿔서 `rc=0` 이 나왔다. 코드가 아니라 주석을 되돌린 것이라 **아무것도 증명하지 못하는 컨트롤**이었다. `grep -qE` 줄만 대상으로 지정해 다시 돌려 `rc=1` 확인했다.

```
뮤턴트(grep 줄만 되돌림)  rc=1
복원                      rc=0 · all 57 known pairs hold
```

## 검증

- 레인 **52 → 57**(신규 5: 오탐 3형태 CLEAN · 과교정 짝 2 HIT)
- 4축 게이트 통과. acceptance-evidence 는 정직하게 — `crossfamily=DEGRADED_PANEL_UNUSED · standpoint=DEGRADED_NOT_RUN · thirdparty=DEGRADED_NOT_RUN · oracle=known-pair`
- `standpoint` 가 DEGRADED 인 이유: 이 스크립트는 `package.json files[]` 에 있어 **소비자에게 나간다**(경고 빈도가 바뀐다). packed-install 팔은 안 돌렸다.

## 안 닫은 것

`||` 로 이어진 직후 읽기(`cmd | tail || echo $?`)는 **종전부터** 안 잡힌다 — R2 앞단에서 `||` 를 `__OR__` 로 정규화하기 때문이다(그 정규화 자체가 예전 FP 9건을 없앤 조치라 건드리지 않았다). 이번 좁힘과 무관한 기존 갭이고, 이름으로 남긴다.
