### PR TITLE
docs(readme): 마켓플레이스 진입 경로 — 배지 + 본문 링크 (4판)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -7,6 +7,7 @@
   <a href="https://github.com/VoltAgent/awesome-agent-skills#community-skills"><img src="https://img.shields.io/badge/listed_in-awesome--agent--skills-0ea5e9.svg" alt="Listed in awesome-agent-skills"></a>
   <a href="https://github.com/anthropics/claude-code"><img src="https://img.shields.io/badge/Claude_Code-compatible-a855f7.svg" alt="Claude Code compatible — official Claude Code repository"></a>
   <a href="https://chrono-meta.github.io/forge-harness/"><img src="https://img.shields.io/badge/whole_map-interactive-6366f1.svg" alt="FH whole map — interactive diagrams on GitHub Pages"></a>
+  <a href="https://github.com/marketplace/actions/fh-gate-typed-ai-code-review-verdict"><img src="https://img.shields.io/badge/GitHub_Action-marketplace-2088FF.svg" alt="GitHub Actions Marketplace — fh-gate"></a>
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
   <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-22c55e.svg" alt="MIT License"></a>
@@ -64,6 +65,8 @@ brew tap chrono-meta/forge-harness && brew install forge-harness   # あるい�
   env:
     ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
+
+[GitHub Actions マーケットプレイス](https://github.com/marketplace/actions/fh-gate-typed-ai-code-review-verdict) に掲載されている。
 
 このステップは `verdict`（PASS · PENDING · BLOCKED · ESCALATE · HARNESS_ERROR · ARG_ERROR ·
 DRY_RUN · UNKNOWN）と `reviewed` を出します。**`reviewed: false` は合格ではありません** —

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,6 +7,7 @@
   <a href="https://github.com/VoltAgent/awesome-agent-skills#community-skills"><img src="https://img.shields.io/badge/listed_in-awesome--agent--skills-0ea5e9.svg" alt="Listed in awesome-agent-skills"></a>
   <a href="https://github.com/anthropics/claude-code"><img src="https://img.shields.io/badge/Claude_Code-compatible-a855f7.svg" alt="Claude Code compatible — official Claude Code repository"></a>
   <a href="https://chrono-meta.github.io/forge-harness/"><img src="https://img.shields.io/badge/whole_map-interactive-6366f1.svg" alt="FH whole map — interactive diagrams on GitHub Pages"></a>
+  <a href="https://github.com/marketplace/actions/fh-gate-typed-ai-code-review-verdict"><img src="https://img.shields.io/badge/GitHub_Action-marketplace-2088FF.svg" alt="GitHub Actions Marketplace — fh-gate"></a>
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
   <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-22c55e.svg" alt="MIT License"></a>
@@ -51,6 +52,8 @@ brew tap chrono-meta/forge-harness && brew install forge-harness   # 또는 이�
   env:
     ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
+
+[GitHub Actions 마켓플레이스](https://github.com/marketplace/actions/fh-gate-typed-ai-code-review-verdict)에 등재돼 있다.
 
 이 스텝은 `verdict`(PASS · PENDING · BLOCKED · ESCALATE · HARNESS_ERROR · ARG_ERROR · DRY_RUN ·
 UNKNOWN)와 `reviewed` 를 내놓습니다. **`reviewed: false` 는 통과가 아닙니다** — 백엔드가 끝내 답을

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   <a href="https://github.com/VoltAgent/awesome-agent-skills#community-skills"><img src="https://img.shields.io/badge/listed_in-awesome--agent--skills-0ea5e9.svg" alt="Listed in awesome-agent-skills"></a>
   <a href="https://github.com/anthropics/claude-code"><img src="https://img.shields.io/badge/Claude_Code-compatible-a855f7.svg" alt="Claude Code compatible — official Claude Code repository"></a>
   <a href="https://chrono-meta.github.io/forge-harness/"><img src="https://img.shields.io/badge/whole_map-interactive-6366f1.svg" alt="FH whole map — interactive diagrams on GitHub Pages"></a>
+  <a href="https://github.com/marketplace/actions/fh-gate-typed-ai-code-review-verdict"><img src="https://img.shields.io/badge/GitHub_Action-marketplace-2088FF.svg" alt="GitHub Actions Marketplace — fh-gate"></a>
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
   <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-22c55e.svg" alt="MIT License"></a>
@@ -53,6 +54,8 @@ brew tap chrono-meta/forge-harness && brew install forge-harness   # or this
   env:
     ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
+
+Listed on the [GitHub Actions Marketplace](https://github.com/marketplace/actions/fh-gate-typed-ai-code-review-verdict).
 
 The step exposes `verdict` (PASS · PENDING · BLOCKED · ESCALATE · HARNESS_ERROR · ARG_ERROR · DRY_RUN · UNKNOWN)
 and `reviewed`. **`reviewed: false` is not a pass** — a backend that never answered, a dry run, or an exit

--- a/README.zh.md
+++ b/README.zh.md
@@ -7,6 +7,7 @@
   <a href="https://github.com/VoltAgent/awesome-agent-skills#community-skills"><img src="https://img.shields.io/badge/listed_in-awesome--agent--skills-0ea5e9.svg" alt="Listed in awesome-agent-skills"></a>
   <a href="https://github.com/anthropics/claude-code"><img src="https://img.shields.io/badge/Claude_Code-compatible-a855f7.svg" alt="Claude Code compatible — official Claude Code repository"></a>
   <a href="https://chrono-meta.github.io/forge-harness/"><img src="https://img.shields.io/badge/whole_map-interactive-6366f1.svg" alt="FH whole map — interactive diagrams on GitHub Pages"></a>
+  <a href="https://github.com/marketplace/actions/fh-gate-typed-ai-code-review-verdict"><img src="https://img.shields.io/badge/GitHub_Action-marketplace-2088FF.svg" alt="GitHub Actions Marketplace — fh-gate"></a>
   <a href="https://www.npmjs.com/package/@chrono-meta/fh-gate"><img src="https://img.shields.io/npm/v/@chrono-meta/fh-gate.svg?color=cb3837" alt="npm"></a>
   <a href="https://github.com/chrono-meta/homebrew-forge-harness"><img src="https://img.shields.io/badge/homebrew-tap-FBB040.svg" alt="Homebrew tap"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-22c55e.svg" alt="MIT License"></a>
@@ -63,6 +64,8 @@ brew tap chrono-meta/forge-harness && brew install forge-harness   # 或者用�
   env:
     ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
+
+已在 [GitHub Actions 应用市场](https://github.com/marketplace/actions/fh-gate-typed-ai-code-review-verdict) 上架。
 
 这个 step 会输出 `verdict`（PASS · PENDING · BLOCKED · ESCALATE · HARNESS_ERROR · ARG_ERROR ·
 DRY_RUN · UNKNOWN）和 `reviewed`。**`reviewed: false` 不是通过** —— 后端始终没有回答、一次 dry


### PR DESCRIPTION
Action 은 어제 게시됐는데 README 에서 거기로 가는 길이 없었다.

## 슬러그는 추측하지 않았다

| 후보 | HTTP |
|---|---|
| `fh-gate` | 404 |
| `forge-harness-gate` | 404 |
| `fh-gate-typed-ai-code-review` | 404 |
| **`fh-gate-typed-ai-code-review-verdict`** | **200** |

맞는 하나는 **직접 요청 200** 과 **마켓플레이스 검색 결과** 두 신호가 독립으로 일치한다.
컨트롤(`checkout`) 200 — 계기가 산 것과 죽은 것을 가른다.

## 넣은 자리

- **배지** — npm 배지 앞 (4판 동일 위치)
- **본문** — Actions 예제 코드블록 바로 아래, 언어별 한 문장

삽입 스크립트가 **앵커 개수 == 1** 을 단언한 뒤에만 쓴다. 4판 전부 2건(배지+본문) 확인.

## ⚠️ 정직하게 — 컨트롤 하나는 죽었다

배지 **이미지** URL 쪽 컨트롤은 판별력이 없다. shields.io 는 존재하지 않는 경로
(`https://img.shields.io/badge/`)에도 `200` 을 준다. 그러므로 이 PR 이 검증한 것은
**링크뿐이고 배지 이미지는 아니다**. 마커에도 그렇게 적었다.

## 명시된 잔여

`action.yml` 의 `name:` 과 이 슬러그는 **결합돼 있는데 그걸 지키는 레인이 없다.**
이름을 바꾸면 링크 4개가 조용히 죽는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FGFMzea5ceHT9w86v1yTR