### PR TITLE
docs(gate): 표면 등급이 정하는 것은 degrade 방향만이 아니라 허용 오류율이다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -797,6 +797,19 @@ when the surface genuinely lacks its target (e.g. the code-security pass is N/A 
 list ships no source/executable file — **grep the file list, don't assert "docs-only"**).
 *Applicable-but-tooling-down* is never not-applicable.
 
+**Surface class sets the error budget, not only the degrade direction** (operator decision 2026-09-08).
+The same automated verdict engine is usable on one surface and not on another, and the discriminator is
+what a wrong verdict costs. Measured that day across five review arms on the same eight cases: claim
+error rates ran **2.7 % – 13.6 %**, and every one of them is usable *on a review surface*, because a
+wrong finding costs a reader a minute. On publish · delete · history-rewrite there is no "costs a
+minute": the wrong call is the whole loss. 🟥 **So an automated verdict never clears an irreversible
+gate on its own, however good its measured rate** — it feeds a fail-closed gate whose terminal step
+stays a human or an explicit logged override. The corollary is the one that actually bites: **do not
+promote a verdict engine to an irreversible surface by improving its number.** The number is not the
+property that changes between the two surfaces. A precision figure also improves for free whenever the
+pipeline can *delete* claims, so on any surface it is meaningless beside the error rate of the
+deletions (`scripts/finding_verify.py` refuses to complete a run whose drops were never audited).
+
 A gate guarding an irreversible boundary that silently proceeds when its tooling is down is **fail-open**
 — by this floor's definition, not a gate. (The same reflex already ships piecewise — `mcp_tool_gating
 §unlisted → ask (fail-closed)`, corpus-grounding's fail-closed-no-generator — this section names the


### PR DESCRIPTION
## 무엇

§Irreversibility Gates 에 한 문단. **표면 등급이 정하는 것은 degrade 방향만이 아니라 «자동 판정에 허용되는 오류율»이기도 하다.**

## 근거 (같은 날 실측)

B-1 본 실행, GHSA 8케이스 × 3rep, 조건 블라인드 채점. 다섯 팔의 주장 오류율:

| 팔 | 오류율 |
|---|---|
| octo | 2.7% |
| F_xf (강제 cross-family) | 5.3% |
| F 기본 | 9.6% |
| N 맨몸 | 9.7% |
| F_slim | 13.6% |

**리뷰 표면에서는 다섯 다 쓸 만하다** — 틀린 지적 하나가 독자 1분이다. 발행·삭제·이력재작성에는 그 «1분» 이 없다.

## 논지

🟥 자동 판정은 **수치가 아무리 좋아도** 비가역 게이트를 단독으로 통과하지 못한다. fail-closed 게이트에 입력으로 들어가고, 종단은 사람 또는 명시적으로 로그된 override 로 남는다.

실제로 무는 따름정리: **수치를 올려서 비가역 표면으로 승격시키지 마라.** 두 표면 사이에서 바뀌는 것은 숫자가 아니라 성질이다.

덧붙여, 주장을 **삭제할 수 있는** 파이프라인에서는 정밀도가 공짜로 좋아진다. 그래서 어느 표면에서든 생존자 오류율은 **드롭의 오류율과 함께가 아니면** 의미가 없다(#686 의 `finding_verify.py` 가 미감사 실행을 rc=4 로 «완료되지 않음» 처리한다).

## 안 한 것

- **오류율 문턱을 만들지 않았다.** «X% 이하면 자동» 은 판단을 코드로 굳히는 것이고 §Mechanization Boundary 위반이다. 마커 `soul` 에 «절대 안 함» 으로 적었다.
- 살리언스 sim 미실행 — 플로어 티어가 이 구분을 실제로 하는지는 미측정이고 마커에 그렇게 적었다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FGFMzea5ceHT9w86v1yTR
