### PR TITLE
fix(gate): gate_shape_scan 여러 줄 docstring 안쪽 오탐 — 짝 상태 추적 + 판정형 질문 reps≥3 교리 (pmh-dev #76 역수확)

### DIFF
--- a/knowledge/shared/harness-core/field_verdict_crossfamily_gate.md
+++ b/knowledge/shared/harness-core/field_verdict_crossfamily_gate.md
@@ -93,6 +93,12 @@ it?) before acting — mechanical anchor over agreement.
 2. **Cross-family adversarial review** — `auto-decorrelation` recruits ≥1 different-family auditor
    (e.g. `codex` gpt-5.5 / high for repo-grounded verdict code). The same standing verifier the
    4-axis gate uses for load-bearing FH assets, now applied to **field** load-bearing changes.
+   🟥 **Judgment-type questions need reps ≥ 3** (pmh-dev #76, 2026-09-11): the same «is this silent
+   fallback by-design or fail-open?» prompt at the same temperature returned DESIGN / DEFECT / DESIGN
+   across three runs of one auditor. A single run of a judgment question therefore cannot be recorded
+   as `panel(...)` CONCUR — run it ≥3×, report the split, and treat a split as *unresolved*, not as
+   whichever side came first. Fact-type questions (grep, existence, «does line N call X») are stable
+   across reps and families and need neither repetition nor a family change.
 3. **Confirm → fix → re-verify loop** — iterate until the cross-family pass is **CONVERGED**: no
    reachable false-PASS / false-CONFIRMED / masked-FAIL / crash-where-safe-fail-required. **Each fix
    ships a mechanical regression test** reproducing the closed hole — a *required* convergence

--- a/scripts/gate_shape_scan.sh
+++ b/scripts/gate_shape_scan.sh
@@ -46,7 +46,15 @@ scan_one() { # $1=file → prints hits, returns 0 hit / 1 none / 3 unscannable
   if /usr/bin/file -b --mime-encoding "$f" 2>/dev/null | /usr/bin/grep -q '^binary$'; then
     echo "UNSCANNABLE  $f (binary)"; return 3; fi
   # one pass: drop comment-led lines, then classify (VERDICT wins over EXPOSURE over IRREV per line)
-  body=$(/usr/bin/grep -nEv "$COMMENT_RE" "$f" 2>/dev/null || true)
+  # 🟥 pmh-dev #76 (2026-09-11): 여러 줄 docstring 의 «안쪽» 줄은 줄머리가 따옴표가 아니라 COMMENT_RE 를 통과했다 —
+  #    실물: 파이썬 테스트의 docstring 안 «fail-safe … 봉인» 문장이 GATE-SHAPED 로 지목됨. 줄 단위 grep 앞에
+  #    """ / ''' 짝 상태를 awk 로 추적해 열린 동안의 줄을 전부 버린다(여는 줄·닫는 줄 포함). 한 줄 docstring 은
+  #    짝수라 상태가 안 바뀌고 종전 COMMENT_RE 가 그대로 거른다. 잔여(이름으로): JS 템플릿 리터럴(`) · 일반 문자열 안의 """.
+  body=$(/usr/bin/awk -v q="'''" -v t='"""' '
+    { line=$0; n=gsub(t, "&", line); n+=gsub(q, "&", line)
+      if (indoc) { if (n % 2 == 1) indoc=0; next }
+      if (n % 2 == 1) { indoc=1; next }
+      print NR ":" $0 }' "$f" 2>/dev/null | /usr/bin/grep -Ev "^[0-9]+:${COMMENT_RE#^}" || true)
   v=$(printf '%s\n' "$body" | /usr/bin/grep -Ei "$VERDICT_RE" || true)
   v2=$(printf '%s\n' "$body" | /usr/bin/grep -E "$ENUM_RE" || true)
   e=$(printf '%s\n' "$body" | /usr/bin/grep -E "$EXPOSURE_RE" || true)
@@ -64,7 +72,7 @@ scan_one() { # $1=file → prints hits, returns 0 hit / 1 none / 3 unscannable
 }
 
 selftest() { # known pair — positive must hit, negative must not, comment-only must not
-  local d rc_pos rc_pos2 rc_neg rc_cmt rc_bin rc_irr rc_bnd rc_star fails=0
+  local d rc_pos rc_pos2 rc_neg rc_cmt rc_bin rc_irr rc_bnd rc_star rc_doc rc_doc2 fails=0
   d="$(mktemp -d 2>/dev/null)" || d=""
   [ -n "$d" ] && [ -w "$d" ] || { echo "SELFTEST: ENV-BLOCKED (mktemp -d failed) — result unmeasured, not a pass"; return 3; }
   printf 'export class S {\n  start() {\n    this.app.listen(this.config.port, () => {});\n  }\n}\n' > "$d/pos_exposure.ts"
@@ -75,6 +83,8 @@ selftest() { # known pair — positive must hit, negative must not, comment-only
   printf 'set -e\ngit push origin main \\\n  --force\n' > "$d/pos_irrev.sh"
   printf 'authored_by = "x"\nallowance = 3\nauthor = "y"\n' > "$d/neg_boundary.py"
   printf 'int f(int *allow) {\n  *allow = 1;\n  return 0;\n}\n' > "$d/pos_star.c"
+  printf 'def t():\n    """docstring\n    PASS allow true — fail-safe 계통은 봉인\n    """\n    return 1\n' > "$d/neg_docstring.py"     # pmh-dev #76
+  printf 'def t():\n    """docstring\n    PASS allow true\n    """\n    return Verdict.ALLOW\n' > "$d/pos_after_docstring.py"
   scan_one "$d/pos_exposure.ts" >/dev/null; rc_pos=$?
   scan_one "$d/pos_verdict.py"  >/dev/null; rc_pos2=$?
   scan_one "$d/neg_util.py"     >/dev/null; rc_neg=$?
@@ -83,6 +93,8 @@ selftest() { # known pair — positive must hit, negative must not, comment-only
   scan_one "$d/pos_irrev.sh"    >/dev/null; rc_irr=$?
   scan_one "$d/neg_boundary.py" >/dev/null; rc_bnd=$?
   scan_one "$d/pos_star.c"      >/dev/null; rc_star=$?
+  scan_one "$d/neg_docstring.py" >/dev/null; rc_doc=$?
+  scan_one "$d/pos_after_docstring.py" >/dev/null; rc_doc2=$?
   [ "$rc_pos" -eq 0 ]  && echo "  ✅ known-positive exposure (listen()) → GATE-SHAPED"      || { echo "  ❌ known-positive exposure rc=$rc_pos"; fails=1; }
   [ "$rc_pos2" -eq 0 ] && echo "  ✅ known-positive verdict (ALLOW/DENY) → GATE-SHAPED"    || { echo "  ❌ known-positive verdict rc=$rc_pos2"; fails=1; }
   [ "$rc_neg" -eq 1 ]  && echo "  ✅ known-negative util (docstring 'Pass') → NOT"          || { echo "  ❌ known-negative util rc=$rc_neg"; fails=1; }
@@ -91,6 +103,8 @@ selftest() { # known pair — positive must hit, negative must not, comment-only
   [ "$rc_irr" -eq 0 ]  && echo "  ✅ known-positive irreversible (continued --force line) → GATE-SHAPED" || { echo "  ❌ known-positive irrev rc=$rc_irr"; fails=1; }
   [ "$rc_bnd" -eq 1 ]  && echo "  ✅ boundary: author/authored/allowance → NOT"                || { echo "  ❌ boundary rc=$rc_bnd"; fails=1; }
   [ "$rc_star" -eq 0 ] && echo "  ✅ code line starting with *allow (not a comment) → GATE-SHAPED" || { echo "  ❌ star-code rc=$rc_star"; fails=1; }
+  [ "$rc_doc" -eq 1 ]  && echo "  ✅ multi-line docstring interior ('PASS allow') → NOT (pmh-dev #76)" || { echo "  ❌ docstring interior rc=$rc_doc"; fails=1; }
+  [ "$rc_doc2" -eq 0 ] && echo "  ✅ control: real verdict line AFTER the docstring → GATE-SHAPED"   || { echo "  ❌ after-docstring rc=$rc_doc2"; fails=1; }
   /bin/rm -rf "$d"
   [ "$fails" -eq 0 ] && { echo "SELFTEST: PASS"; return 0; } || { echo "SELFTEST: FAIL"; return 3; }
 }

--- a/scripts/test_gate_shape_scan_lanes.sh
+++ b/scripts/test_gate_shape_scan_lanes.sh
@@ -32,5 +32,16 @@ bash "$SCAN" "$D/au.py" >/dev/null 2>&1; R1=$?; bash "$SCAN" "$D/az.py" >/dev/nu
 MUT="$D/scan_mut.sh"; /usr/bin/sed 's/^EXPOSURE_RE=.*/EXPOSURE_RE='"'"'(NEVER_MATCHES_XYZ)'"'"'/' "$SCAN" > "$MUT"
 bash "$MUT" "$D/serve.go" >/dev/null 2>&1; RC=$?
 [ "$RC" -eq 1 ] && ok "L7 되돌림: EXPOSURE 제거 → serve.go 가 NOT 로 떨어진다 (레인이 실물을 잰다)" || no "L7 되돌림" "rc=$RC (제거해도 초록이면 앵커가 장식)"
+# L8 — pmh-dev #76: 여러 줄 docstring 안쪽 줄은 게이트가 아니다 (""" · ''' · 컨트롤 = docstring 뒤 실제 판정 줄)
+printf 'def t():\n    """docstring\n    PASS allow true\n    """\n    return 1\n' > "$D/doc3.py"
+printf "def t():\n    '''docstring\n    return Verdict.ALLOW in prose\n    '''\n    return 1\n" > "$D/doc1.py"
+printf 'def t():\n    """docstring\n    PASS allow true\n    """\n    return Verdict.ALLOW\n' > "$D/doc_ctrl.py"
+bash "$SCAN" "$D/doc3.py" >/dev/null 2>&1; R1=$?; bash "$SCAN" "$D/doc1.py" >/dev/null 2>&1; R2=$?; bash "$SCAN" "$D/doc_ctrl.py" >/dev/null 2>&1; R3=$?
+[ "$R1" -eq 1 ] && [ "$R2" -eq 1 ] && [ "$R3" -eq 0 ] && ok "L8 docstring 안쪽(triple-double · triple-single)은 NOT · 그 뒤 실제 판정 줄은 GATE-SHAPED" || no "L8 docstring" "triple=$R1 single=$R2 ctrl=$R3"
+# L8b — 되돌림: 짝 상태 추적을 죽이면 L8 이 빨개지는가
+MUT2="$D/scan_mut2.sh"; /usr/bin/sed 's/if (n % 2 == 1) { indoc=1; next }/if (0) { indoc=1; next }/' "$SCAN" > "$MUT2"
+bash "$MUT2" "$D/doc3.py" >/dev/null 2>&1; RC=$?
+[ "$RC" -eq 0 ] && ok "L8b 되돌림: 짝 상태 제거 → doc3.py 가 GATE-SHAPED 로 돌아간다 (레인이 실물을 잰다)" || no "L8b 되돌림" "rc=$RC"
+
 /bin/rm -rf "$D"
 echo "PASS=$PASS FAIL=$FAIL"; [ "$FAIL" -eq 0 ] && { echo "FAILED=0"; exit 0; } || { echo "FAILED=1"; exit 1; }


### PR DESCRIPTION
## 무엇을 왜

pmh-dev #76(2026-09-11)의 역수확 2건.

**① `scripts/gate_shape_scan.sh` — 여러 줄 docstring 안쪽 줄 오탐.** `COMMENT_RE` 는 줄머리만 보므로 `"""` 로 열린 docstring 의 «안쪽» 줄이 그대로 스캔됐다. 실물: qasp PR #11 리뷰에서 `tests/test_p11_retrospective.py:7` 의 docstring 문장(«fail-safe 계통은 … 봉인»)이 GATE-SHAPED 로 지목됨.

수리 = 줄 단위 grep 앞에 awk 로 `"""`/`'''` 짝 상태를 추적해 열린 동안의 줄(여는·닫는 줄 포함)을 버린다. 한 줄 docstring 은 짝수라 상태가 안 바뀌고 종전 규칙이 그대로 거른다.

```
이슈의 known-pair 그대로 실행
kp1  X / """docstring / PASS allow true / """      수리 전 rc=0 (오탐 재현) → 수리 후 rc=1
kp2  X / """docstring / totally normal text"""     수리 전후 rc=1 (컨트롤)
```

**② `field_verdict_crossfamily_gate.md` §4-2 — 판정형 질문은 reps ≥ 3.** 같은 프롬프트·온도로 3회 → DESIGN / DEFECT / DESIGN. reps=1 의 판정형 질문은 `panel(...)` CONCUR 로 기록할 수 없고, split 은 unresolved 로. 사실형 질문(grep·존재성)은 reps·계열 무관 안정.

## 계기가 산다는 증거
- selftest 8→10항(neg_docstring · pos_after_docstring = docstring 뒤 실제 판정 줄은 여전히 GATE-SHAPED) PASS
- 레인 9→11: L8(triple-double · triple-single · 컨트롤) · **L8b 되돌림** — 짝 상태 한 줄을 무효화하면 doc3.py 가 GATE-SHAPED 로 돌아간다
- 소비자 레인 `test_gate_two_verdicts_lanes.sh` all green · degrade scan 스멜 0

## 안 닫은 것
- JS 템플릿 리터럴(`) · 일반 문자열 안의 삼중따옴표(홀수면 그 뒤 줄이 사라진다 — fail-open 방향, 드묾) — 이름으로 남김.
- crossfamily = `DEGRADED_PANEL_UNUSED`(codex 는 F_r2ctrl 24런 점유 중). 다음 codex 창에서 R10 감사에 이 diff 를 얹는다.
- pmh 설치본은 이 PR 머지 후 그쪽에서 갱신 — `tests/test_p11_retrospective.py:7` 로 재확인 요청(#76 코멘트).

## 게이트
`marker: tracks/_meta/.axes_23_passed_fix_gate-shape-docstring_2026-09-12.marker` · `crossfamily: DEGRADED_PANEL_UNUSED` · `standpoint: tier2b(pmh-dev)` · `oracle: known-pair`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdR2YU5LBu3jBBzdPjJbxE