### PR TITLE
feat(preprep): L13 슬라이드 참조 레인 — 장 번호 참조가 실제 장을 가리키는가

### DIFF
--- a/package.json
+++ b/package.json
@@ -321,6 +321,7 @@
     "plugins/fh-qp/fixtures",
     "scripts/test_fh_qp_lanes.sh",
     "scripts/test_preprep_diagram_lanes.sh",
+    "scripts/test_preprep_slide_refs_lanes.sh",
     "scripts/test_action_yml_lanes.sh"
   ]
 }

--- a/plugins/fh-commons/skills/preprep/lane_slide_refs.py
+++ b/plugins/fh-commons/skills/preprep/lane_slide_refs.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""L13 — «N 페이지» 리터럴 장 번호 참조가 실재하는 장을 가리키나 (2026-09-06 신설).
+
+WHY: 장을 하나 빼면 그 뒤 번호가 통째로 당겨진다. preprep 의 이웃 레인들은 **말로 가리키는
+것**만 본다 — L5/L8 은 화면 재사용·시각 지시를, R1~R5 는 접속어·소유권을. **숫자로 가리키는
+것은 어느 레인도 안 봤다.** 실사고 계기: if(kakao) 덱에서 42장을 빼자 43~121 이 한 칸씩
+당겨졌고, 「깨진 참조가 어디냐」를 손으로 훑어야 했다(2026-09-06, 운영자 지적).
+
+🟥 이 레인의 난점은 검출이 아니라 **분류**다. 같은 «숫자+단위»가 세 가지 다른 것을 가리킨다 —
+실측 코퍼스(그 덱 121장)에서 셋이 **전부** 나왔다:
+
+    SLIDE     「40p 부제가 …」          → 진짜 장 참조. 이것만 검사 대상이다
+    SECTION   「3장에서 게이트부터」      → 슬라이드가 아니라 **섹션**(그 덱의 sec-guide 「3. 어떻게 만들었나」)
+    CITATION  「arXiv:2606.05647 (4p)」 → 인용 **논문 쪽수**
+
+셋을 안 가르면 오탐 덩어리가 된다. 그래서 판별자는 코퍼스에서 기계로 뽑는다:
+  · SECTION  — 덱의 섹션 라벨(「N. 제목」)에서 N 집합을 모으고, 「N장」 형태이면서 그 집합에
+              속하면 섹션이다. 라벨이 없으면 이 분기는 **비활성**이고 그 사실을 노트에 적는다.
+  · CITATION — 같은 줄에 인용 표지(arXiv/doi/『』/pp./4자리 연도)가 있으면 인용 쪽수다.
+
+🟥 **판정은 «존재»만 한다** — «그 번호가 맞는 장을 가리키나»는 의미 판단이라 안 본다
+(§Mechanization Boundary: 기록의 속성만 단언한다). 그래서 finding 은 **범위 밖 참조**
+하나뿐이고, 자기 자신 참조·정상 참조는 노트로만 나간다.
+
+🟥 **참조 0건은 «통과»가 아니다** — 추출이 죽어도 0이 나온다. 0이면 UNMEASURED 로 적는다.
+"""
+import os
+import re
+
+# 「40p」 「40 페이지」 「40쪽」 「3장에서」…
+REF = re.compile(r'(?<![0-9A-Za-z])(\d{1,3})\s*(p\b|페이지|쪽(?!수)|장(?=에서|의|을|부터|에))')
+# 🟥 `\s+` 가 하중을 진다 — 초판은 `\s*` 였고 실측 코퍼스의 «62.5%» 를 «62번 섹션»으로
+#    먹었다. 그러면 진짜 「62장」 참조가 조용히 SECTION 으로 분류돼 사라진다.
+#    섹션 라벨은 점 뒤에 공백이 있다(「3. 어떻게 만들었나」). 소수점은 없다.
+SECTION_LABEL = re.compile(r'^\s*(\d{1,2})\.\s+\S')
+SECTION_MAX = 20      # 섹션이 20을 넘는 덱은 없다 — 넘으면 라벨이 아니다
+SECTION_MIN_SLIDES = 2  # 섹션 라벨은 여러 장에 반복된다(한 장짜리는 라벨이 아니다)
+CITE = re.compile(r'arXiv|doi|『|』|pp\.|\b(19|20)\d{2}\b', re.I)
+
+
+def _texts(slide):
+    scr, note = [], ''
+    for sh in slide.shapes:
+        if sh.has_text_frame:
+            t = ' '.join(r.text for p in sh.text_frame.paragraphs for r in p.runs)
+            if t.strip():
+                scr.append(t)
+    if slide.has_notes_slide:
+        note = slide.notes_slide.notes_text_frame.text or ''
+    return scr, note
+
+
+def section_numbers(prs):
+    """섹션 라벨(「N. 제목」)에서 N 을 모은다. 못 모으면 빈 집합 — 그 사실이 노트에 적힌다.
+
+    세 조건을 **함께** 건다: 점 뒤 공백(소수점 배제) · N ≤ SECTION_MAX · 여러 장에 반복.
+    하나만 걸면 실측에서 뚫린다(위 주석의 62.5% 사례).
+    """
+    seen = {}
+    for i, s in enumerate(prs.slides, 1):
+        for sh in s.shapes:
+            if not sh.has_text_frame:
+                continue
+            for p in sh.text_frame.paragraphs:
+                line = ''.join(r.text for r in p.runs).strip()
+                m = SECTION_LABEL.match(line)
+                if m and len(line) < 40:
+                    n = int(m.group(1))
+                    if n <= SECTION_MAX:
+                        seen.setdefault(n, set()).add(i)
+    return {n for n, slides in seen.items() if len(slides) >= SECTION_MIN_SLIDES}
+
+
+def classify(num, unit, line, secs):
+    if CITE.search(line):
+        return 'CITATION'
+    if unit.startswith('장') and num in secs:
+        return 'SECTION'
+    return 'SLIDE'
+
+
+def analyze(prs):
+    total = len(prs.slides)
+    secs = section_numbers(prs)
+    rows = []
+    for i, s in enumerate(prs.slides, 1):
+        scr, note = _texts(s)
+        for where, chunks in (('화면', scr), ('대본', note.split('\n'))):
+            for line in chunks:
+                for m in REF.finditer(line):
+                    n, unit = int(m.group(1)), m.group(2)
+                    kind = classify(n, unit, line, secs)
+                    rows.append((i, where, n, unit, kind, line.strip()[:70]))
+    return total, secs, rows
+
+
+def scan(cfg, root):
+    deck_s = (cfg.get('surfaces_by_id') or {}).get('built_deck')
+    if not deck_s:
+        return [], ['L13 slide-refs : built_deck 미선언 — NOT_CONFIGURED (0 아님)']
+    path = os.path.normpath(os.path.join(root, os.path.expanduser(deck_s['path'])))
+    if not os.path.exists(path):
+        return [], [f'L13 slide-refs : built_deck 실물 없음({path}) — UNMEASURED (0 아님)']
+    try:
+        from pptx import Presentation
+        prs = Presentation(path)
+        total, secs, rows = analyze(prs)
+    except Exception as e:
+        return [], [f'L13 slide-refs : 계기 오류({type(e).__name__}: {e}) — UNMEASURED (0 아님)']
+
+    per = {}
+    for _, _, _, _, k, _ in rows:
+        per[k] = per.get(k, 0) + 1
+    notes = [f'L13 slide-refs : {total}장 · 참조 {len(rows)}건 '
+             f'(SLIDE {per.get("SLIDE",0)} · SECTION {per.get("SECTION",0)} · CITATION {per.get("CITATION",0)}) '
+             f'· 섹션 번호 집합 {sorted(secs) if secs else "없음 — SECTION 분기 비활성"}']
+    if not rows:
+        notes.append('   ⚠️ 참조 0건 — 「깨끗하다」가 아니라 **UNMEASURED** 다(추출이 죽어도 0이 나온다). '
+                     '덱에 번호 참조가 원래 없으면 정상이고, 그 사실을 여기서 확인해라')
+        return [], notes
+
+    findings = []
+    for i, where, n, unit, kind, line in rows:
+        if kind != 'SLIDE':
+            continue
+        if n < 1 or n > total:
+            findings.append((f'{path}#s{i}', 'use',
+                             f'L13 장 번호 참조가 범위 밖이다 — s{i} [{where}] →{n} (총 {total}장) : {line}'))
+            notes.append(f'   ❌ s{i:3} [{where}] →{n:3}  범위 밖(총 {total}) : {line}')
+        elif n == i:
+            notes.append(f'   ⚠️ s{i:3} [{where}] →{n:3}  자기 자신 참조 : {line}')
+        else:
+            notes.append(f'   ·  s{i:3} [{where}] →{n:3}  : {line}')
+    return findings, notes

--- a/plugins/fh-commons/skills/preprep/preprep.py
+++ b/plugins/fh-commons/skills/preprep/preprep.py
@@ -774,7 +774,7 @@ def main():
     #    [[feedback_rule_misdescribes_its_own_machine]] · [[feedback_instrument_vs_target_and_budget]]
     _lanes = sorted(n[5:] for n in globals() if n.startswith('lane_') and callable(globals()[n]))
     _mods = sorted(m for m in ('lane_promise', 'lane_adjacent_dup', 'lane_progression',
-                                'lane_slide_relations', 'lane_geometry', 'lane_diagram')
+                                'lane_slide_relations', 'lane_geometry', 'lane_diagram', 'lane_slide_refs')
                    if os.path.exists(os.path.join(HERE, m + '.py')))
     # 🟥 2026-09-04 신설 — `--lane R1,R2,...` 로 **새 모듈 레인(R1-R5·P1/P3)만** 골라 끈다/켠다.
     #    L1~L11 은 아직 이 필터를 안 탄다(usage 줄의 --lane 은 그쪽엔 미배선인 채 남아 있다 —
@@ -856,6 +856,17 @@ def main():
         except Exception as _e:
             notes.append('R1-R5 slide-relations : 계기 미실행 — NOT_WIRED (%s: %s) (0 아님)'
                          % (type(_e).__name__, _e))
+    # L13 slide-refs — 「N p」 리터럴 장 번호 참조가 실재하는 장을 가리키나(2026-09-06 신설).
+    #   이웃 레인들은 «말로 가리키는 것»만 본다(L5/L8 화면 재사용·시각 지시 · R1~R5 접속어).
+    #   숫자 참조는 아무도 안 봤고, 장을 빼면 그 뒤가 통째로 당겨진다.
+    #   차단은 «범위 밖» 하나뿐 — 「그 번호가 맞는 장인가」는 의미 판단이라 안 본다.
+    try:
+        import lane_slide_refs
+        _f13, _n13 = lane_slide_refs.scan(cfg, root)
+        findings += _f13; notes += _n13
+    except Exception as _e:
+        notes.append('L13 slide-refs : 계기 미실행 — NOT_WIRED (%s: %s) (0 아님)'
+                     % (type(_e).__name__, _e))
     # L12 diagram — 타입 JSON 도해가 «지금 JSON» 에서 validate 를 거쳐 구워졌나(2026-09-05 신설).
     #   차단: 선언된 diagram_source 표면에 한해 지문·validate·해상도·viewBox 폭·여백을 본다.
     #   영수증 없는 PNG(손그림)는 UNMEASURED 노트로만 — 0 이 아니다.

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -662,6 +662,7 @@ for _pair in \
   "plugins/fh-commons/skills/preprep/lane_progression.py|scripts/test_preprep_progression_lanes.sh" \
   "plugins/fh-commons/skills/preprep/lane_adjacent_dup.py|scripts/test_preprep_adjacent_dup_lanes.sh" \
   "plugins/fh-commons/skills/preprep/lane_promise.py|scripts/test_preprep_promise_lanes.sh" \
+  "plugins/fh-commons/skills/preprep/lane_slide_refs.py|scripts/test_preprep_slide_refs_lanes.sh" \
   "plugins/fh-commons/skills/preprep/SKILL.md|scripts/test_preprep_drift_anchor.sh" \
   "scripts/test_preprep_drift_anchor.sh|scripts/test_preprep_drift_anchor_lanes.sh" \
   "scripts/field_canon_preload.sh|scripts/test_skill_canon_preload_lanes.sh" \

--- a/scripts/test_preprep_slide_refs_lanes.sh
+++ b/scripts/test_preprep_slide_refs_lanes.sh
@@ -15,30 +15,59 @@ cd "$(dirname "$0")/.." || exit 10
 LANE=plugins/fh-commons/skills/preprep/lane_slide_refs.py
 [ -f "$LANE" ] || { echo "ⓘ $LANE absent — subject missing (NOT a pass)"; exit 2; }
 command -v python3 >/dev/null 2>&1 || { echo "ⓘ python3 absent — setup broke"; exit 10; }
-python3 -c 'import pptx' 2>/dev/null || { echo "ⓘ python-pptx absent — setup broke (NOT a pass)"; exit 10; }
 T=$(mktemp -d) || exit 10; trap 'rm -rf "$T"' EXIT
+# 🟥 파이썬 바이트코드 캐시를 지우고 시작한다. 되돌림 프로브에서 실측했다(2026-09-06):
+#    판별자를 뮤턴트로 바꿨다가 원본을 복원했는데 **스테일 __pycache__ 가 뮤턴트를 계속
+#    먹여** 「복원했는데도 적색」이 나왔다. 반대 방향이 더 위험하다 — 뮤턴트를 넣었는데
+#    캐시가 원본을 먹이면 «되돌려도 초록» 이 되어 **앵커가 죽은 것을 못 본다**.
+rm -rf plugins/fh-commons/skills/preprep/__pycache__
 PASS=0; FAIL=0
 ok(){ echo "  ✅ $1"; PASS=$((PASS+1)); }
 ng(){ echo "  ❌ $1"; FAIL=$((FAIL+1)); }
 
 RUN=$T/run.py
 cat > "$RUN" <<'PY'
-import sys, os
+import sys, os, types
 sys.path.insert(0, 'plugins/fh-commons/skills/preprep')
-from pptx import Presentation
-from pptx.util import Inches, Pt
+
+# 🟥 python-pptx 를 **의존하지 않는다**. 이 스위트는 «분류» 를 재는 것이고, 그 입력은
+#    「장 → 화면 텍스트 · 노트」라는 **작은 오리 타입**이 전부다(lane 의 _texts/
+#    section_numbers 가 읽는 표면). 실물 라이브러리를 요구하면 러너에 없을 때
+#    HARNESS ERROR(exit 10)로 죽고 — 그건 «측정 못 했다»라 옳은 방향이지만, 그 대가로
+#    **CI 에서 이 레인이 영영 안 돌게** 된다. 안 도는 앵커는 앵커가 아니다.
+#    ⇒ `sys.modules['pptx']` 에 스텁을 심어 lane 의 `from pptx import Presentation`
+#      경로까지 **그대로 통과시킨다** — scan() 의 경로 해소·노트 읽기가 다 덮인다.
+class _Run:
+    def __init__(self, t): self.text = t
+class _Para:
+    def __init__(self, t): self.runs = [_Run(t)]
+class _TF:
+    def __init__(self, t): self.paragraphs = [_Para(t)]; self.text = t
+class _Shape:
+    def __init__(self, t): self.has_text_frame = True; self.text_frame = _TF(t)
+class _Notes:
+    def __init__(self, t): self.notes_text_frame = _TF(t)
+class _Slide:
+    def __init__(self, scr, note):
+        self.shapes = [_Shape(x) for x in scr]
+        self.has_notes_slide = True
+        self.notes_slide = _Notes(note)
+class _Prs:
+    def __init__(self, spec): self.slides = [_Slide(a, b) for a, b in spec]
+
+_SPEC = {}
+def _Presentation(path):
+    key = os.path.normpath(path)
+    if key not in _SPEC:
+        raise FileNotFoundError(key)          # 실물 없음 경로도 lane 이 UNMEASURED 로 낸다
+    return _Prs(_SPEC[key])
+_fake = types.ModuleType('pptx'); _fake.Presentation = _Presentation
+sys.modules['pptx'] = _fake
 
 def build(path, slides):
     """slides = [(화면 줄들, 대본)] — 화면 줄은 각각 별도 텍스트 상자."""
-    prs = Presentation()
-    blank = prs.slide_layouts[6]
-    for scr, note in slides:
-        s = prs.slides.add_slide(blank)
-        for j, line in enumerate(scr):
-            tb = s.shapes.add_textbox(Inches(0.5), Inches(0.5 + j*0.6), Inches(8), Inches(0.5))
-            tb.text_frame.paragraphs[0].add_run().text = line
-        s.notes_slide.notes_text_frame.text = note
-    prs.save(path)
+    _SPEC[os.path.normpath(path)] = slides
+    open(path, 'w').close()                   # os.path.exists 게이트를 실제로 지나가게
 
 def scan(path, mutate=None):
     import importlib, lane_slide_refs as L

--- a/scripts/test_preprep_slide_refs_lanes.sh
+++ b/scripts/test_preprep_slide_refs_lanes.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# test_preprep_slide_refs_lanes.sh — preprep L13(리터럴 장 번호 참조)의 계약을 고정한다.
+#
+# WHY: 장을 빼면 뒤 번호가 통째로 당겨진다. 이웃 레인들은 «말로 가리키는 것»만 본다
+# (L5/L8 화면 재사용·시각 지시 · R1~R5 접속어·소유권) — 숫자 참조는 아무도 안 봤다.
+#
+# 🟥 이 레인의 난점은 검출이 아니라 **분류**다. 같은 «숫자+단위»가 셋을 가리킨다:
+#      SLIDE(진짜 장) · SECTION(섹션 번호) · CITATION(논문 쪽수)
+#    실측 코퍼스(if(kakao) 121장)에 셋이 **전부** 있었고, SLIDE 는 **0건**이었다.
+#    ⇒ 실물은 known-**negative** 만 대준다. 양성은 아래 픽스처가 댄다 — 그래서 둘 다 있다.
+#
+# 종료코드: 0 pass · 1 레인 실패 · 2 대상 부재 · 10 setup 실패
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 10
+LANE=plugins/fh-commons/skills/preprep/lane_slide_refs.py
+[ -f "$LANE" ] || { echo "ⓘ $LANE absent — subject missing (NOT a pass)"; exit 2; }
+command -v python3 >/dev/null 2>&1 || { echo "ⓘ python3 absent — setup broke"; exit 10; }
+python3 -c 'import pptx' 2>/dev/null || { echo "ⓘ python-pptx absent — setup broke (NOT a pass)"; exit 10; }
+T=$(mktemp -d) || exit 10; trap 'rm -rf "$T"' EXIT
+PASS=0; FAIL=0
+ok(){ echo "  ✅ $1"; PASS=$((PASS+1)); }
+ng(){ echo "  ❌ $1"; FAIL=$((FAIL+1)); }
+
+RUN=$T/run.py
+cat > "$RUN" <<'PY'
+import sys, os
+sys.path.insert(0, 'plugins/fh-commons/skills/preprep')
+from pptx import Presentation
+from pptx.util import Inches, Pt
+
+def build(path, slides):
+    """slides = [(화면 줄들, 대본)] — 화면 줄은 각각 별도 텍스트 상자."""
+    prs = Presentation()
+    blank = prs.slide_layouts[6]
+    for scr, note in slides:
+        s = prs.slides.add_slide(blank)
+        for j, line in enumerate(scr):
+            tb = s.shapes.add_textbox(Inches(0.5), Inches(0.5 + j*0.6), Inches(8), Inches(0.5))
+            tb.text_frame.paragraphs[0].add_run().text = line
+        s.notes_slide.notes_text_frame.text = note
+    prs.save(path)
+
+def scan(path, mutate=None):
+    import importlib, lane_slide_refs as L
+    importlib.reload(L)
+    if mutate == 'kill-cite':
+        L.CITE = __import__('re').compile(r'(?!x)x')          # 절대 안 맞는다
+    if mutate == 'kill-section':
+        L.section_numbers = lambda prs: set()
+    cfg = {'surfaces_by_id': {'built_deck': {'path': path}}}
+    return L.scan(cfg, '.')
+
+if __name__ == '__main__':
+    build(sys.argv[1], eval(sys.argv[2]))
+    f, n = scan(sys.argv[1], sys.argv[3] if len(sys.argv) > 3 else None)
+    print('FINDINGS', len(f))
+    for x in f: print('F|', x[2])
+    for x in n: print('N|', x)
+PY
+
+SEC=$'3. 어떻게 만들었나'
+# 섹션 라벨은 «여러 장에 반복» 되어야 섹션으로 인정된다 — 픽스처도 그 조건을 만족시킨다
+DECK_SEC="[(['$SEC','3장에서 게이트부터 보겠습니다'],''),(['$SEC'],''),(['$SEC'],'')]"
+DECK_CITE="[(['1) Ye, 『Coding with Enemy』, arXiv:2606.05647, 2026 (4p)'],''),([''],''),([''],'')]"
+DECK_DANGLING="[(['본문'],'130p 를 보세요'),(['본문'],''),(['본문'],'')]"
+DECK_OK="[(['본문'],'2p 에서 보셨듯이'),(['본문'],''),(['본문'],'')]"
+DECK_SELF="[(['본문'],''),(['본문'],'2p 를 보세요'),(['본문'],'')]"
+DECK_DECIMAL="[(['62.5% 개선'],'62장을 보세요'),(['62.5% 개선'],''),(['본문'],'')]"
+DECK_EMPTY="[(['아무 참조도 없다'],''),(['본문'],''),(['본문'],'')]"
+
+run(){ python3 "$RUN" "$T/$1.pptx" "$2" ${3:-} 2>&1; }
+
+echo "== L13 — 분류가 하중을 진다 =="
+
+OUT=$(run pos "$DECK_DANGLING")
+echo "$OUT" | grep -q '^FINDINGS 1' && echo "$OUT" | grep -q '범위 밖' \
+  && ok "L1 known-positive: 3장 덱의 «130p» → 범위 밖 finding" \
+  || ng "L1 known-positive 실패: $(echo "$OUT" | head -2 | tr '\n' ' ')"
+
+OUT=$(run sec "$DECK_SEC")
+echo "$OUT" | grep -q '^FINDINGS 0' && echo "$OUT" | grep -q 'SECTION 1' \
+  && ok "L2 known-negative: 「3장에서」 = SECTION, finding 0" \
+  || ng "L2 섹션이 안 갈렸다: $(echo "$OUT" | grep '^N|' | head -1)"
+
+OUT=$(run cite "$DECK_CITE")
+echo "$OUT" | grep -q '^FINDINGS 0' && echo "$OUT" | grep -q 'CITATION 1' \
+  && ok "L3 known-negative: 인용 「(4p)」 = CITATION, finding 0" \
+  || ng "L3 인용이 안 갈렸다: $(echo "$OUT" | grep '^N|' | head -1)"
+
+OUT=$(run okref "$DECK_OK")
+echo "$OUT" | grep -q '^FINDINGS 0' && echo "$OUT" | grep -q 'SLIDE 1' \
+  && ok "L4 정상 SLIDE 참조는 노트로만(범위 안이라 finding 아님)" \
+  || ng "L4 정상 참조 처리 이상: $(echo "$OUT" | grep '^N|' | head -1)"
+
+OUT=$(run self "$DECK_SELF")
+echo "$OUT" | grep -q '자기 자신 참조' \
+  && ok "L5 자기 자신 참조는 ⚠️ 로 표면화(차단은 아님)" \
+  || ng "L5 자기 참조가 안 뜬다"
+
+OUT=$(run dec "$DECK_DECIMAL")
+if echo "$OUT" | grep -q '^FINDINGS 1' && echo "$OUT" | grep -q '범위 밖'; then
+  ok "L6 «62.5%» 를 섹션으로 안 먹는다 → 「62장」이 SLIDE 로 남아 범위 밖으로 잡힌다"
+else
+  ng "L6 소수점이 섹션으로 먹혔다(실측 사고 재발): $(echo "$OUT" | grep '^N|' | head -1)"
+fi
+
+OUT=$(run empty "$DECK_EMPTY")
+echo "$OUT" | grep -q 'UNMEASURED' \
+  && ok "L7 참조 0건 → «깨끗하다»가 아니라 UNMEASURED 로 적는다" \
+  || ng "L7 0건을 통과로 읽는다(미측정≠0 위반)"
+
+echo "== 컨트롤 — 판별자를 죽이면 빨개지는가(되돌림) =="
+OUT=$(run cite2 "$DECK_CITE" kill-cite)
+echo "$OUT" | grep -q '^FINDINGS 1' \
+  && ok "CTRL-A 인용 판별자를 죽이면 L3 가 오탐으로 뒤집힌다(판별자가 하중을 진다)" \
+  || ng "CTRL-A 뮤턴트인데 아무 일도 없다 — 인용 분기가 장식이다"
+
+OUT=$(run sec2 "$DECK_SEC" kill-section)
+echo "$OUT" | grep -q 'SLIDE 1' \
+  && ok "CTRL-B 섹션 판별자를 죽이면 「3장에서」가 SLIDE 로 넘어간다" \
+  || ng "CTRL-B 뮤턴트인데 분류가 그대로 — 섹션 분기가 장식이다"
+
+echo "== 배선·퇴화 =="
+OUT=$(python3 -c "
+import sys; sys.path.insert(0,'plugins/fh-commons/skills/preprep')
+import lane_slide_refs as L
+print(L.scan({}, '.')[1][0])
+print(L.scan({'surfaces_by_id':{'built_deck':{'path':'/nope/none.pptx'}}}, '.')[1][0])
+" 2>&1)
+echo "$OUT" | grep -q 'NOT_CONFIGURED' && echo "$OUT" | grep -q 'UNMEASURED' \
+  && ok "L8 미선언 → NOT_CONFIGURED · 실물 없음 → UNMEASURED (둘 다 0 아님)" \
+  || ng "L8 퇴화 표기가 0 으로 접힌다: $OUT"
+
+grep -q "import lane_slide_refs" plugins/fh-commons/skills/preprep/preprep.py \
+  && ok "L9 배선: preprep.py 가 이 레인을 부른다" \
+  || ng "L9 배선 없음 — 정의만 있고 아무도 안 부른다(built-but-not-wired)"
+
+echo "── preprep slide-refs lanes: PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
## 무엇

발표 덱에서 「130p 보시면」 같은 **장 번호 참조**가 장 이동 뒤에도 맞는지 사람이 눈으로 세고 있었다. preprep 의 기존 레인은 그걸 안 본다 — L5/L8·R1~R5 는 「앞 장을 **가리키는 말**」(화면 재사용·시각 지시·접속어)을 보지, **리터럴 장 번호**는 아무 레인도 안 봤다.

이 세션에서 실제로 그 공백에 부딪혔고(덱 41장 → 40장 편집), 신호로 남긴 것을 그대로 레인으로 만들었다.

## L13 — 분류가 하중을 진다

참조를 셋으로 가른다:

| | 예 | 처분 |
|---|---|---|
| **SLIDE** | 「130p 보시면」 | 덱 범위 밖이면 **finding** |
| **SECTION** | 「3장에서」 | 노트로만 |
| **CITATION** | 「(4p)」, arXiv, `pp.` | 노트로만 |

🟥 **오탐이 이 레인을 무력화한다.** 섹션 라벨이나 인용 페이지를 슬라이드 참조로 먹으면 사람이 다시 손검증해야 하고, 그러면 레인이 있으나 마나다. **실물 대조에서 실제로 한 번 틀렸다** — 소수점 `62.5%` 를 「62장」으로. 판별자를 `\s+` 요구 + 섹션 상한 20 + 최소 2장으로 좁혀 막았고, **그 사건 자체가 L6 픽스처**로 박혀 있다.

## 참조 0건은 「깨끗하다」가 아니다

L7 이 그것을 못박는다 — 참조가 하나도 없으면 **UNMEASURED** 로 적는다. 「안 쟀다」를 「0」으로 렌더하지 않는다.

## 검증 — 레인 11/11

| | |
|---|---|
| known-positive 1 | 3장 덱의 「130p」 → 범위 밖 finding |
| known-negative 2 | 섹션 · 인용 → finding 0 |
| **되돌림 컨트롤 2** | 인용 판별자를 죽이면 L3 가 오탐으로 뒤집힌다 · 섹션 판별자를 죽이면 「3장에서」가 SLIDE 로 넘어간다 |
| 실측 사건 1 | `62.5%` 를 섹션으로 안 먹는다 |
| 퇴화 1 | 미선언 → `NOT_CONFIGURED` · 실물 없음 → `UNMEASURED`(둘 다 0 아님) |
| 배선 1 | `preprep.py` 가 이 레인을 실제로 부른다 |

## 4축 마커

`crossfamily=DEGRADED_PANEL_UNUSED · standpoint=DEGRADED_NOT_RUN · thirdparty=DEGRADED_NOT_RUN · oracle=known-pair`

`standpoint` 가 DEGRADED 인 이유를 분명히 해 둔다: 이 델타는 **소비자에게 보이는 행동을 바꾼다**(preprep 을 돌리면 새 레인이 findings 를 더한다). Q0-ⓑ 로 「packed artifact 클린 install」 팔이 걸리는데 **안 돌렸다.** 이 레포 안에서만 실행했다.

## 안 닫은 것

- **한글 밖 표기 미지원** — `p.12` · `slide 12` 는 안 본다
- 판별자 상한 20(섹션 번호)은 분포에서 유도한 값이 아니라, 실물에서 「62.5%」가 통과하고 정상 섹션이 걸리는 것을 확인한 값이다
