### PR TITLE
docs(gate): Pre-Publish Surface Gate 에 «학술 예치»(Zenodo/DOI/arXiv) 표면

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -801,7 +801,13 @@ before any scrub. So the audit must fire **pre-publish**, not after.
 **When this gate fires** — *before* any action that makes a repo/package **publicly visible for the
 first time**, especially one **derived from internal/company assets** (operator-IP that originated in a
 private harness): `gh repo create --public`, `gh repo edit --visibility public`, a first push to a new
-public remote, `npm publish`, `twine upload`, a private→public visibility flip.
+public remote, `npm publish`, `twine upload`, a private→public visibility flip, **and a scholarly
+deposit** — Zenodo / figshare / OSF publish, a DOI mint or new version, an arXiv `submit` / `replace`:
+**any action that mints or alters a persistent public identifier**, first-time or not. 🟥 **What the
+form shows is not what the server received** — check the deposit's draft **API**, the file **md5**, and
+the **machine-readable fields** (references · related identifiers · dates) separately from the body:
+`templates/PRE-PUBLISH-CHECKLIST.md` **Step 1b** (four items, un-hookable surface — prose is the floor;
+measured case: `claude_md_gate_details.md §Pre-Publish-Hook-Coverage`).
 
 **Required before the public action** (all must be non-LEAK/non-FAIL) — this gate is the **umbrella that
 invokes them**, not a competitor; when publish intent is detected, fire *this* gate (it then runs the chain),
