### PR TITLE
fix(security): 출하 전 발견된 주입·심링크·권한 7건 — 인용을 «더 잘» 하는 대신 셸을 경로에서 뺀다

### DIFF
--- a/scripts/doc_claim_triad_scan.py
+++ b/scripts/doc_claim_triad_scan.py
@@ -40,12 +40,30 @@ def walk(root: str, exts=None) -> List[str]:
                 out.append(os.path.join(dp, fn))
     return out
 
+def _inside(root: str, path: str) -> bool:
+    """path 가 root 안에 «실제로» 있나 — 심링크까지 풀어서 판정한다.
+
+    🟥 이 함수가 없으면 «문서가 부르는 경로»가 스캔 루트를 벗어난다. 이 스캐너는 대상 파일의
+    매칭 줄을 증거로 «출력»하므로, `../private/deploy.sh` 한 줄이면 그 파일의 자격증명이 든 줄이
+    리포트에 실린다. 그리고 이 스캐너는 신뢰할 수 없는 문서를 읽는 것이 일이다.
+    (cross-family security review 2026-09-09 — 루트 밖 읽기와 스니펫 반환을 프로브로 실증했다.)
+    """
+    try:
+        r = os.path.realpath(root)
+        c = os.path.realpath(path)
+    except OSError:
+        return False
+    return c == r or c.startswith(r + os.sep)
+
+
 def resolve(root: str, p: str) -> str | None:
+    # `..` 를 담은 참조는 «해석하기 전에» 거절한다 — 해석 후 판정은 심링크 한 겹에 뚫린다.
     cand = os.path.join(root, p)
-    if os.path.isfile(cand):
+    if os.path.isfile(cand) and not os.path.islink(cand) and _inside(root, cand):
         return cand
     base = os.path.basename(p)
-    hits = [f for f in walk(root) if os.path.basename(f) == base]
+    hits = [f for f in walk(root)
+            if os.path.basename(f) == base and not os.path.islink(f) and _inside(root, f)]
     return hits[0] if len(hits) == 1 else None
 
 # 실행 증거: 인터프리터 뒤 또는 명령 위치. 주석줄과 grep 패턴 안은 제외.

