### PR TITLE
docs(papers): 링크를 지금 유효한 판으로 · 「arXiv in review」 는 거짓이 됐다

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -433,8 +433,8 @@ Claude Code は作業の複雑さでモデルを自動選択しません — こ
 | [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) | スキルとパターンの貢献方法 |
 | [`tracks/_contrib/`](tracks/_contrib/README.md) | **同意レーン** — 非識別化した作業セッションを共有; レポが運用者たちにまたがって複利で積み上がる |
 
-> **FH 論文**: v1.0 方法論 · [Zenodo](https://zenodo.org/records/20397566) (DOI
-> 10.5281/zenodo.20397566) · cs.SE companion、掲載済み ·
-> [Zenodo](https://zenodo.org/records/20680081) (DOI 10.5281/zenodo.20680081) · cs.AI companion は
+> **FH 論文**: v1.0.1 方法論 · [Zenodo](https://zenodo.org/records/22542168) (DOI
+> 10.5281/zenodo.22542168) · cs.SE companion v1.1、掲載済み ·
+> [Zenodo](https://zenodo.org/records/20740038) (DOI 10.5281/zenodo.20740038) · cs.AI companion は
 > 準備中。これら、独立した収束的研究、そしてそれぞれの但し書き:
 > [`docs/OUTPUT_EVIDENCE.md`](docs/OUTPUT_EVIDENCE.md)。

--- a/README.ko.md
+++ b/README.ko.md
@@ -421,8 +421,8 @@ Claude Code 는 작업 복잡도로 모델을 자동 선택하지 않습니다. 
 | [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) | 스킬과 패턴 기여 방법 |
 | [`tracks/_contrib/`](tracks/_contrib/README.md) | **동의 레인** — 비식별화된 작업 세션 공유. 레포가 운영자들에 걸쳐 복리로 쌓임 |
 
-> **FH 논문**: v1.0 방법론 · [Zenodo](https://zenodo.org/records/20397566) (DOI
-> 10.5281/zenodo.20397566) · cs.SE companion, 게재됨 ·
-> [Zenodo](https://zenodo.org/records/20680081) (DOI 10.5281/zenodo.20680081) · cs.AI companion
+> **FH 논문**: v1.0.1 방법론 · [Zenodo](https://zenodo.org/records/22542168) (DOI
+> 10.5281/zenodo.22542168) · cs.SE companion v1.1, 게재됨 ·
+> [Zenodo](https://zenodo.org/records/20740038) (DOI 10.5281/zenodo.20740038) · cs.AI companion
 > 준비 중. 이것들과 독립적인 수렴 연구, 그리고 각각의 주의사항:
 > [`docs/OUTPUT_EVIDENCE.md`](docs/OUTPUT_EVIDENCE.md).

--- a/README.md
+++ b/README.md
@@ -412,8 +412,8 @@ and the phrase that triggers it:
 | [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) | How to contribute skills and patterns |
 | [`tracks/_contrib/`](tracks/_contrib/README.md) | **Consent lane** — share a de-identified work session; the repo compounds across operators |
 
-> **FH papers**: v1.0 methodology · [Zenodo](https://zenodo.org/records/20397566) (DOI
-> 10.5281/zenodo.20397566) · cs.SE companion, published ·
-> [Zenodo](https://zenodo.org/records/20680081) (DOI 10.5281/zenodo.20680081) · cs.AI companion in
+> **FH papers**: v1.0.1 methodology · [Zenodo](https://zenodo.org/records/22542168) (DOI
+> 10.5281/zenodo.22542168) · cs.SE companion v1.1, published ·
+> [Zenodo](https://zenodo.org/records/20740038) (DOI 10.5281/zenodo.20740038) · cs.AI companion in
 > preparation. Those, the independent convergent work, and the caveats on each:
 > [`docs/OUTPUT_EVIDENCE.md`](docs/OUTPUT_EVIDENCE.md).

--- a/README.zh.md
+++ b/README.zh.md
@@ -400,8 +400,8 @@ Claude Code 不会按任务复杂度自动选择模型 —— 这个要你设置
 | [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) | 如何贡献技能与模式 |
 | [`tracks/_contrib/`](tracks/_contrib/README.md) | **同意通道** —— 分享一个去标识化的工作会话；仓库在众多操作者之间复利累积 |
 
-> **FH 论文**：v1.0 方法论 · [Zenodo](https://zenodo.org/records/20397566)（DOI
-> 10.5281/zenodo.20397566）· cs.SE companion，已发表 ·
-> [Zenodo](https://zenodo.org/records/20680081)（DOI 10.5281/zenodo.20680081）· cs.AI companion
+> **FH 论文**：v1.0.1 方法论 · [Zenodo](https://zenodo.org/records/22542168)（DOI
+> 10.5281/zenodo.22542168）· cs.SE companion v1.1，已发表 ·
+> [Zenodo](https://zenodo.org/records/20740038)（DOI 10.5281/zenodo.20740038）· cs.AI companion
 > 筹备中。这些、独立的收敛性工作，以及每一项的注意事项：
 > [`docs/OUTPUT_EVIDENCE.md`](docs/OUTPUT_EVIDENCE.md)。

--- a/docs/OUTPUT_EVIDENCE.md
+++ b/docs/OUTPUT_EVIDENCE.md
@@ -35,8 +35,8 @@
 
 | Artifact | Reference |
 |---|---|
-| Paper v1.0 — methodology | Zenodo DOI [`10.5281/zenodo.20397566`](https://zenodo.org/records/20397566) — 2-layer design, 6-axis framework, 4-agent orchestration, compounding loop, with empirical evidence. arXiv in review |
-| cs.SE companion — governance-gate methodology | **published** · Zenodo DOI [`10.5281/zenodo.20680081`](https://zenodo.org/records/20680081) (latest v1.1 `10.5281/zenodo.20740038` · CC-BY-4.0) · arXiv **submitted** (cs.SE). The moderation outcome is not tracked in this repo, so treat "submitted" as the last state this page can vouch for, not as current |
+| Paper v1.0.1 — methodology | Zenodo DOI [`10.5281/zenodo.22542168`](https://zenodo.org/records/22542168) (all versions: `10.5281/zenodo.20397565`) — 2-layer design, 6-axis framework, 4-agent orchestration, compounding loop, with empirical evidence. **arXiv: rejected at moderation (2026-09-06)**; v1.0.1 is the corrected version (11 of 17 reference entries in v1.0 did not match the works cited — see the erratum in the record). Do not read the rejection as an assessment of the methodology, and do not read v1.0.1 as re-reviewed: it has not been resubmitted |
+| cs.SE companion — governance-gate methodology | **published** · Zenodo DOI [`10.5281/zenodo.20740038`](https://zenodo.org/records/20740038) (v1.1; all versions `10.5281/zenodo.20680080` · CC-BY-4.0) · arXiv **submitted** (cs.SE). The moderation outcome is not tracked in this repo, so treat "submitted" as the last state this page can vouch for, not as current |
 | cs.AI companion — "Governance Dividend" | in preparation |
 | Package | npm [`@chrono-meta/fh-gate`](https://www.npmjs.com/package/@chrono-meta/fh-gate) — multi-backend governance gate (claude · codex · auto) |
 | Codex-compatible | `docs/codex-compat.md` — methodology layer runs model-agnostic. Marked **beta** there in the *validation-maturity* sense (external validation is still thin), **not** the *scope* sense: partial automation-layer support is the design, not an unfinished state |

--- a/knowledge/shared/harness-core/fh_ecosystem_positioning.md
+++ b/knowledge/shared/harness-core/fh_ecosystem_positioning.md
@@ -146,4 +146,4 @@ This is the N-fold synergy claim stated precisely. The controlled experiment des
 - `multi_model_sidecar_strategy.md` — orchestrator-swap experiment that generated this audit
 - `README.md §Architecture` — 2-layer design (methodology vs automation)
 - `AGENTS.md` — 6-agent registry (fact-checker added after this audit)
-- FH paper (Zenodo: 10.5281/zenodo.20397566) — harness-as-durable-layer thesis this positioning extends
+- FH paper (Zenodo: 10.5281/zenodo.20397565) — harness-as-durable-layer thesis this positioning extends

--- a/knowledge/shared/harness-core/fh_integration_contract.md
+++ b/knowledge/shared/harness-core/fh_integration_contract.md
@@ -344,4 +344,4 @@ The bridge layer (v1.0) will implement these. This contract is the specification
 - `fh_ecosystem_positioning.md` — ecosystem context + synergy map + v2 paper connection
 - `tracks/_meta/` — governance logs written here on each gate run
 - `multi_model_sidecar_strategy.md` — multi-model orchestration (related pattern)
-- FH paper (Zenodo: 10.5281/zenodo.20397566) — harness-as-durable-layer thesis this contract operationalizes
+- FH paper (Zenodo: 10.5281/zenodo.20397565) — harness-as-durable-layer thesis this contract operationalizes

--- a/knowledge/shared/harness-core/fh_opencode_governance_wrapper.md
+++ b/knowledge/shared/harness-core/fh_opencode_governance_wrapper.md
@@ -160,4 +160,4 @@ On session end, check `/tmp/fh-pending-governance.txt` and run the governance pa
 - `fh_ecosystem_positioning.md` — ecosystem context, synergy map, v2 paper connection
 - `multi_model_sidecar_strategy.md` — multi-model orchestration (sidecar pattern for adding Gemini/Codex review)
 - `tracks/_meta/fh_opencode_governance_experiment_2026_05_31.md` — full empirical record (local)
-- FH paper (Zenodo: 10.5281/zenodo.20397566) — harness-as-durable-layer thesis
+- FH paper (Zenodo: 10.5281/zenodo.20397565) — harness-as-durable-layer thesis

--- a/knowledge/shared/harness-core/goal_quench_anthropic_issue.md
+++ b/knowledge/shared/harness-core/goal_quench_anthropic_issue.md
@@ -84,7 +84,7 @@ Limitations of the userspace approach (why native support is needed):
 - Stop hook cannot invoke Claude recursively (verification triggers on next session, not immediately)
 - Checkpoint requires manual commit — no structured sub-goal output from Haiku
 
-**Paper reference**: forge-harness: A Meta-Harness Engineering Platform for Terminal-Native Claude Code Workflows. Zenodo DOI: 10.5281/zenodo.20397566. arXiv: [pending number].
+**Paper reference**: forge-harness: A Meta-Harness Engineering Platform for Terminal-Native Claude Code Workflows. Zenodo DOI: 10.5281/zenodo.20397565. arXiv: [pending number].
 
 ---
 

--- a/knowledge/shared/harness-core/multi_model_sidecar_strategy.md
+++ b/knowledge/shared/harness-core/multi_model_sidecar_strategy.md
@@ -778,7 +778,7 @@ Missing any layer = compression risk. (Path conventions adapt per project — se
 
 - `README.md §Architecture — 2-layer design` — sidecar note in Automation layer section
 - `knowledge/shared/harness-core/agents_md_runtime_details.md §Sidecar-routing-and-waiting` — sidecar note distinguishing adapter invocation from agent dispatch
-- FH paper (Zenodo DOI: 10.5281/zenodo.20397566, arXiv: submit/7657304) — harness-as-durable-layer thesis
+- FH paper (Zenodo DOI: 10.5281/zenodo.20397565 — all versions) — harness-as-durable-layer thesis. The arXiv submission `submit/7657304` was rejected at moderation 2026-09-06; cite the Zenodo record, not that ID
 - A sister-harness `sidecar-orchestrator` SKILL.md (2026-06-01) — gh copilot + corporate endpoint + 3-tier fallback + 3-layer persistence
 - arXiv:2605.26302 AgingBench — compression aging defense rationale
 - `hybrid_orchestration_architecture_roadmap.md` — proposed (not-yet-implemented) architecture direction that would generalize this sidecar strategy into a hybrid orchestration engine


### PR DESCRIPTION
운영자 관측: README 논문 링크가 예전 버전으로 간다.

## 자리마다 다르게 처리했다

「어느 판인지」가 필요한 자리와 「그 논문」을 가리키는 자리는 다르다.

| 자리 | 쓴 DOI | 이유 |
|---|---|---|
| README ×4 · `docs/OUTPUT_EVIDENCE.md` | 버전 DOI — methodology `22542168`(v1.0.1) · governance `20740038`(v1.1) | 독자가 «어느 판을 받는지» 알아야 한다 |
| `knowledge/` 본문 인용 5곳 | concept DOI `20397565` | 판이 아니라 «그 논문» 을 가리키는 자리. Zenodo 가 항상 최신으로 해석한다 |

## 링크보다 무거웠던 것

`docs/OUTPUT_EVIDENCE.md` 가 methodology 논문을 **「arXiv in review」** 라고 적고 있었는데
09-06 에 반려됐다. 공개 증거 페이지의 거짓 진술이라 같이 고쳤다 — 반려 사실과 v1.0.1 정정본을
명시로 올리고, **「방법론에 대한 평가로 읽지 마라」** 와 **「v1.0.1 을 재심사된 것으로도 읽지 마라」**
를 함께 적었다. 죽은 arXiv ID(`submit/7657304`)를 인용하던 sidecar 문서도 죽었다고 명시했다.

## 손대지 않은 곳

`plugins/fh-meta/skills/phantom-quench/SKILL.md:25` — *"the **v1 paper** cites the old name"*.
치환하면 문장이 거짓이 된다.

## 검증

- 새 URL 4개 `200` · 존재하지 않는 `records/99999999` 컨트롤 `404` — 계기가 산 것과 죽은 것을 가른다
- 실 `npm pack` tarball 전개 후 grep: 옛 번호 **0건** / 새 번호 **2건** — 「0건」이 파일을 못 읽어서
  나온 0 이 아님을 같은 실행에서 증명
- 팩 매니페스트에 제외 컨트롤 동반(`tracks/_meta/edit_manifest.yaml` · `CLAUDE.local.md` 실제 제외)

`standpoint: tier2(consumer-install)` — 워크트리가 아니라 소비자가 받는 팩 산출물에서 읽었다.

## 남은 것

오늘 governance v1.2 를 발행하면 `20740038` 이 다시 낡는다. 발행 직후 같은 세션에서 갱신한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FGFMzea5ceHT9w86v1yTR