### PR TITLE
feat(pipeline): #686 typed-finding 파이프라인의 접착 코드 — 래퍼 · 두 갈래 분할 드라이버 · defeater 필드

### DIFF
--- a/scripts/finding_fleet.sh
+++ b/scripts/finding_fleet.sh
@@ -43,9 +43,12 @@ EOF
 PROMPT_HEAD='You are one reviewer in a parallel fleet. Review the file below for defects in your assigned area.
 
 Output ONLY JSON Lines, one object per finding, nothing else — no prose, no code fences:
-{"title":"<short claim>","file":"<name>","line":<int>,"severity":"S|A|B","category":"<one word>","detail":"<what goes wrong and when>","confidence":<0.0-1.0>}
+{"title":"<short claim>","file":"<name>","line":<int>,"severity":"S|A|B","category":"<one word>","detail":"<what goes wrong and when>","defeater":"<what would be OBSERVED if this claim were wrong>","confidence":<0.0-1.0>}
 
 S = exploitable or fail-open. A = real but non-blocking. B = minor.
+`defeater` is required and must name something observable — a value, an output, a code path that
+would be reached — not "if I misread it". A claim whose own falsification condition cannot be stated
+is a claim you are not yet entitled to make.
 Report only defects you can point to a specific line for. If you find none, output nothing.
 
 Your assigned area: '

