### PR TITLE
feat(gate): Load-Bearing Change Gate 는 매핑 안 된 판정 코드에도 발화한다 — gate_shape_scan.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -591,7 +591,31 @@ optimistic reading and miss it.**
 **Trigger (per changed file — grep-assisted, salience-dependent, no field hook)**: an AI-authored
 change to a **verdict/gate enum or exit code** (PASS/FAIL/BLOCK/allow/deny), an **irreversible-op**
 path (publish/delete/history-rewrite), or a **safety invariant** (floor, verdict-binding, a
-pre-push/pre-commit hook). Grep the diff for verdict-enum returns / gate exits / safety-marked
+pre-push/pre-commit hook). 🟥 **Registration is not a precondition** (operator decision
+2026-09-08). When the session is asked for a **merge / landing verdict** on a file that is gate code,
+this gate applies **whether or not** the file's project is mapped, tracked, or in a repo this hub
+knows. Two narrowings keep that from becoming «every review is a gate»: ⓐ the ask must be a
+**verdict on landing** (merge / ship / approve — a read-only explanation or a refactor question is
+not one) · ⓑ «gate code» is decided by **`bash scripts/gate_shape_scan.sh <file>`** — word-bounded
+verdict identifiers (a **closed** list — allow/deny/permit/approve·approval/verdict/permission/
+auth·authn·authz·authorize·authorization·authenticat*·auth_x; `author` and `allowance` do not match;
+uppercase `PASS|FAIL|BLOCK`), a bind/listen exposure, or an irreversible-op call; comment-led lines
+skipped; binary → `UNSCANNABLE`, and **exit 3 dominates a hit** — never a silent miss (known-pair
+lane `scripts/test_gate_shape_scan_lanes.sh`, 9 lanes incl. a revert probe).
+The task *naming* the file as gate/auth/exposure code is a **manual escalation on top**, not part
+of the classifier — a prompt is not a property of the file. ⓒ **FH-owned assets are excluded** —
+they already carry the 4-axis gate; this gate is for *field* code, mapped or not. Record surface for
+an unmapped file: `tracks/_meta/field_gate_review_<YYYY-MM-DD>_<slug>.md` (file · verdict ·
+`crossfamily:` verbatim from the enum · degrade-scan result · regression test landed-or-owed), and
+the reply links it. An **owed** regression test keeps the verdict `NOT-CONVERGED`; it does not
+converge on a promise. 🟥 **Pilot evidence, below bar** (floor tier, blind, one variable — this
+paragraph injected): **before 0/1** — the session answered *"FH 자산도 매핑된 필드 하네스도 아니라서
+… 적용 대상이 아닙니다"* and reviewed bare; **after 2/3** ran the gate (one named
+`DEGRADED_SINGLE_FAMILY`, one ran the degrade scan and attempted cross-family recruit). The before
+arm is `reps=1`, and the after arm ran the *first* draft, not this text — a calibrated `>=3`-per-arm
+rerun on this wording is owed before the number supports anything beyond «the direction moved».
+Registration was never the reason this gate exists; the degrade-direction blind spot is, and it
+does not check who owns the file. Grep the diff for verdict-enum returns / gate exits / safety-marked
 functions — strong-advisory trigger, so under-trigger is a named residual, not an airtight claim.
 
 **Gate (before merge, not after)**: ① **degrade-direction lint**
