### PR TITLE
fix(plist): XML 주석의 이중 하이픈 제거 — plutil 만 통과하던 파일

### DIFF
--- a/scripts/com.forge-harness.live-eval.plist
+++ b/scripts/com.forge-harness.live-eval.plist
@@ -14,16 +14,16 @@
         <string>/bin/bash</string>
         <string>/path/to/forge-harness/scripts/probe_live_eval.sh</string>
         <!-- 🟥 COST + API-KEY DECISION IS THE OPERATOR'S — this template ships with NO default
-             --subset/--ids limiter, i.e. installing it as-is runs the FULL selected set (12
+             the subset / ids limiter flags limiter, i.e. installing it as-is runs the FULL selected set (12
              probes x 2 calls = 24 live `claude -p` invocations) every night. Read
              scripts/probe_live_eval.sh's own header (§COST) before installing, and add a
-             --subset N or --ids P1,P2 argument here if a nightly full-set run is not what you
+             a subset or ids argument argument here if a nightly full-set run is not what you
              want. This plist is a template, not a recommendation of scope. -->
         <!-- 🟥 reps=3 (2026-09-06). 이 인자가 없으면 reps=1 이고, 그때의 pass_rate 로는 문턱을
              정할 수 없다 — 실측: 유효 런 3 개 재채점에서 12 프로브 중 5 개가 flaky, 같은 코퍼스
              15 분 간격 두 런에서 4 개가 뒤집혔고 관측 pass_rate 는 0.50/0.67/0.67 이었다(단일 rep
              노이즈 폭 > 문턱까지의 거리). 판정은 과반, 분산은 리포트 `reps(pass/ran)` 칸에 남는다.
-             ⚠️ 비용이 3 배다: 24 → **72** 회 `claude -p`. 줄이려면 --subset/--ids 를 같이 줘라. -->
+             ⚠️ 비용이 3 배다: 24 → **72** 회 `claude -p`. 줄이려면 the subset / ids limiter flags 를 같이 줘라. -->
         <string>--reps</string>
         <string>3</string>
     </array>


### PR DESCRIPTION
## 어떻게 발견했나

`--reps 3` 배선이 오늘 02:30 무인 런에서 실제로 서는지 dry-run 으로 확인하다가 나왔다. 무인 런은 **그 환경에서** 확인해야 한다는 규율이 계기다.

## 무엇이 문제였나

이 plist 는 **표준 XML 이 아니었다.** XML 주석에는 `--` 가 들어갈 수 없는데, COST 경고 주석이 `--subset/--ids` 를 그대로 적고 있었다. (오늘 내가 넣은 줄이 아니라 **원래 있던 줄**이다.)

## 🟥 계기 셋이 갈렸다 — 이게 이 PR 의 요점

```
plutil -lint : OK                                            ← 애플 파서는 관대하다
xmllint      : Comment must not contain '--' (double-hyphen)
python expat : not well-formed (invalid token): line 17
```

`plutil` 만 보면 **영영 안 보인다.** launchd 도 애플 파서라 지금까지 잘 돌았고, 그래서 운영 실패로는 한 번도 안 드러났다. 그러나 이 파일은 `package.json` `files[]` 에 실려 **소비자에게 나가는 템플릿**이고, 소비자의 도구 사슬이 우리 것과 같다는 보장이 없다.

## 무엇을 고쳤나

주석 안의 플래그 표기를 어법으로 풀었다 — `--subset/--ids` → *"the subset / ids limiter flags"*. 정확한 철자는 `scripts/probe_live_eval.sh` 헤더 §COST 가 정본이라 **죽은 포인터가 안 된다.** 🟥 **주석의 정보(비용 경고 · reps 근거)는 하나도 안 지웠다** — 읽히게 만들려고 내용을 버리는 건 이 수정의 반대다.

## 컨트롤 셋

| | |
|---|---|
| **known-negative** | 나머지 forge-harness plist **6개를 같은 세 파서로 전수 검사** → 전부 OK. 이 결함이 이 파일 고유임을 보인다 |
| **before/after** | 수정 전 `plutil OK / xmllint FAIL / expat FAIL` → 수정 후 **셋 다 OK** |
| **실배선** | 재적재 후 `launchctl list com.forge-harness.live-eval` 이 `ProgramArguments` 에 `"--reps"; "3"` 을 들고 있는 것을 출력으로 확인. 상태 `1` → `0` |

## 반증 조건

주석에서 플래그 철자를 뺀 탓에 누군가 «어떤 인자를 넣어야 하는지」를 못 찾는 것이 관측되면 이 수정의 전제가 틀린 것이다. 그때 처방은 주석에 `--` 를 되돌리는 게 아니라(불법이다) 스크립트 헤더로 가는 포인터를 굵게 하는 것이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FGFMzea5ceHT9w86v1yTR