--- a/scripts/finding_pipeline.sh
+++ b/scripts/finding_pipeline.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# finding_pipeline.sh — the driver that runs fleet → cross-family reject → drop audit end to end.
+# Until this file the two halves existed but nothing called them together outside the lane suite.
+#
+#   bash scripts/finding_pipeline.sh <target-file> --out <dir> [--fleet <table>]
+#
+# WHY THE TWO-SPLIT SHAPE (the load-bearing design decision, not an implementation detail):
+# finding_verify.py refuses to let a family judge its own findings — it stamps them `unverified`
+# rather than judging. With a two-family fleet, ONE verify pass therefore leaves half the findings
+# unjudged, and an `unverified` finding still counts as a survivor. Running it that way and reporting
+# the survivor count would silently mean "half of these were never checked". So the run is split by
+# producer:
+#     gemini-produced  → verifier codex  → drop auditor gemini
+#     codex-produced   → verifier gemini → drop auditor codex
+#
+# 🟥 NAMED RESIDUAL — with only two families the drop auditor is ALWAYS the producer (an appeal),
+# never a disinterested third party. That is weaker than the protocol allows for, and it is a property
+# of the panel size. Do not read `AUDITED` from a two-family run as `independently audited`; the
+# per-finding `audit_role` field says which it was.
+# 🟥 AND A THIRD FAMILY DOES NOT COME FOR FREE. An earlier draft of this comment claimed the driver
+# "picks up a third family automatically". It cannot: finding_verifier.sh only speaks codex|gemini, so
+# an unknown family exits 2 and the drops come back unaudited (rc=4). Routing is therefore restricted
+# to families the wrapper actually implements — SUPPORTED below — and adding one means adding a
+# backend there first. (cross-family review, 2026-09-09; the claim was mine and was wrong.)
+#
+# EXIT  0 every split verified and every drop audited, with survivors · 1 verified but nothing survived
+#       2 usage / schema · 3 UNVERIFIED — some split was not cross-verified (degraded, never a silent
+#       pass) · 4 drops happened that were never audited
+set -uo pipefail
+
+SUPPORTED_FAMILIES="codex gemini"          # must match finding_verifier.sh's own case statement
+
+TARGET=""; OUT=""; FLEET=""
+usage() { echo "usage: finding_pipeline.sh <target-file> --out <dir> [--fleet <table>]" >&2; exit 2; }
+need() { [ $# -ge 2 ] || { echo "finding_pipeline: $1 needs a value" >&2; exit 2; }; }
+[ $# -ge 1 ] || usage
+TARGET="$1"; shift
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --out)   need "$@"; OUT="$2"; shift 2 ;;    # `shift 2` on a trailing flag consumes nothing and
+    --fleet) need "$@"; FLEET="$2"; shift 2 ;;  # spins forever; codex reproduced the hang.
+    *) usage ;;
+  esac
+done
+[ -n "$TARGET" ] && [ -f "$TARGET" ] && [ -r "$TARGET" ] \
+  || { echo "finding_pipeline: target must be a readable file" >&2; exit 2; }
+[ -n "$OUT" ] || usage
+mkdir -p "$OUT" || { echo "finding_pipeline: cannot create --out" >&2; exit 2; }
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FLEET_SH="$HERE/finding_fleet.sh"; VERIFY_PY="$HERE/finding_verify.py"; VERIFIER_SH="$HERE/finding_verifier.sh"
+for f in "$FLEET_SH" "$VERIFY_PY" "$VERIFIER_SH"; do
+  [ -f "$f" ] || { echo "finding_pipeline: missing $f — skipped, NOT passed" >&2; exit 3; }
+done
+
+# 🟥 Everything below that lands inside a --verifier string is executed by `subprocess.run(shell=True)`
+# in finding_verify.py. Outer double quotes make it ONE python argument; they do NOT quote it for that
+# shell. A target path with a space split into two arguments, and one with shell metacharacters ran
+# them — an injected trailing command could print forged verdicts and exit 0. Quote for the receiving
+# shell, not for this one.
+Q_TARGET="$(printf '%q' "$TARGET")"
+Q_VERIFIER="$(printf '%q' "$VERIFIER_SH")"
+
+# ── 1. fleet ──────────────────────────────────────────────────────────────────────────────────────
+# A reused --out is not a fresh run: finding_fleet.sh concatenates EVERY part_*.jsonl it finds, so a
+# member that is absent this time still contributes yesterday's findings — which can silently supply
+# the second family and make a single-family run look cross-verified.
+/bin/rm -rf "$OUT/fleet"
+FA=(); [ -n "$FLEET" ] && FA=(--fleet "$FLEET")
+bash "$FLEET_SH" "$TARGET" --out "$OUT/fleet" ${FA[@]+"${FA[@]}"} 2>&1 | tee "$OUT/fleet_run.log"
+FLEET_RC=${PIPESTATUS[0]}
+FINDINGS="$OUT/fleet/findings.jsonl"
+if [ "$FLEET_RC" -ne 0 ] || [ ! -s "$FINDINGS" ]; then
+  echo "PIPELINE target=$(basename "$TARGET") fleet_rc=$FLEET_RC findings=0 status=UNREVIEWED"
+  echo "  🟥 an empty finding list is UNREVIEWED, not clean (finding_fleet.sh says so and this agrees)" >&2
+  exit 3
+fi
+# A fleet is "ok" when ONE member succeeded. A member that crashed after emitting a few findings still
+# leaves its family present, so the split routing below sees two families and the run looks complete.
+FAILED_MEMBERS=$(grep -c '^MEMBER .* rc=[^0]' "$OUT/fleet_run.log" 2>/dev/null); FAILED_MEMBERS=${FAILED_MEMBERS:-0}
+
+# ── 2. split by producer, verify each half with the other family ──────────────────────────────────
+# Families are read into a newline-delimited list and validated. An unquoted space-joined expansion
+# let a family literally named "codex gemini" split into two names that match no record, skipping
+# every finding while the run still exited 0.
+/usr/bin/python3 -c '
+import json,re,sys
+seen=[]
+for l in open(sys.argv[1],encoding="utf-8"):
+    l=l.strip()
+    if not l: continue
+    f=json.loads(l).get("producer_family")
+    if f is None: continue
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+", str(f)):
+        sys.stderr.write("finding_pipeline: illegal producer_family %r — refusing to route\n" % (f,))
+        sys.exit(2)
+    if f not in seen: seen.append(f)
+print("\n".join(seen))' "$FINDINGS" > "$OUT/families.txt" 2>"$OUT/families.err"
+FAMRC=$?
+if [ "$FAMRC" -ne 0 ] || [ ! -s "$OUT/families.txt" ]; then
+  cat "$OUT/families.err" >&2
+  echo "finding_pipeline: findings carry no usable producer_family — cannot route" >&2; exit 3
+fi
+
+supported() { case " $SUPPORTED_FAMILIES " in *" $1 "*) return 0;; *) return 1;; esac; }
+pick_verifier() { # $1=producer — a DIFFERENT family the wrapper can actually run
+  local p="$1" f
+  while IFS= read -r f; do [ -n "$f" ] && [ "$f" != "$p" ] && supported "$f" && { echo "$f"; return; }; done < "$OUT/families.txt"
+  echo ""
+}
+pick_auditor() { # $1=producer $2=verifier — prefer a third party; fall back to producer (appeal)
+  local p="$1" v="$2" f
+  while IFS= read -r f; do
+    [ -n "$f" ] && [ "$f" != "$p" ] && [ "$f" != "$v" ] && supported "$f" && { echo "$f"; return; }
+  done < "$OUT/families.txt"
+  supported "$p" && { echo "$p"; return; }
+  echo ""
+}
+
+# Exit codes are TYPES, not severities — `max(0,1)` turned "one split found nothing" into the whole
+# run's verdict while a confirmed survivor sat in the other split. Rank them explicitly instead, and
+# derive 1-vs-0 from the survivor count at the end, never from a split.
+WORST_RANK=0; WORST_CODE=0
+rank_of() { case "$1" in 2) echo 4;; 3) echo 3;; 4) echo 2;; *) echo 0;; esac; }
+note_rc() { local r; r=$(rank_of "$1"); if [ "$r" -gt "$WORST_RANK" ]; then WORST_RANK="$r"; WORST_CODE="$1"; fi; }
+
+: > "$OUT/confirmed.jsonl"; : > "$OUT/dropped.jsonl"; : > "$OUT/splits.txt"
+
+while IFS= read -r PROD; do
+  [ -n "$PROD" ] || continue
+  VER="$(pick_verifier "$PROD")"
+  if [ -z "$VER" ]; then
+    echo "  ⚠️  split producer=$PROD — no other SUPPORTED family present; its findings cannot be cross-verified" >&2
+    note_rc 3; printf 'split producer=%s verifier=NONE rc=3 (no cross-family)\n' "$PROD" >> "$OUT/splits.txt"; continue
+  fi
+  AUD="$(pick_auditor "$PROD" "$VER")"
+  SD="$OUT/split_$PROD"
+  mkdir -p "$SD" || { echo "finding_pipeline: cannot create $SD" >&2; note_rc 2; continue; }
+  # An extraction that FAILS and an extraction that finds nothing are not the same event; the first
+  # draft's `[ -s ] || continue` read both as "empty partition" and left WORST at 0.
+  if ! /usr/bin/python3 -c '
+import json,sys
+prod=sys.argv[2]
+for l in open(sys.argv[1],encoding="utf-8"):
+    l=l.strip()
+    if l and json.loads(l).get("producer_family")==prod: print(l)' "$FINDINGS" "$PROD" > "$SD/in.jsonl"; then
+    echo "finding_pipeline: split extraction failed for producer=$PROD" >&2; note_rc 3; continue
+  fi
+  if [ ! -s "$SD/in.jsonl" ]; then
+    printf 'split producer=%s verifier=%s rc=0 (no findings)\n' "$PROD" "$VER" >> "$OUT/splits.txt"; continue
+  fi
+
+  AUDARGS=()
+  if [ -n "$AUD" ]; then
+    AUDARGS=(--audit-verifier "bash $Q_VERIFIER --family $AUD --target $Q_TARGET --audit" --audit-family "$AUD")
+  else
+    echo "  ⚠️  split producer=$PROD — no supported auditor; any drop will come back UNAUDITED" >&2
+  fi
+  /usr/bin/python3 "$VERIFY_PY" "$SD/in.jsonl" --out "$SD" \
+    --verifier "bash $Q_VERIFIER --family $VER --target $Q_TARGET" --family "$VER" \
+    ${AUDARGS[@]+"${AUDARGS[@]}"} > "$SD/summary.txt" 2>"$SD/err.txt"
+  RC=$?
+  note_rc "$RC"
+  cat "$SD/summary.txt"
+  printf 'split producer=%s verifier=%s auditor=%s rc=%s\n' "$PROD" "$VER" "${AUD:-NONE}" "$RC" >> "$OUT/splits.txt"
+  [ -f "$SD/confirmed.jsonl" ] && cat "$SD/confirmed.jsonl" >> "$OUT/confirmed.jsonl"
+  [ -f "$SD/dropped.jsonl" ]   && cat "$SD/dropped.jsonl"   >> "$OUT/dropped.jsonl"
+done < "$OUT/families.txt"
+
+# 🟥 NOT `$(grep -c ... || echo 0)`: grep -c PRINTS "0" and ALSO exits 1 on no match, so the fallback
+# appends a second line and the count becomes "0\n0", which truncates the summary printf.
+count_lines() { local n; n=$(grep -c "$1" "$2" 2>/dev/null); printf '%s' "${n:-0}" | tr -d ' \n'; }
+TOTAL_CONF=$(count_lines '^{' "$OUT/confirmed.jsonl")
+TOTAL_DROP=$(count_lines '^{' "$OUT/dropped.jsonl")
+TOTAL_UNVER=$(count_lines '"verdict": *"unverified"' "$OUT/confirmed.jsonl")
+# An `unaudited` drop is NOT an audited one — counting it as such is how "we checked the deletions"
+# becomes true by wording alone.
+TOTAL_AUD=$(count_lines '"drop_verdict": *"\(correct-drop\|wrong-drop\|uncertain\)"' "$OUT/dropped.jsonl")
+TOTAL_WRONG=$(count_lines '"reinstated": *true' "$OUT/confirmed.jsonl")
+
+if [ "$FAILED_MEMBERS" -gt 0 ]; then
+  echo "  ⚠️  $FAILED_MEMBERS fleet member(s) exited non-zero — a member that crashed after emitting some findings leaves its family looking complete" >&2
+  note_rc 3
+fi
+
+RC_FINAL="$WORST_CODE"
+[ "$WORST_RANK" -eq 0 ] && [ "$TOTAL_CONF" -eq 0 ] && RC_FINAL=1
+
+printf 'PIPELINE target=%s families=%s confirmed=%s dropped=%s unverified=%s audited_drops=%s reinstated=%s failed_members=%s rc=%s\n' \
+  "$(basename "$TARGET")" "$(tr '\n' ',' < "$OUT/families.txt" | sed 's/,$//')" "$TOTAL_CONF" "$TOTAL_DROP" \
+  "$TOTAL_UNVER" "$TOTAL_AUD" "$TOTAL_WRONG" "$FAILED_MEMBERS" "$RC_FINAL"
+# `unverified` is reported on its own line rather than folded into `confirmed`, because folding it is
+# exactly the "not found rendered as zero" family this repo keeps re-finding.
+exit "$RC_FINAL"