@@ -938,7 +944,7 @@ Proposal format: `"I see [X]. Want me to run /[skill] to [one-line description]?
 | "connect a project", "map this project", "link to hub" | `auto_project_mapping.md` (mapping) |
 | "harness-ify this project", "full harness setup", "프로젝트 하네스화", "promote to full harness" | `auto_project_mapping.md §6` (Full-Harness Mode) |
 | "check install", "verify setup", "confirm install", "install-doctor" | `/install-doctor` |
-| "publish", "make public", "make this repo public", "go public", "gh repo create --public", "flip to public", "first public push", "publish the package", "npm publish", "twine upload", **opening/updating a PR or pushing content to the public hub** (esp. company-origin) (publish intent — **proactive**, fire *before* the action; adding content to an already-public repo IS publishing that content) | **Pre-Publish Surface Gate** (see above → `/public-surface-audit` + `/marketplace-gate` Check 5 must PASS first). The commit-time half is now **hook-enforced** (mechanical confidentiality scan — see Pre-Publish Gate §Hook coverage (b)), so this proactive trigger is the salience layer over a mechanical floor. |
+| "publish", "make public", "make this repo public", "go public", "gh repo create --public", "flip to public", "first public push", "publish the package", "npm publish", "twine upload", **"zenodo", "figshare", "OSF", "DOI", "DOI mint / 발급", "new version" under a concept DOI, "arXiv submit / replace / 제출", "예치", "deposit"** (scholarly deposit — the deposit's *metadata* is the surface, not only its PDF), **opening/updating a PR or pushing content to the public hub** (esp. company-origin) (publish intent — **proactive**, fire *before* the action; adding content to an already-public repo IS publishing that content) | **Pre-Publish Surface Gate** (see above → `/public-surface-audit` + `/marketplace-gate` Check 5 must PASS first). The commit-time half is now **hook-enforced** (mechanical confidentiality scan — see Pre-Publish Gate §Hook coverage (b)), so this proactive trigger is the salience layer over a mechanical floor. |
 | "delete the branch", "브랜치 삭제", "브랜치 정리", "clean up branches", "force-push", "rewrite history", "지워도 돼?" (destructive intent — **proactive**, fire *before* the action) | **Destructive-Op Gate** (see above → enumerate → recover → destroy; `templates/predelete_check.sh`) |
 | **"새 기능 검증해줘", "test this feature", "이 TC 확인해줘" — verifying the user's PRODUCT/feature (not FH itself)** | **Route to the mapped field harness first** (Cross-Project Skill Bus / registry) — the field harness owns product verification. The harness-verification rows in this table (`verify-bidirectional` · `prompt-regression` · `sim-conductor` · `pipeline-conductor`) verify the *harness*, and must not shadow a product-verification ask (a field project's *harness assets* — its skills/rules — still use those FH verification rows) |
 | "지난주에 뭐 했지", "what did we do last week", "예전에 이거 한 적 있나" (recall intent) | **CATALOG-first recall** — read `CATALOG.md`, identify candidates by tag/date, then open only those files. Never scan session files one by one |

--- a/knowledge/shared/harness-core/claude_md_gate_details.md
+++ b/knowledge/shared/harness-core/claude_md_gate_details.md
@@ -173,6 +173,32 @@ destroys live state without anyone noticing. This is why the loss class is calle
 
 ---
 
+### Scholarly deposit (Zenodo / DOI / arXiv) — measured 2026-09-07, why Step 1b exists
+
+Two things happened on the same day, on the same record (`10.5281/zenodo.22542168`, v1.0.1):
+
+1. **Form ≠ server.** The rich-text description and the companion-DOI related identifier were visible
+   in the deposit form and **absent** from `/api/records/<id>/draft`. The editor had not flushed its
+   state to the server. Nothing in the Pre-Publish gate covered this surface; a hand API read caught it
+   minutes before Publish.
+2. **The machine fields outlive the PDF.** v1.0.1 is a *corrective* release: its body fixes eleven
+   misattributed references. Its Zenodo `references` field still carried **all eleven** pre-correction
+   attributions — the exact strings the release existed to retract — because the PDF was replaced and
+   the metadata was not. `references` / `related identifiers` are what DataCite and citation graphs
+   consume; the PDF is what a human opens. Fixed by editing the record (22 → 24 entries, verified
+   server-side, DOI unchanged).
+
+Consequences that became the four Step 1b items: read the draft through the **service's** API (Zenodo
+InvenioRDM `/api/records/<id>/draft`, legacy `/api/deposit/depositions/<id>`, figshare
+`/v2/account/articles/<id>`), compare against the text you pasted (string vs JSON), md5 the file, and
+on a corrective release diff the machine fields too. The post-publish read is a **detector**, not a
+gate — a wrong field there is fixed by a new corrective version, never silently.
+
+Salience check (same day, floor tier, blind, reps 3, one variable — the edited text injected into a
+clean clone via `--setup`): before 0–1/3 → after 3/3 on all four items. ⚠️ The first sim run was void:
+`sim_isolated_run.sh` clones **HEAD**, so uncommitted edits were absent from every arm — it measured
+the pre-change tree. Recorded so the next author injects the working tree instead of trusting the clone.
+
 ## §Pre-Publish-Hook-Coverage
 
 **Hook coverage — three distinct actions** (refined 2026-06-17 for (a)/(b); (c) added 2026-06-27):

--- a/templates/PRE-PUBLISH-CHECKLIST.md
+++ b/templates/PRE-PUBLISH-CHECKLIST.md
@@ -24,6 +24,8 @@ Any first-time public action:
 - `gh repo edit --visibility public` (private → public flip)
 - first `git push` to a **new public remote**
 - `npm publish` · `python -m build && twine upload dist/*` · any registry publish
+- **scholarly deposit** — Zenodo / figshare / OSF publish, DOI mint, new version under a concept DOI,
+  arXiv `submit` / `replace`. A DOI outlives an npm version; its machine fields outlive the PDF.
 
 ## Step 0 — Cheap mechanical pre-flags (10 seconds)
 
@@ -63,6 +65,33 @@ git ls-files | grep -iE '<internal-acronym>'
   code-security pass on a repo that ships no code; grep the file list, don't assert "docs-only".)
 - **Generated artifacts count.** An exported HTML/PDF carrying a username is a real public-surface leak —
   fix = regenerate from a sanitized source, not hand-edit.
+
+## Step 1b — Scholarly deposit only (Zenodo / DOI / arXiv): the form is not the server
+
+Run **after** filling the form and **before** pressing Publish. Every line is an API read, not a screen read.
+
+- [ ] Read the draft through the **service's draft-read API** — Zenodo (InvenioRDM) `/api/records/<id>/draft`,
+      Zenodo legacy `/api/deposit/depositions/<id>`, figshare `/v2/account/articles/<id>`, OSF its node/preprint
+      endpoint — and compare `description`, `creators`, `license`, `keywords` against **the text you pasted
+      into the form** (keep that text in a file; the comparison is string-vs-JSON, not screen-vs-screen).
+      (measured 2026-09-07: description + companion DOI were in the form and **absent from the server** —
+      the rich-text editor had not flushed)
+- [ ] File **md5** equals the local artifact (size alone is not identity)
+- [ ] **Corrective release?** Then the correction must land in the machine fields too — `references`,
+      `related identifiers`, `dates` — not only in the PDF body (measured: a corrective PDF shipped
+      with all eleven wrong attributions still in `references`)
+- [ ] **After** Publish (a detector, not a gate — the record is already public): read the public
+      record API once; `updated` ≥ the wall-clock time you pressed Publish, the fields above still present,
+      file checksum unchanged. On a **moderated** service (OSF preprints, arXiv) a pending/announce state
+      is expected, not a failure. If a field is wrong here, the remedy is a **new corrective version**
+      (never silent) — this line cannot un-publish anything, which is why the three lines above run first.
+
+**Completion**: Step 0 + Step 1 + **Step 1b** (when the surface is a scholarly deposit) — 1b is not
+optional on that surface.
+
+**Why no hook here**: the deposit lives on another service; nothing in this repo runs at that boundary.
+This list is the floor. A `zenodo_draft_check.sh` that diffs draft-vs-form is the first thing to build
+on the *second* real demand — 2026-09-07 was the first.
 
 ## Step 2 — If LEAK: scrub on a PRIVATE copy, then publish
 


### PR DESCRIPTION
DOI/Zenodo/figshare/OSF/arXiv 발행이 Pre-Publish 게이트 목록에 **한 글자도 없었다**(CLAUDE.md zenodo 0 · 체크리스트 0, 컨트롤 `npm publish` 5). 09-07 그 표면을 두 번 눌렀고, 막은 건 게이트가 아니라 우연한 API 대조였다 — 그게 폼↔서버 불일치 1건과 «정정 릴리스의 `references` 가 정정 전 11건 그대로»를 잡았다.

## 추가
- **상주** CLAUDE.md +6/−13: 발화 조건 + «폼≠서버» 원리 + Step 1b 포인터(7줄). `residency: irreversible-gate`
- **상세** `claude_md_gate_details.md §Pre-Publish-Hook-Coverage` +26: 실측 사연 둘 + 서비스별 API 경로
- **체크리스트** Step 1b 4항 + 완료 조건

## 검증
| 축 | 실행 |
|---|---|
| ⓔ 플로어 블라인드 sim | reps 3, 한 변수(`--setup` 주입): **before 0–1/3 → after 3/3 → 축약본 3/3**, 네 요소 전부 |
| ⓐ codex | 8건 전부 반영 — 사후 검사를 게이트처럼 적은 초판 · 서비스별 API 경로 · 과대주장 |
| 상주 유입 게이트 | `residency:` 부재를 막았고 → 상주 13줄을 7줄로 축약, 사연은 상세로 |
| 🟥 계기 | 1차 sim 무효 — 러너가 `git clone --local` 로 HEAD 복제, 미커밋 편집 부재. before 컨트롤로 재활용. 헤더 `--tools` 파서 부재(신호) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FGFMzea5ceHT9w86v1yTR