### PR TITLE
fix(publish): verify-on-registry 에 재시도 — 발행 성공을 전파 지연이 적색으로 만들었다

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,8 +58,23 @@ jobs:
       - name: publish (prepublishOnly 게이트 경유, provenance)
         run: npm publish --provenance --access public
       - name: verify on registry
+        # 🟥 왜 재시도가 필요한가 (2026-09-06, v3.1.0 실측): `npm publish` 가 성공한 직후
+        #    이 단계가 곧바로 조회했다가 **E404 «No match found for version 3.1.0»** 로 죽었다.
+        #    그런데 같은 시각 패키지는 실제로 올라가 있었다 — 1 분 뒤 로컬에서 조회하니
+        #    `latest: 3.1.0` 이었다. 즉 npm 의 읽기 복제본이 아직 전파 전이었고, 이 단계는
+        #    **eventually-consistent 한 상태를 대기 없이** 물었다.
+        #    발행은 성공인데 워크플로가 빨갛게 남는 것은 가장 나쁜 형태다 — 「발행 실패」와
+        #    「전파 지연」이 같은 얼굴이 되고, 그 게이트를 다음부터 아무도 안 읽는다.
+        #    ⚠️ 재시도가 «없는 것을 있다»고 만들지는 않는다: 마지막 시도까지 값이 안 맞으면
+        #    그대로 실패한다. 늘린 것은 **관측 창**이지 통과 조건이 아니다.
         run: |
           v=$(node -p "require('./package.json').version")
-          got=$(npm view @chrono-meta/fh-gate@"$v" version)
-          [ "$got" = "$v" ] || { echo "🟥 registry shows '$got' not '$v'"; exit 1; }
+          got=""
+          for i in 1 2 3 4 5 6; do
+            got=$(npm view @chrono-meta/fh-gate@"$v" version 2>/dev/null || true)
+            [ "$got" = "$v" ] && break
+            echo "  … attempt $i/6: registry has '${got:-<none>}', want '$v' — waiting 10s (read-replica lag)"
+            sleep 10
+          done
+          [ "$got" = "$v" ] || { echo "🟥 registry still shows '${got:-<none>}' not '$v' after 6 attempts (~60s)"; exit 1; }
           echo "✅ @chrono-meta/fh-gate@$v on registry"


### PR DESCRIPTION
## 실측

v3.1.0 발행(run `34039915526`)에서 났다.

| 단계 | 결과 |
|---|---|
| `publish (prepublishOnly 게이트 경유, provenance)` | **success** |
| `verify on registry` | **failure** — `npm error 404 No match found for version 3.1.0` |

그런데 같은 패키지가 실제로는 올라가 있었다. 약 1분 뒤 로컬 조회:

```
npm view @chrono-meta/fh-gate dist-tags
{ latest: '3.1.0' }
```

즉 npm 읽기 복제본이 전파되기 전에 조회한 것이고, 이 단계는 **eventually-consistent 한 상태를 대기 없이** 묻고 있었다.

## 왜 고칠 값이 있나

발행은 됐는데 워크플로가 빨간 것이 가장 나쁜 형태다 — **「발행 실패」와 「전파 지연」이 같은 얼굴**이 된다. 그러면 다음부터 그 게이트를 아무도 안 읽고, 진짜 발행 실패도 같이 묻힌다.

## 무엇을

10초 간격 6회(≈60초) 재시도.

🟥 **통과 조건은 글자 하나 안 바뀌었다.** 루프는 같은 등식(`got = v`)을 그대로 쓰고, 마지막 시도까지 안 맞으면 `exit 1` 한다. 늘린 것은 **관측 창**이지 통과 조건이 아니다. `npm view` 가 다른 이유로 죽어도 빈 값은 비교를 통과하지 못하고, 실패 메시지가 `<none>` 을 이름으로 찍는다.

## 오라클

**back-to-back.** 같은 명령이 두 시점에 다른 답을 낸 것 자체가 «대상이 시간에 의존한다」는 증거이고, 두 관측이 서로의 컨트롤이다(대상 동일 · 시점만 다름).

## 안 닫은 것

**60초가 충분한가는 관측 1건에서 온 값이다.** 다시 거짓 적색이 나면 창을 늘리지 말고 verify 를 별도 잡으로 떼라 — 마커 `defeater:` 에 그 분기를 적어 뒀다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FGFMzea5ceHT9w86v1yTR