--- a/scripts/finding_verifier.sh
+++ b/scripts/finding_verifier.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# finding_verifier.sh — the wrapper finding_verify.py's --verifier contract asks for, and which did
+# not exist. Reads findings JSONL on stdin, writes verdict JSONL on stdout:
+#     {"id","verdict":"confirmed|false-positive|needs-debate","why"}
+# With --audit it answers the drop-audit protocol instead:
+#     {"id","verdict":"correct-drop|wrong-drop|uncertain","why"}
+#
+# WHY THIS EXISTS: finding_verify.py runs whatever shell command you hand it. Until this file, the
+# only commands that satisfied its protocol were the hardcoded stubs inside the lane suite, so the
+# pipeline could only ever report status=UNVERIFIED (rc=3) against real findings. A pipeline whose
+# only live path is its own fixture is not wired (CLAUDE.md §built-but-not-wired).
+#
+# 🟥 THE VERIFIER MUST SEE THE CODE, NOT ONLY THE CLAIM. A verdict on "is this finding real" that is
+# reached from the claim text alone measures plausibility, not truth — the model agrees with a
+# well-written wrong claim. So --target is REQUIRED and its content is put in front of the model.
+#
+# EXIT  0 answered · 2 usage · 3 the CLI failed or produced no parsable verdict (caller degrades;
+#       finding_verify.py turns an empty answer into `unverified`, never into a silent pass)
+set -uo pipefail
+
+CODEX="${FH_CODEX_BIN:-$(command -v codex 2>/dev/null || echo "$HOME/.npm-global/bin/codex")}"
+AGY="${FH_AGY_BIN:-$(command -v agy 2>/dev/null || echo "$HOME/.local/bin/agy")}"
+
+FAMILY=""; TARGET=""; MODE="verify"; KEEP=""
+usage() { echo "usage: finding_verifier.sh --family codex|gemini --target <file> [--audit] [--keep <dir>]" >&2; exit 2; }
+# `shift 2` with only one word left FAILS and consumes nothing, so the loop spins forever. Under
+# `set -uo pipefail` (no errexit) nothing stops it. codex reproduced a hang on a trailing --family.
+need() { [ $# -ge 2 ] || { echo "finding_verifier: $1 needs a value" >&2; exit 2; }; }
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --family) need "$@"; FAMILY="$2"; shift 2 ;;
+    --target) need "$@"; TARGET="$2"; shift 2 ;;
+    --audit)  MODE="audit"; shift ;;
+    --keep)   need "$@"; KEEP="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+[ -n "$FAMILY" ] || usage
+# `-f` is a TYPE test, not a readability test: an unreadable regular file passes it, the later `cat`
+# fails silently, and the model then judges claims WITHOUT the source — which is the one thing the
+# header above says must never happen. Test readability, and check the read itself below.
+[ -n "$TARGET" ] && [ -f "$TARGET" ] && [ -r "$TARGET" ] \
+  || { echo "finding_verifier: --target must name a readable file" >&2; exit 2; }
+
+WORK="$(mktemp -d 2>/dev/null)" || { echo "finding_verifier: mktemp failed" >&2; exit 3; }
+cleanup() { [ -n "$KEEP" ] && cp "$WORK"/* "$KEEP"/ 2>/dev/null; rm -rf "$WORK"; }
+trap cleanup EXIT
+
+cat > "$WORK/findings.jsonl"
+if [ ! -s "$WORK/findings.jsonl" ]; then exit 0; fi   # nothing asked, nothing to answer
+
+if [ "$MODE" = "verify" ]; then
+  HEAD='You are an independent verifier from a different model family than the reviewer who wrote the
+claims below. For EACH claim decide whether it is real, judged against the file itself.
+
+Output ONLY JSON Lines, one object per claim id, nothing else — no prose, no code fences:
+{"id":"<the id verbatim>","verdict":"confirmed|false-positive|needs-debate","why":"<one line, cite the line number you checked>"}
+
+confirmed      = you read the cited location and the described failure can actually occur there.
+false-positive = the location does not say what the claim says, or the failure cannot occur.
+needs-debate   = it depends on a caller or config you cannot see from this file alone.
+
+Answer for EVERY id. Do not invent ids. Do not add findings of your own.'
+else
+  HEAD='You are auditing DELETIONS made by a different reviewer. Each record below is a claim that was
+dropped as a false positive. For EACH one decide whether dropping it was right, judged against the file.
+
+Output ONLY JSON Lines, one object per id, nothing else — no prose, no code fences:
+{"id":"<the id verbatim>","verdict":"correct-drop|wrong-drop|uncertain","why":"<one line, cite the line number you checked>"}
+
+correct-drop = the claim really was wrong; deleting it was right.
+wrong-drop   = the claim was true and was deleted in error (it will be reinstated).
+uncertain    = you cannot tell from this file alone.
+
+Answer for EVERY id. A drop you cannot justify is not "correct" by default.'
+fi
+
+{ printf '%s\n\n===== CLAIMS =====\n' "$HEAD"; cat "$WORK/findings.jsonl"
+  printf '\n===== FILE: %s =====\n' "$(basename "$TARGET")"; cat "$TARGET"; } > "$WORK/prompt.txt" \
+  || { echo "finding_verifier: could not build the prompt (source unreadable?)" >&2; exit 3; }
+# A prompt that does not actually contain the file is a verdict reached from the claim text alone.
+if ! grep -q "===== FILE: $(basename "$TARGET") =====" "$WORK/prompt.txt"; then
+  echo "finding_verifier: source did not reach the prompt — refusing to ask" >&2; exit 3
+fi
+
+case "$FAMILY" in
+  codex)  "$CODEX" exec --sandbox read-only --skip-git-repo-check -m gpt-6-astra \
+            -c model_reasoning_effort="high" < "$WORK/prompt.txt" > "$WORK/raw.txt" 2>"$WORK/err.txt" ;;
+  gemini) "$AGY" --model gemini-3.8-flash-high --output-format text --print-timeout 5m \
+            -p "$(cat "$WORK/prompt.txt")" < /dev/null > "$WORK/raw.txt" 2>"$WORK/err.txt" ;;
+  *) echo "finding_verifier: unknown family '$FAMILY' (codex|gemini)" >&2; exit 2 ;;
+esac
+RC=$?
+
+# The CLI's own exit code is not the WHOLE verdict — codex has exited non-zero while still printing
+# usable output, and zero while printing none — but the first draft used it for nothing at all, which
+# made the "cli failed" guard decorative (cross-family finding, 2026-09-09). It is now one of two
+# inputs: a non-zero CLI that nevertheless answered EVERY claim asked is reported and allowed; a
+# non-zero CLI that answered only some is a degraded run (exit 3), because the missing answers and the
+# crash have the same cause and "fewer verdicts" would otherwise read as "fewer problems".
+ASKED=$(grep -c '^{' "$WORK/findings.jsonl" 2>/dev/null); ASKED=${ASKED:-0}
+MODE="$MODE" /usr/bin/python3 - "$WORK/raw.txt" <<'PY'
+import json, os, sys
+allowed = (("confirmed", "false-positive", "needs-debate") if os.environ["MODE"] == "verify"
+           else ("correct-drop", "wrong-drop", "uncertain"))
+n = 0
+for line in open(sys.argv[1], encoding="utf-8", errors="replace"):
+    line = line.strip().lstrip("﻿")
+    if not line.startswith("{"):
+        continue                       # tolerate banners and fences, same as finding_fleet.sh
+    try:
+        d = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    if not d.get("id") or d.get("verdict") not in allowed:
+        continue                       # an out-of-enum verdict is dropped, never coerced
+    n += 1
+    print(json.dumps({"id": d["id"], "verdict": d["verdict"], "why": d.get("why", "")},
+                     ensure_ascii=False))
+open(os.path.join(os.path.dirname(sys.argv[1]), "n_answered"), "w").write(str(n))
+sys.exit(0 if n else 3)
+PY
+PRC=$?
+if [ "$PRC" -ne 0 ]; then
+  echo "finding_verifier: family=$FAMILY mode=$MODE cli_rc=$RC — no parsable verdict" >&2
+  head -c 400 "$WORK/err.txt" >&2 2>/dev/null
+  exit 3
+fi
+ANSWERED=$(cat "$WORK/n_answered" 2>/dev/null); ANSWERED=${ANSWERED:-0}
+if [ "$RC" -ne 0 ] && [ "$ANSWERED" -lt "$ASKED" ]; then
+  echo "finding_verifier: family=$FAMILY mode=$MODE cli_rc=$RC answered=$ANSWERED/$ASKED — partial answer from a failed CLI, degrading" >&2
+  exit 3
+fi
+[ "$RC" -ne 0 ] && echo "finding_verifier: family=$FAMILY cli_rc=$RC but answered $ANSWERED/$ASKED — allowed, recorded" >&2
+exit 0

--- a/scripts/finding_verify.py
+++ b/scripts/finding_verify.py
@@ -189,7 +189,18 @@ def main():
                     else:
                         kept.append(d)
                 dropped = kept
-                audit_status = "AUDITED"
+                # 🟥 AUDITED must mean EVERY drop was answered. Setting it unconditionally let an
+                # auditor that answered one unrelated id produce `audited=0 drop_audit=AUDITED` and
+                # exit 0 — the deletions went unchecked while the record said they were checked.
+                # (cross-family review 2026-09-09, reproduced; an EMPTY audit already returned 4, so
+                # the hole was specifically the PARTIAL answer.) A partial audit is not an audit.
+                unanswered = sum(1 for d in dropped if d.get("drop_verdict") == "unaudited")
+                if unanswered:
+                    audit_status = "PARTIAL"
+                    audit_note = ("auditor answered %d of %d drops; %d unanswered — a partial audit "
+                                  "is not an audit" % (audited, audited + unanswered, unanswered))
+                else:
+                    audit_status = "AUDITED"
     elif not dropped:
         audit_status = "NO-DROPS"
 
@@ -210,7 +221,7 @@ def main():
         "" if not audit_note else " reason=" + audit_note.replace("\n", " ")))
     if unverified:
         return 3
-    if audit_status == "UNAUDITED":
+    if audit_status in ("UNAUDITED", "PARTIAL"):
         return 4                      # drops happened and nobody checked them: not a completed run
     return 0 if confirmed else 1
 

--- a/scripts/test_finding_pipeline_lanes.sh
+++ b/scripts/test_finding_pipeline_lanes.sh
@@ -124,6 +124,237 @@ python3 "$MUT" "$D/f.jsonl" --out "$D/o6" --verifier "sh $D/v_ok.sh" --family al
   && ok "L9 되돌림: 가드를 지우면 자기 계열이 자기 것을 지운다 (레인이 실물을 잰다)" \
   || no "L9 되돌림" "가드를 지워도 드롭 0 — L7 은 장식이다"
 
+# ══ 접착 코드 레인 (2026-09-09) — finding_verifier.sh (G1) · finding_pipeline.sh (G2) · defeater (G6) ══
+# 🟥 이 레인들이 지키는 것도 «방향»이다. 래퍼가 답을 못 받았는데 0 을 돌려주면 verify 는 그것을
+#    «판정 없음 → unverified» 가 아니라 «빈 판정»으로 삼키고, 파이프라인은 초록으로 끝난다.
+VERIFIER="$HERE/finding_verifier.sh"; PIPE="$HERE/finding_pipeline.sh"
+if [ ! -f "$VERIFIER" ] || [ ! -f "$PIPE" ]; then
+  no "L15 접착 코드 실재" "finding_verifier.sh / finding_pipeline.sh 부재 — skipped, NOT passed"
+else
+bash -n "$VERIFIER" && ok "L15a verifier 구문" || no "L15a verifier 구문"
+bash -n "$PIPE"     && ok "L15b pipeline 구문" || no "L15b pipeline 구문"
+
+printf 'x = 1\n' > "$D/tgt.py"
+
+# 가짜 CLI — 배너/펜스로 감싸고, enum 밖 verdict 를 하나 섞는다
+cat > "$D/fake_ok.sh" <<'EOS'
+#!/bin/sh
+cat >/dev/null
+echo "== banner the model likes to print =="
+echo '```json'
+echo '{"id":"a1","verdict":"confirmed","why":"line 3 does this"}'
+echo '{"id":"a2","verdict":"probably-fine","why":"out of enum"}'
+echo '{"id":"a2","verdict":"false-positive","why":"line 9 says otherwise"}'
+echo '```'
+EOS
+chmod +x "$D/fake_ok.sh"
+cat > "$D/fake_mute.sh" <<'EOS'
+#!/bin/sh
+cat >/dev/null
+echo "I looked at the file but will not answer in JSON."
+EOS
+chmod +x "$D/fake_mute.sh"
+
+# L16 — 배너/펜스를 견디고, enum 밖 verdict 는 «강제 변환» 이 아니라 «드롭» 이다
+V16=$(FH_CODEX_BIN="$D/fake_ok.sh" bash "$VERIFIER" --family codex --target "$D/tgt.py" < "$D/f.jsonl" 2>/dev/null); RC=$?
+N16=$(printf '%s\n' "$V16" | grep -c '^{')
+{ [ "$RC" -eq 0 ] && [ "$N16" = 2 ] && printf '%s' "$V16" | grep -q '"verdict": "false-positive"' \
+  && ! printf '%s' "$V16" | grep -q 'probably-fine'; } \
+  && ok "L16 래퍼: 배너/펜스 견딤 · enum 밖 verdict 드롭 (2건만 통과)" \
+  || no "L16 래퍼 파싱" "rc=$RC n=$N16 · $V16"
+
+# L17 — 빈 입력은 «물어본 게 없다» 이므로 rc=0 · 출력 0 (CLI 를 부르지도 않는다)
+V17=$(FH_CODEX_BIN="$D/fake_ok.sh" bash "$VERIFIER" --family codex --target "$D/tgt.py" < /dev/null 2>/dev/null); RC=$?
+{ [ "$RC" -eq 0 ] && [ -z "$V17" ]; } && ok "L17 빈 입력 → rc=0 · 출력 0" || no "L17 빈 입력" "rc=$RC out=$V17"
+
+# L18 🟥 degrade 방향의 핵심 — 답을 «못 받은» 것은 rc=3 이지 rc=0 이 아니다
+V18=$(FH_CODEX_BIN="$D/fake_mute.sh" bash "$VERIFIER" --family codex --target "$D/tgt.py" < "$D/f.jsonl" 2>/dev/null); RC=$?
+{ [ "$RC" -eq 3 ] && [ -z "$V18" ]; } \
+  && ok "L18 파싱 가능한 판정 0 → rc=3 (침묵을 «통과» 로 접지 않는다)" || no "L18 무응답 degrade" "rc=$RC out=$V18"
+
+# L19 — 사용법 가드: --target 없으면 rc=2, 모르는 계열이면 rc=2
+bash "$VERIFIER" --family codex < /dev/null >/dev/null 2>&1; [ $? -eq 2 ] \
+  && ok "L19a --target 부재 → rc=2" || no "L19a --target 가드"
+echo '{"id":"a1","title":"t"}' | bash "$VERIFIER" --family nosuch --target "$D/tgt.py" >/dev/null 2>&1; [ $? -eq 2 ] \
+  && ok "L19b 모르는 계열 → rc=2" || no "L19b 계열 가드"
+
+# ── L20~L22 드라이버 ────────────────────────────────────────────────────────────────────────────
+# 두 계열이 각각 한 건씩 내는 가짜 fleet. 그래야 «두 갈래 분할» 이 실제로 갈린다.
+cat > "$D/m_codex.sh" <<'EOS'
+#!/bin/sh
+cat >/dev/null
+echo '{"title":"codex claim","file":"tgt.py","line":1,"severity":"A","defeater":"line 1 would differ"}'
+EOS
+cat > "$D/m_gem.sh" <<'EOS'
+#!/bin/sh
+cat >/dev/null
+echo '{"title":"gemini claim","file":"tgt.py","line":1,"severity":"S","defeater":"no such call site"}'
+EOS
+chmod +x "$D/m_codex.sh" "$D/m_gem.sh"
+printf 'codex|logic|%s\ngemini|security|%s\n' "sh $D/m_codex.sh" "sh $D/m_gem.sh" > "$D/fleet.tbl"
+
+# 두 계열 모두 «상대편 것은 confirmed» 라고 답하는 가짜 검증기
+# 🟥 이 가짜 CLI 는 stdin «과» 인자를 «둘 다» 읽어야 한다 — finding_verifier.sh 의 codex 갈래는
+#    프롬프트를 stdin 으로, gemini 갈래는 `-p` 인자로 준다. stdin 만 읽는 픽스처를 쓰면 gemini
+#    갈래가 «답을 못 받았다»(rc=3)로 떨어지고, 그건 코드 결함처럼 보이지만 죽은 컨트롤이다.
+#    (실측 2026-09-09: 이 레인의 첫 판이 정확히 그렇게 L20 을 거짓 적색으로 만들었다.)
+cat > "$D/fake_conf.sh" <<'EOS'
+#!/bin/sh
+IN=$(cat)
+[ -n "$IN" ] || IN="$*"
+printf '%s\n' "$IN" | tr ',' '\n' | sed -n 's/.*"id": *"\([^"]*\)".*/{"id":"\1","verdict":"confirmed","why":"checked"}/p'
+EOS
+chmod +x "$D/fake_conf.sh"
+
+P20=$(FH_CODEX_BIN="$D/fake_conf.sh" FH_AGY_BIN="$D/fake_conf.sh" \
+      bash "$PIPE" "$D/tgt.py" --out "$D/pipe20" --fleet "$D/fleet.tbl" 2>"$D/pipe20.err"); RC=$?
+SUM=$(printf '%s\n' "$P20" | grep '^PIPELINE ')
+{ [ "$RC" -eq 0 ] && printf '%s' "$SUM" | grep -q 'confirmed=2' && printf '%s' "$SUM" | grep -q 'unverified=0'; } \
+  && ok "L20 드라이버: 두 계열 분할로 «양쪽 다» 판정된다 (unverified=0)" \
+  || no "L20 두 갈래 분할" "rc=$RC · $SUM · $(tail -3 "$D/pipe20.err")"
+
+# L21 🟥 한 계열만 있으면 그 findings 는 교차검증이 구조적으로 불가 — 초록이 아니라 rc=3
+printf 'codex|logic|%s\n' "sh $D/m_codex.sh" > "$D/fleet1.tbl"
+FH_CODEX_BIN="$D/fake_conf.sh" bash "$PIPE" "$D/tgt.py" --out "$D/pipe21" --fleet "$D/fleet1.tbl" \
+  >"$D/p21" 2>"$D/p21.err"; RC=$?
+{ [ "$RC" -eq 3 ] && grep -q 'cannot be cross-verified' "$D/p21.err"; } \
+  && ok "L21 단일 계열 fleet → rc=3 (같은 계열 자기검증으로 «통과» 시키지 않는다)" \
+  || no "L21 단일 계열 degrade" "rc=$RC · $(cat "$D/p21.err")"
+
+# L22 — fleet 이 아무것도 못 내면 UNREVIEWED(rc=3) 이지 clean 이 아니다
+cat > "$D/m_none.sh" <<'EOS'
+#!/bin/sh
+cat >/dev/null
+EOS
+chmod +x "$D/m_none.sh"
+printf 'codex|logic|%s\ngemini|security|%s\n' "sh $D/m_none.sh" "sh $D/m_none.sh" > "$D/fleet0.tbl"
+bash "$PIPE" "$D/tgt.py" --out "$D/pipe22" --fleet "$D/fleet0.tbl" >"$D/p22" 2>&1; RC=$?
+{ [ "$RC" -eq 3 ] && grep -q 'UNREVIEWED' "$D/p22"; } \
+  && ok "L22 findings 0 → UNREVIEWED rc=3 (빈 목록은 clean 이 아니다)" || no "L22 UNREVIEWED" "rc=$RC · $(cat "$D/p22")"
+
+# L23 되돌림 프로브 — pick_verifier 가 «생산자와 다른 계열» 을 고르는 줄을 죽이면 L20 이 빨개져야 한다
+# 🟥 뮤턴트는 «의존 파일 옆에» 두어야 한다. finding_pipeline.sh 는 자기 위치에서 fleet/verify/
+#    verifier 를 찾으므로, 뮤턴트만 임시 디렉터리에 두면 프로브는 «가드가 죽었나» 가 아니라
+#    «파일이 없나» 를 잰다 — 빨간색이 나오지만 이유가 다르다(실측 2026-09-09, 이 레인의 첫 판).
+MUTD="$D/mut"; mkdir -p "$MUTD"
+cp "$HERE/finding_fleet.sh" "$HERE/finding_verify.py" "$HERE/finding_verifier.sh" "$MUTD/"
+MUTP="$MUTD/finding_pipeline.sh"
+/usr/bin/python3 - "$PIPE" "$MUTP" <<'PY'
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+s = open(src, encoding="utf-8").read()
+key = '  while IFS= read -r f; do [ -n "$f" ] && [ "$f" != "$p" ] && supported "$f" && { echo "$f"; return; }; done < "$OUT/families.txt"'
+assert key in s, "pick_verifier body moved — the revert probe is pinned to a line that no longer exists"
+s = s.replace(key, '  echo "$p"')   # 자기 계열을 검증기로 고른다
+open(dst, "w", encoding="utf-8").write(s)
+PY
+FH_CODEX_BIN="$D/fake_conf.sh" FH_AGY_BIN="$D/fake_conf.sh" \
+  bash "$MUTP" "$D/tgt.py" --out "$D/pipe23" --fleet "$D/fleet.tbl" >"$D/p23" 2>&1
+M23=$(grep '^PIPELINE ' "$D/p23" | grep -c 'unverified=2')
+[ "$M23" = 1 ] \
+  && ok "L23 되돌림: 검증기를 자기 계열로 바꾸면 전부 unverified 로 떨어진다 (L20 은 장식이 아니다)" \
+  || no "L23 되돌림" "뮤턴트인데 unverified=2 가 안 나왔다 — L20 이 실물을 안 잰다 · $(grep '^PIPELINE ' "$D/p23")"
+
+# L24 — G6: fleet 프롬프트가 defeater 를 «요구» 하는가 (축③ 을 잴 수 있는 최소 조건)
+{ grep -q '"defeater"' "$FLEET" && grep -q 'defeater. is required' "$FLEET"; } \
+  && ok "L24 fleet 스키마에 defeater 요구 (축③ 측정 가능)" || no "L24 defeater 스키마"
+fi
+
+# ══ cross-family 라운드 1 이 연 구멍들의 회귀 앵커 (codex, 2026-09-09) ══════════════════════════
+# 🟥 각 레인은 «수리가 됐나」가 아니라 «그 구멍이 다시 열리면 빨개지나」를 잰다.
+run_bounded() { # $1=초 · 나머지=명령. 되돌림이 무한루프를 되살려도 스위트가 안 멈추게.
+  local secs="$1"; shift
+  "$@" & local pid=$!
+  ( sleep "$secs"; kill -9 "$pid" 2>/dev/null ) & local wd=$!
+  wait "$pid" 2>/dev/null; local rc=$?
+  kill -9 "$wd" 2>/dev/null; wait "$wd" 2>/dev/null
+  return "$rc"
+}
+
+# 계열마다 다르게 답하는 가짜 CLI — codex 산출은 기각, gemini 산출은 인정, 감사는 correct-drop
+cat > "$D/fake_smart.sh" <<'EOS'
+#!/bin/sh
+IN=$(cat)
+[ -n "$IN" ] || IN="$*"
+case "$IN" in *"correct-drop"*) MODE=audit ;; *) MODE=verify ;; esac
+printf '%s\n' "$IN" | tr ',' '\n' | sed -n 's/.*"id": *"\([^"]*\)".*/\1/p' | sort -u | while read -r id; do
+  if [ "$MODE" = audit ]; then
+    echo "{\"id\":\"$id\",\"verdict\":\"correct-drop\",\"why\":\"line 1 checked\"}"
+  else
+    case "$id" in
+      codex-*)  echo "{\"id\":\"$id\",\"verdict\":\"false-positive\",\"why\":\"line 1 says otherwise\"}" ;;
+      *)        echo "{\"id\":\"$id\",\"verdict\":\"confirmed\",\"why\":\"line 1 holds\"}" ;;
+    esac
+  fi
+done
+EOS
+chmod +x "$D/fake_smart.sh"
+
+# L25 🟥 부분 감사는 감사가 아니다 — 무관한 id 하나만 답한 감사자가 «AUDITED · rc=0» 을 만들었다
+cat > "$D/a_partial.sh" <<'EOS'
+#!/bin/sh
+cat >/dev/null
+echo '{"id":"nonexistent-id","verdict":"correct-drop","why":"unrelated"}'
+EOS
+chmod +x "$D/a_partial.sh"
+python3 "$VERIFY" "$D/f.jsonl" --out "$D/oP" --verifier "sh $D/v_ok.sh" --family beta \
+  --audit-verifier "sh $D/a_partial.sh" --audit-family gamma >"$D/sP" 2>&1; RC=$?
+{ [ "$RC" -eq 4 ] && grep -q 'drop_audit=PARTIAL' "$D/sP" && grep -q 'audited=0' "$D/sP"; } \
+  && ok "L25 부분 감사 → PARTIAL · rc=4 (무관한 id 하나로 «감사했다» 가 안 된다)" \
+  || no "L25 부분 감사" "rc=$RC · $(cat "$D/sP")"
+
+# L26 🟥 주입 — 타깃 경로에 공백과 셸 메타문자가 있어도 «명령으로 실행되지 않는다»
+TGD="$D/inj"; mkdir -p "$TGD"
+# 🟥 파일명에 «/» 를 못 넣으므로 주입 페이로드는 상대 경로로 두고, 러너를 그 디렉터리에서 돌린다.
+# (첫 판은 절대경로를 파일명에 박아 픽스처가 생성조차 안 됐다 — 죽은 계기였다.)
+BADNAME='a b;touch PWNED.py'
+( cd "$TGD" && printf 'x = 1\n' > "$BADNAME" ) 2>/dev/null
+if [ -f "$TGD/$BADNAME" ]; then
+  printf 'codex|logic|%s\ngemini|security|%s\n' "sh $D/m_codex.sh" "sh $D/m_gem.sh" > "$D/fleetI.tbl"
+  ( cd "$TGD" && FH_CODEX_BIN="$D/fake_smart.sh" FH_AGY_BIN="$D/fake_smart.sh" \
+      bash "$PIPE" "$BADNAME" --out "$D/pipeI" --fleet "$D/fleetI.tbl" ) >"$D/pI" 2>&1
+  RCI=$?
+  # 두 가지를 «같이» 본다: ⓐ 주입이 실행되지 않았나 ⓑ 공백 있는 경로로도 실제로 완주하나
+  #    (ⓑ 없이 ⓐ 만 보면 «아예 안 돌아서 안전한» 것과 구별이 안 된다 — 죽은 컨트롤)
+  { [ ! -e "$TGD/PWNED.py" ] && [ "$RCI" -eq 0 ] && grep -q 'confirmed=' "$D/pI"; } \
+    && ok "L26 주입: 메타문자·공백 타깃이 «인자」로만 전달되고, 그러고도 완주한다" \
+    || no "L26 주입" "PWNED=$([ -e "$TGD/PWNED.py" ] && echo 생성됨 || echo 없음) rc=$RCI · $(grep '^PIPELINE' "$D/pI" || tail -2 "$D/pI")"
+else
+  no "L26 주입" "픽스처 생성 실패 — 미측정(통과 아님)"
+fi
+
+# L27 🟥 값 없는 플래그는 «멈춤」이 아니라 rc=2 (첫 판은 무한루프였다)
+run_bounded 8 bash "$VERIFIER" --family; RC=$?
+[ "$RC" -eq 2 ] && ok "L27a verifier: 값 없는 --family → rc=2 (무한루프 아님)" || no "L27a 트레일링 플래그" "rc=$RC (137 이면 워치독이 죽인 것 = 여전히 멈춘다)"
+run_bounded 8 bash "$PIPE" "$D/tgt.py" --out; RC=$?
+[ "$RC" -eq 2 ] && ok "L27b pipeline: 값 없는 --out → rc=2" || no "L27b 트레일링 플래그" "rc=$RC"
+
+# L28 🟥 종료코드는 «심각도 숫자」가 아니라 «종류» — 생존자가 있는데 rc=1 이 나오면 안 된다
+printf 'codex|logic|%s\ngemini|security|%s\n' "sh $D/m_codex.sh" "sh $D/m_gem.sh" > "$D/fleetT.tbl"
+FH_CODEX_BIN="$D/fake_smart.sh" FH_AGY_BIN="$D/fake_smart.sh" \
+  bash "$PIPE" "$D/tgt.py" --out "$D/pipeT" --fleet "$D/fleetT.tbl" >"$D/pT" 2>&1; RC=$?
+SUMT=$(grep '^PIPELINE ' "$D/pT")
+{ [ "$RC" -eq 0 ] && printf '%s' "$SUMT" | grep -q 'confirmed=1' && printf '%s' "$SUMT" | grep -q 'dropped=1'; } \
+  && ok "L28 한 split 이 «생존 0»(rc=1) 이어도 다른 split 의 생존자가 있으면 전체 rc=0" \
+  || no "L28 종료코드 종류" "rc=$RC · $SUMT · $(tail -3 "$D/pT")"
+
+# L29 🟥 --out 재사용이 «지난 런의 계열」을 수입하면 안 된다 (단일 계열이 교차검증된 것처럼 보인다)
+printf 'codex|logic|%s\n' "sh $D/m_codex.sh" > "$D/fleetS.tbl"
+FH_CODEX_BIN="$D/fake_smart.sh" bash "$PIPE" "$D/tgt.py" --out "$D/pipeT" --fleet "$D/fleetS.tbl" >"$D/pS" 2>&1; RC=$?
+{ [ "$RC" -eq 3 ] && ! grep -q 'gemini' "$D/pipeT/families.txt"; } \
+  && ok "L29 --out 재사용: 지난 런의 part_*.jsonl 을 수입하지 않는다 (단일 계열 → rc=3)" \
+  || no "L29 stale --out" "rc=$RC families=$(cat "$D/pipeT/families.txt" 2>/dev/null | tr '\n' ',')"
+
+# L30 — 읽을 수 없는 타깃은 «타입은 파일」이어도 rc=2 (모델이 소스 없이 판정하지 않게)
+UNR="$D/unreadable.py"; printf 'x=1\n' > "$UNR"; chmod 000 "$UNR" 2>/dev/null
+if [ -r "$UNR" ]; then
+  no "L30 읽기불가 타깃" "chmod 000 이 안 먹었다(root?) — 미측정, 통과 아님"
+else
+  echo '{"id":"a1","title":"t"}' | bash "$VERIFIER" --family codex --target "$UNR" >/dev/null 2>&1; RC=$?
+  [ "$RC" -eq 2 ] && ok "L30 읽기불가 타깃 → rc=2 (-f 는 타입만 본다)" || no "L30 읽기불가 타깃" "rc=$RC"
+  chmod 644 "$UNR" 2>/dev/null
+fi
+
 /bin/rm -rf "$D"
 echo "PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ] && { echo "FAILED=0"; exit 0; } || { echo "FAILED=1"; exit 1; }