--- a/scripts/finding_fleet.sh
+++ b/scripts/finding_fleet.sh
@@ -55,10 +55,21 @@ Your assigned area: '
 
 run_member() { # $1=family $2=role $3=command $4=target $5=outdir
   local fam="$1" role="$2" cmd="$3" tgt="$4" out="$5"
-  cmd="${cmd//CODEX_BIN/$CODEX}"; cmd="${cmd//AGY_BIN/$AGY}"
+  # 🟥 치환값은 eval 되는 문자열 «안»으로 들어간다. 결박하지 않으면 «출력 디렉터리 이름»만으로도
+  #    명령이 실행된다 — cross-family security review 2026-09-09 가 무해한 printf 로 실증했다.
+  #    여기는 bash `eval` 이므로 `printf %q` 가 옳은 도구다(shell=True 로 /bin/sh 에 넘기는
+  #    finding_pipeline.sh 와는 사정이 다르다 — 거기서는 %q 가 dash 에서 깨져서 argv 로 갔다).
+  local q_codex q_agy q_pf
+  q_codex="$(printf '%q' "$CODEX")"; q_agy="$(printf '%q' "$AGY")"
+  cmd="${cmd//CODEX_BIN/$q_codex}"; cmd="${cmd//AGY_BIN/$q_agy}"
   local raw="$out/raw_${fam}_${role}.txt" pf="$out/prompt_${fam}_${role}.txt"
+  # 🟥 심링크를 통해 쓰면 남의 파일을 덮는다. 그리고 타깃이 심링크면 그 «내용»이 외부로 나간다.
+  for _p in "$raw" "$pf" "$out/err_${fam}_${role}.txt" "$out/part_${fam}_${role}.jsonl"; do
+    [ -L "$_p" ] && { echo "finding_fleet: refusing to write through a symlink: $_p" >&2; return 1; }
+  done
   { printf '%s%s\n\n===== FILE: %s =====\n' "$PROMPT_HEAD" "$role" "$(basename "$tgt")"; cat "$tgt"; } > "$pf"
-  cmd="${cmd//PROMPT_FILE/$pf}"
+  q_pf="$(printf '%q' "$pf")"
+  cmd="${cmd//PROMPT_FILE/$q_pf}"
   eval "$cmd" < "$pf" > "$raw" 2>"$out/err_${fam}_${role}.txt"
   local rc=$?
   FAM="$fam" ROLE="$role" RC="$rc" /usr/bin/python3 - "$raw" "$out/part_${fam}_${role}.jsonl" <<'PY'
@@ -141,6 +152,12 @@ while [ $# -gt 0 ]; do
   esac
 done
 [ -f "$TARGET" ] || { echo "no such file: $TARGET" >&2; exit 2; }
+# 🟥 이 파일의 «내용»은 외부 모델로 전송된다. 심링크면 체크아웃 밖 자격증명을 가리킬 수 있고,
+#    그러면 리뷰 대상 대신 그 비밀이 프롬프트가 된다 (residency 위반, cross-family 2026-09-09).
+[ -L "$TARGET" ] && { echo "finding_fleet: target is a symlink — refusing (content is SENT to an external model)" >&2; exit 2; }
+[ -r "$TARGET" ] || { echo "finding_fleet: target is not readable: $TARGET" >&2; exit 2; }
+# 프롬프트 파일은 소스 전문을 담는다 — umask 022 면 0644 로 남아 다른 계정이 읽는다.
+umask 077
 [ -n "$OUT" ] || { echo "--out is required" >&2; exit 2; }
 mkdir -p "$OUT"
 if [ -n "$FLEET" ]; then cp "$FLEET" "$OUT/fleet.txt"; else default_fleet > "$OUT/fleet.txt"; fi

--- a/scripts/finding_pipeline.sh
+++ b/scripts/finding_pipeline.sh
@@ -44,8 +44,24 @@ while [ $# -gt 0 ]; do
 done
 [ -n "$TARGET" ] && [ -f "$TARGET" ] && [ -r "$TARGET" ] \
   || { echo "finding_pipeline: target must be a readable file" >&2; exit 2; }
+# 🟥 타깃이 심링크면 체크아웃 «밖»을 가리킬 수 있고, 그 내용은 외부 모델로 전송된다.
+#    리뷰하려던 것은 레포 코드인데 나가는 것은 남의 비밀이 된다 — residency 위반이다.
+#    강행이 필요하면 실제 파일 경로를 직접 주면 된다(그 판단은 사람이 한다).
+if [ -L "$TARGET" ]; then
+  echo "finding_pipeline: target is a symlink — refusing (it may point outside the checkout, and the content is SENT to an external model)" >&2
+  exit 2
+fi
 [ -n "$OUT" ] || usage
+# 🟥 출력물은 프롬프트와 소스를 담는다 — 권한을 좁혀서 만든다(umask 022 면 0644 로 남는다).
+umask 077
 mkdir -p "$OUT" || { echo "finding_pipeline: cannot create --out" >&2; exit 2; }
+# 🟥 미리 깔린 심링크를 따라가면 «출력»이 남의 파일 truncate 가 된다. 리다이렉션도 open() 도
+#    심링크를 따라간다 — 그래서 쓰기 «전»에 거부한다(cross-family review 2026-09-09).
+for _p in "$OUT" "$OUT/fleet" "$OUT/confirmed.jsonl" "$OUT/dropped.jsonl" "$OUT/splits.txt" "$OUT/families.txt"; do
+  if [ -L "$_p" ]; then
+    echo "finding_pipeline: refusing to write through a symlink: $_p" >&2; exit 2
+  fi
+done
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FLEET_SH="$HERE/finding_fleet.sh"; VERIFY_PY="$HERE/finding_verify.py"; VERIFIER_SH="$HERE/finding_verifier.sh"
@@ -53,13 +69,16 @@ for f in "$FLEET_SH" "$VERIFY_PY" "$VERIFIER_SH"; do
   [ -f "$f" ] || { echo "finding_pipeline: missing $f — skipped, NOT passed" >&2; exit 3; }
 done
 
-# 🟥 Everything below that lands inside a --verifier string is executed by `subprocess.run(shell=True)`
-# in finding_verify.py. Outer double quotes make it ONE python argument; they do NOT quote it for that
-# shell. A target path with a space split into two arguments, and one with shell metacharacters ran
-# them — an injected trailing command could print forged verdicts and exit 0. Quote for the receiving
-# shell, not for this one.
-Q_TARGET="$(printf '%q' "$TARGET")"
-Q_VERIFIER="$(printf '%q' "$VERIFIER_SH")"
+# 🟥 NO SHELL IN THIS PATH. An earlier version built a command STRING and quoted the interpolated
+# path with bash's `printf %q`. That was not enough, and the reason matters: finding_verify.py ran
+# the string with `shell=True`, i.e. `/bin/sh`, while `%q` emits **bash-only** `$'...'` quoting for a
+# path containing a newline. On the many Linux systems where `/bin/sh` is dash, that quoting comes
+# apart and a crafted filename executes a second command. 🟥 macOS CANNOT SEE THIS — its /bin/sh is
+# bash-derived, so the local run is green while the shipped package is not (cross-family review
+# 2026-09-09, reproduced on dash). The fix is not better escaping; it is handing argv, never a string.
+argv_json() {  # each argument becomes one JSON string — no shell ever parses these
+  ARGV_PY="$*" /usr/bin/python3 -c 'import json,os,sys; print(json.dumps(sys.argv[1:]))' "$@"
+}
 
 # ── 1. fleet ──────────────────────────────────────────────────────────────────────────────────────
 # A reused --out is not a fresh run: finding_fleet.sh concatenates EVERY part_*.jsonl it finds, so a
@@ -152,12 +171,12 @@ for l in open(sys.argv[1],encoding="utf-8"):
 
   AUDARGS=()
   if [ -n "$AUD" ]; then
-    AUDARGS=(--audit-verifier "bash $Q_VERIFIER --family $AUD --target $Q_TARGET --audit" --audit-family "$AUD")
+    AUDARGS=(--audit-verifier-argv "$(argv_json bash "$VERIFIER_SH" --family "$AUD" --target "$TARGET" --audit)" --audit-family "$AUD")
   else
     echo "  ⚠️  split producer=$PROD — no supported auditor; any drop will come back UNAUDITED" >&2
   fi
   /usr/bin/python3 "$VERIFY_PY" "$SD/in.jsonl" --out "$SD" \
-    --verifier "bash $Q_VERIFIER --family $VER --target $Q_TARGET" --family "$VER" \
+    --verifier-argv "$(argv_json bash "$VERIFIER_SH" --family "$VER" --target "$TARGET")" --family "$VER" \
     ${AUDARGS[@]+"${AUDARGS[@]}"} > "$SD/summary.txt" 2>"$SD/err.txt"
   RC=$?
   note_rc "$RC"

--- a/scripts/finding_verifier.sh
+++ b/scripts/finding_verifier.sh
@@ -41,6 +41,15 @@ done
 # header above says must never happen. Test readability, and check the read itself below.
 [ -n "$TARGET" ] && [ -f "$TARGET" ] && [ -r "$TARGET" ] \
   || { echo "finding_verifier: --target must name a readable file" >&2; exit 2; }
+# 🟥 심링크 거부 — 이 파일의 내용은 «외부 모델로 전송»된다. 체크아웃 안의 링크가 바깥
+#    자격증명을 가리키면, 리뷰하려던 코드 대신 그 비밀이 프롬프트가 된다(residency 위반).
+#    cross-family security review 2026-09-09.
+if [ -L "$TARGET" ]; then
+  echo "finding_verifier: --target is a symlink — refusing (content is SENT to an external model)" >&2
+  exit 2
+fi
+# 프롬프트 파일은 소스 전문을 담는다 — 0644 로 남기지 않는다.
+umask 077
 
 WORK="$(mktemp -d 2>/dev/null)" || { echo "finding_verifier: mktemp failed" >&2; exit 3; }
 cleanup() { [ -n "$KEEP" ] && cp "$WORK"/* "$KEEP"/ 2>/dev/null; rm -rf "$WORK"; }

--- a/scripts/finding_verify.py
+++ b/scripts/finding_verify.py
@@ -87,8 +87,20 @@ def run_verifier(cmd, findings, allowed=VERDICTS):
     the expected set is dropped rather than coerced -- a stage that silently reinterprets an unknown
     label is how an unanswered question becomes an answer."""
     payload = "\n".join(json.dumps(f, ensure_ascii=False) for f in findings) + "\n"
+    # 🟥 A LIST MEANS argv; A STRING MEANS A SHELL. The caller decides, and the shipped caller
+    # (finding_pipeline.sh) now hands a list, so no shell parses our paths.
+    #
+    # Why this branch exists (cross-family security review, 2026-09-09, reproduced on dash):
+    # the string form is executed with `shell=True`, i.e. by `/bin/sh`. Quoting the interpolated
+    # path with bash's `printf %q` is NOT enough, because %q emits bash-only `$'...'` for a path
+    # containing a newline, and `/bin/sh` on most Linux distributions is **dash**, which does not
+    # understand that syntax -- the quoting comes apart and a crafted filename executes a second
+    # command. macOS cannot observe this at all: its /bin/sh is bash-derived, so a local run is
+    # green while the shipped npm package is not. The fix is not better escaping; it is not
+    # handing a shell the string in the first place.
+    shell = isinstance(cmd, str)
     try:
-        p = subprocess.run(cmd, shell=True, input=payload, capture_output=True,
+        p = subprocess.run(cmd, shell=shell, input=payload, capture_output=True,
                            text=True, timeout=int(os.environ.get("FH_VERIFY_TIMEOUT", "600")))
     except Exception as e:                                   # noqa: BLE001 - degrade on anything
         return {}, f"verifier did not run: {e}"
@@ -114,6 +126,11 @@ def main():
     ap = argparse.ArgumentParser(add_help=True)
     ap.add_argument("findings", help="JSONL file, or - for stdin")
     ap.add_argument("--out", required=True, help="directory for confirmed.jsonl / dropped.jsonl")
+    ap.add_argument("--verifier-argv", default=None,
+                    help="JSON array form of --verifier. Executed as argv (no shell), which is the "
+                         "only form immune to path-shaped injection. Wins over --verifier.")
+    ap.add_argument("--audit-verifier-argv", default=None,
+                    help="JSON array form of --audit-verifier. Same reason.")
     ap.add_argument("--verifier", default=os.environ.get("FH_VERIFY_CMD", ""),
                     help="shell command; findings JSONL on stdin, verdict JSONL on stdout")
     ap.add_argument("--family", default=os.environ.get("FH_VERIFY_FAMILY", "unstated"),
@@ -124,10 +141,29 @@ def main():
                     help="model family of the auditor; must differ from the verifier's")
     a = ap.parse_args()
 
+    # argv 형태가 있으면 그것이 실행 형태다 — 문자열은 셸을 타므로 후순위다.
+    def _as_argv(raw, label):
+        if not raw:
+            return None
+        try:
+            v = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise SystemExit("%s must be a JSON array: %s" % (label, e))
+        if not (isinstance(v, list) and v and all(isinstance(x, str) for x in v)):
+            raise SystemExit("%s must be a non-empty JSON array of strings" % label)
+        return v
+
+    a.verifier = _as_argv(a.verifier_argv, "--verifier-argv") or a.verifier
+    a.audit_verifier = _as_argv(a.audit_verifier_argv, "--audit-verifier-argv") or a.audit_verifier
+
+    # 문자열이든 리스트든 «비어 있나»를 같은 방법으로 묻는다 — 리스트에 .strip() 은 없다.
+    def _configured(cmd):
+        return bool(cmd) if isinstance(cmd, list) else bool(str(cmd or "").strip())
+
     findings = read_findings(a.findings)
     os.makedirs(a.out, exist_ok=True)
 
-    if not a.verifier.strip():
+    if not _configured(a.verifier):
         verdicts, err = {}, "no verifier configured (--verifier / FH_VERIFY_CMD)"
     else:
         verdicts, err = run_verifier(a.verifier, findings)
@@ -163,7 +199,7 @@ def main():
     audited = wrong_drops = reinstated = 0
     audit_status = "UNAUDITED"
     audit_note = ""
-    if dropped and a.audit_verifier.strip():
+    if dropped and _configured(a.audit_verifier):
         if a.audit_family == a.family:
             audit_note = ("auditor is the family that made the drop (%s) -- refused; a deletion is not "
                           "checked by the party that made it" % a.family)

--- a/scripts/gate_shape_scan.sh
+++ b/scripts/gate_shape_scan.sh
@@ -52,10 +52,14 @@ scan_one() { # $1=file → prints hits, returns 0 hit / 1 none / 3 unscannable
   e=$(printf '%s\n' "$body" | /usr/bin/grep -E "$EXPOSURE_RE" || true)
   r=$(printf '%s\n' "$body" | /usr/bin/grep -E "$IRREV_RE" || true)
   hits=0
-  [ -n "$v" ]  && { hits=1; printf '%s\n' "$v"  | /usr/bin/cut -c1-140 | /usr/bin/sed "s|^|VERDICT   $f:|"; }
-  [ -n "$v2" ] && { hits=1; printf '%s\n' "$v2" | /usr/bin/cut -c1-140 | /usr/bin/sed "s|^|VERDICT   $f:|"; }
-  [ -n "$e" ]  && { hits=1; printf '%s\n' "$e"  | /usr/bin/cut -c1-140 | /usr/bin/sed "s|^|EXPOSURE  $f:|"; }
-  [ -n "$r" ]  && { hits=1; printf '%s\n' "$r"  | /usr/bin/cut -c1-140 | /usr/bin/sed "s|^|IRREV     $f:|"; }
+  # 🟥 파일명을 sed 프로그램에 넣지 않는다. `s|^|... $f:|` 는 파일명 안의 `|` 로 구분자를 벗어나고,
+  #    거기에 `r <path>` 를 이어 붙이면 임의 파일 내용이 스캔 출력에 실리고 `w` 는 덮어쓴다
+  #    (cross-family security review 2026-09-09, 무해한 프로브로 추가 파일 읽기 실증).
+  #    awk 의 ENVIRON 은 값을 «프로그램»이 아니라 «데이터»로 받으므로 이 통로가 닫힌다.
+  [ -n "$v" ] && { hits=1; printf '%s\n' "$v" | /usr/bin/cut -c1-140 | FH_LABEL="VERDICT   $f:" /usr/bin/awk '{print ENVIRON["FH_LABEL"] $0}'; }
+  [ -n "$v2" ] && { hits=1; printf '%s\n' "$v2" | /usr/bin/cut -c1-140 | FH_LABEL="VERDICT   $f:" /usr/bin/awk '{print ENVIRON["FH_LABEL"] $0}'; }
+  [ -n "$e" ] && { hits=1; printf '%s\n' "$e" | /usr/bin/cut -c1-140 | FH_LABEL="EXPOSURE  $f:" /usr/bin/awk '{print ENVIRON["FH_LABEL"] $0}'; }
+  [ -n "$r" ] && { hits=1; printf '%s\n' "$r" | /usr/bin/cut -c1-140 | FH_LABEL="IRREV     $f:" /usr/bin/awk '{print ENVIRON["FH_LABEL"] $0}'; }
   [ "$hits" -gt 0 ] && return 0 || return 1
 }
 

--- a/scripts/test_finding_pipeline_lanes.sh
+++ b/scripts/test_finding_pipeline_lanes.sh
@@ -355,6 +355,67 @@ else
   chmod 644 "$UNR" 2>/dev/null
 fi
 
+# ══ 보안 회귀 앵커 (cross-family security review 2026-09-09) ═══════════════════════════════════
+# 🟥 각 레인은 «지금 안전한가»가 아니라 «그 구멍을 되돌리면 빨개지나»를 잰다.
+#    되돌림 방법은 각 주석에 적어 뒀다.
+
+# L31 (S1) — 출력 디렉터리 «이름»에 든 $(...) 가 실행되면 안 된다 (fleet 의 eval 경로)
+#    되돌림: finding_fleet.sh 의 q_pf/q_codex/q_agy 결박을 빼고 raw 치환으로 되돌리면 빨개진다
+SENT="$D/S1_EXECUTED"
+EVILOUT="$D/out\$(touch $SENT)"
+printf 'x = 1\n' > "$D/s1.py"
+printf 'codex|logic|%s\n' "sh $D/m_codex.sh" > "$D/fleetS1.tbl"
+FH_CODEX_BIN=/bin/true bash "$HERE/finding_fleet.sh" "$D/s1.py" --out "$EVILOUT" --fleet "$D/fleetS1.tbl" >/dev/null 2>&1
+[ ! -e "$SENT" ] \
+  && ok "L31 (S1) 출력 경로의 \$(...) 가 실행되지 않는다 (eval 치환 결박)" \
+  || no "L31 (S1) eval 주입" "출력 디렉터리 이름의 명령이 실행됐다"
+
+# L32 (S2) — 검증기는 «셸 문자열»이 아니라 argv 로 넘어간다
+#    되돌림: finding_pipeline.sh 를 --verifier 문자열 형태로 되돌리면 빨개진다.
+#    🟥 왜 문자열이 위험한지: shell=True 는 /bin/sh 이고, bash %q 의 $'...' 는 dash 에서 안 통한다.
+#       macOS 는 /bin/sh 가 bash 계열이라 «실행해도» 이 축이 안 보인다 — 그래서 형태를 단언한다.
+{ /usr/bin/grep -q -- '--verifier-argv' "$PIPE" && /usr/bin/grep -q -- '--audit-verifier-argv' "$PIPE" \
+  && ! /usr/bin/grep -qE '^\s*--verifier "bash ' "$PIPE"; } \
+  && ok "L32 (S2) 파이프라인이 argv 형태로 넘긴다 (셸이 경로를 파싱하지 않는다)" \
+  || no "L32 (S2) argv 형태" "문자열 --verifier 로 되돌아갔다 — dash 에서 인용이 깨진다"
+
+# L32b (S2) — finding_verify.py 가 리스트를 받으면 shell 없이 실행한다
+/usr/bin/grep -q 'shell = isinstance(cmd, str)' "$VERIFY" \
+  && ok "L32b (S2) verify 는 리스트=argv · 문자열=셸 로 갈라 실행한다" \
+  || no "L32b (S2) shell 분기" "shell=True 고정으로 되돌아갔다"
+
+# L33 (S5) — 타깃이 심링크면 «내용이 외부로 나가므로» 거부해야 한다
+printf 'SECRET=abc\n' > "$D/outside_secret.txt"
+ln -sf "$D/outside_secret.txt" "$D/link_target.py"
+bash "$VERIFIER" --family codex --target "$D/link_target.py" < /dev/null >/dev/null 2>&1; RC=$?
+[ "$RC" -eq 2 ] && ok "L33 (S5) verifier: 심링크 타깃 거부 → rc=2 (외부 비밀 업로드 차단)" || no "L33 (S5) 심링크 타깃" "rc=$RC"
+bash "$HERE/finding_fleet.sh" "$D/link_target.py" --out "$D/o33" >/dev/null 2>&1; RC=$?
+[ "$RC" -eq 2 ] && ok "L33b (S5) fleet: 심링크 타깃 거부 → rc=2" || no "L33b (S5) fleet 심링크" "rc=$RC"
+
+# L34 (S4) — 출력물이 심링크면 «남의 파일 truncate» 이므로 쓰기 전에 거부
+printf 'DO NOT TRUNCATE\n' > "$D/victim.conf"
+mkdir -p "$D/o34"; ln -sf "$D/victim.conf" "$D/o34/confirmed.jsonl"
+printf 'x = 1\n' > "$D/s4.py"
+bash "$PIPE" "$D/s4.py" --out "$D/o34" --fleet "$D/fleet.tbl" >/dev/null 2>&1; RC=$?
+{ [ "$RC" -eq 2 ] && /usr/bin/grep -q "DO NOT TRUNCATE" "$D/victim.conf"; } \
+  && ok "L34 (S4) 출력 심링크 거부 → rc=2 · 바깥 파일 온전" \
+  || no "L34 (S4) 출력 심링크" "rc=$RC victim=$(head -c 20 "$D/victim.conf")"
+
+# L35 (A7) — 프롬프트 파일은 소스 전문을 담는다. 다른 계정이 읽으면 안 된다
+printf 'x = 1\n' > "$D/s7.py"
+FH_CODEX_BIN=/bin/true bash "$HERE/finding_fleet.sh" "$D/s7.py" --out "$D/o35" --fleet "$D/fleetS1.tbl" >/dev/null 2>&1
+PF=$(ls "$D/o35"/prompt_*.txt 2>/dev/null | head -1)
+if [ -n "$PF" ]; then
+  MODE=$(/usr/bin/stat -f "%OLp" "$PF" 2>/dev/null || /usr/bin/stat -c "%a" "$PF" 2>/dev/null)
+  case "$MODE" in *[04]|*[04][04]) OTHERS_R=1;; *) OTHERS_R=0;; esac
+  # 마지막 자리(others)가 4 이상이면 읽힌다
+  LAST=${MODE#${MODE%?}}
+  [ "$LAST" -lt 4 ] && ok "L35 (A7) 프롬프트 파일이 others 에게 안 읽힌다 (mode=$MODE)" \
+                    || no "L35 (A7) 프롬프트 권한" "mode=$MODE — 소스 전문이 더 넓게 읽힌다"
+else
+  no "L35 (A7) 프롬프트 권한" "프롬프트 파일이 안 생겼다 — 미측정(통과 아님)"
+fi
+
 /bin/rm -rf "$D"
 echo "PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ] && { echo "FAILED=0"; exit 0; } || { echo "FAILED=1"; exit 1; }


### PR DESCRIPTION
## 왜 지금

**릴리스 3.2.0 의 Pre-Publish 게이트에서 멈춘 것을 푸는 PR 이다.** 게이트 단계로 cross-family 보안 패스
(codex, 출하될 실행 파일 6개 «전문»)를 돌렸더니 **S급 5 · A급 3** 이 나왔다. 그중 **7건**을 닫는다.

🟢 **범위 — 좋은 소식부터**: 이 6개 파일은 전부 `v3.1.4` **이후** 추가분이라 **npm 에 나간 적이 없다.**
비가역 단계 «전»에 잡혔다. 그래서 처방이 «회수»가 아니라 «발행 보류 후 수리»다.

## 🟥 S2 — 오늘 오전의 내 수리가 불충분했고, 보안 리포트까지 틀리게 냈다

```
bash printf %q          → 개행 포함 경로에 bash 전용  $'...'  를 낸다
subprocess(shell=True)  → /bin/sh 이고, 리눅스에선 흔히 dash
dash 는 $'...' 를 모른다 → 인용이 벌어지고 두 번째 명령이 실행된다
```

🟥 **macOS 는 이 축을 구조적으로 못 본다** — `/bin/sh` 가 bash 계열이라 로컬은 초록인데 출하물은
아니다. 「내 셸에서는 됐다」의 교과서적 얼굴이고, 하필 **npm 은 리눅스로 나간다.** 로컬 `/bin/dash` 로
직접 재현했다.

**처방은 «더 잘 인용»이 아니라 형태 교체다.** `finding_verify.py` 에 argv 분기(`shell = isinstance(cmd, str)`)를
넣고, 파이프라인이 `--verifier-argv`(JSON 배열)로 넘긴다 — **셸이 우리 경로를 파싱하는 일 자체가 사라진다.**
기존 문자열 `--verifier` 는 그대로 동작한다(레인 스텁 포함).

## 나머지 6건

| # | 무엇 | 처방 |
|:-:|---|---|
| S1 | `eval` 문자열에 경로가 결박 없이 치환 — **출력 디렉터리 «이름»의 `$(...)` 가 실행**(무해 프로브 실증) | 치환값을 `%q` 로 결박. 🟥 여기는 bash `eval` 이라 `%q` 가 **옳은** 도구다 — S2 와 사정이 다르다 |
| S3 | 파일명이 sed 프로그램(`s\|^\|… $f:\|`)에 들어가 `\|` 로 구분자 이탈 → `r <path>` 로 임의 파일이 출력에 실리고 `w` 로 덮어씀 | 파일명을 **프로그램이 아니라 데이터로** 넘긴다 (awk `ENVIRON`) |
| S4 | 출력물 심링크 → 리다이렉션·`open()` 이 따라가 **바깥 파일 truncate** | 쓰기 «전» 거부 |
| S5 | 타깃 심링크 → 체크아웃 밖 자격증명이 **외부 모델로 전송**. **residency 위반이다** | fleet·verifier 양쪽 거부 |
| A7 | 프롬프트 파일이 umask 022 로 `0644` — 소스 전문이 더 넓게 읽힌다 | `umask 077` |
| A8 | `../` 참조가 스캔 루트를 벗어나 **바깥 파일의 줄이 증거로 출력**(프로브 실증) | realpath 봉쇄 + 심링크 거부 |

**미수리 잔여 1건 — A6**: gemini 는 프롬프트를 `-p` 인자로 받으므로 소스 전문이 argv 에 노출된다.
agy 의 인터페이스라 우리 층에서 못 닫는다. 이름으로 남긴다.

## 검증

```
레인            33 → 40   (신규 L31~L35 = 닫은 구멍마다 하나씩)
gate_shape_scan  9/9      (수리 후)
doc_claim_triad 11/11     (수리 후)
되돌림 프로브    S5 가드 무력화 → 정확히 L33 «만» 적색 (39/1) → 복원 40/0
dash 재현        %q 출력이 $'...' 였고 /bin/dash 가 리터럴로 못 읽었다
```

L32 는 **«형태»를 단언한다**(argv 를 쓰는가). 실행으로는 macOS 에서 이 축이 안 보이기 때문이다 —
**계기가 대상을 못 보는 자리에서는 형태를 박는 것이 정직하다.**

## 마커

`crossfamily: panel(codex) · residency=CLEAN(files=7)` · `oracle: known-pair` ·
**`soul-check: violated`** — 초판이 절대-안-함(«인용을 더 잘 해서 넘어가지 않는다»)을 정확히 어겼고,
그 상태로 보안 리포트를 냈다. 자력 적발 0. 기록된 위반이 숨긴 위반보다 낫다.