@@ -961,7 +985,7 @@ Proposal format: `"I see [X]. Want me to run /[skill] to [one-line description]?
 | "memory feels bloated", "clean up memory", "memory too large", "memory hygiene" | `/memory-hygiene` |
 | **사람이 읽을 산출물이 나가기 직전** — README·가이드·리포트·장표·PR 본문 등 «독자가 여는» 것 (proactive; 코드가 옳아도 걸린다 — 이 행이 잡는 건 정확성이 아니라 **가독성**이다) | **독자로서 한 번 읽어라** — 첫 8줄에 결론이 있나 · 본문이 고정 템플릿에 덮이지 않나 · 마지막 인상이 무엇인가. 렌즈는 이미 있다: `/sim-conductor` A-1(`beginner` cold-read) 또는 직접 렌더해서 읽기. 🟥 **정적 검사는 「없는 것」을 잡고 「안 읽히는 것」은 못 잡는다** — 실측 2건이 독립 수렴했다(qasp 축: 지적 12건 중 스캐너 적발 0 · gstack 3자대면: 배포된 리포트 본문 3줄 vs 고정 템플릿 21줄). pre-commit 이 같은 상기를 advisory 로 낸다(차단 아님) |
 | "ready to PR", "about to push", "merge this", "PR 올려줘", FH asset changed in session | 4-axis auto-gate (see above — runs automatically, no proposal needed) |
-| **field verdict/gate/safety/irreversible code changed** in a mapped project (function returning a verdict enum / gate exit code / safety-invariant · publish/delete/history path) — **proactive, before merge** | **Field-Harness Load-Bearing Change Gate** (see above → degrade-lint → cross-family review → converge; same rigor as FH assets, applied to field code) |
+| **field verdict/gate/safety/irreversible code changed** in a mapped project **— or a merge/landing verdict asked on any gate-shaped file, mapped or not** (function returning a verdict enum / gate exit code / safety-invariant · access-control / approval / auth / exposure boundary · publish/delete/history path; «gate-shaped» = the mechanical identifier test in §Field-Harness Load-Bearing Change Gate, not a feel) — **proactive, before merge** | **Field-Harness Load-Bearing Change Gate** (see above → degrade-lint → cross-family review → converge; same rigor as FH assets, applied to field code) |
 | **a diff (yours or an unattended pipeline's) alters another harness's actual behavior, gate outcome, or interaction contract** — building automation that opens PRs autonomously, touching a synced/shared-body surface, or any change whose effect crosses a harness boundary (not merely a file-class match — most self-improvement is `not-applicable` here, which is the expected common case) — **proactive, before push, never as a post-PR comment** | **Standpoint axis** (`knowledge/shared/harness-core/field_verdict_crossfamily_gate.md §7` — orthogonal to `crossfamily:`; run the diff from the TARGET harness's own repo/standpoint via `tier2`/`tier2b`/`tier3`, or record `not-applicable`/`DEGRADED_*` on the closed enum. Missed once in-session while building `scripts/frontier_digest_autopilot.sh` 2026-08-15 — mis-routed to `fh-meta:hub-cc-pr-reviewer` (same-repo self-consistency, a different lens) before the operator caught it; this row exists so the next session connects the trigger without two rounds of correction.) |
 | **"진단해줘", "개선해줘", "diagnose this", "improve this harness", "check this project", "audit this project"** — said while working **in a mapped project** (not a single-file ask) | **Field-Harness Diagnostic** (see §Field-Harness Diagnostic above → compose existing checks into one ranked M/S/R list → HITL approval per item, nothing auto-fixed) |
 | **"새 프로젝트", "하네스 작성해줘", "이 프로젝트 가속화", "harness-ify this", "accelerate this project"** — an onboarding/acceleration door (returning-menu ①②③) | **Onboarding / Acceleration Autopilot** (see §Onboarding / Acceleration Autopilot above → Phase 0 auto-discover + branch → innovator-centered recommend → ranked install plan → HITL per item, non-overwriting; "끝까지 자율로" → full-autonomy under /goal-quench gate) |

--- a/knowledge/shared/harness-core/field_verdict_crossfamily_gate.md
+++ b/knowledge/shared/harness-core/field_verdict_crossfamily_gate.md
@@ -127,6 +127,32 @@ the grep — an agent under merge pressure can under-trigger by treating a chang
 That residual is the reason the gate is reinforced by the always-on Autonomous-Initiative trigger
 row + the operator's proactive framing, not by the grep alone.
 
+**Registration is not a precondition (operator decision 2026-09-08).** «Field surface» above was
+read as «a mapped project's surface», and a session handed an unmapped gate file answered *"적용
+대상이 아닙니다"* and reviewed it bare — 0 degrade scan, 0 cross-family — missing a GHSA-grade
+network-exposure defect. The blind spot this gate guards is a property of the *reviewer's family*,
+not of the file's owner, so ownership cannot switch it off. Scope, narrowed so it does not become
+«every review is a gate»: ⓐ the ask is a **merge / landing verdict** (not an explanation or a style
+question) · ⓑ the file is **gate-shaped by `scripts/gate_shape_scan.sh`** — a closed, word-bounded
+verdict-identifier list (allow/deny/permit/approve·approval/verdict/permission/auth family incl.
+authorize·authorization·authenticat*; `author`/`allowance` excluded), a bind/listen exposure, or an
+irreversible-op call; comment-led lines skipped (`* ` and `-- ` only when followed by space, so
+`*allow = 1` and a continued `--force` line are code); binary → `UNSCANNABLE`, and exit 3 dominates
+any hit (never a silent miss). The classifier is the scope test; it is **not** the FH-owned
+exclusion — that is caller-side (the 4-axis gate already covers FH paths). The task's own naming of the file as gate / auth / exposure
+code is a manual escalation on top of the classifier, not a substitute for it. Known-negative: a
+utility with none of those is out of scope; `reject(` is deliberately not a verdict token (Promise
+API collision, measured — named residual). ⓒ **FH-owned assets are excluded** — they carry the
+4-axis gate; this gate is for field code, and «field» means *not FH*, not *mapped*. **Record surface
+for an unmapped file**: no marker directory exists for it, so the session writes
+`tracks/_meta/field_gate_review_<YYYY-MM-DD>_<slug>.md` — file · verdict · `crossfamily:` verbatim
+from the enum · degrade-scan result · regression test *landed* or *owed* — and the review reply
+links it. An **owed** regression test keeps the verdict `NOT-CONVERGED` until it lands and runs;
+the gate's convergence sub-condition is unchanged. **Pilot evidence (below bar)**: floor tier,
+blind, one variable — before 0/1 fired · after 2/3 on the first draft; a calibrated `>=3`-per-arm
+rerun on the final wording is owed. Resident summary: `CLAUDE.md
+§Field-Harness Load-Bearing Change Gate`.
+
 **Residency** — sanitize company code (redact vendor/domain literals) before any external-family
 dispatch; domain data never leaves. **Autonomy** — autonomous once the operator has consented in
 the UAP (`tracks/_meta/user_adaptation_profile.md`, defined in `knowledge/shared/rules/operational_adaptation.md`),

--- a/knowledge/shared/rules/auto_project_mapping.md
+++ b/knowledge/shared/rules/auto_project_mapping.md
@@ -66,7 +66,7 @@ Mapping complete: N projects
 
 Basic mapping (steps 1–5) registers a project *lightly* (tracks/ + a starter CLAUDE.md + hub link). **Full-Harness Mode adds the project-local harness assets** — identity ① (Control Tower) propagating harness structure to a connected project; the *how* is executed via the Core Axis.
 
-**Scope**: target *mapped* projects only. For FH-self setup / acceleration baseline (zshrc, sentinels, the FH self-gate) use `/install-wizard` — do **not** run §6 on the FH hub itself. **Prerequisite**: the project is already mapped (steps 1–5); §6 is strictly additive. This mode is also the **emit terminus of a chamber run** — a simulate-first incubation that holds routes here on emit (`harness_incubator_doctrine.md §3` Minimal execution skeleton ⑤).
+**Scope**: target *mapped* projects only. (Mapping scopes *installation* of harness assets — it is **not** the precondition for FH's review gates: the Field-Harness Load-Bearing Change Gate fires on a merge verdict for any gate-shaped file, mapped or not — `field_verdict_crossfamily_gate.md §Registration is not a precondition`, 2026-09-08.) For FH-self setup / acceleration baseline (zshrc, sentinels, the FH self-gate) use `/install-wizard` — do **not** run §6 on the FH hub itself. **Prerequisite**: the project is already mapped (steps 1–5); §6 is strictly additive. This mode is also the **emit terminus of a chamber run** — a simulate-first incubation that holds routes here on emit (`harness_incubator_doctrine.md §3` Minimal execution skeleton ⑤).
 
 **Triggers**: "harness-ify this project", "full harness setup", "프로젝트 하네스화", "promote to full harness", or an opt-in prompt offered right after a basic mapping (*"Promote {project} to a full harness now?"*).
 

--- a/package.json
+++ b/package.json
@@ -136,6 +136,8 @@
     "scripts/test_residency_closure_lanes.sh",
     "scripts/doc_claim_triad_scan.py",
     "scripts/test_doc_claim_triad_lanes.sh",
+    "scripts/gate_shape_scan.sh",
+    "scripts/test_gate_shape_scan_lanes.sh",
     "scripts/test_marker_standpoint_lanes.sh",
     "scripts/test_marker_thirdparty_lanes.sh",
     "scripts/test_marker_axes_run_lanes.sh",

--- a/scripts/gate_shape_scan.sh
+++ b/scripts/gate_shape_scan.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# gate_shape_scan.sh — is this file «gate-shaped»? The mechanical half of the Field-Harness
+# Load-Bearing Change Gate trigger for files whose project is NOT mapped (CLAUDE.md
+# §Field-Harness Load-Bearing Change Gate · field_verdict_crossfamily_gate.md
+# §Registration is not a precondition, 2026-09-08).
+#
+# IT IS A CLASSIFIER OF THE FILE'S SHAPE, NOT A VERDICT ON THE FILE. A hit means «this file is
+# in the gate's scope — run degrade-lint + cross-family before a merge verdict». A miss means
+# «not in scope by identifier»; the task's own naming of the file as gate/auth/exposure code is a
+# separate MANUAL escalation and is not read here (a prompt is not a property of the file).
+#
+# What counts (three classes — each hit is printed with the class and the matched line):
+#   VERDICT   word-bounded, case-insensitive: allow(ed) deny denied permit(ted) approve/approved/approval
+#             verdict permission(s) auth authn authz authorize(d) authorization authenticat* auth_<x>
+#             (🟥 `author`/`authored`/`allowance` do NOT match — the auth branch is a closed list, not `auth.*`)
+#             (🟥 `reject` is deliberately absent — it collides with the Promise API `reject(err)`,
+#              measured on a real TS mock server: 2 hits, both Promise callbacks. Named residual:
+#              a gate that spells its refusal `reject(` is missed by this class; `deny` is not.)
+#             permission auth authn authz  ·  plus the UPPERCASE enum literals PASS FAIL BLOCK
+#             (uppercase only — lowercase `pass`/`fail`/`block` are ordinary words/keywords)
+#   EXPOSURE  a socket/server bind or listen: listen( bind( ListenAndServe Serve( 0.0.0.0 INADDR_ANY
+#   IRREV     an irreversible-op path: publish( delete( unlink( rm -rf force-push --force
+#             history-rewrite filter-branch reset --hard
+# Comment/string handling (named residual, crude on purpose): a line whose first non-blank
+# characters are `#`, `//`, `* ` (star+space/end: block-comment body), `/*`, `-- ` (dash-dash+space/end:
+# SQL/Lua), `;`, `"""`, `'''` is skipped; `*allow = 1` and a continued `--force` line are CODE and scanned. Inline trailing comments
+# and string literals are NOT stripped — a false positive here costs one review, a false negative
+# costs a missed gate, so the scan leans toward firing.
+# Supported: any text file. Binary or unreadable → UNSCANNABLE (exit 3), never a silent miss.
+#
+# Usage:  bash scripts/gate_shape_scan.sh <file> [file ...]
+#         bash scripts/gate_shape_scan.sh --selftest        # known-pair calibration
+# Exit:   0 = GATE-SHAPED (≥1 hit, all files scannable) · 1 = NOT-GATE-SHAPED · 3 = UNSCANNABLE/usage
+#         (3 dominates 0: a hit next to an unscannable file still exits 3 — that file is unresolved)
+set -uo pipefail
+export LC_ALL=C
+VERDICT_RE='\b(allow(ed)?|deny|denied|permit(ted)?|approv(e|ed|al)|verdict|permissions?|auth(n|z|orize|orized|orization|entic[a-z]*|_[a-z_]+)?)\b'
+ENUM_RE='\b(PASS|FAIL|BLOCK)\b'
+EXPOSURE_RE='(\blisten\(|\bbind\(|ListenAndServe|\bServe\(|0\.0\.0\.0|INADDR_ANY)'
+IRREV_RE='(\bpublish\(|\bdelete\(|\bunlink\(|rm -rf|force-push|--force\b|history-rewrite|filter-branch|reset --hard)'
+COMMENT_RE='^[[:space:]]*(#|//|\*([[:space:]]|$)|/\*|--([[:space:]]|$)|;|"""|'"'''"')'
+
+scan_one() { # $1=file → prints hits, returns 0 hit / 1 none / 3 unscannable
+  local f="$1" body v e r hits
+  [ -r "$f" ] || { echo "UNSCANNABLE  $f (unreadable)"; return 3; }
+  if /usr/bin/file -b --mime-encoding "$f" 2>/dev/null | /usr/bin/grep -q '^binary$'; then
+    echo "UNSCANNABLE  $f (binary)"; return 3; fi
+  # one pass: drop comment-led lines, then classify (VERDICT wins over EXPOSURE over IRREV per line)
+  body=$(/usr/bin/grep -nEv "$COMMENT_RE" "$f" 2>/dev/null || true)
+  v=$(printf '%s\n' "$body" | /usr/bin/grep -Ei "$VERDICT_RE" || true)
+  v2=$(printf '%s\n' "$body" | /usr/bin/grep -E "$ENUM_RE" || true)
+  e=$(printf '%s\n' "$body" | /usr/bin/grep -E "$EXPOSURE_RE" || true)
+  r=$(printf '%s\n' "$body" | /usr/bin/grep -E "$IRREV_RE" || true)
+  hits=0
+  [ -n "$v" ]  && { hits=1; printf '%s\n' "$v"  | /usr/bin/cut -c1-140 | /usr/bin/sed "s|^|VERDICT   $f:|"; }
+  [ -n "$v2" ] && { hits=1; printf '%s\n' "$v2" | /usr/bin/cut -c1-140 | /usr/bin/sed "s|^|VERDICT   $f:|"; }
+  [ -n "$e" ]  && { hits=1; printf '%s\n' "$e"  | /usr/bin/cut -c1-140 | /usr/bin/sed "s|^|EXPOSURE  $f:|"; }
+  [ -n "$r" ]  && { hits=1; printf '%s\n' "$r"  | /usr/bin/cut -c1-140 | /usr/bin/sed "s|^|IRREV     $f:|"; }
+  [ "$hits" -gt 0 ] && return 0 || return 1
+}
+
+selftest() { # known pair — positive must hit, negative must not, comment-only must not
+  local d rc_pos rc_pos2 rc_neg rc_cmt rc_bin rc_irr rc_bnd rc_star fails=0
+  d="$(mktemp -d 2>/dev/null)" || d=""
+  [ -n "$d" ] && [ -w "$d" ] || { echo "SELFTEST: ENV-BLOCKED (mktemp -d failed) — result unmeasured, not a pass"; return 3; }
+  printf 'export class S {\n  start() {\n    this.app.listen(this.config.port, () => {});\n  }\n}\n' > "$d/pos_exposure.ts"
+  printf 'def check(user):\n    if user.role == "admin":\n        return Verdict.ALLOW\n    return Verdict.DENY\n' > "$d/pos_verdict.py"
+  printf 'def add(a, b):\n    """Return the sum. Pass through ints."""\n    return a + b\n\ndef fmt(x):\n    return f"{x:.2f}"\n' > "$d/neg_util.py"
+  printf '# we allow anything here\n// auth is elsewhere\n/* listen( is not called */\n * allow: block-comment body\n-- deny in a SQL comment\nx = 1\n' > "$d/neg_comments.py"
+  printf '\x00\x01\x02binary\x00' > "$d/bin.dat"
+  printf 'set -e\ngit push origin main \\\n  --force\n' > "$d/pos_irrev.sh"
+  printf 'authored_by = "x"\nallowance = 3\nauthor = "y"\n' > "$d/neg_boundary.py"
+  printf 'int f(int *allow) {\n  *allow = 1;\n  return 0;\n}\n' > "$d/pos_star.c"
+  scan_one "$d/pos_exposure.ts" >/dev/null; rc_pos=$?
+  scan_one "$d/pos_verdict.py"  >/dev/null; rc_pos2=$?
+  scan_one "$d/neg_util.py"     >/dev/null; rc_neg=$?
+  scan_one "$d/neg_comments.py" >/dev/null; rc_cmt=$?
+  scan_one "$d/bin.dat"         >/dev/null; rc_bin=$?
+  scan_one "$d/pos_irrev.sh"    >/dev/null; rc_irr=$?
+  scan_one "$d/neg_boundary.py" >/dev/null; rc_bnd=$?
+  scan_one "$d/pos_star.c"      >/dev/null; rc_star=$?
+  [ "$rc_pos" -eq 0 ]  && echo "  ✅ known-positive exposure (listen()) → GATE-SHAPED"      || { echo "  ❌ known-positive exposure rc=$rc_pos"; fails=1; }
+  [ "$rc_pos2" -eq 0 ] && echo "  ✅ known-positive verdict (ALLOW/DENY) → GATE-SHAPED"    || { echo "  ❌ known-positive verdict rc=$rc_pos2"; fails=1; }
+  [ "$rc_neg" -eq 1 ]  && echo "  ✅ known-negative util (docstring 'Pass') → NOT"          || { echo "  ❌ known-negative util rc=$rc_neg"; fails=1; }
+  [ "$rc_cmt" -eq 1 ]  && echo "  ✅ comment-only mentions (#, //, /*, ' * ', '-- ') → NOT"                            || { echo "  ❌ comment-only rc=$rc_cmt"; fails=1; }
+  [ "$rc_bin" -eq 3 ]  && echo "  ✅ binary → UNSCANNABLE (not a silent miss)"              || { echo "  ❌ binary rc=$rc_bin"; fails=1; }
+  [ "$rc_irr" -eq 0 ]  && echo "  ✅ known-positive irreversible (continued --force line) → GATE-SHAPED" || { echo "  ❌ known-positive irrev rc=$rc_irr"; fails=1; }
+  [ "$rc_bnd" -eq 1 ]  && echo "  ✅ boundary: author/authored/allowance → NOT"                || { echo "  ❌ boundary rc=$rc_bnd"; fails=1; }
+  [ "$rc_star" -eq 0 ] && echo "  ✅ code line starting with *allow (not a comment) → GATE-SHAPED" || { echo "  ❌ star-code rc=$rc_star"; fails=1; }
+  /bin/rm -rf "$d"
+  [ "$fails" -eq 0 ] && { echo "SELFTEST: PASS"; return 0; } || { echo "SELFTEST: FAIL"; return 3; }
+}
+
+[ $# -ge 1 ] || { echo "usage: $0 <file> [file ...] | --selftest" >&2; exit 3; }
+[ "$1" = "--selftest" ] && { selftest; exit $?; }
+ANY=0; UNS=0
+for f in "$@"; do scan_one "$f"; rc=$?; [ "$rc" -eq 0 ] && ANY=1; [ "$rc" -eq 3 ] && UNS=1; done
+if [ "$UNS" -eq 1 ]; then
+  [ "$ANY" -eq 1 ] && echo "GATE-SHAPED in the scannable files —"
+  echo "UNSCANNABLE — ≥1 file could not be classified; decide those by hand. Exit 3 dominates any hit (never a silent miss)"; exit 3
+elif [ "$ANY" -eq 1 ]; then echo "GATE-SHAPED — run degrade-lint + cross-family before a merge verdict"; exit 0
+else echo "NOT-GATE-SHAPED (by identifier; the task's own naming is a separate manual escalation)"; exit 1; fi

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -439,6 +439,10 @@ fi
 if [ ! -f scripts/gate_shape_scan.sh ]; then
   _absent_subject_verdict "gate-shape lanes" "scripts/gate_shape_scan.sh" || fail=1
 elif [ -f scripts/test_gate_shape_scan_lanes.sh ]; then
+  # direct dispatch of the subject's own selftest (caller surface for the ratchet), then the lane
+  if ! bash scripts/gate_shape_scan.sh --selftest >/dev/null 2>&1; then
+    echo "FAIL  gate-shape selftest: known-pair calibration failed"; fail=1
+  fi
   if ! bash scripts/test_gate_shape_scan_lanes.sh; then
     fail=1
   fi

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -433,6 +433,20 @@ else
   fail=1
 fi
 
+# gate-shape classifier — the mechanical half of the unmapped-file trigger of the Field-Harness
+# Load-Bearing Change Gate (2026-09-08). A classifier of scope, not a verdict; its lane holds the
+# known-pair (exposure/verdict positives · util/comment negatives · Promise reject( FP anchor).
+if [ ! -f scripts/gate_shape_scan.sh ]; then
+  _absent_subject_verdict "gate-shape lanes" "scripts/gate_shape_scan.sh" || fail=1
+elif [ -f scripts/test_gate_shape_scan_lanes.sh ]; then
+  if ! bash scripts/test_gate_shape_scan_lanes.sh; then
+    fail=1
+  fi
+else
+  echo "FAIL  gate-shape lanes: gate_shape_scan.sh present but its anchor is missing"
+  fail=1
+fi
+
 # package-coverage — a shipped doc must not point at a file the tarball omits. Distinct from the
 # ref-path check below: that one asks "does this path exist at all", this one asks "does the
 # CONSUMER get it". Measured 2026-07-28: 35 paths existed, were named by a shipped doc, and were

--- a/scripts/test_gate_shape_scan_lanes.sh
+++ b/scripts/test_gate_shape_scan_lanes.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# test_gate_shape_scan_lanes.sh — scripts/gate_shape_scan.sh 회귀 앵커.
+# 지키는 것은 «판별력»: known-pair 가 갈리는가, 주석만 있는 파일이 안 걸리는가, 바이너리가
+# «아님» 으로 접히지 않는가, Promise `reject(` 가 게이트로 읽히지 않는가(실측 오탐).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; SCAN="$HERE/gate_shape_scan.sh"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  ✅ %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  ❌ %s — %s\n' "$1" "${2:-}"; }
+echo "── test_gate_shape_scan_lanes ──"
+[ -x "$SCAN" ] || { no "L1 실행비트" "$SCAN"; echo "FAILED=1"; exit 1; }
+bash -n "$SCAN" && ok "L1 구문" || no "L1 구문"
+OUT=$(bash "$SCAN" --selftest 2>&1); RC=$?
+[ "$RC" -eq 0 ] && ok "L2 selftest rc=0 (known-pair 5)" || no "L2 selftest" "rc=$RC · $OUT"
+D="$(mktemp -d 2>/dev/null)" || D=""; [ -n "$D" ] && [ -w "$D" ] || { no "L3 환경" "mktemp -d 불가 — 레인 미측정(통과 아님)"; echo "PASS=$PASS FAIL=$FAIL"; echo "FAILED=1"; exit 1; }
+printf 'export function up(p) {\n  return new Promise((resolve, reject) => {\n    if (!p) reject(new Error("x"));\n    resolve(p);\n  });\n}\n' > "$D/promise.ts"
+bash "$SCAN" "$D/promise.ts" >/dev/null 2>&1; RC=$?
+[ "$RC" -eq 1 ] && ok "L3 Promise reject( 는 게이트가 아니다 (실측 오탐 앵커)" || no "L3 Promise reject" "rc=$RC"
+printf 'func main() {\n  http.ListenAndServe("0.0.0.0:8080", nil)\n}\n' > "$D/serve.go"
+bash "$SCAN" "$D/serve.go" >/dev/null 2>&1; RC=$?
+[ "$RC" -eq 0 ] && ok "L4 Go ListenAndServe → GATE-SHAPED" || no "L4 Go exposure" "rc=$RC"
+printf 'def f():\n    return "PASS"\n' > "$D/enum.py"; printf 'def g():\n    pass\n' > "$D/lower.py"
+bash "$SCAN" "$D/enum.py" >/dev/null 2>&1; R1=$?; bash "$SCAN" "$D/lower.py" >/dev/null 2>&1; R2=$?
+[ "$R1" -eq 0 ] && [ "$R2" -eq 1 ] && ok "L5 대문자 PASS 만 enum (소문자 pass 는 키워드)" || no "L5 enum case" "PASS rc=$R1 pass rc=$R2"
+bash "$SCAN" >/dev/null 2>&1; RC=$?; [ "$RC" -eq 3 ] && ok "L6 인자 없음 → usage rc=3" || no "L6 usage" "rc=$RC"
+printf '\x00\x01bin' > "$D/b.dat"; bash "$SCAN" "$D/serve.go" "$D/b.dat" >/dev/null 2>&1; RC=$?
+[ "$RC" -eq 3 ] && ok "L6b [gate-shaped, binary] → 3 이 0 을 이긴다 (무음 미스 금지)" || no "L6b 혼합 exit" "rc=$RC"
+printf 'x = author\n' > "$D/au.py"; printf 'ok = authorize(u)\n' > "$D/az.py"
+bash "$SCAN" "$D/au.py" >/dev/null 2>&1; R1=$?; bash "$SCAN" "$D/az.py" >/dev/null 2>&1; R2=$?
+[ "$R1" -eq 1 ] && [ "$R2" -eq 0 ] && ok "L6c 경계: author 는 아니고 authorize 는 맞다" || no "L6c auth 경계" "author rc=$R1 authorize rc=$R2"
+# L7 — 되돌림: 분류기의 EXPOSURE 클래스를 죽이면 L4 가 빨개지는가 (앵커가 장식이 아님을 실행으로)
+MUT="$D/scan_mut.sh"; /usr/bin/sed 's/^EXPOSURE_RE=.*/EXPOSURE_RE='"'"'(NEVER_MATCHES_XYZ)'"'"'/' "$SCAN" > "$MUT"
+bash "$MUT" "$D/serve.go" >/dev/null 2>&1; RC=$?
+[ "$RC" -eq 1 ] && ok "L7 되돌림: EXPOSURE 제거 → serve.go 가 NOT 로 떨어진다 (레인이 실물을 잰다)" || no "L7 되돌림" "rc=$RC (제거해도 초록이면 앵커가 장식)"
+/bin/rm -rf "$D"
+echo "PASS=$PASS FAIL=$FAIL"; [ "$FAIL" -eq 0 ] && { echo "FAILED=0"; exit 0; } || { echo "FAILED=1"; exit 1; }

--- a/scripts/test_gate_shape_scan_lanes.sh
+++ b/scripts/test_gate_shape_scan_lanes.sh
@@ -10,7 +10,7 @@ no(){ FAIL=$((FAIL+1)); printf '  ❌ %s — %s\n' "$1" "${2:-}"; }
 echo "── test_gate_shape_scan_lanes ──"
 [ -x "$SCAN" ] || { no "L1 실행비트" "$SCAN"; echo "FAILED=1"; exit 1; }
 bash -n "$SCAN" && ok "L1 구문" || no "L1 구문"
-OUT=$(bash "$SCAN" --selftest 2>&1); RC=$?
+OUT=$(bash "$HERE/gate_shape_scan.sh" --selftest 2>&1); RC=$?   # 직접 호출(변수 경유 아님) — new-code-anchor 가 실행으로 센다
 [ "$RC" -eq 0 ] && ok "L2 selftest rc=0 (known-pair 5)" || no "L2 selftest" "rc=$RC · $OUT"
 D="$(mktemp -d 2>/dev/null)" || D=""; [ -n "$D" ] && [ -w "$D" ] || { no "L3 환경" "mktemp -d 불가 — 레인 미측정(통과 아님)"; echo "PASS=$PASS FAIL=$FAIL"; echo "FAILED=1"; exit 1; }
 printf 'export function up(p) {\n  return new Promise((resolve, reject) => {\n    if (!p) reject(new Error("x"));\n    resolve(p);\n  });\n}\n' > "$D/promise.ts"


### PR DESCRIPTION
## 무엇

Field-Harness Load-Bearing Change Gate 의 발화 조건에서 «프로젝트 등록» 을 뺀다 (운영자 결정 2026-09-08). 머지/착지 판정을 요구받은 파일이 게이트 모양이면, 그 프로젝트가 매핑돼 있든 아니든 게이트(degrade 스캔 → cross-family → 수렴)가 걸린다.

## 왜

FH 를 실은 세션이 매핑 안 된 게이트 파일(네트워크 노출 경계)의 머지 판정을 받고 *"FH 자산도 매핑된 필드 하네스도 아니라서 … 적용 대상이 아닙니다"* 라며 맨몸으로 리뷰했다 — degrade 스캔 0 · cross-family 0 · GHSA 급 결함 미발견. 이 게이트가 막는 사각(같은 계열 리뷰어의 낙관 방향)은 리뷰어의 성질이지 파일 소유자의 성질이 아니다.

## 어떻게 (codex 5라운드 수렴 — 초판이 «기계 테스트» 라 적고 기계가 없었다)

- **트리거 두 겹 좁힘**: ⓐ 머지/착지 판정 요청만(설명·리팩터 질문은 아님) · ⓑ «게이트 모양» 은 **`scripts/gate_shape_scan.sh`** 가 정한다 — 닫힌 verdict 토큰 목록(`author`/`allowance` 제외) · bind/listen 노출 · 비가역 호출 · 주석 접두 스킵 · 바이너리 `UNSCANNABLE` 이 히트를 이긴다(무음 미스 금지). 과제가 파일을 «게이트 코드» 라 부르는 것은 분류기 위의 수동 승격이지 대체가 아니다.
- **FH 자산 제외**(4축 게이트가 이미 덮는다) · **기록 자리** = `tracks/_meta/field_gate_review_<date>_<slug>.md`(파일·판정·`crossfamily:`·degrade 결과·회귀 테스트 landed/owed) · **owed 테스트는 NOT-CONVERGED 유지**.
- 정본 셋을 같은 커밋에서: `CLAUDE.md` · `field_verdict_crossfamily_gate.md §Registration is not a precondition` · `auto_project_mapping.md §6 scope`(매핑 = 설치 범위, 게이트 전제 아님).
- 분류기 selftest 8(양성 4·음성 3·바이너리) + 레인 9(L7 되돌림: EXPOSURE 제거 → 양성이 NOT 로 떨어짐) · selfcheck·package.json 배선.

## 실측 (pilot, 바 미달 — 본문에 그렇게 적혀 있다)

플로어 블라인드 sim, 한 변수(초판 주입): before **0/1** «적용 대상 아님» → after **2/3** 발화(r2 `DEGRADED_SINGLE_FAMILY` 명시 · r3 degrade 스캔 + recruit 시도). before 는 reps 1, after 는 **최종 문안이 아니라 초판** — 최종 문안의 `>=3` 재측정은 owed 로 명기.

## 잔여

- 식별자 목록의 과/저발화는 실사용에서 잰다(`reject(` 는 Promise 충돌로 의도적 제외 — named residual).
- FH 자산 제외는 호출자 측이지 분류기가 강제하지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FGFMzea5ceHT9w86v1yTR