### PR DESCRIPTION
## 무엇이 없었나

#686 은 `finding_fleet.sh` 와 `finding_verify.py` 를 남겼는데 **둘을 잇는 것이 없었다.**
`finding_verify.py` 의 `--verifier` 계약(«findings JSONL stdin → verdict JSONL stdout»)을 만족하는
명령이 **레포에 0개**였다 — 레인 안의 하드코딩 스텁(`v_ok.sh`)뿐이었다. 그래서 실물 findings 에
대해서는 파이프라인이 항상 `status=UNVERIFIED (rc=3)` 로만 돌 수 있었다.
**자기 픽스처만 통과하는 파이프라인은 배선된 것이 아니다** (§built-but-not-wired).

## 넣은 것

| 파일 | 무엇 |
|---|---|
| `scripts/finding_verifier.sh` (신규) | 검증기/감사기 래퍼. `--target` **필수**이고 «소스가 프롬프트에 도달했나»를 호출 전에 확인한다 — 주장 텍스트만 보고 내린 판정은 진위가 아니라 그럴듯함을 잰다 |
| `scripts/finding_pipeline.sh` (신규) | fleet → 거부 → 드롭 감사 드라이버 |
| `scripts/finding_fleet.sh` | 스키마에 **`defeater` 요구** — 없으면 5팔 표의 축③(반증 조건)이 구조적으로 측정 불가라 비교가 깨진다 |
| `scripts/finding_verify.py` | 부분 감사 fail-open 수리 |
| `scripts/test_finding_pipeline_lanes.sh` | 레인 20 → **33** |

