### PR TITLE
docs(agents): 오류예산 교리를 Codex 진입점으로 — 자동 판정은 수치 불문 비가역 게이트를 단독 통과 못 한다

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,12 @@ Because non-Claude runtimes do not auto-load Claude path rules, apply these rule
    require instrument suspicion.
 6. **Irreversible intent:** before publish, delete, or history rewrite, read and apply the
    Pre-Publish or Destructive-Op gate in `CLAUDE.md`. `pre-push` is only the git-side backstop.
+   **An automated verdict never clears an irreversible gate on its own, whatever its measured error
+   rate.** Surface class decides, not the number: a wrong finding on a review surface costs a reader
+   a minute, while on publish/delete/rewrite the wrong call is the whole loss. So improving a verdict
+   engine's score is not a route to promoting it onto an irreversible surface — the terminal step
+   stays a human or an explicit logged override. This matters here because a non-Claude runtime
+   reading this file is itself often the verdict engine in question.
 7. **Self-contrast on asset touch:** the trigger for the three-layer self-contrast (process ·
    engines · identities) is *touching an FH/PMH asset*, not being asked. Pick verification axes by
    failure mode — running all six every time is not the rule. Record, in the existing Axes 2–3


### PR DESCRIPTION
## 무엇

`AGENTS.md` 항목 6(Irreversible intent)에 오류예산 한 줄을 미러한다. 원 교리는 #687 에서 이미 4축을 탔다.

## 왜

종전 항목 6 은 *"read and apply the Pre-Publish or Destructive-Op gate in `CLAUDE.md`"* 로 **위임만** 했다.
그 위임은 CLAUDE.md 를 자동 로드하는 런타임에서만 해소된다 — 비-Claude 런타임은 이 파일이 진입점이고,
**하필 그 런타임 자신이 판정 엔진인 경우가 많다.**

## 넣은 것 (산문 5문장, 코드/인용/버전 토큰 없음)

- 자동 판정은 측정 오류율이 얼마든 비가역 게이트를 **단독으로** 통과시키지 못한다
- 정하는 것은 **표면 등급**이지 수치가 아니다 — 리뷰 표면의 오판은 독자의 1분, 발행/삭제/이력재작성의 오판은 손실 전체
- 그러므로 판정 엔진의 **점수를 올리는 것은 비가역 표면으로 승격하는 경로가 아니다**
- 종단 단계는 사람 또는 명시적으로 기록된 override 로 남는다

## 4축

| 축 | 상태 |
|---|---|
| Axis 1 | **SKIP (not-checked, NOT a pass)** — `regression_guard` 의 pathspec 에 `AGENTS.md` 가 없다. CLAUDE.md 가 이미 명명한 잔여이고 이 PR 이 만든 것이 아니다 |
| Axes 2–3 | 경량 — 산문 전용(펜스 없음 · `arXiv:`/`DOI`/`http`/`x.y.z` 토큰 없음). 원 교리는 #687 에서 마커를 탔다 |
| Axis 4 | `edit_manifest.yaml` 2026-09-09 `entrypoint-sync` 엔트리 |

## 명명된 잔여

플로어 티어 sim 미실행. 이 커밋은 이미 게이트를 탄 교리의 **산문 미러**이고, 원 문단의 검증은 #687 에 있다.
다음 Codex 세션 실사용에서 이 항목이 인용되는지 1건 기록하는 것이 매니페스트의 `verify_next` 다.