### 🟥 두 갈래 «분할» 이 이 PR 의 하중선이다

`finding_verify.py` 는 자기 계열 산출을 판정하지 않고 `unverified` 로 스탬프하는데, **그 unverified 는
생존자로 «센다».** 두 계열 fleet 에 verify 를 한 번만 돌리면 **절반이 판정 안 된 채 초록**이 된다.
그래서 producer 별로 갈라 서로를 판정시킨다:

```
gemini 산출 → 검증기 codex  → 드롭 감사 gemini
codex  산출 → 검증기 gemini → 드롭 감사 codex
```

**명명된 잔여**: 계열이 둘뿐이면 드롭 감사자가 **항상 생산자**(= `audit_role: appeal`)이고 제3자가 아니다.
두 계열 런의 `AUDITED` 를 «독립 감사»로 읽지 마라 — per-finding `audit_role` 이 어느 쪽인지 적는다.

## cross-family 라운드 1 (codex `gpt-6-astra`) — S 11 · A 2 · B 1, 9건 수리

재현된 것 셋:

- 🟥 **주입** — 타깃 경로가 `subprocess(shell=True)` 로 샜다. 공백은 인자 분리, `;` 는 실행.
  codex 가 무해한 `printf` 를 실제로 실행시켜 보였다. → `printf %q` 로 결박
- 🟥 **부분 감사가 `AUDITED` 였다 (#686 출하본)** — 감사자가 무관한 id 하나만 답해도
  `audited=0 drop_audit=AUDITED rc=0`. 빈 감사는 이미 4를 냈으므로 구멍은 «부분» 쪽이었다.
  → `PARTIAL` 상태 + rc=4. **부분 감사는 감사가 아니다**
- 🟥 **종료코드를 «숫자 최대»로 접었다** — 생존자가 있는 split 이 있는데 다른 split 의 `1` 이 전체를
  `1` 로 만들었다. 종료코드는 **종류**이지 심각도 순서가 아니다 → 종류별 rank

그리고 **내 주석이 하나 거짓이었다** — 「제3 계열을 자동으로 집어든다」고 썼는데 래퍼가 `codex|gemini`
만 안다. 라우팅을 지원 계열로 제한하고 주석을 정정했다.

## 레인 개발 중 만난 «죽은 컨트롤» 둘 — 레인 주석에 남겼다

- 가짜 CLI 가 stdin 만 읽어 **gemini 갈래(`-p` 인자)를 거짓 적색**으로 만들었다
- 뮤턴트를 의존 파일에서 떼어 놔 «가드가 죽었나»가 아니라 **«파일이 없나»를 재고** 있었다

## 검증

```
레인            33/33   (L23 되돌림: 검증기를 자기 계열로 바꾸면 unverified=2 로 적색, 복원 시 초록)
selfcheck       PASS (rc=0)
degrade 스캔    0 smells
```
849행의 `❌ … expected block, got pass` 는 **뮤턴트 프로브의 선의의 적색**이다(`reddened lanes: 1`, 실 트리 무변경).

## ⓔ 첫 실사용 — 실제 CLI 로 완주

회수한 B-1 `case_h02.ts` 1건을 **실제 codex(gpt-6-astra) + agy(gemini-3.8-flash-high)** 로:

```
PIPELINE target=case_h02.ts families=codex,gemini confirmed=3 dropped=0 unverified=0 ... rc=0
```
`unverified=0` = 두 갈래가 **서로를 실제로 판정했다**. `defeater` **3/3** 비공허·관측가능
(예: *"Posting an application/pdf payload containing byte 0xFF would leave…"*).

🟥 **드롭이 0 이었으므로 감사 경로는 실사용 미검증이다.** 마커·매니페스트에 그대로 적었다.

## 마커

`crossfamily: panel(codex) · residency=CLEAN(files=4)` · `standpoint: not-applicable` · `oracle: known-pair` ·
`soul-check: violated` (초판이 절대-안-함을 세 자리에서 어겼고 자력 적발 0 — 기록된 위반이 숨긴 위반보다 낫다)
